### PR TITLE
Add Tailwindcss, enhance

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -5,6 +5,7 @@ dependencies:
   '@babel/plugin-proposal-object-rest-spread': 7.7.7_@babel+core@7.7.7
   '@babel/preset-env': 7.7.7_@babel+core@7.7.7
   '@babel/preset-typescript': 7.7.7_@babel+core@7.7.7
+  '@fullhuman/postcss-purgecss': 1.3.0
   '@rush-temp/ramp-core': 'file:projects/ramp-core.tgz_webpack@4.41.3'
   '@rush-temp/ramp-geoapi': 'file:projects/ramp-geoapi.tgz'
   '@types/arcgis-js-api': 4.14.0
@@ -29,12 +30,15 @@ dependencies:
   eslint-plugin-prettier: 3.1.2_eslint@5.16.0+prettier@1.19.1
   eslint-plugin-vue: 6.1.2_eslint@5.16.0
   js-sql-parser: 1.0.7
+  postcss-nested: 4.2.1
+  precss: 4.0.0
   prettier: 1.19.1
   proj4: 2.6.0
   sass: 1.24.3
   sass-loader: 8.0.0_sass@1.24.3+webpack@4.41.3
   source-map-loader: 0.2.3
   svg.js: 2.7.1
+  tailwindcss: 1.1.4
   terraformer: 1.0.9
   terraformer-arcgis-parser: 1.1.0
   tslib: 1.10.0
@@ -898,6 +902,18 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==
+  /@csstools/convert-colors/1.4.0:
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
+  /@csstools/sass-import-resolve/1.0.0:
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-pH4KCsbtBLLe7eqUrw8brcuFO8IZlN36JjdKlOublibVdAIPHCzEnpBWOVUXK5sCf+DpBi8ZtuWtjF0srybdeA==
   /@cypress/listr-verbose-renderer/0.4.1:
     dependencies:
       chalk: 1.1.3
@@ -916,6 +932,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
+  /@fullhuman/postcss-purgecss/1.3.0:
+    dependencies:
+      postcss: 7.0.26
+      purgecss: 1.4.2
+    dev: false
+    resolution:
+      integrity: sha512-zvfS3dPKD2FAtMcXapMJXGbDgEp9E++mLR6lTgSruv6y37uvV5xJ1crVktuC1gvnmMwsa7Zh1m05FeEiz4VnIQ==
   /@hapi/address/2.1.4:
     dev: false
     resolution:
@@ -2775,6 +2798,12 @@ packages:
     dev: false
     resolution:
       integrity: sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
+  /camelcase-css/2.0.1:
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
   /camelcase/4.1.0:
     dev: false
     engines:
@@ -3424,6 +3453,15 @@ packages:
     dev: false
     resolution:
       integrity: sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==
+  /css-blank-pseudo/0.1.4:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==
   /css-color-names/0.0.4:
     dev: false
     resolution:
@@ -3437,6 +3475,16 @@ packages:
       node: '>4'
     resolution:
       integrity: sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==
+  /css-has-pseudo/0.10.0:
+    dependencies:
+      postcss: 7.0.26
+      postcss-selector-parser: 5.0.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==
   /css-loader/3.4.1_webpack@4.41.3:
     dependencies:
       camelcase: 5.3.1
@@ -3459,6 +3507,15 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-+ybmv7sVxxNEenQhkifQDvny/1iNQM7YooJbSfVUdQQvisyg1aKIqgGjCjoFSyVLJMp17z9rfZFQaR5HGHcMbw==
+  /css-prefers-color-scheme/3.1.1:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==
   /css-select-base-adapter/0.1.1:
     dev: false
     resolution:
@@ -3513,6 +3570,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  /cssdb/4.4.0:
+    dev: false
+    resolution:
+      integrity: sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==
   /cssesc/2.0.0:
     dev: false
     engines:
@@ -4933,6 +4994,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+  /flatten/1.0.3:
+    dev: false
+    resolution:
+      integrity: sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
   /flush-write-stream/1.1.1:
     dependencies:
       inherits: 2.0.4
@@ -5029,6 +5094,16 @@ packages:
       node: '>=6 <7 || >=8'
     resolution:
       integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
+  /fs-extra/8.1.0:
+    dependencies:
+      graceful-fs: 4.2.3
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+    dev: false
+    engines:
+      node: '>=6 <7 || >=8'
+    resolution:
+      integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
   /fs-minipass/2.0.0:
     dependencies:
       minipass: 3.1.1
@@ -5325,6 +5400,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+  /has-flag/1.0.0:
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
   /has-flag/3.0.0:
     dev: false
     engines:
@@ -6672,6 +6753,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
+  /js-base64/2.5.1:
+    dev: false
+    resolution:
+      integrity: sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==
   /js-beautify/1.10.2:
     dependencies:
       config-chain: 1.1.12
@@ -7074,6 +7159,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  /lodash._reinterpolate/3.0.0:
+    dev: false
+    resolution:
+      integrity: sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
   /lodash.defaultsdeep/4.6.1:
     dev: false
     resolution:
@@ -7098,6 +7187,23 @@ packages:
     dev: false
     resolution:
       integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+  /lodash.template/4.5.0:
+    dependencies:
+      lodash._reinterpolate: 3.0.0
+      lodash.templatesettings: 4.2.0
+    dev: false
+    resolution:
+      integrity: sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
+  /lodash.templatesettings/4.2.0:
+    dependencies:
+      lodash._reinterpolate: 3.0.0
+    dev: false
+    resolution:
+      integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
+  /lodash.toarray/4.4.0:
+    dev: false
+    resolution:
+      integrity: sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
   /lodash.transform/4.6.0:
     dev: false
     resolution:
