### PR TITLE
panels: implement 'more options' control

### DIFF
--- a/packages/ramp-core/src/components/panel-stack/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/dropdown-menu.vue
@@ -1,0 +1,41 @@
+<template>
+    <div>
+        <button class="text-gray-500 hover:text-black p-2" @click="open = !open">
+            <slot name="header"></slot>
+        </button>
+        <button
+            v-if="open"
+            @click="open = false"
+            tabindex="-1"
+            class="fixed inset-0 h-full w-full bg-black opacity-0 cursor-default"
+        ></button>
+        <div v-if="open" class="rv-dropdown shadow-md border border-gray:200 absolute mt-2 py-2 w-64 bg-white rounded z-10">
+            <slot></slot>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+@Component
+export default class MenuV extends Vue {
+    data() {
+        return {
+            open: false
+        };
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.rv-dropdown > * {
+    display: block;
+    padding: 0.5rem 1rem 0.5rem 1rem;
+    color: #2d3748;
+}
+.rv-dropdown > *:hover {
+    background-color: #eee;
+}
+</style>

--- a/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
@@ -1,0 +1,33 @@
+<template>
+    <dropdown-menu>
+        <template #header>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-5 h-5">
+                <path
+                    d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                />
+            </svg>
+        </template>
+        <slot></slot>
+    </dropdown-menu>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+import DropdownMenuV from './dropdown-menu.vue';
+
+@Component({
+    components: {
+        'dropdown-menu': DropdownMenuV
+    }
+})
+export default class MenuV extends Vue {
+    data() {
+        return {
+            open: false
+        };
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -13,10 +13,12 @@ import { Get, Sync, Call } from 'vuex-pathify';
 import PanelScreenV from './panel-screen.vue';
 import PinV from './controls/pin.vue';
 import CloseV from './controls/close.vue';
+import PanelOptionsMenuV from './controls/panel-options-menu.vue';
 
 Vue.component('panel-screen', PanelScreenV);
 Vue.component('pin', PinV);
 Vue.component('close', CloseV);
+Vue.component('panel-options-menu', PanelOptionsMenuV);
 
 import { PanelConfig } from '@/store/modules/panel';
 import { PanelItemAPI } from '../../api';

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
@@ -6,6 +6,11 @@
 
         <template #controls>
             <!-- this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes -->
+            <panel-options-menu>
+                <a href="#">Option 1</a>
+                <a href="#">Option 2</a>
+                <a href="#">Option 3</a>
+            </panel-options-menu>
             <pin :active="pinned && pinned.id === 'p1'" @click="pinPanel"></pin>
         </template>
 


### PR DESCRIPTION
Adds a dropdown menu to panel controls. Open to any suggestions or changes. As of right now, menu contents are hardcoded for demonstration purposes. 

From comments:
```
Determine how we want to display options here.

1. Should it be something like I have here (using slots)?
2. Should we do something like RAMP3 where we have a prop that takes in an array of available options (like options=["fullscreen", "..."])?
3. Should we just decide on what options should be displayed on all panels and just have them hard-coded in?
4. Something else?
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/44)
<!-- Reviewable:end -->
