### PR TITLE
Appbar part 1 (with tailwind adjustments)

### DIFF
--- a/packages/ramp-core/public/diligord-fixture.js
+++ b/packages/ramp-core/public/diligord-fixture.js
@@ -66,15 +66,15 @@
                         h(
                             'button',
                             {
-                                class: 'bg-purple-500 hover:bg-purple-700 text-white font-bold py-2 px-4',
+                                class: 'bg-purple-500 hover:bg-purple-700 text-white font-bold py-8 px-16',
                                 on: { click: () => (this.count += 10) }
                             },
                             [h('span', this.count)]
                         ),
-                        h('label', { class: 'mt-4' }, 'Change panel title'),
+                        h('label', { class: 'mt-16' }, 'Change panel title'),
 
                         h('input', {
-                            class: 'border-2  p-2',
+                            class: 'border-2  p-8',
 
                             // bind title to the input value
                             domProps: {

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -62,7 +62,10 @@
                             },
                             customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                         }
-                    ]
+                    ],
+                    fixtures: {
+                        appbar: [{ id: 'gazebo' }, { id: 'divider' }, { id: 'legend' }, { id: 'divider' }]
+                    }
                 });
 
                 // start loading fixtures; this is just an example
@@ -70,6 +73,7 @@
                 // TODO: remove
                 rInstance.fixture.add('snowman');
                 rInstance.fixture.add('gazebo');
+                rInstance.fixture.add('appbar');
                 rInstance.fixture.add(window.hostFixtures.diligord);
             }
         </script>

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -6,11 +6,13 @@ import App from '@/app.vue';
 import { createStore, RootState } from '@/store';
 import { ConfigStore } from '@/store/modules/config';
 