@@ -7602,6 +7708,12 @@ packages:
       node: '>= 0.4.6'
     resolution:
       integrity: sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==
+  /node-emoji/1.10.0:
+    dependencies:
+      lodash.toarray: 4.4.0
+    dev: false
+    resolution:
+      integrity: sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
   /node-forge/0.9.0:
     dev: false
     engines:
@@ -7732,6 +7844,10 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+  /normalize.css/8.0.1:
+    dev: false
+    resolution:
+      integrity: sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
   /npm-run-path/2.0.2:
     dependencies:
       path-key: 2.0.1
@@ -8372,6 +8488,28 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+  /postcss-advanced-variables/3.0.0:
+    dependencies:
+      '@csstools/sass-import-resolve': 1.0.0
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-e5tcG0+l2qaqV65+qQCAW91vX4+mYbh2m5tdBYrzOhYjFgtNmtehmZWotvzWTGbtgbP11tgGirEYy2P7m6HceQ==
+  /postcss-atroot/0.1.3:
+    dependencies:
+      postcss: 5.2.18
+    dev: false
+    resolution:
+      integrity: sha1-Z1LAIwx0UUBUk0WysOMOvtoBpAU=
+  /postcss-attribute-case-insensitive/4.0.1:
+    dependencies:
+      postcss: 7.0.26
+      postcss-selector-parser: 5.0.0
+    dev: false
+    resolution:
+      integrity: sha512-L2YKB3vF4PetdTIthQVeT+7YiSzMoNMLLYxPXXppOOP7NoazEAy45sh2LvJ8leCQjfBcfkYQs8TtCcQjeZTp8A==
   /postcss-calc/7.0.1:
     dependencies:
       css-unit-converter: 1.1.1
@@ -8381,6 +8519,53 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==
+  /postcss-color-functional-notation/2.0.1:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==
+  /postcss-color-gray/5.0.0:
+    dependencies:
+      '@csstools/convert-colors': 1.4.0
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==
+  /postcss-color-hex-alpha/5.0.3:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==
+  /postcss-color-mod-function/3.0.3:
+    dependencies:
+      '@csstools/convert-colors': 1.4.0
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==
+  /postcss-color-rebeccapurple/4.0.1:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==
   /postcss-colormin/4.0.3:
     dependencies:
       browserslist: 4.8.3
@@ -8402,6 +8587,41 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==
+  /postcss-custom-media/7.0.8:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==
+  /postcss-custom-properties/8.0.11:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==
+  /postcss-custom-selectors/5.1.2:
+    dependencies:
+      postcss: 7.0.26
+      postcss-selector-parser: 5.0.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==
+  /postcss-dir-pseudo-class/5.0.0:
+    dependencies:
+      postcss: 7.0.26
+      postcss-selector-parser: 5.0.0
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==
   /postcss-discard-comments/4.0.2:
     dependencies:
       postcss: 7.0.26
@@ -8434,6 +8654,105 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==
+  /postcss-double-position-gradients/1.0.0:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==
+  /postcss-env-function/2.0.2:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==
+  /postcss-extend-rule/2.0.0:
+    dependencies:
+      postcss: 6.0.23
+      postcss-nesting: 5.0.0
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-dgr1GJzW3lUBczZJO5Fm51rktn34Uc99xR1uQyC2Td8JPep/Y+TRx6TjK0yngikOd4LxV1xyuohMMpcaOBgrfA==
+  /postcss-focus-visible/4.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==
+  /postcss-focus-within/3.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==
+  /postcss-font-variant/4.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    resolution:
+      integrity: sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==
+  /postcss-functions/3.0.0:
+    dependencies:
+      glob: 7.1.6
+      object-assign: 4.1.1
+      postcss: 6.0.23
+      postcss-value-parser: 3.3.1
+    dev: false
+    resolution:
+      integrity: sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=
+  /postcss-gap-properties/2.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==
+  /postcss-image-set-function/3.0.1:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==
+  /postcss-initial/3.0.2:
+    dependencies:
+      lodash.template: 4.5.0
+      postcss: 7.0.26
+    dev: false
+    resolution:
+      integrity: sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==
+  /postcss-js/2.0.3:
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 7.0.26
+    dev: false
+    resolution:
+      integrity: sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==
+  /postcss-lab-function/2.0.1:
+    dependencies:
+      '@csstools/convert-colors': 1.4.0
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==
   /postcss-load-config/2.1.0:
     dependencies:
       cosmiconfig: 5.2.1
@@ -8454,6 +8773,22 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-cLWoDEY5OwHcAjDnkyRQzAXfs2jrKjXpO/HQFcc5b5u/r7aa471wdmChmwfnv7x2u840iat/wi0lQ5nbRgSkUA==
+  /postcss-logical/3.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==
+  /postcss-media-minmax/4.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==
   /postcss-merge-longhand/4.0.11:
     dependencies:
       css-color-names: 0.0.4
@@ -8557,6 +8892,29 @@ packages:
     dev: false
     resolution:
       integrity: sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==
