### PR TITLE
Fix travis build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: required
+dist: trusty
 language: node_js
 node_js:
-  - '8.9.4'
+  - '10.16.3'
 script:
   - set -e
 

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --name r4mp --inline-vue src/main.ts",
+    "build": "vue-cli-service build --target lib --name r4mp src/main.ts",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint"

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --formats umd --name r4mp src/main.ts",
+    "build": "vue-cli-service build --target lib --formats umd --name r4mp src/main.ts 2>&1",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint"

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --name r4mp src/main.ts",
+    "build": "vue-cli-service build --target lib --formats umd --name r4mp src/main.ts",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint"

--- a/packages/ramp-core/vue.config.js
+++ b/packages/ramp-core/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    chainWebpack: config => {
+        config.performance.hints(false);
+    }
+};


### PR DESCRIPTION
List of things fixed to make travis work:
- old node has been updated to slightly less old node. Its now `10.16.3` which is what I use locally and close to what RAMP2/3 were using (`10.16.1`). This was required for Rush support.
- Webpack yelling about entrypoint sizes, these warnings aren't really helpful aside from a reminder to use code-splitting and other things of the sort, but we're already planning on tinkering with that.
- vue-cli-service warning that the build is building. Very scary.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/33)
<!-- Reviewable:end -->