-import { FixtureAPI, PanelAPI } from './internal';
+import { FixtureAPI, PanelAPI, APIScope } from './internal';
 
 export class InstanceAPI {
     fixture: FixtureAPI;
     panel: PanelAPI;
+    // allow fixture apis to be added on, this is solely to make typescript happy
+    [key: string]: any;
 
     /**
      * A public event bus for all events. Can also be used by fixtures to talk to each other.
@@ -101,7 +103,7 @@ export class InstanceAPI {
      * @memberof InstanceAPI
      */
     emit(event: string, ...args: any[]): this {
-        this._eventBus.$off(event, ...args);
+        this._eventBus.$emit(event, ...args);
         return this;
     }
 }

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -166,8 +166,12 @@ export class PanelItemAPI extends APIScope {
         this._config = config;
 
         // register all the panel screen components globally
-        // TODO: check if already registered and don't do it again
-        this._config.screens.forEach(({ id, component }) => Vue.component(id, component));
+        this._config.screens.forEach(({ id, component }) => {
+            // only register if it hasn't been registered before
+            if (!(id in this.$vApp.$options.components!)) {
+                Vue.component(id, component);
+            }
+        });
     }
 
     /**

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -32,6 +32,9 @@ export default class EsriMap extends Vue {
 
     @Watch('mapConfig')
     onMapConfigChange(newValue: RampMapConfig, oldValue: RampMapConfig) {
+        if (newValue === oldValue) {
+            return;
+        }
         this.map = (window as any).RAMP.geoapi.maps.createMap(this.mapConfig, this.$el as HTMLDivElement);
         this.onLayerArrayChange(this.layers, []);
     }

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -1,6 +1,6 @@
 <template>
-    <button class="text-gray-500 hover:text-black p-2" :class="{ 'text-gray-700': active }" @click="$emit('click')">
-        <svg class="fill-current w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512">
+    <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
+        <svg class="fill-current w-16 h-16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512">
             <path
                 d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
             />

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -1,7 +1,7 @@
 <template>
-    <button class="text-gray-500 hover:text-black p-2" :class="{ 'text-gray-700': active }" @click="$emit('click')">
+    <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
         <svg
-            class="fill-current w-4 h-4"
+            class="fill-current w-16 h-16"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 384 512"
             :transform="`rotate(${active ? 30 : 0})`"

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="shadow-tm bg-white w-350 h-full xs:mr-0 sm:mr-3 last:mr-0 pointer-events-auto">
+    <div class="shadow-tm bg-white w-350 h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto">
         <!-- this renders a panel screen which is currently in view -->
         <!-- TODO: add animation transition animation here -->
         <component :is="panelConfig.route.id" v-bind="panelConfig.route.props" :panel="panel"></component>
@@ -21,7 +21,7 @@ Vue.component('close', CloseV);
 Vue.component('panel-options-menu', PanelOptionsMenuV);
 
 import { PanelConfig } from '@/store/modules/panel';
-import { PanelItemAPI } from '../../api';
+import { PanelItemAPI } from '@/api';
 
 @Component
 export default class PanelContainerV extends Vue {
@@ -34,8 +34,4 @@ export default class PanelContainerV extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
-.w-350 {
-    width: 350px;
-}
-</style>
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -1,14 +1,14 @@
 <template>
     <div>
-        <header class="flex items-center border-b border-solid border-gray-600 px-2">
-            <h2 class="flex-grow text-lg py-4 pl-2">
+        <header class="flex items-center border-b border-solid border-gray-600 px-8">
+            <h2 class="flex-grow text-lg py-16 pl-8">
                 <slot name="header"></slot>
             </h2>
 
             <slot name="controls"></slot>
         </header>
 
-        <div class="m-2">
+        <div class="m-8">
             <slot name="content"></slot>
         </div>
     </div>

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -4,7 +4,7 @@
 
         <!-- TODO: should inner shell be a separate component? -->
         <div class="inner-shell absolute top-0 left-0 h-full w-full pointer-events-none">
-            <panel-stack class="absolute inset-0 xs:pl-12 md:p-3 md:pl-20 lg:p-3"></panel-stack>
+            <panel-stack class="absolute inset-0 xs:pl-48 md:p-12 md:pl-80 lg:p-12"></panel-stack>
         </div>
     </div>
 </template>

--- a/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
+++ b/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
@@ -1,0 +1,93 @@
+import Vue from 'vue';
+
+import { APIScope } from '@/api/common';
+import { InstanceAPI } from '@/api/internal';
+import { AppbarItemConfig } from '../store';
+
+const DIVIDER_ID = 'divider';
+
+export class AppbarAPI extends APIScope {
+    constructor(iApi: InstanceAPI) {
+        super(iApi);
+
+        this.$iApi.appbar = this;
+    }
+
+    /**
+     * Overwrites the current appbar config
+     *
+     * @param {any} appbarConfig The new appbar config
+     * @returns {Promise<AppbarItemAPI[]} The list of current Appbar Items in the store, as AppbarItemAPIs
+     * @memberof AppbarAPI
+     */
+    async set(appbarConfig: any): Promise<AppbarItemAPI[] | AppbarItemAPI | undefined> {
+        if (!appbarConfig) {
+            return undefined;
+        }
+
+        for (let i = 0; i < appbarConfig.length; i++) {
+            const config = appbarConfig[i];
+
+            // if theres no component specified and its not a divider, retrieve the component from the fixtures folder
+            if (!config.component && config.id !== DIVIDER_ID) {
+                config.component = (await import(`@/fixtures/${config.id}/index.ts`)).AppbarButton;
+                config.id = config.id + '-appbar-button';
+            }
+        }
+        this.$vApp.$store.set('appbar/items', appbarConfig);
+
+        return this.get()!;
+    }
+
+    /**
+     * Returns the list of all AppbarItemAPIs if no id, otherwise returns the AppbarItemAPI relating to id.
+     *
+     * @param {string} id Optional. If specified returns the AppbarItem with id
+     * @returns {AppbarItemAPI[] | AppbarItemAPI | null}
+     * @memberof AppbarAPI
+     */
+    get(id?: string): AppbarItemAPI[] | AppbarItemAPI | null {
+        if (id) {
+            const config = this.$vApp.$store.get<AppbarItemConfig | null>('appbar/getById!', id);
+            return config ? new AppbarItemAPI(this.$iApi, config) : null;
+        }
+
+        const configs = this.$vApp.$store.get<any | null>('appbar/items');
+        if (!configs) {
+            return null;
+        }
+
+        let items: AppbarItemAPI[] = [];
+        Object.keys(configs).forEach((id: string) => {
+            items.push(new AppbarItemAPI(this.$iApi, configs[id]));
+        });
+
+        return items;
+    }
+}
+
+export class AppbarItemAPI extends APIScope {
+    readonly _config: AppbarItemConfig;
+
+    /**
+     * ID of this appbar item.
+     *
+     * @readonly
+     * @type {string}
+     * @memberof AppbarItemAPI
+     */
+    get id(): string {
+        return this._config.id;
+    }
+
+    constructor(iApi: InstanceAPI, config: AppbarItemConfig) {
+        super(iApi);
+
+        this._config = config;
+
+        // Register component if it hasn't been registered before
+        if (!(this.id in this.$vApp.$options.components!)) {
+            Vue.component(this.id, this._config.component);
+        }
+    }
+}