+  /postcss-nested/4.2.1:
+    dependencies:
+      postcss: 7.0.26
+      postcss-selector-parser: 6.0.2
+    dev: false
+    resolution:
+      integrity: sha512-AMayXX8tS0HCp4O4lolp4ygj9wBn32DJWXvG6gCv+ZvJrEa00GUxJcJEEzMh87BIe6FrWdYkpR2cuyqHKrxmXw==
+  /postcss-nesting/5.0.0:
+    dependencies:
+      postcss: 6.0.23
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-Yoe3w2mcVslnEJl5zLyz1yBxCFUpYu138apEEOCwS2HRdDw/TDxTwD1fXBrIarL8J1cPzHfVwO1m40B2/UpGCw==
+  /postcss-nesting/7.0.1:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==
   /postcss-normalize-charset/4.0.1:
     dependencies:
       postcss: 7.0.26
@@ -8657,6 +9015,90 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==
+  /postcss-overflow-shorthand/2.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==
+  /postcss-page-break/2.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    resolution:
+      integrity: sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==
+  /postcss-place/4.0.1:
+    dependencies:
+      postcss: 7.0.26
+      postcss-values-parser: 2.0.1
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==
+  /postcss-preset-env/6.7.0:
+    dependencies:
+      autoprefixer: 9.7.3
+      browserslist: 4.8.3
+      caniuse-lite: 1.0.30001019
+      css-blank-pseudo: 0.1.4
+      css-has-pseudo: 0.10.0
+      css-prefers-color-scheme: 3.1.1
+      cssdb: 4.4.0
+      postcss: 7.0.26
+      postcss-attribute-case-insensitive: 4.0.1
+      postcss-color-functional-notation: 2.0.1
+      postcss-color-gray: 5.0.0
+      postcss-color-hex-alpha: 5.0.3
+      postcss-color-mod-function: 3.0.3
+      postcss-color-rebeccapurple: 4.0.1
+      postcss-custom-media: 7.0.8
+      postcss-custom-properties: 8.0.11
+      postcss-custom-selectors: 5.1.2
+      postcss-dir-pseudo-class: 5.0.0
+      postcss-double-position-gradients: 1.0.0
+      postcss-env-function: 2.0.2
+      postcss-focus-visible: 4.0.0
+      postcss-focus-within: 3.0.0
+      postcss-font-variant: 4.0.0
+      postcss-gap-properties: 2.0.0
+      postcss-image-set-function: 3.0.1
+      postcss-initial: 3.0.2
+      postcss-lab-function: 2.0.1
+      postcss-logical: 3.0.0
+      postcss-media-minmax: 4.0.0
+      postcss-nesting: 7.0.1
+      postcss-overflow-shorthand: 2.0.0
+      postcss-page-break: 2.0.0
+      postcss-place: 4.0.1
+      postcss-pseudo-class-any-link: 6.0.0
+      postcss-replace-overflow-wrap: 3.0.0
+      postcss-selector-matches: 4.0.0
+      postcss-selector-not: 4.0.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==
+  /postcss-property-lookup/2.0.0:
+    dependencies:
+      object-assign: 4.1.1
+      postcss: 6.0.23
+      tcomb: 3.2.29
+    dev: false
+    resolution:
+      integrity: sha512-KUb53a7UZWDMVb0SRODOonc4H1wlbgQ0VfYwmJaR1xWPorhariEz0U7x0ri3W/imFs6HqLYWP7hl2yMvi5Ty+w==
+  /postcss-pseudo-class-any-link/6.0.0:
+    dependencies:
+      postcss: 7.0.26
+      postcss-selector-parser: 5.0.0
+    dev: false
+    engines:
+      node: '>=6.0.0'
+    resolution:
+      integrity: sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==
   /postcss-reduce-initial/4.0.3:
     dependencies:
       browserslist: 4.8.3
@@ -8679,6 +9121,26 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==
+  /postcss-replace-overflow-wrap/3.0.0:
+    dependencies:
+      postcss: 7.0.26
+    dev: false
+    resolution:
+      integrity: sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==
+  /postcss-selector-matches/4.0.0:
+    dependencies:
+      balanced-match: 1.0.0
+      postcss: 7.0.26
+    dev: false
+    resolution:
+      integrity: sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==
+  /postcss-selector-not/4.0.0:
+    dependencies:
+      balanced-match: 1.0.0
+      postcss: 7.0.26
+    dev: false
+    resolution:
+      integrity: sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==
   /postcss-selector-parser/3.1.1:
     dependencies:
       dot-prop: 4.2.0
@@ -8738,6 +9200,37 @@ packages:
     dev: false
     resolution:
       integrity: sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
+  /postcss-values-parser/2.0.1:
+    dependencies:
+      flatten: 1.0.3
+      indexes-of: 1.0.1
+      uniq: 1.0.1
+    dev: false
+    engines:
+      node: '>=6.14.4'
+    resolution:
+      integrity: sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
+  /postcss/5.2.18:
+    dependencies:
+      chalk: 1.1.3
+      js-base64: 2.5.1
+      source-map: 0.5.7
+      supports-color: 3.2.3
+    dev: false
+    engines:
+      node: '>=0.12'
+    resolution:
+      integrity: sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
+  /postcss/6.0.23:
+    dependencies:
+      chalk: 2.4.2
+      source-map: 0.6.1
+      supports-color: 5.5.0
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==
   /postcss/7.0.26:
     dependencies:
       chalk: 2.4.2
@@ -8748,6 +9241,20 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
+  /precss/4.0.0:
+    dependencies:
+      postcss: 7.0.26
+      postcss-advanced-variables: 3.0.0
+      postcss-atroot: 0.1.3
+      postcss-extend-rule: 2.0.0
+      postcss-nested: 4.2.1
+      postcss-preset-env: 6.7.0
+      postcss-property-lookup: 2.0.0
+    dev: false
+    engines:
+      node: '>=4.0.0'
+    resolution:
+      integrity: sha512-cRPZMKpHLZXR6gJlrXRjJe7SQMf+wYxg6rKp+TwYsYABjApSj9z8E8yIlagqADaWyikeIZttaNU6xqSjFIAP/g==
   /prelude-ls/1.1.2:
     dev: false
     engines:
