### PR TITLE
Simplify geoApi loader

### DIFF
--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -9,7 +9,7 @@ import GapiLoader, { Map, GeoApi, RampMapConfig } from 'ramp-geoapi';
 @Component
 export default class EsriMap extends Vue {
     created(): void {
-        const gapiPromise: Promise<GeoApi> = GapiLoader('https://js.arcgis.com/4.14', window);
+        const gapiPromise: Promise<GeoApi> = GapiLoader(window);
 
         gapiPromise.then((gapi: GeoApi) => {
             const esriMapConfig: RampMapConfig = {

--- a/packages/ramp-geoapi/README.md
+++ b/packages/ramp-geoapi/README.md
@@ -1,11 +1,17 @@
-# Temp Test GeoAPI Funtime Party
+# GeoAPI Package
 
+Serves as an insulator / abstraction from the actual mapping API.
+Currently the mapping API is [ESRI JS API 4](https://developers.arcgis.com/javascript/index.html), so this package also serves to keep the Dojo framework fenced in.
+
+Original Typescript / Webpack magic framework was stolen from https://github.com/juristr/webpack-typescript-starter
+
+Short example of how to consume/instantiate the GeoAPI from another package using default configuration
+
+```ts
+import GapiLoader, { GeoApi } from 'ramp-geoapi';
+
+const gapiPromise: Promise<GeoApi> = GapiLoader(window);
+gapiPromise.then((gapi: GeoApi) => {
+    gapi.doSomething();
+});
 ```
-npm install
-npm run start
-http://localhost:9000/
-```
-
-
-Typescript / Webpack magic framework stolen from https://github.com/juristr/webpack-typescript-starter
-

--- a/packages/ramp-geoapi/src/gapiTypes.ts
+++ b/packages/ramp-geoapi/src/gapiTypes.ts
@@ -9,6 +9,15 @@ import UtilModule from './util/UtilModule';
 // gapi loader needs to be a oneshot default due to magic (something about module load being dependant on dojo script load [waves hands, points at Aly]).
 // so putting the types here so they can be shared around
 
+export interface EpsgLookup {
+    (code: string | number): Promise<string>;
+}
+
+export interface GeoApiOptions {
+    apiUrl?: string;
+    epsgLookup?: EpsgLookup
+}
+
 export interface DojoWindow extends Window {
     require?: any;  // require is both a function, and has event handlers. probably a way to define in typescript interface, not going to right now.
 }
@@ -72,10 +81,6 @@ export class EsriBundle {
     dojoQuery: dojo.query;
     esriConfig: esri.config;
     esriRequest: (url: string, opts: esri.RequestOptions) => Promise<esri.RequestResponse>; // esri.request; // TODO figure out how to do this.  the esri.request doesn't align right with what dojo spits back. if it has to be a function, add the types to the signature
-}
-
-export interface EpsgLookup {
-    (code: string | number): Promise<string>;
 }
 
 // TODO might be worth making this a class or a generator function with defaults.  dont know what the impact of making all properties optonal is.

--- a/packages/ramp-geoapi/src/main.ts
+++ b/packages/ramp-geoapi/src/main.ts
@@ -1,4 +1,4 @@
-import { GeoApi, DojoWindow, EsriBundle, InfoBundle, EpsgLookup } from './gapiTypes';
+import { GeoApi, DojoWindow, EsriBundle, InfoBundle, EpsgLookup, GeoApiOptions } from './gapiTypes';
 // import { FakeNewsMapModule } from './fakenewsmap';
 import MapModule from './map/MapModule';
 
@@ -96,7 +96,17 @@ function initAll(esriBundle: EsriBundle, window: DojoWindow, epsgLookup: EpsgLoo
 }
 
 // TODO if we find we have more things like epsgLookup that need to be provided at initialization, consider changing the paremeter into an options object
-export default async (esriApiUrl: string, window: DojoWindow, epsgLookup: EpsgLookup = undefined): Promise<GeoApi> => {
+
+/**
+ * The main loader of the GeoAPI.
+ * Options:
+ * - esriApiUrl: url to an instance of the ESRI JS API 4.x. Default value is official source using the version that has passed development tests. Can override to older versions or a different host location.
+ * - epsgLookup: a function that takes an EPSG code and returns a promise of a proj4 projection string for the EPSG code. Default function will use epsg.io service endpoint.
+ * @param {Window} window a reference to the host page window. Required to dynamically add the script for the mapping api
+ * @param {Object} [options] contains any of the above options
+ * @returns {Promise} resolves with instantiated GeoAPI object
+ */
+export default async (window: DojoWindow, options: GeoApiOptions = {}): Promise<GeoApi> => {
 
     // esriDeps is an array pairing ESRI JSAPI dependencies with their imported names
     // in esriBundle
@@ -177,9 +187,9 @@ export default async (esriApiUrl: string, window: DojoWindow, epsgLookup: EpsgLo
         oScript.onerror = (err: any) => reject(err);
         oScript.onload = () => resolve();
         oHead.appendChild(oScript);
-        oScript.src = esriApiUrl;
+        oScript.src = options.apiUrl || 'https://js.arcgis.com/4.14'; // default value should be used for general testing and be considered our "supported" version
     });
 
     const esriBundle = await makeDojoRequests(esriDeps, window);
-    return initAll(esriBundle, window, epsgLookup);
+    return initAll(esriBundle, window, options.epsgLookup);
 };


### PR DESCRIPTION
Defaults ESRI API url to our tested/supported version on ESRI's host. Leaves option to override.
Collapsed option params to one param.
Updated GeoAPI readme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/34)
<!-- Reviewable:end -->