--- a/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
+++ b/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
@@ -20,9 +20,9 @@ export class AppbarAPI extends APIScope {
      * @returns {Promise<AppbarItemAPI[]} The list of current Appbar Items in the store, as AppbarItemAPIs
      * @memberof AppbarAPI
      */
-    async set(appbarConfig: any): Promise<AppbarItemAPI[] | AppbarItemAPI | undefined> {
+    async set(appbarConfig: any): Promise<AppbarItemAPI[] | AppbarItemAPI | null> {
         if (!appbarConfig) {
-            return undefined;
+            return null;
         }
 
         for (let i = 0; i < appbarConfig.length; i++) {

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -1,0 +1,23 @@
+<template>
+    <div class="absolute top-0 left-0 flex flex-col items-center bg-black opacity-75 h-full w-40 md:w-64 pointer-events-auto">
+        <component v-for="(item, index) in items" :is="item.id" :key="`${item.id}-${index}`" class="h-16 mt-8 mb-8 first:mt-16"></component>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Watch, Component } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+import { AppbarItemConfig } from './store';
+import DividerV from './divider.vue';
+
+Vue.component('divider', DividerV);
+
+@Component
+export default class AppbarV extends Vue {
+    get items() {
+        return this.$iApi.$vApp.$store.get('appbar/items');
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/appbar/divider.vue
+++ b/packages/ramp-core/src/fixtures/appbar/divider.vue
@@ -1,0 +1,17 @@
+<template>
+    <span class="border-b pl-24 md:pl-48"></span>
+</template>
+
+<script lang="ts">
+import { Vue, Watch, Component } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+@Component
+export default class DividerV extends Vue {}
+</script>
+
+<style lang="scss" scoped>
+span {
+    height: 0 !important;
+}
+</style>

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -1,0 +1,37 @@
+import Vue from 'vue';
+
+import { FixtureConfigHelper } from '@/store/modules/fixture';
+
+import AppbarV from './appbar.vue';
+import { AppbarAPI } from './api/appbar';
+import { appbar } from './store/index';
+
+class AppbarFixture extends FixtureConfigHelper {
+    async added() {
+        console.log(`[fixture] ${this.id} added`);
+
+        const fixture = this.$iApi.fixture.get(this.id)!;
+
+        this.vApp.$store.registerModule('appbar', appbar());
+
+        this.$iApi.emit('appbarApi', new AppbarAPI(this.$iApi));
+
+        const appbarInstance = new (Vue.extend(AppbarV))({
+            iApi: this.$iApi,
+            propsData: { fixture }
+        });
+
+        appbarInstance.$mount();
+        const innerShell = this.vApp.$el.getElementsByClassName('inner-shell')[0];
+        innerShell.insertBefore(appbarInstance.$el, innerShell.children[0]);
+
+        await this.$iApi.appbar.set(this.vApp.$store.get('config/getFixtureConfig', 'appbar'));
+    }
+
+    removed() {
+        this.$iApi.appbar = null;
+        this.vApp.$store.unregisterModule('appbar');
+    }
+}
+
+export default new AppbarFixture('appbar');

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
@@ -1,0 +1,29 @@
+import Vue, { VueConstructor } from 'vue';
+
+export class AppbarState {
+    /**
+     * A list of all open (visible and hidden) panels.
+     *
+     * @type {AppbarItemConfig[]}
+     * @memberof AppbarState
+     */
+    items: AppbarItemConfig[] = [];
+}
+
+export interface AppbarItemConfig {
+    /**
+     * ID of this Appbar item.
+     *
+     * @type {string}
+     * @memberof AppbarItemConfig
+     */
+    id: string;
+
+    /**
+     * The component to be displayed on the Appbar
+     *
+     * @type {VueConstructor<Vue>}
+     * @memberof AppbarItemConfig
+     */
+    component?: VueConstructor<Vue>;
+}

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
@@ -1,0 +1,44 @@
+import { ActionContext, Action, Mutation } from 'vuex';
+import { make } from 'vuex-pathify';
+
+import { AppbarState, AppbarItemConfig } from './appbar-state';
+import { RootState } from '@/store/state';
+
+type AppbarContext = ActionContext<AppbarState, RootState>;
+
+export enum AppbarAction {}
+
+export enum AppbarMutation {
+    ADD_ITEM = 'ADD_ITEM',
+    REMOVE_ITEM = 'REMOVE_ITEM'
+}
+
+const getters = {
+    getById: (state: AppbarState) => (id: string): AppbarItemConfig | undefined => {
+        return state.items.find(item => item.id === id);
+    }
+};
+
+const actions = {};
+
+const mutations = {
+    [AppbarMutation.ADD_ITEM](state: AppbarState, value: AppbarItemConfig): void {
+        state.items.push(value);
+    },
+
+    [AppbarMutation.REMOVE_ITEM](state: AppbarState, value: AppbarItemConfig): void {
+        state.items.splice(state.items.indexOf(value), 1);
+    }
+};
+
+export function appbar() {
+    const state = new AppbarState();
+
+    return {
+        namespaced: true,
+        state,
+        getters: { ...getters },
+        actions: { ...actions },
+        mutations: { ...mutations, ...make.mutations(['items']) }
+    };
+}

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
@@ -14,8 +14,8 @@ export enum AppbarMutation {
 }
 
 const getters = {
-    getById: (state: AppbarState) => (id: string): AppbarItemConfig | undefined => {
-        return state.items.find(item => item.id === id);
+    getById: (state: AppbarState) => (id: string): AppbarItemConfig | null => {
+        return state.items.find(item => item.id === id) || null;
     }
 };
 

--- a/packages/ramp-core/src/fixtures/appbar/store/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/index.ts
@@ -1,0 +1,2 @@
+export * from './appbar-state';
+export * from './appbar-store';

--- a/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
@@ -1,0 +1,34 @@
+<template>
+    <button class="text-green-600 hover:text-green-200 p-6" @click="togglePanel()">
+        G
+    </button>
+</template>
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+
+import P1Screen1V from './p1-screen-1.vue';
+import P1Screen2V from './p1-screen-2.vue';
+
+@Component
+export default class GazeboAppbarButton extends Vue {
+    togglePanel(): void {
+        const panel = this.$iApi.panel.get('p1');
+        if (panel) {
+            panel.close();
+        } else {
+            this.$iApi.panel.open({
+                id: 'p1',
+                screens: [
+                    { id: 'p-1-screen-1', component: P1Screen1V },
+                    { id: 'p-1-screen-2', component: P1Screen2V }
+                ],
+                route: {
+                    id: 'p-1-screen-1'
+                }
+            });
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -50,3 +50,6 @@ class GazeboFixture extends FixtureConfigHelper {
 }
 
 export default new GazeboFixture('gazebo');
+
+import GazeboAppbarButton from './gazebo-appbar-button.vue';
+export { GazeboAppbarButton as AppbarButton };

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
@@ -17,7 +17,7 @@
         <template #content>
             <div class="flex flex-col items-center">
                 <!-- this is fine -->
-                <button @click="route = { id: 'p-1-screen-2' }" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4">
+                <button @click="route = { id: 'p-1-screen-2' }" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16">
                     See Gazebo 2
                 </button>
 

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
@@ -12,7 +12,7 @@
         <template #content>
             <div class="flex flex-col items-center">
                 <!-- this is fine -->
-                <button @click="goToScreen('p-1-screen-1')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4">
+                <button @click="goToScreen('p-1-screen-1')" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16">
                     See Gazebo 1
                 </button>
 

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
@@ -17,17 +17,17 @@
         <template #content>
             I'm a simple panel.
 
-            <div class="flex flex-col items-center mt-4">
+            <div class="flex flex-col items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->
                 <button
                     @click="panel.route({ id: 'p-2-screen-2', props: { greeting: 'Howdy?' } })"
-                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4"
+                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-16"
                 >
                     Go back to B
                 </button>
             </div>
 
-            <p class="mt-4">{{ greeting }}</p>
+            <p class="mt-16">{{ greeting }}</p>
         </template>
     </panel-screen>
 </template>

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
@@ -18,17 +18,17 @@
         <template #content>
             I'm a simple panel.
 
-            <div class="flex flex-col items-center mt-4">
+            <div class="flex flex-col items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->
                 <button
                     @click="panel.route({ id: 'p-2-screen-1', props: { greeting: 'Greeting from Screen B' } })"
-                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4"
+                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-16"
                 >
                     Switch to Screen A
                 </button>
             </div>
 
-            <p class="mt-4">{{ greeting }}</p>
+            <p class="mt-16">{{ greeting }}</p>
         </template>
     </panel-screen>
 </template>

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -1,0 +1,2 @@
+import LegendAppbarButton from './legend-appbar-button.vue';
+export { LegendAppbarButton as AppbarButton };

--- a/packages/ramp-core/src/fixtures/legend/legend-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend-appbar-button.vue
@@ -1,0 +1,21 @@
+<template>
+    <button class="text-gray-400 hover:text-white hover: p-6" @click="onClick()">
+        <!-- https://material.io/resources/icons/?icon=layers&style=baseline -->
+        <svg class="fill-current w-24 h-24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z" />
+        </svg>
+    </button>
+</template>
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+
+@Component
+export default class LegendAppbarButton extends Vue {
+    onClick() {
+        console.log('legend appbar button clicked');
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/store/modules/config/config-store.ts
+++ b/packages/ramp-core/src/store/modules/config/config-store.ts
@@ -14,6 +14,10 @@ type ConfigContext = ActionContext<ConfigState, RootState>;
 const getters = {
     getMapConfig: (state: ConfigState): RampMapConfig => {
         return state.config.map as RampMapConfig;
+    },
+
+    getFixtureConfig: (state: ConfigState) => (key: string): any => {
+        return state.config.fixtures[key];
     }
 };
 

--- a/packages/ramp-core/src/types.d.ts
+++ b/packages/ramp-core/src/types.d.ts
@@ -18,4 +18,5 @@ export interface EnhancedWindow extends Window {
 export interface RampConfig {
     map: RampMapConfig;
     layers: RampLayerConfig[];
+    fixtures: { [key: string]: any };
 }

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -1,5 +1,12 @@
 const postcss = require('postcss');
 
+// generate spacing rules, these create width, height, padding, margin, etc. rules
+// will end up with w-0 = 0px, w-1 = 1px, and so on
+spacingConfig = {};
+for (i = 0; i < 1000; i++) {
+    spacingConfig[i] = `${i}px`;
+}
+
 module.exports = {
     theme: {
         // remove all breakpoints because ramp components will depend on the shell size, not the size of the window/page
@@ -8,9 +15,11 @@ module.exports = {
         },
         boxShadow: {
             tm: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 3px 0 rgba(0, 0, 0, 0.1)'
-        }
+        },
+        spacing: spacingConfig
     },
     variants: {
+        // https://tailwindcss.com/docs/pseudo-class-variants
         // add the `container-query` variant to all the core plugins which have `responsive` specified (hint: it's all of them)
         alignContent: ['responsive', 'container-query'],
         alignItems: ['responsive', 'container-query'],
@@ -48,7 +57,7 @@ module.exports = {
         lineHeight: ['responsive', 'container-query'],
         listStylePosition: ['responsive', 'container-query'],
         listStyleType: ['responsive', 'container-query'],
-        margin: ['responsive', 'last', 'container-query'],
+        margin: ['responsive', 'last', 'container-query', 'first'],
         maxHeight: ['responsive', 'container-query'],
         maxWidth: ['responsive', 'container-query'],
         minHeight: ['responsive', 'container-query'],


### PR DESCRIPTION
- The tailwind config has been changed to give more fine-grained control over widths, heights, padding, etc. and to not rely on host page font sizes (`rem`)
  - now `w-10` would be `10px` instead of something like `2.5rem`, `rem` is controlled by the root font size, and since we are just a library we will have no control over it.
  - current styles have been changed to work with the new scaling

The bigger portion of work in this is the Appbar

Any arbitrary vue component can be added to the appbar, the config for an item is 
```
{
    id: "my-appbar-button",
    component: MyAppbarButton
}
```

If an item is supplied without a component it is assumed to be a fixture (that we've developed), and will pull the appbar button from the named fixture folder.

```
{
    id: "legend"
}
```
pulls the appbar button from `legend` and registers it under `legend-appbar-button`.

Similarly there is a Divider component that can be used by specifying an item with the `divider` id.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/45)
<!-- Reviewable:end -->