@@ -8793,6 +9300,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
+  /pretty-hrtime/1.0.3:
+    dev: false
+    engines:
+      node: '>= 0.8'
+    resolution:
+      integrity: sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
   /pretty/2.0.0:
     dependencies:
       condense-newlines: 0.2.1
@@ -8917,6 +9430,19 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+  /purgecss/1.4.2:
+    dependencies:
+      glob: 7.1.6
+      postcss: 7.0.26
+      postcss-selector-parser: 6.0.2
+      yargs: 14.2.2
+    dev: false
+    engines:
+      node: '>=4.4.0'
+      npm: '>=5.2.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-hkOreFTgiyMHMmC2BxzdIw5DuC6kxAbP/gGOGd3MEsF3+5m69rIvUEPaxrnoUtfODTFKe9hcXjGwC6jcjoyhOw==
   /q/1.5.1:
     dev: false
     engines:
@@ -9077,6 +9603,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
+  /reduce-css-calc/2.1.7:
+    dependencies:
+      css-unit-converter: 1.1.1
+      postcss-value-parser: 3.3.1
+    dev: false
+    resolution:
+      integrity: sha512-fDnlZ+AybAS3C7Q9xDq5y8A2z+lT63zLbynew/lur/IR24OQF5x98tfNwf79mzEdfywZ0a2wpM860FhFfMxZlA==
   /regenerate-unicode-properties/8.1.0:
     dependencies:
       regenerate: 1.4.0
@@ -9456,6 +9989,13 @@ packages:
       node-sass: ^4.0.0
       sass: ^1.3.0
       webpack: ^4.36.0
+    peerDependenciesMeta:
+      fibers:
+        optional: true
+      node-sass:
+        optional: true
+      sass:
+        optional: true
     resolution:
       integrity: sha512-+qeMu563PN7rPdit2+n5uuYVR0SSVwm0JsOUsaJXzgYcClWSlmX0iHDnmeOobPkf5kUglVot3QS6SyLyaQoJ4w==
   /sass/1.24.3:
@@ -10141,6 +10681,14 @@ packages:
       node: '>=0.8.0'
     resolution:
       integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+  /supports-color/3.2.3:
+    dependencies:
+      has-flag: 1.0.0
+    dev: false
+    engines:
+      node: '>=0.8.0'
+    resolution:
+      integrity: sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
   /supports-color/5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -10215,12 +10763,38 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  /tailwindcss/1.1.4:
+    dependencies:
+      autoprefixer: 9.7.3
+      bytes: 3.1.0
+      chalk: 2.4.2
+      fs-extra: 8.1.0
+      lodash: 4.17.15
+      node-emoji: 1.10.0
+      normalize.css: 8.0.1
+      postcss: 7.0.26
+      postcss-functions: 3.0.0
+      postcss-js: 2.0.3
+      postcss-nested: 4.2.1
+      postcss-selector-parser: 6.0.2
+      pretty-hrtime: 1.0.3
+      reduce-css-calc: 2.1.7
+    dev: false
+    engines:
+      node: '>=8.9.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-p4AxVa4CKpX7IbNxImwNMGG9MHuLgratOaOE/iGriNd4AsRQRM2xMisoQ3KQHqShunrWuObga7rI7xbNsVoWGA==
   /tapable/1.1.3:
     dev: false
     engines:
       node: '>=6'
     resolution:
       integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
+  /tcomb/3.2.29:
+    dev: false
+    resolution:
+      integrity: sha512-di2Hd1DB2Zfw6StGv861JoAF5h/uQVu/QJp2g8KVbtfKnoHdBQl5M32YWq6mnSYBQ1vFFrns5B1haWJL7rKaOQ==
   /terraformer-arcgis-parser/1.1.0:
     dependencies:
       '@types/geojson': 1.0.6
@@ -11446,6 +12020,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  /yargs-parser/15.0.0:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+    dev: false
+    resolution:
+      integrity: sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
   /yargs-parser/16.1.0:
     dependencies:
       camelcase: 5.3.1
@@ -11501,6 +12082,22 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
+  /yargs/14.2.2:
+    dependencies:
+      cliui: 5.0.0
+      decamelize: 1.2.0
+      find-up: 3.0.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 3.1.0
+      which-module: 2.0.0
+      y18n: 4.0.0
+      yargs-parser: 15.0.0
+    dev: false
+    resolution:
+      integrity: sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==
   /yargs/15.1.0:
     dependencies:
       cliui: 6.0.0
@@ -11546,6 +12143,7 @@ packages:
       integrity: sha512-jcKpkthap6x63MB4TxwCyuIGkV0oYP/YRyuQU5UO0Yz/E/ZAu+653/uov+phdmO54n6BcvFRyyt0RRrWdN2mpw==
   'file:projects/ramp-core.tgz_webpack@4.41.3':
     dependencies:
+      '@fullhuman/postcss-purgecss': 1.3.0
       '@types/jest': 24.0.25
       '@vue/cli-plugin-babel': 4.1.2_@vue+cli-service@4.1.2
       '@vue/cli-plugin-e2e-cypress': 4.1.2_24f387d243024b6d224425483548dff1
@@ -11561,9 +12159,12 @@ packages:
       eslint: 5.16.0
       eslint-plugin-prettier: 3.1.2_eslint@5.16.0+prettier@1.19.1
       eslint-plugin-vue: 6.1.2_eslint@5.16.0
+      postcss-nested: 4.2.1
+      precss: 4.0.0
       prettier: 1.19.1
       sass: 1.24.3
       sass-loader: 8.0.0_sass@1.24.3+webpack@4.41.3
+      tailwindcss: 1.1.4
       tslib: 1.10.0
       typescript: 3.5.3
       vue: 2.6.11
@@ -11577,7 +12178,7 @@ packages:
     peerDependencies:
       webpack: '*'
     resolution:
-      integrity: sha512-cbLnS48ee7FVoDCRGH7ZWHDhqdhZ3W9h/XL/3VeWy30S29BCCsCH297WsY6dAWWVlmo4nG70RUaNiNmkFtO1Pg==
+      integrity: sha512-rZ8+/FHgR3gqvsY1FDxyK/3LTTr+0KgrB3QU65MezsbKr8NMrwH83HMEeGE39cJ35L8Pjol0KioN5xOdQE/Krw==
       tarball: 'file:projects/ramp-core.tgz'
     version: 0.0.0
   'file:projects/ramp-geoapi.tgz':
@@ -11612,6 +12213,7 @@ packages:
       integrity: sha512-Aj91IWDw3RhVYp6cI4T4P9y5s4rvgWwE0bkZQo1jIKxaC5seIKQvwyJv4EmSwOaOGClqVfSkScWw4qhotGzMlA==
       tarball: 'file:projects/ramp-geoapi.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@babel/cli': ^7.2.3
   '@babel/core': ^7.4.0
@@ -11619,6 +12221,7 @@ specifiers:
   '@babel/plugin-proposal-object-rest-spread': ^7.4.0
   '@babel/preset-env': ^7.4.1
   '@babel/preset-typescript': ^7.3.3
+  '@fullhuman/postcss-purgecss': ~1.3.0
   '@rush-temp/ramp-core': 'file:./projects/ramp-core.tgz'
   '@rush-temp/ramp-geoapi': 'file:./projects/ramp-geoapi.tgz'
   '@types/arcgis-js-api': ~4.14.0
@@ -11643,12 +12246,15 @@ specifiers:
   eslint-plugin-prettier: ^3.1.1
   eslint-plugin-vue: ^6.0.0
   js-sql-parser: 1.0.7
+  postcss-nested: ~4.2.1
+  precss: ~4.0.0
   prettier: ^1.19.1
   proj4: 2.6.0
   sass: ^1.23.7
   sass-loader: ^8.0.0
   source-map-loader: 0.2.3
   svg.js: 2.7.1
+  tailwindcss: ~1.1.4
   terraformer: 1.0.9
   terraformer-arcgis-parser: 1.1.0
   tslib: ~1.10.0

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -1,42 +1,45 @@
 {
-  "name": "ramp-core",
-  "version": "0.1.0",
-  "private": true,
-  "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build --target lib --formats umd --name r4mp src/main.ts 2>&1",
-    "test:unit": "vue-cli-service test:unit",
-    "test:e2e": "vue-cli-service test:e2e",
-    "lint": "vue-cli-service lint"
-  },
-  "dependencies": {
-    "core-js": "^3.4.4",
-    "ramp-geoapi": "0.0.1",
-    "vue": "^2.6.10",
-    "vue-class-component": "^7.0.2",
-    "vue-property-decorator": "^8.3.0",
-    "vuex": "^3.1.2"
-  },
-  "devDependencies": {
-    "@types/jest": "^24.0.19",
-    "@vue/cli-plugin-babel": "^4.1.0",
-    "@vue/cli-plugin-e2e-cypress": "^4.1.0",
-    "@vue/cli-plugin-eslint": "^4.1.0",
-    "@vue/cli-plugin-typescript": "^4.1.0",
-    "@vue/cli-plugin-unit-jest": "^4.1.0",
-    "@vue/cli-plugin-vuex": "^4.1.0",
-    "@vue/cli-service": "^4.1.0",
-    "@vue/eslint-config-prettier": "^5.0.0",
-    "@vue/eslint-config-typescript": "^4.0.0",
-    "@vue/test-utils": "1.0.0-beta.29",
-    "eslint": "^5.16.0",
-    "eslint-plugin-prettier": "^3.1.1",
-    "eslint-plugin-vue": "^6.0.0",
-    "prettier": "^1.19.1",
-    "sass": "^1.23.7",
-    "sass-loader": "^8.0.0",
-    "tslib": "~1.10.0",
-    "typescript": "~3.5.3",
-    "vue-template-compiler": "^2.6.10"
-  }
+    "name": "ramp-core",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "serve": "vue-cli-service serve",
+        "build": "vue-cli-service build --target lib --formats umd --name r4mp src/main.ts 2>&1",
+        "test:unit": "vue-cli-service test:unit",
+        "test:e2e": "vue-cli-service test:e2e",
+        "lint": "vue-cli-service lint"
+    },
+    "dependencies": {
+        "core-js": "^3.4.4",
+        "ramp-geoapi": "0.0.1",
+        "vue": "^2.6.10",
+        "vue-class-component": "^7.0.2",
+        "vue-property-decorator": "^8.3.0",
+        "vuex": "^3.1.2"
+    },
+    "devDependencies": {
+        "@fullhuman/postcss-purgecss": "~1.3.0",
+        "@types/jest": "^24.0.19",
+        "@vue/cli-plugin-babel": "^4.1.0",
+        "@vue/cli-plugin-e2e-cypress": "^4.1.0",
+        "@vue/cli-plugin-eslint": "^4.1.0",
+        "@vue/cli-plugin-typescript": "^4.1.0",
+        "@vue/cli-plugin-unit-jest": "^4.1.0",
+        "@vue/cli-plugin-vuex": "^4.1.0",
+        "@vue/cli-service": "^4.1.0",
+        "@vue/eslint-config-prettier": "^5.0.0",
+        "@vue/eslint-config-typescript": "^4.0.0",
+        "@vue/test-utils": "1.0.0-beta.29",
+        "eslint": "^5.16.0",
+        "eslint-plugin-prettier": "^3.1.1",
+        "eslint-plugin-vue": "^6.0.0",
+        "postcss-nested": "~4.2.1",
+        "prettier": "^1.19.1",
+        "sass": "^1.23.7",
+        "sass-loader": "^8.0.0",
+        "tailwindcss": "~1.1.4",
+        "tslib": "~1.10.0",
+        "typescript": "~3.5.3",
+        "vue-template-compiler": "^2.6.10"
+    }
 }

--- a/packages/ramp-core/postcss.config.js
+++ b/packages/ramp-core/postcss.config.js
@@ -16,6 +16,6 @@ module.exports = {
         // needed to scope tailwind styles
         require('postcss-nested'),
         // needed to cut down on css file size, tailwind is very large without any trimming
-        ...(process.env.NODE_ENV === 'production' ? [purgecss] : [purgecss])
+        ...(process.env.NODE_ENV === 'production' ? [purgecss] : [])
     ]
 };

--- a/packages/ramp-core/postcss.config.js
+++ b/packages/ramp-core/postcss.config.js
@@ -1,0 +1,21 @@
+// purgecss stuff is from https://tailwindcss.com/docs/controlling-file-size
+const purgecss = require('@fullhuman/postcss-purgecss')({
+    // Paths to all of the template files in your project
+    content: ['./src/**/*.html', './src/**/*.vue'],
+
+    whitelist: ['xs', 'sm', 'md', 'lg'],
+
+    // Include any special characters you're using in this regular expression
+    defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
+});
+
+module.exports = {
+    plugins: [
+        require('tailwindcss'),
+        require('autoprefixer'),
+        // needed to scope tailwind styles
+        require('postcss-nested'),
+        // needed to cut down on css file size, tailwind is very large without any trimming
+        ...(process.env.NODE_ENV === 'production' ? [purgecss] : [purgecss])
+    ]
+};

--- a/packages/ramp-core/postcss.config.js
+++ b/packages/ramp-core/postcss.config.js
@@ -3,7 +3,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
     // Paths to all of the template files in your project
     content: ['./src/**/*.html', './src/**/*.vue'],
 
-    whitelist: ['xs', 'sm', 'md', 'lg'],
+    whitelist: ['xs', 'sm', 'md', 'lg'], // whitelist ramp shell size classes so they are not purged
 
     // Include any special characters you're using in this regular expression
     defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title>ramp-core</title>
-  </head>
-  <body>
-    <noscript>
-      <strong>We're sorry but ramp-core doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
-    </noscript>
-    <div id="app"></div>
-    <!-- built files will be auto injected -->
-  </body>
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+        <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
+        <title>ramp-core</title>
+    </head>
+    <body>
+        <noscript>
+            <strong>We're sorry but ramp-core doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+        </noscript>
+        <div id="app"></div>
+        <!-- built files will be auto injected -->
+    </body>
 </html>

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -9,23 +9,26 @@ import { Vue, Component } from 'vue-property-decorator';
 
 import RvShell from '@/components/rv-shell.vue';
 
+import ro from '@/scripts/resize-observer.js';
+
 @Component({
     components: {
         RvShell
     }
 })
-export default class App extends Vue {}
+export default class App extends Vue {
+    mounted() {
+        // let ResizeObserver observe the app div
+        // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
+        ro.observe(this.$el);
+    }
+}
 </script>
 
 <style lang="scss">
 @import './styles/main.css';
 
 #app {
-    font-family: 'Avenir', Helvetica, Arial, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-align: center;
-    color: #2c3e50;
-    margin-top: 60px;
+    height: 900px;
 }
 </style>

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -17,7 +17,9 @@ import RvShell from '@/components/rv-shell.vue';
 export default class App extends Vue {}
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
+@import './styles/main.css';
+
 #app {
     font-family: 'Avenir', Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -1,19 +1,19 @@
 <template>
-    <div id="app">
-        <rv-shell></rv-shell>
+    <div class="ramp-app">
+        <shell></shell>
     </div>
 </template>
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 
-import RvShell from '@/components/rv-shell.vue';
+import Shell from '@/components/shell.vue';
 
 import ro from '@/scripts/resize-observer.js';
 
 @Component({
     components: {
-        RvShell
+        Shell
     }
 })
 export default class App extends Vue {
@@ -27,8 +27,10 @@ export default class App extends Vue {
 
 <style lang="scss">
 @import './styles/main.css';
+</style>
 
-#app {
+<style lang="scss" scoped>
+.ramp-app {
     height: 900px;
 }
 </style>

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="mapDiv"></div>
+    <div id="mapDiv" class="h-full"></div>
 </template>
 
 <script lang="ts">
@@ -45,11 +45,4 @@ export default class EsriMap extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
-#mapDiv {
-    padding: 20px;
-    margin: 20px;
-    height: 400px;
-    width: 400px;
-}
-</style>
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="mapDiv" class="h-full"></div>
+    <div class="h-full"></div>
 </template>
 
 <script lang="ts">
@@ -39,7 +39,7 @@ export default class EsriMap extends Vue {
                 initialBasemapId: 'esriImagery'
             };
 
-            const map: Map = gapi.maps.createMap(esriMapConfig, 'mapDiv');
+            const map: Map = gapi.maps.createMap(esriMapConfig, this.$el as HTMLDivElement);
         });
     }
 }

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -1,5 +1,7 @@
 <template>
-    <esri-map></esri-map>
+    <div class="h-full">
+        <esri-map></esri-map>
+    </div>
 </template>
 
 <script lang="ts">
@@ -12,7 +14,7 @@ import EsriMap from '@/components/map/esri-map.vue';
         EsriMap
     }
 })
-export default class RvShell extends Vue {}
+export default class Shell extends Vue {}
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/scripts/resize-observer.js
+++ b/packages/ramp-core/src/scripts/resize-observer.js
@@ -1,0 +1,32 @@
+// From https://philipwalton.com/articles/responsive-components-a-solution-to-the-container-queries-problem/
+
+// Only run if ResizeObserver is supported.
+if ('ResizeObserver' in self) {
+    // Create a single ResizeObserver instance to handle all
+    // container elements. The instance is created with a callback,
+    // which is invoked as soon as an element is observed as well
+    // as any time that element's size changes.
+    var ro = new ResizeObserver(function(entries) {
+        // Default breakpoints that should apply to all observed
+        // elements that don't define their own custom breakpoints.
+        var defaultBreakpoints = { xs: 384, sm: 576, md: 768, lg: 960 };
+
+        entries.forEach(function(entry) {
+            // If breakpoints are defined on the observed element,
+            // use them. Otherwise use the defaults.
+            var breakpoints = entry.target.dataset.breakpoints ? JSON.parse(entry.target.dataset.breakpoints) : defaultBreakpoints;
+
+            // Update the matching breakpoints on the observed element.
+            Object.keys(breakpoints).forEach(function(breakpoint) {
+                var minWidth = breakpoints[breakpoint];
+                if (entry.contentRect.width >= minWidth) {
+                    entry.target.classList.add(breakpoint);
+                } else {
+                    entry.target.classList.remove(breakpoint);
+                }
+            });
+        });
+    });
+}
+
+export default ro;

--- a/packages/ramp-core/src/shims-vue.d.ts
+++ b/packages/ramp-core/src/shims-vue.d.ts
@@ -2,3 +2,5 @@ declare module '*.vue' {
     import Vue from 'vue';
     export default Vue;
 }
+
+declare module '@/scripts/resize-observer.js';

--- a/packages/ramp-core/src/shims-vue.d.ts
+++ b/packages/ramp-core/src/shims-vue.d.ts
@@ -2,5 +2,3 @@ declare module '*.vue' {
     import Vue from 'vue';
     export default Vue;
 }
-
-declare module '@/scripts/resize-observer.js';

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -1,0 +1,5 @@
+#app {
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+}

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -1,4 +1,4 @@
-#app {
+.ramp-app {
     @tailwind base;
     @tailwind components;
     @tailwind utilities;

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -1,0 +1,104 @@
+const postcss = require('postcss');
+
+module.exports = {
+    theme: {
+        // remove all breakpoints because ramp components will depend on the shell size, not the size of the window/page
+        screens: {
+            // sm: '640px'
+        }
+    },
+    variants: {
+        // add the `container-query` variant to all the core plugins which have `responsive` specified (hint: it's all of them)
+        alignContent: ['responsive', 'container-query'],
+        alignItems: ['responsive', 'container-query'],
+        alignSelf: ['responsive', 'container-query'],
+        appearance: ['responsive', 'container-query'],
+        backgroundAttachment: ['responsive', 'container-query'],
+        backgroundColor: ['responsive', 'container-query', 'hover', 'focus'],
+        backgroundPosition: ['responsive', 'container-query'],
+        backgroundRepeat: ['responsive', 'container-query'],
+        backgroundSize: ['responsive', 'container-query'],
+        borderCollapse: ['responsive', 'container-query'],
+        borderColor: ['responsive', 'container-query', 'hover', 'focus'],
+        borderRadius: ['responsive', 'container-query'],
+        borderStyle: ['responsive', 'container-query'],
+        borderWidth: ['responsive', 'container-query'],
+        boxShadow: ['responsive', 'container-query', 'hover', 'focus'],
+        cursor: ['responsive', 'container-query'],
+        display: ['responsive', 'container-query'],
+        fill: ['responsive', 'container-query'],
+        flex: ['responsive', 'container-query'],
+        flexDirection: ['responsive', 'container-query'],
+        flexGrow: ['responsive', 'container-query'],
+        flexShrink: ['responsive', 'container-query'],
+        flexWrap: ['responsive', 'container-query'],
+        float: ['responsive', 'container-query'],
+        fontFamily: ['responsive', 'container-query'],
+        fontSize: ['responsive', 'container-query'],
+        fontSmoothing: ['responsive', 'container-query'],
+        fontStyle: ['responsive', 'container-query'],
+        fontWeight: ['responsive', 'container-query', 'hover', 'focus'],
+        height: ['responsive', 'container-query'],
+        inset: ['responsive', 'container-query'],
+        justifyContent: ['responsive', 'container-query'],
+        letterSpacing: ['responsive', 'container-query'],
+        lineHeight: ['responsive', 'container-query'],
+        listStylePosition: ['responsive', 'container-query'],
+        listStyleType: ['responsive', 'container-query'],
+        margin: ['responsive', 'container-query'],
+        maxHeight: ['responsive', 'container-query'],
+        maxWidth: ['responsive', 'container-query'],
+        minHeight: ['responsive', 'container-query'],
+        minWidth: ['responsive', 'container-query'],
+        objectFit: ['responsive', 'container-query'],
+        objectPosition: ['responsive', 'container-query'],
+        opacity: ['responsive', 'container-query', 'hover', 'focus'],
+        order: ['responsive', 'container-query'],
+        outline: ['responsive', 'container-query', 'focus'],
+        overflow: ['responsive', 'container-query'],
+        padding: ['responsive', 'container-query'],
+        pointerEvents: ['responsive', 'container-query'],
+        position: ['responsive', 'container-query'],
+        resize: ['responsive', 'container-query'],
+        stroke: ['responsive', 'container-query'],
+        tableLayout: ['responsive', 'container-query'],
+        textAlign: ['responsive', 'container-query'],
+        textColor: ['responsive', 'container-query', 'hover', 'focus'],
+        textDecoration: ['responsive', 'container-query', 'hover', 'focus'],
+        textTransform: ['responsive', 'container-query'],
+        userSelect: ['responsive', 'container-query'],
+        verticalAlign: ['responsive', 'container-query'],
+        visibility: ['responsive', 'container-query'],
+        whitespace: ['responsive', 'container-query'],
+        width: ['responsive', 'container-query'],
+        wordBreak: ['responsive', 'container-query'],
+        zIndex: ['responsive', 'container-query']
+    },
+    corePlugins: {
+        preflight: false // remove reset CSS because we don't want to mess up host page default styles
+    },
+    plugins: [
+        function({ addVariant, e }) {
+            addVariant('container-query', ({ container, separator }) => {
+                // this is a list of possible ramp shell sizes; pixel sizes TBD
+                const shellSizes = ['xs', 'sm', 'md', 'lg'];
+
+                const newRules = [];
+
+                // `container` is itself a clone; thanks Tailwind :/
+                container.walkRules(rule => {
+                    shellSizes.forEach(shellSize => {
+                        const newRule = rule.clone(); // clone a rule so not to modify the original clone
+
+                        // prefix shell size selector to the rule; slice the dot from the rule selector
+                        // resulting class name is of the form `.[xs|sm|md|lg]:{selector}`
+                        newRule.selector = `.${shellSize} .${shellSize}\\:${newRule.selector.slice(1)}`;
+                        newRules.push(newRule);
+                    });
+                });
+
+                container.append(newRules);
+            });
+        }
+    ]
+};

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -92,7 +92,7 @@ module.exports = {
 
                         // prefix shell size selector to the rule; slice the dot from the rule selector
                         // resulting class name is of the form `.[xs|sm|md|lg]:{selector}`
-                        newRule.selector = `.${shellSize} .${shellSize}\\:${newRule.selector.slice(1)}`;
+                        newRule.selector = `&.${shellSize} .${shellSize}\\:${newRule.selector.slice(1)}`;
                         newRules.push(newRule);
                     });
                 });

--- a/packages/ramp-core/tsconfig.json
+++ b/packages/ramp-core/tsconfig.json
@@ -3,12 +3,12 @@
     "target": "esnext",
     "module": "esnext",
     "strict": true,
-    "jsx": "preserve",
     "importHelpers": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
+    "allowJs": true,
     "sourceMap": true,
     "baseUrl": ".",
     "types": [
@@ -29,10 +29,8 @@
   },
   "include": [
     "src/**/*.ts",
-    "src/**/*.tsx",
     "src/**/*.vue",
     "tests/**/*.ts",
-    "tests/**/*.tsx"
   ],
   "exclude": [
     "node_modules"

--- a/packages/ramp-geoapi/src/map/Map.ts
+++ b/packages/ramp-geoapi/src/map/Map.ts
@@ -13,7 +13,7 @@ export class Map extends MapBase {
     // TODO think about how to expose. protected makes sense, but might want to make it public to allow hacking and use by a dev module if we decide to
     innerView: esri.MapView;
 
-    constructor (infoBundle: InfoBundle, config: RampMapConfig, targetDiv: string) {
+    constructor (infoBundle: InfoBundle, config: RampMapConfig, targetDiv: string | HTMLDivElement) {
 
         super(infoBundle, config);
 

--- a/packages/ramp-geoapi/src/map/MapModule.ts
+++ b/packages/ramp-geoapi/src/map/MapModule.ts
@@ -13,7 +13,7 @@ export default class MapModule extends BaseBase {
     }
 
     // TODO will we have a config type? is it bad to have something that is defined on the client be defined here?
-    createMap(config: any, targetDiv: string): Map {
+    createMap(config: any, targetDiv: string | HTMLDivElement): Map {
         const map: Map = new Map(this.infoBundle(), config, targetDiv);
         return map;
     }


### PR DESCRIPTION
This PR adds: https://tailwindcss.com/

We enhanced tailwind by adding our own rules for app container sizes using tailwind plugins and [ResizeObserver](https://philipwalton.com/articles/responsive-components-a-solution-to-the-container-queries-problem/). You can test this by running `rush serve` and looking at the `.ramp-app` div in devtools while resizing the window (which resizes the container).

The PR also enhances the postcss build by removing all unused css rules using [Purgecss](https://www.purgecss.com/). This is testable by looking at the css output after a `rush build`, we're running purgecss on prod builds only.

There's also some cleanup of html and css.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/35)
<!-- Reviewable:end -->
