### PR TITLE
API classes for geometry and friends

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Install Rush if you don't already have it:
 
-````
+```
 npm install -g @microsoft/rush
 ```
 

--- a/common/docs/README.md
+++ b/common/docs/README.md
@@ -1,0 +1,12 @@
+# DOC PARTY
+
+The idea for this folder is collect dev-friendly documentation for the moment.
+
+The slack chat is for discussions, the [design repo](https://github.com/ramp4-pcar4/r4design/issues) is for design decisions. This folder would contain things that answer these types of questions:
+
+- How do I use X?
+- What can X do?
+- How is X expected to behave?
+- What is recommended approach for doing X?
+
+Once the project matures, these docs can be the basis of official public docs, help documentation, etc.

--- a/common/docs/api/geometry.md
+++ b/common/docs/api/geometry.md
@@ -67,7 +67,7 @@ Various co-ordinate inputs of the constructors.
 
 ```
 const mptFromCoords = new RAMP.GEO.MultiPoint('myid', [[-76.77, 44.42], [-68.69, 51.39]]);
-const mptFromMultiPt = new RAMP.GEO.Point('myid', mptFromCoords);
+const mptFromMultiPt = new RAMP.GEO.MultiPoint('myid', mptFromCoords);
 const pt = new RAMP.GEO.Point('myid', [-76.77, 44.42]);
 const mptMixedPoints = new RAMP.GEO.MultiPoint('myid', [pt, [-68.69, 51.39], {x: "-97.86", y: 55.74}]);
 ```
@@ -93,8 +93,8 @@ mpt.updateAt(pt, 0);     // multipoint innards are now [[-78.22, 44.42], [-68.69
 This has effectively the same interface as `MultiPoint`, so examples will be sparse. `LineString` enforces a minimum of two vertices.
 
 ```
-const lineFromCoords = new RAMP.GEO.MultiPoint('myid', [[-76.77, 44.42], [-68.69, 51.39]]);
-const lineFromLine = new RAMP.GEO.Point('myid', lineFromCoords); // also accepts MultiPoint
+const lineFromCoords = new RAMP.GEO.LineString('myid', [[-76.77, 44.42], [-68.69, 51.39]]);
+const lineFromLine = new RAMP.GEO.LineString('myid', lineFromCoords); // also accepts MultiPoint
 lineFromCoords.type; // 'LineString'
 ```
 

--- a/common/docs/api/geometry.md
+++ b/common/docs/api/geometry.md
@@ -1,0 +1,196 @@
+# API Geometry Classes
+
+In general, the constructors are very flexible in accepting the varying and mixed geometry formats. The geometry input is parsed recursively, so in almost all cases if it makes sense logically, the constructor will parse it.
+
+## Spatial Reference
+
+This is fairly in-line with ESRI's format. It supports WKID and WKT, and optional latestWKID parameters.
+
+```
+const lambertSR = new RAMP.GEO.SpatialReference(3978);
+const fancySRwithLatest = new RAMP.GEO.SpatialReference(102100, 3857);
+const azimuthSR = new RAMP.GEO.SpatialReference('PROJCS["Sphere_ARC_INFO_Azimuthal_Equidistant",GEOGCS["GCS_Sphere_ARC_INFO",DATUM["D_Sphere_ARC_INFO",SPHEROID["Sphere_ARC_INFO",6370997.0,0.0]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Azimuthal_Equidistant"],PARAMETER["False_Easting",0.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",-90.0],PARAMETER["Latitude_Of_Origin",90.0],UNIT["Meter",1.0]]');
+const iAmFalse = lambertSR.isEqual(aziumthSR);
+```
+
+## Point
+
+Various co-ordinate inputs of the constructors.
+
+```
+const pt1 = new RAMP.GEO.Point('myid', [-76.77, 44.42]);
+const pt2 = new RAMP.GEO.Point('myid', {x: -76.77, y: 44.42});
+const pt3 = new RAMP.GEO.Point('myid', pt2);
+const pt4 = new RAMP.GEO.Point('myid', [-76.77, '44.42']);
+const pt5 = new RAMP.GEO.Point('myid', {x: '-76.77', y: 44.42});
+```
+
+Various methods
+
+```
+const pt = new RAMP.GEO.Point('myid', [-76.77, 44.42]);
+pt.type; // 'Point'
+pt.id; // 'myid'
+pt.sr; // { wkid: 4326 }
+pt.x; // -76.77
+pt.y; // 44.42
+pt.toArray(); // [-76.77, 44.42]
+pt.x = -77.13; // point has updated.
+```
+
+### Spatial References on Geometry
+
+The optional constructor parameter for spatial references is available on all geometry. We will use `Point` to illustrate.
+
+```
+const lambertSR = new RAMP.GEO.SpatialReference(3978);
+const lambertPt1 = new RAMP.GEO.Point('myid', [1461066.3, -303263.6], lambertSR);
+const lambertPt2 = new RAMP.GEO.Point('myid', [1461066.3, -303263.6], 3978);
+const lambertPt3 = new RAMP.GEO.Point('myid', lambertPt); // Note no explicit spatial reference passed in. Single RAMP geometry inputs provide their SR to the new instance
+const badLambertPt = new RAMP.GEO.Point('myid', [1461066.3, -303263.6]); // will have lambert values and Lat-Long spatial reference
+const wktPt = new RAMP.GEO.Point('myid', [123, 456], 'wkt string value');
+```
+
+### Raw Input for Geometry
+
+If the co-ordinate input is a well formed array of numbers (including that all polygon rings are closed), we can leverage the optional `raw` flag on the constructor. This is an efficiency flag, indicating the data can be consumed as is, there is no need to validate and parse the values. This option exists for all geometry types except `Extent`. If in doubt of the array format, it will always match the output of the `.toArray()` method of the particular geometry type.
+
+While our `Point` example may seem trivial, performance gains are to be had when dealing with geometries having high vertex counts.
+
+```
+const lambertPt = new RAMP.GEO.Point('myid', [1461066.3, -303263.6], 3978, true);
+```
+
+## MultiPoint
+
+Various co-ordinate inputs of the constructors.
+
+```
+const mptFromCoords = new RAMP.GEO.MultiPoint('myid', [[-76.77, 44.42], [-68.69, 51.39]]);
+const mptFromMultiPt = new RAMP.GEO.Point('myid', mptFromCoords);
+const pt = new RAMP.GEO.Point('myid', [-76.77, 44.42]);
+const mptMixedPoints = new RAMP.GEO.MultiPoint('myid', [pt, [-68.69, 51.39], {x: "-97.86", y: 55.74}]);
+```
+
+Various methods
+
+```
+const mpt = new RAMP.GEO.MultiPoint('myid', [[-76.77, 44.42], [-68.69, 51.39]]);
+mpt.type;                // 'MultiPoint'
+mpt.id;                  // 'myid'
+mpt.sr;                  // { wkid: 4326 }
+mpt.length;              // 2
+mpt.pointArray;          // [Point, Point] where each Point corresponds to the co-ords and is typed as RAMP API Point. These Points are not bound to the MultiPoint.
+mpt.toArray();           // [[-76.77, 44.42], [-68.69, 51.39]]
+
+const pt = mpt.getAt(0); // Point corresponding to -76.77, 44.42. This object is not bound to the MultiPoint
+pt.x = -78.22;           // pt has updated, mpt has not
+mpt.updateAt(pt, 0);     // multipoint innards are now [[-78.22, 44.42], [-68.69, 51.39]]
+```
+
+## Line String
+
+This has effectively the same interface as `MultiPoint`, so examples will be sparse. `LineString` enforces a minimum of two vertices.
+
+```
+const lineFromCoords = new RAMP.GEO.MultiPoint('myid', [[-76.77, 44.42], [-68.69, 51.39]]);
+const lineFromLine = new RAMP.GEO.Point('myid', lineFromCoords); // also accepts MultiPoint
+lineFromCoords.type; // 'LineString'
+```
+
+## Linear Ring
+
+This also has effectively the same interface as `MultiPoint`. `LinearRing` enforces that the last vertex must be identical to the first vertex. However, being both smart and kind, the constructor will inject a closing vertex if it is missing from the source. After closure, `LinearRing` expects a minimum of four vertices. For optimal drawing, the vertices should be in a clockwise order.
+
+```
+const ringIncomplete = new RAMP.GEO.LinearRing('myid', [[-76.77, 44.42], [-97.86, 55.74], [-68.69, 51.39]]);
+ringIncomplete.toArray(); // [[-76.77, 44.42], [-97.86, 55.74], [-68.69, 51.39], [-76.77, 44.42]]
+ringIncomplete.type;      // 'LinearRing'
+```
+
+## Multi Line String
+
+Various co-ordinate inputs of the constructors.
+
+```
+const mlsFromCoords = new RAMP.GEO.MultiLineString('myid', [[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39]], [[-97.86, 55.74], [-82.15, 49.34]]]);
+const mlsFromMultiLine = new RAMP.GEO.MultiLineString('myid', mlsFromCoords); // also accepts LineString, MultiPoint
+const line = new RAMP.GEO.LineString('myid', [[-97.86, 55.74], [-82.15, 49.34]]);
+const point = new RAMP.GEO.Point('myid', [-68.69, 51.39]);
+const mlsFromMixedLines = new RAMP.GEO.MultiLineString('myid', [[[-76.77, "44.42"], {x: "-80.95", y: 49.96}, point], line]);
+```
+
+Various methods
+
+```
+const mls = new RAMP.GEO.MultiLineString('myid', [[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39]], [[-97.86, 55.74], [-82.15, 49.34]]]);
+mls.type;                // 'MultiLineString'
+mls.id;                  // 'myid'
+mls.sr;                  // { wkid: 4326 }
+mls.length;              // 2
+mls.lineArray;           // [LineString, LineString] where each LineString corresponds to the line co-ords and is typed as RAMP API LineString. These LineStrings are not bound to the MultiLineString.
+mls.toArray();           // [[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39]], [[-97.86, 55.74], [-82.15, 49.34]]]
+
+const ln = mls.getAt(1); // Line corresponding to [-97.86, 55.74], [-82.15, 49.34]. This object is not bound to the MultiLineString
+const pt = new RAMP.GEO.Point('pt', [-99, 55]);
+ln.updateAt(pt, 0);
+mls.updateAt(ln, 1);     // multilinestring innards are now [[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39]], [[-99, 55], [-82.15, 49.34]]]
+```
+
+## Polygon
+
+Various co-ordinate inputs of the constructors.
+
+```
+const polyFromCoords = new RAMP.GEO.Polygon('myid', [[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39], [-76.77, 44.42]], [[-97.86, 55.74], [-82.15, 49.34], [-116.95, 51.30], [-97.86, 55.74]]]);
+const polyFromPoly = new RAMP.GEO.Polygon('myid', polyFromCoords); // also accepts MultiLineString, LinearRing, LineString, MultiPoint
+const line = new RAMP.GEO.MultiPoint('myid', [[-97.86, 55.74], [-82.15, 49.34], [-76.77, 44.42]]);
+const point = new RAMP.GEO.Point('myid', [-68.69, 51.39]);
+const polyFromMixedUnclosedRings = new RAMP.GEO.Polygon('myid', [[[-116.95, 51.30], point, {x: "-80.95", y: 49.96}], line]);
+```
+
+Various methods
+
+```
+const poly = new RAMP.GEO.Polygon('myid', [[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39]], [[-97.86, 55.74], [-82.15, 49.34], [-116.95, 51.30]]]);
+poly.type;                // 'Polygon'
+poly.id;                  // 'myid'
+poly.sr;                  // { wkid: 4326 }
+poly.length;              // 2
+poly.ringArray;           // [LinearRing, LinearRing] where each LinearRing corresponds to the ring co-ords (including closing vertex) and is typed as RAMP API LinearRing. These LinearRings are not bound to the Polygon.
+poly.toArray();           // [[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39], [-76.77, 44.42]], [[-97.86, 55.74], [-82.15, 49.34], [-116.95, 51.30], [-97.86, 55.74]]]
+
+const lr = new RAMP.GEO.LinearRing('lr', [[-97.86, 55.74], [-88, 44], [-116.95, 51.30]]);
+poly.addLinearRings([lr]); // new ring is added
+```
+
+odds are more methods will be added to Polygon, including the `getAt()` and `updateAt()` that are present on other geometries.
+
+## MultiPolygon
+
+Various co-ordinate inputs of the constructors.
+
+```
+const mpyFromCoords = new RAMP.GEO.MultiPolygon('myid', [[[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39], [-76.77, 44.42]]], [[[-97.86, 55.74], [-82.15, 49.34], [-116.95, 51.30], [-97.86, 55.74]]]]);
+const mpyFromMPoly = new RAMP.GEO.MultiPolygon('myid', mpyFromCoords); // also accepts Polygon, MultiLineString, LinearRing, LineString, MultiPoint
+// the examples are getting large, so omitted, but rest assured the constructor will accept an array of mixed formats that equate to Polygon-esque structures
+```
+
+Various methods
+
+```
+const mpy = new RAMP.GEO.MultiPolygon('myid', [[[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39]]], [[[-97.86, 55.74], [-82.15, 49.34], [-116.95, 51.30]]]]);
+mpy.type;                // 'MultiPolygon'
+mpy.id;                  // 'myid'
+mpy.sr;                  // { wkid: 4326 }
+mpy.length;              // 2
+mpy.polygonArray;        // [Polygon, Polygon] where each Polygon corresponds to the polygon co-ords and is typed as RAMP API Polygon. These Polygons are not bound to the MultiPolygon.
+mpy.toArray();           // [[[[-76.77, 44.42], [-80.95, 49.96], [-68.69, 51.39], [-76.77, 44.42]]], [[[-97.86, 55.74], [-82.15, 49.34], [-116.95, 51.30], [-97.86, 55.74]]]]
+
+const poly = new RAMP.GEO.Polygon('p', [[[-97.86, 55.74], [-88, 44], [-116.95, 51.30]]]);
+mpy.addPolygon(poly); // new polygon is added
+```
+
+odds are more methods will be added to MultiPolygon, including the `getAt()` and `updateAt()` that are present on other geometries.
+
+more to be added...

--- a/common/docs/api/migration.md
+++ b/common/docs/api/migration.md
@@ -1,0 +1,11 @@
+# API Migration Guide
+
+A list things that have changed (as in, breaking change) from the RAMP2 API
+
+## GEOM
+
+- Geometries are no longer always in Lat-Long projection & co-ord values.
+- `SpatialReference` is added and is a property of all geometry objects.
+- `XY` class is removed, as it's main purpose was to shuttle values between Lat-Long and other projections.
+- `XYBounds` class is now `Extent`, and shares the same base class as other geometries.
+- All geometry constructors have optional spatial reference parameter. Not providing it will default to Lat-Long. Note that co-ord inputs will not be projected, they will be assumed to be in Lat-Long already.

--- a/common/docs/app/appbar.md
+++ b/common/docs/app/appbar.md
@@ -1,0 +1,23 @@
+# Appbar
+
+(this content was lifted from the Appbar PR notes)
+
+Any arbitrary vue component can be added to the appbar, the config for an item is
+
+```
+{
+    id: "my-appbar-button",
+    component: MyAppbarButton
+}
+```
+
+If an item is supplied without a component it is assumed to be a fixture (that we've developed), and will pull the appbar button from the named fixture folder.
+
+```
+{
+    id: "legend"
+}
+```
+pulls the appbar button from `legend` and registers it under `legend-appbar-button`.
+
+Similarly there is a Divider component that can be used by specifying an item with the `divider` id.

--- a/common/docs/configuration/migration.md
+++ b/common/docs/configuration/migration.md
@@ -1,0 +1,3 @@
+# Config Migration Guide
+
+TODO list things that have changed (as in, breaking change) from the RAMP2 Config Schema

--- a/packages/ramp-geoapi/src/api/Attributes.ts
+++ b/packages/ramp-geoapi/src/api/Attributes.ts
@@ -1,0 +1,28 @@
+
+// TODO add proper documentation
+
+// unsure if we need a class.
+// attributes are currently just key value pairs. so can just use that unless we need some type of attribute tools, like .clone()
+// or some type of events for things changing / reloading
+
+// type Attributes = {[key: string]: any}; // TODO maybe limit 'any' to string & number? some WFS have objects as values, but we really dont support it
+
+// for now just trying to put the def in ApiDefs instead of it's own file.
+// resurrect this if we need a proper class for Attributes as considered above.
+/*
+// experiencing weirdness with building. compiler does not want to generate an Attributes.d.ts file when it's just the interface in this file.
+// The class seems to give it a kick.
+// Revisit later incase my computer was just being dumb.
+class IAmError {
+    name: string;
+    constructor() {
+        this.name = 'Error';
+    }
+}
+
+interface Attributes {[key: string]: any};
+
+export { IAmError };
+export { Attributes };
+export default Attributes;
+*/

--- a/packages/ramp-geoapi/src/api/Graphic.ts
+++ b/packages/ramp-geoapi/src/api/Graphic.ts
@@ -1,0 +1,51 @@
+// TODO add proper documentation
+
+// this will collate:
+
+// geometry
+// attributes
+// style
+// hover
+
+// makes a bit more sense, also helps make the geometry more memory-friendly (i.e. not having space allocated for null pointers to styles and hovers in big point chains)
+
+import Hover from './Hover';
+import { Attributes } from './apiDefs';
+import BaseGeometry from './geometry/BaseGeometry';
+import StyleOptions from './style/StyleOptions';
+
+export default class Graphic {
+
+    attributes: Attributes;
+    geometry: BaseGeometry;
+    style: StyleOptions;
+
+    private _hover: Hover;
+
+    // TODO event system to be decided
+    // _hoverRemoved: Subject<string> = new Subject();
+
+    /** Returns the hovertip for the graphic, if any. */
+    get hover(): Hover {
+        return this._hover;
+    }
+
+    /** Adds a hovertip to the graphic. If one already exists, replace it. */
+    set hover(hover: Hover) {
+        if (hover && this._hover && this._hover.id !== hover.id) {
+            this.removeHover();
+        }
+
+        this._hover = hover;
+    }
+
+    /** Removes the hovertip from the graphic if it exists. */
+    removeHover() {
+        if (this._hover) {
+            // TODO re-add event call once events are figured out
+            // this._hoverRemoved.next(this._id);
+            this._hover = undefined;
+        }
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/Hover.ts
+++ b/packages/ramp-geoapi/src/api/Hover.ts
@@ -1,0 +1,106 @@
+// TODO add proper documentation
+// TODO this is sketchy for now. not sure what kind of hover magic we will support
+//      only on SimpleLayer type things?
+//      should Hover be a part of Graphic instead of Geometry?
+// for the time being, we are just using RAMP2 object for placeholder
+
+interface HovertipOptions {
+    keepOpen: boolean;
+    position: string;
+    xOffset: number;
+    yOffset: number;
+    followCursor: boolean;
+}
+
+export default class Hover {
+    /** @ignore */
+    _id: string;
+    /** @ignore */
+    _text: string;
+    /** @ignore */
+    _keepOpen: boolean = false;
+    /** @ignore */
+    _position: string = 'top';
+    /** @ignore */
+    _xOffset: number = 0;
+    /** @ignore */
+    _yOffset: number = 0;
+    /** @ignore */
+    _followCursor: boolean = false;
+
+    /**
+     * Set the id and hovertip text. Also set any of the optional hovertip options if provided.
+     *
+     * The different options and values available are the following:
+     * <ul>
+     *     <li>keepOpen:        true or false. default is false.
+     *     <li>position:        'top', 'bottom', 'left' or 'right'. default is 'top'. (if followCursor is true, position value will be ignored.)
+     *     <li>xOffset:         any number. default is 0.
+     *     <li>yOffset:         any number. default is 0.
+     *     <li>followCursor:    true or false. default is false. (if keepOpen is true, followCursor value will be ignored.)
+     * </ul>
+     *
+     * TODO: add option for position 'center' specifically used for polygons.
+     */
+    constructor(id: string | number, text: string, opts?: HovertipOptions) {
+        this._id = id.toString();
+        this._text = text;
+        if (opts) {
+            if (opts.keepOpen !== undefined) {
+                this._keepOpen = opts.keepOpen;
+            }
+            if (opts.position !== undefined) {
+                this._position = opts.position;
+            }
+            if (opts.xOffset !== undefined) {
+                this._xOffset = opts.xOffset;
+            }
+            if (opts.yOffset !== undefined) {
+                this._yOffset = opts.yOffset;
+            }
+            if (opts.followCursor !== undefined) {
+                this._followCursor = opts.followCursor;
+            }
+        }
+    }
+
+    /** Returns the hovertip id. */
+    get id(): string {
+        return this._id;
+    }
+
+    /** Returns the contents of the hovertip. */
+    get text(): string {
+        return this._text;
+    }
+
+    /** Returns true if the hovertip is meant to remain open. */
+    get keepOpen(): boolean {
+        return this._keepOpen;
+    }
+
+    /** Returns the default position of the hovertip. */
+    get position(): string {
+        return this._position;
+    }
+
+    /** Returns the pixel offset on x of the hovertip. */
+    get xOffset(): number {
+        return this._xOffset;
+    }
+
+    /** Returns the pixel offset on y of the hovertip. */
+    get yOffset(): number {
+        return this._yOffset;
+    }
+
+    /** Returns true if the hovertip is meant to follow the cursor movement. */
+    get followCursor(): boolean {
+        return this._followCursor;
+    }
+
+    /** Returns the string 'Hover'. */
+    get type(): string {
+        return 'Hover';
+    }
+}

--- a/packages/ramp-geoapi/src/api/README.md
+++ b/packages/ramp-geoapi/src/api/README.md
@@ -1,0 +1,5 @@
+Fun facts about the API folder.
+
+Stuff in here is actually part of the application API. We host it here so GeoAPI functions can use these types as part of the public parameters, thus saving us writing more wrapper code.
+
+None of the code here should be aware of GeoAPI at all.

--- a/packages/ramp-geoapi/src/api/api.ts
+++ b/packages/ramp-geoapi/src/api/api.ts
@@ -1,0 +1,39 @@
+// idea is import an export everything, making one module to import as { * }
+
+// can use the following to import. figure out later if this is the best way
+// import {Point} from './api'
+
+// import Attributes from './Attributes';
+import Extent from './geometry/Extent';
+import Graphic from './Graphic';
+import Hover from './Hover';
+import LineString from './geometry/LineString';
+import LineStyleOptions from './style/LineStyleOptions';
+import LinearRing from './geometry/LinearRing';
+import MultiLineString from './geometry/MultiLineString';
+import MultiPoint from './geometry/MultiPoint';
+import MultiPolygon from './geometry/MultiPolygon';
+import Point from './geometry/Point';
+import PointStyleOptions from './style/PointStyleOptions';
+import Polygon from './geometry/Polygon';
+import PolygonStyleOptions from './style/PolygonStyleOptions';
+import SpatialReference from './geometry/SpatialReference';
+
+// TODO break into subcollection? like geometry, style? maybe do that on the actual API (which will consume these)
+export {
+    // Attributes,
+    Extent,
+    Graphic,
+    Hover,
+    LineString,
+    LineStyleOptions,
+    LinearRing,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    PointStyleOptions,
+    Polygon,
+    PolygonStyleOptions,
+    SpatialReference
+};

--- a/packages/ramp-geoapi/src/api/apiDefs.ts
+++ b/packages/ramp-geoapi/src/api/apiDefs.ts
@@ -1,0 +1,108 @@
+import SpatialReference from './geometry/SpatialReference';
+
+// NOTE: some values have changed since RAMP2.
+//       this is due to esri api 4 using different constants, and working exclusively in the
+//       api domain of constants. RAMP2 we were often in the ArcGIS server domain.
+//       e.g. 'esriSLSDashDot' is now 'dash-dot'
+
+export enum GeometryType {
+    POINT = 'Point',
+    MULTIPOINT = 'MultiPoint',
+    LINESTRING = 'LineString',
+    MULTILINESTRING = 'MultiLineString',
+    POLYGON = 'Polygon',
+    MULTIPOLYGON = 'MultiPolygon',
+    LINEARRING = 'LinearRing',
+    EXTENT = 'Extent'
+}
+
+// TODO add support for PATH type?
+//      would allow person to define a sybmol using svg. would need to enhance our style params to allow for svg path.
+//      alternately we can hotwire the .icon field. so if PATH, use .icon. might also make sense to add ICON to the enum,
+//      and have it be a special case just for the constructor and minimize confusion of callers.
+export enum PointStyle {
+    CIRCLE = 'circle',
+    CROSS = 'cross',
+    DIAMOND = 'diamond',
+    SQUARE = 'square',
+    TRIANGLE = 'triangle',
+    X = 'x'
+}
+
+export enum LineStyle {
+    DASH = 'dash',
+    DASHDOT = 'dash-dot',
+    DASHDOTDOT = 'short-dash-dot-dot', // for backwards compatibility
+    DOT = 'dot',
+    LONGDASH = 'long-dash',
+    LONGDASHDOT = 'long-dash-dot',
+    LONGDASHDOTDOT = 'long-dash-dot-dot',
+    NONE = 'none',
+    NULL = 'none', // for backwards compatibility
+    SHORTDASH = 'short-dash',
+    SHORTDASHDOT = 'short-dash-dot',
+    SHORTDASHDOTDOT = 'short-dash-dot-dot',
+    SHORTDOT = 'short-dot',
+    SOLID = 'solid'
+}
+
+export enum FillStyle {
+    BDIAG = 'backward-diagonal',
+    CROSS = 'cross',
+    DIAG_CROSS = 'diagonal-cross',
+    FDIAG = 'forward-diagonal',
+    HORIZONTAL = 'horizontal',
+    NONE = 'none',
+    NULL = 'none', // for backwards compatibility
+    SOLID = 'solid',
+    VERTICAL = 'vertical'
+}
+
+export interface ColourParams {
+    r: number;
+    g: number;
+    b: number;
+    a?: number;
+}
+
+export interface StyleParams {
+    style?: string;
+    colour?: Array<number> | string | ColourParams;
+    width?: number;
+}
+
+export interface PointStyleParams extends StyleParams {
+    style?: PointStyle;
+    icon?: string;
+    height?: number;
+    xOffset?: number;
+    yOffset?: number;
+}
+
+// essentially just pretties up the name. no new params
+export interface LineStyleParams extends StyleParams {
+    style?: LineStyle;
+}
+
+// TODO document the funnybusiness of this.
+// because we extend interfaces, this param object has an extra set of things
+export interface PolygonStyleParams extends StyleParams {
+    outlineColor?: Array<number> | string | ColourParams;
+    outlineWidth?: number;
+    outlineStyle?: LineStyle;
+
+    //the above 3 are for flexibility and backwards compatibility. the property below allows a shortcut by just supplying a line style
+    outlineParams?: LineStyleParams;
+
+    // again, mostly for backwards compatibility. opacity can now be provided on the colour itself. and we can use inherited style and colour for the fills as default
+    // (these params will have priority)
+    fillColor?: Array<number> | string | ColourParams;
+    fillOpacity?: number;
+    fillStyle?: FillStyle;
+}
+
+export interface Attributes {[key: string]: any};
+
+export type SrDef = SpatialReference | string | number;
+
+export type IdDef = string | number;

--- a/packages/ramp-geoapi/src/api/geometry/BaseGeometry.ts
+++ b/packages/ramp-geoapi/src/api/geometry/BaseGeometry.ts
@@ -1,0 +1,47 @@
+// TODO add proper documentation
+
+import SpatialReference from './SpatialReference';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+// TODO since this class is often used as a parameter type (i.e. something that accepts any of our geometries),
+//      maybe pick a different name, like Geometry, AnyGeometry, RampGeometry
+
+/**
+ * Baseclass of all geometries. All geometry types must derive from this class. Not intented to be instantiated on its own.
+ */
+export default class BaseGeometry {
+
+    // TODO make this readonly? overkill?
+    /** Spatial Reference of the geometry */
+    sr: SpatialReference;
+
+    /** Id of the geometry */
+    readonly id: string;
+
+    constructor(id: IdDef, sr?: SrDef) {
+        this.id = id.toString();
+
+        // default to lat long if no SR is provided
+        if (!sr) {
+            this.sr = SpatialReference.latLongSR();
+        } else if (sr instanceof SpatialReference) {
+            this.sr = sr.clone();
+        } else {
+            // cheating typescript. this will pass a string wkt or number wkid
+            this.sr = new SpatialReference(<any>sr);
+        }
+    }
+
+    /**
+     * Returns the type of the geometry object.
+     * Function implementation in subclasses.
+     */
+    get type(): GeometryType {
+        return undefined;
+    }
+
+    protected childIdGenerator(idx: number): string {
+        return `${this.id}-${idx}`;
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/geometry/Extent.ts
+++ b/packages/ramp-geoapi/src/api/geometry/Extent.ts
@@ -1,0 +1,85 @@
+// TODO add proper documentation
+
+import BaseGeometry from './BaseGeometry';
+import Point from './Point';
+import Polygon from './Polygon';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class Extent extends BaseGeometry {
+
+    // doing things a bit different for Extents.
+    // tried array of arrays to be consistent with other geometeries, but
+    // was more extra coding and overhead of unrequired array
+    protected rawMin: Array<number>;
+    protected rawMax: Array<number>;
+
+    /**
+     * Constructs an Extent from the given source of verticies
+     *
+     * @param {String | Integer} id An identifier for the Extent
+     * @param {Array | Point | Object} minGeometry A point equivalent marking the minimal value corner of the extent. Supported formats of [xVal, yVal], {x: xVal, y: yVal}, or Point
+     * @param {Array | Point | Object} maxGeometry A point equivalent marking the maximal value corner of the extent. Supported formats of [xVal, yVal], {x: xVal, y: yVal}, or Point
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the geometry. Defaults to Lat/Long if not provided
+     */
+    // from two things that can be interpreted as points
+    constructor(id: IdDef, minPoint: Point, maxPoint: Point, sr?: SrDef)
+    constructor(id: IdDef, minCoords: Array<number>, maxCoords: Array<number>, sr?: SrDef)
+    constructor(id: IdDef, minXY: object, maxXY: object, sr?: SrDef)
+    constructor(id: IdDef, minAnyFormat: any, maxAnyFormat: any, sr?: SrDef)
+    constructor(id: IdDef, minGeometry: any, maxGeometry: any, sr?: SrDef) {
+        super(id, minGeometry.sr || sr);
+
+        this.rawMin = Point.parseXY(minGeometry);
+        this.rawMax = Point.parseXY(maxGeometry);
+    }
+
+    // TODO getter / setter for individul values? classic [x|y][min|max] set
+
+    /** Returns the string 'Extent'. */
+    get type(): GeometryType {
+        return GeometryType.EXTENT;
+    }
+
+    get xmin(): number {
+        return this.rawMin[0];
+    }
+
+    get ymin(): number {
+        return this.rawMin[1];
+    }
+
+    get xmax(): number {
+        return this.rawMax[0];
+    }
+
+    get ymax(): number {
+        return this.rawMax[1];
+    }
+
+    clone(): Extent {
+        return new Extent(this.id, this.rawMin, this.rawMax, this.sr);
+    }
+
+    /**
+     * Returns an array of point arrays (e.g. [[x1, y1], [x2, y2]] )
+     */
+    toArray(): Array<Array<number>> {
+        return [this.rawMin.slice(), this.rawMax.slice()];
+    }
+
+    toPolygon(): Polygon {
+        // avoid slices since the constructor is going to copy them anyways
+        const poly = [[this.rawMin, [this.xmin, this.ymax], this.rawMax, [this.xmax, this.ymin], this.rawMin]];
+        return new Polygon(this.id, poly, this.sr, true);
+    }
+
+    static fromParams(id: IdDef,
+        xmin: string | number,
+        ymin: string | number,
+        xmax: string | number,
+        ymax: string | number,
+        sr?: SrDef): Extent {
+        return new Extent(id, [xmin, ymin], [xmax, ymax], sr);
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/geometry/LineString.ts
+++ b/packages/ramp-geoapi/src/api/geometry/LineString.ts
@@ -1,0 +1,47 @@
+// TODO add proper documentation
+
+import Point from './Point';
+import MultiPoint from './MultiPoint';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class LineString extends MultiPoint {
+
+    /**
+     * Constructs a LineString from the given source of a line
+     *
+     * @param {String | Integer} id An identifier for the LineString
+     * @param {Array | LineString | MultiPoint} geometry A LineString or MultiPoint geometry, or an array of verticies. Each array element must be parseable as a point. Supported formats of [xVal, yVal], {x: xVal, y: yVal}, or Point
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the geometry. Defaults to Lat/Long if not provided
+     * @param {Boolean} [raw] An efficiency flag. If set, it means the verticies is in the pure format of [[number, number],...] and we can skip data validations and parsing.
+     */
+    // from existing geometry that can be interpreted as a line
+    constructor(id: IdDef, line: LineString)
+    constructor(id: IdDef, multiPoint: MultiPoint)
+    // from arrays of verticies that can be interpreted as a line
+    constructor(id: IdDef, listOfCoords: Array<Array<number>>, sr?: SrDef, raw?: boolean)
+    constructor(id: IdDef, listOfPoints: Array<Point>, sr?: SrDef)
+    constructor(id: IdDef, listOfXY: Array<object>, sr?: SrDef)
+    constructor(id: IdDef, listOfMixedFormats: Array<any>, sr?: SrDef)
+    constructor(id: IdDef, geometry: any, sr?: SrDef, raw?: boolean) {
+
+        if (raw) {
+            // the first IF here is a bit silly; required to satisfy typescript (as we are extending MultiPoint).
+            // we could adjust the constructor guides to avoid it, but then would confuse users of IDEs in thinking the raw flag
+            // is applicable to non-raw array vertex formats
+            super(id, <Array<Array<number>>>geometry, sr, true);
+        } else if (geometry instanceof MultiPoint) {
+            // LineString classes will also satisfy instanceof
+            super(id, geometry);
+        } else {
+            super(id, geometry, sr);
+            if (this.rawArray.length < 2) {
+                throw new Error('lines require at least two verticies');
+            }
+        }
+    }
+
+    /** Returns the string 'LineString'. */
+    get type(): GeometryType {
+        return GeometryType.LINESTRING;
+    }
+}

--- a/packages/ramp-geoapi/src/api/geometry/LinearRing.ts
+++ b/packages/ramp-geoapi/src/api/geometry/LinearRing.ts
@@ -1,0 +1,89 @@
+// TODO add proper documentation
+
+import Point from './Point';
+import MultiPoint from './MultiPoint';
+import LineString from './LineString';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class LinearRing extends LineString {
+
+    /**
+     * Constructs a LinearRing from the given source of a line. Will close the line if it's not already closed
+     *
+     * @param {String | Integer} id An identifier for the LineString
+     * @param {Array | LineString | MultiPoint} geometry A LineString or MultiPoint geometry, or an array of verticies. Each array element must be parseable as a point. Supported formats of [xVal, yVal], {x: xVal, y: yVal}, or Point
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the geometry. Defaults to Lat/Long if not provided
+     * @param {Boolean} [raw] An efficiency flag. If set, it means the verticies is in the pure format of [[number, number],...,[samenumber, samenumber]] and we can skip data validations and parsing.
+     */
+    // from existing geometry that can be interpreted as a ring
+    constructor(id: IdDef, linearRing: LinearRing)
+    constructor(id: IdDef, line: LineString)
+    constructor(id: IdDef, multiPoint: MultiPoint)
+    // from arrays of verticies that can be interpreted as a ring
+    constructor(id: IdDef, listOfCoords: Array<Array<number>>, sr?: SrDef, raw?: boolean)
+    constructor(id: IdDef, listOfPoints: Array<Point>, sr?: SrDef)
+    constructor(id: IdDef, listOfXY: Array<object>, sr?: SrDef)
+    constructor(id: IdDef, listOfMixedFormats: Array<any>, sr?: SrDef)
+    constructor(id: IdDef, geometry: any, sr?: SrDef, raw?: boolean) {
+
+        if (raw) {
+            // the first IF here is a bit silly; required to satisfy typescript (as we are extending LineString).
+            // we could adjust the constructor guides to avoid it, but then would confuse users of IDEs in thinking the raw flag
+            // is applicable to non-raw array vertex formats
+            super(id, <Array<Array<number>>>geometry, sr, true);
+        } else if (geometry instanceof MultiPoint) {
+            // LineString & LinearRing classes will also satisfy instanceof
+            super(id, geometry);
+        } else {
+            super(id, geometry, sr);
+        }
+
+        // apply closing logic to the now-constructed internal geometry
+        LinearRing.closeRing(this.rawArray);
+
+        if (this.length < 4) {
+            throw new Error('Linear Ring must have at least 3 distinct vertices.');
+        }
+    }
+
+    /** Returns the string 'LinearRing'. */
+    get type(): GeometryType {
+        return GeometryType.LINEARRING;
+    }
+
+    /** Will update the n-th contained point with the values of the point parameter. It is assumed the point is in the same spatial reference as the Multipoint */
+    updateAt(point: Point | Array<number> | object, n: number) {
+        // TODO question if this is good logic.
+        //      it helps a person not paying attention retain their ring.
+        //      if someone is being clever and updates both front and end, no harm i guess, will double the updates
+
+        // add extra logic to ensure ring remains a ring
+        const l = this.length - 1;
+        if (n === 0) {
+            super.updateAt(point, l);
+        } else if (n === l) {
+            super.updateAt(point, 0);
+        }
+        // TODO probably want some type of "my geometry has updated" event triggering on the multipoint. if on a map would need to redraw itself.
+        //      may also need to supress if we have the end case; it would trigger the event twice, and in the first time the ring would not be a ring.
+        //      super.updateAt is very basic, might make more sense to copy the logic here and control the event from this function.
+
+        super.updateAt(point, n);
+    }
+
+    /**
+     * Will inspect an array of verticies. If the last vertex is different than the first vertex,
+     * will add a copy of the first vertex to the end, thus closing the line.
+     * The array parameter will be modified
+     *
+     * @param {Array} points An array of 2-element arrays of verticies.
+     */
+    static closeRing(points: Array<Array<number>>): void {
+        const first = points[0];
+        const last = points[points.length - 1];
+        if (first[0] !== last[0] || first[1] !== last[1]) { // 0 = x, 1 = y
+            points.push(first.slice());
+        }
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/geometry/MultiLineString.ts
+++ b/packages/ramp-geoapi/src/api/geometry/MultiLineString.ts
@@ -1,0 +1,108 @@
+// TODO add proper documentation
+
+import BaseGeometry from './BaseGeometry';
+import Point from './Point';
+import MultiPoint from './MultiPoint';
+import LineString from './LineString';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class MultiLineString extends BaseGeometry {
+
+    // for now, keeping raw for efficiency (not having object padding around every vertex)
+    // TODO think later on pros/cons of changing this to Array<LineString>
+    protected rawArray: Array<Array<Array<number>>>;
+
+    /**
+     * Constructs a MultiLineString from the given source of lines
+     *
+     * @param {String | Integer} id An identifier for the MultiLineString
+     * @param {Array | MultiLineString} geometry A MultiLineString or an array of lines. Each array element must be parseable as a line.
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the geometry. Defaults to Lat/Long if not provided
+     * @param {Boolean} [raw] An efficiency flag. If set, it means the verticies is in the pure format of [[[number, number],...],...] and we can skip data validations and parsing.
+     */
+    // from existing geometry that can be interpreted as a set of lines
+    constructor(id: IdDef, multiLine: MultiLineString)
+    // from existing geometry that can be interpreted as a single-line set
+    constructor(id: IdDef, line: LineString)
+    constructor(id: IdDef, multiPoint: MultiPoint)
+    // from arrays of lines that can be interpreted as a set of lines
+    constructor(id: IdDef, listOfListOfCoords: Array<Array<Array<number>>>, sr?: SrDef, raw?: boolean)
+    constructor(id: IdDef, listOfLines: Array<LineString>, sr?: SrDef)
+    constructor(id: IdDef, listOfMultiPoints: Array<MultiPoint>, sr?: SrDef)
+    constructor(id: IdDef, listOfListOfPoints: Array<Array<Point>>, sr?: SrDef)
+    constructor(id: IdDef, listOfListOfXY: Array<Array<object>>, sr?: SrDef)
+    constructor(id: IdDef, listOfMixedFormats: Array<any>, sr?: SrDef)
+    constructor(id: IdDef, geometry: any, sr?: SrDef, raw?: boolean) {
+        super(id, geometry.sr || sr);
+
+        // TODO expand this to allow single line structures to be passed to the constructor? a set of 1 lines should be valid.
+        //      possibly dont. the parsing logic becomes more complex when trying to descern if the contents of arrays are lines or points.
+        //      and we've already disabled this from other constructor signatures (see Polygon).
+        //      a good policy seem to be "accept singletons if its stored in a single API geometry. arrays of stuff should be properly formatted for multi".
+
+        // the non-raw logic here could be moved to a static .parseMultiLines, similar to Point.parseXY, MultiPoint.parsePointSet
+        // since currently nothing else but this constructor needs the logic, will keep it here. port to static if that changes.
+
+        if (raw) {
+            this.rawArray = MultiLineString.arrayDeepCopy(geometry);
+
+        } else if (geometry instanceof MultiLineString) {
+            this.rawArray = geometry.toArray();
+
+        } else if (geometry instanceof MultiPoint) {
+            // will also handle LineString
+            this.rawArray = [geometry.toArray()];
+
+        } else if (Array.isArray(geometry)) {
+            if (geometry.length === 0) {
+                throw new Error('no lines provided');
+            }
+
+            // process each element, as they could be any format of varying quality
+            this.rawArray = geometry.map(l => MultiPoint.parsePointSet(l));
+
+        } else {
+            throw new Error('invalid lines format for MulitLineString');
+        }
+
+    }
+
+    /** Returns an array of the contained lines formatted as API LineString objects. A new array is returned each time this is called. */
+    get lineArray(): Array<LineString> {
+        return this.rawArray.map((line, i) => new LineString(this.childIdGenerator(i), line, this.sr, true));
+    }
+
+    /** Returns a copy of the n-th contained line. */
+    getAt(n: number): LineString {
+        return new LineString(this.childIdGenerator(n), this.rawArray[n], this.sr, true);
+    }
+
+    /** Will update the n-th contained point with the values of the point parameter. It is assumed the point is in the same spatial reference as the Multipoint */
+    updateAt(line: LineString | Array<Array<Point>> | Array<Array<number>> | Array<Array<object>>, n: number) {
+        // TODO probably want some type of "my geometry has updated" event triggering on the multilinestring. if on a map would need to redraw itself.
+        this.rawArray[n] = MultiPoint.parsePointSet(line);
+    }
+
+    /** Returns the number of contained lines. */
+    get length(): number {
+        return this.rawArray.length;
+    }
+
+    /** Returns the string 'MultiLineString'. */
+    get type(): GeometryType {
+        return GeometryType.MULTILINESTRING;
+    }
+
+    /**
+     * Returns an array of line arrays (e.g. [[[x1, y1], [x2, y2]], [[x3, y3], [x4, y4]]] )
+     */
+    toArray(): Array<Array<Array<number>>> {
+        return MultiLineString.arrayDeepCopy(this.rawArray);
+    }
+
+    private static arrayDeepCopy(a: Array<Array<Array<number>>>): Array<Array<Array<number>>> {
+        // speed tests show loops & slice is 3x faster than JSON parse/stringify
+        return a.map(l => l.map(p => p.slice()));
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/geometry/MultiPoint.ts
+++ b/packages/ramp-geoapi/src/api/geometry/MultiPoint.ts
@@ -1,0 +1,115 @@
+// TODO add proper documentation
+
+import BaseGeometry from './BaseGeometry';
+import Point from './Point';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class MultiPoint extends BaseGeometry {
+
+    // for now, keeping raw for efficiency (not having object padding around every vertex)
+    // TODO think later on pros/cons of changing this to Array<Point>
+    protected rawArray: Array<Array<number>>;
+
+    /**
+     * Constructs a MultiPoint from the given source of verticies
+     *
+     * @param {String | Integer} id An identifier for the MultiPoint
+     * @param {Array | MultiPoint} geometry A MultiPoint geometry or an array of verticies. Each array element must be parseable as a point. Supported formats of [xVal, yVal], {x: xVal, y: yVal}, or Point
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the geometry. Defaults to Lat/Long if not provided
+     * @param {Boolean} [raw] An efficiency flag. If set, it means the verticies is in the pure format of [[number, number],...] and we can skip data validations and parsing.
+     */
+    // from existing geometry that can be interpreted as a set of points
+    constructor(id: IdDef, multiPoint: MultiPoint)
+    // from arrays of verticies that can be interpreted as a set of points
+    constructor(id: IdDef, listOfCoords: Array<Array<number>>, sr?: SrDef, raw?: boolean)
+    constructor(id: IdDef, listOfPoints: Array<Point>, sr?: SrDef)
+    constructor(id: IdDef, listOfXY: Array<object>, sr?: SrDef)
+    constructor(id: IdDef, listOfMixedFormats: Array<any>, sr?: SrDef)
+    constructor(id: IdDef, geometry: any, sr?: SrDef, raw?: boolean) {
+        super(id, geometry.sr || sr);
+
+        // TODO we could extend to have a constructor that takes a Point class, casting to [Point.toArray()].
+        //      leaving out for now, as Multipoint is at the bottom of a lot of big loops,
+        //      so want to avoid an extra IF check in parsePointSet
+
+        if (raw) {
+            this.rawArray = MultiPoint.arrayDeepCopy(geometry);
+        } else {
+            this.rawArray = MultiPoint.parsePointSet(geometry);
+        }
+
+        /*
+        // was a valiant effort but our fastArray was copying verticies byref and causing uninteded linking.
+        // instead have made .parseXY more efficient for Point class input and will live with that.
+        } else if (geometry[0] instanceof Point) {
+            // longshot that its array of API points
+            // use instanceof, as checking .type could pass if someone dumps geojson in here
+            try {
+                this.rawArray = Point.fastArray(<Array<Point>>geometry);
+                fastDone = true;
+            } catch (e) {
+                // do nothing, we will do an element-by-element parse of the array below
+            }
+        }
+        */
+    }
+
+    /** Returns an array of the contained lines formatted as API Point objects. A new array is returned each time this is called. */
+    get pointArray(): Array<Point> {
+        return this.rawArray.map((p, i) => new Point(this.childIdGenerator(i), p, this.sr, true));
+    }
+
+    /** Returns a copy of the n-th contained point. */
+    getAt(n: number): Point {
+        return new Point(this.childIdGenerator(n), this.rawArray[n], this.sr, true);
+    }
+
+    /** Will update the n-th contained point with the values of the point parameter. It is assumed the point is in the same spatial reference as the Multipoint */
+    updateAt(point: Point | Array<number> | object, n: number) {
+        // TODO probably want some type of "my geometry has updated" event triggering on the multipoint. if on a map would need to redraw itself.
+        this.rawArray[n] = Point.parseXY(point);
+    }
+
+    /** Returns the number of contained points. */
+    get length(): number {
+        return this.rawArray.length;
+    }
+
+    /** Returns the string 'MultiPoint'. */
+    get type(): GeometryType {
+        return GeometryType.MULTIPOINT;
+    }
+
+    // TODO make an .addPoint? .removePoint?
+
+    /**
+     * Returns an array of point arrays (e.g. [[x1, y1], [x2, y2]] )
+     */
+    toArray(): Array<Array<number>> {
+        // using private underscore property to avoid copying the array
+        // cannot just slice on rawArray, as it will have pointers to the inner vertex arrays
+        // speed tests show loops & slice is 3x faster than JSON parse/stringify
+        return MultiPoint.arrayDeepCopy(this.rawArray);
+    }
+
+    static parsePointSet(input: any): Array<Array<number>> {
+        if (input instanceof MultiPoint) {
+            // fast return, it's already pure
+            // this will also work for LineString and LinearRing
+            return input.toArray();
+        } else if (Array.isArray(input)) {
+            if (input.length === 0) {
+                throw new Error('no verticies provided');
+            }
+            return input.map(v => Point.parseXY(v));
+        } else {
+            throw new Error('invalid input format for parsePointSet');
+        }
+    }
+
+    private static arrayDeepCopy(a: Array<Array<number>>): Array<Array<number>> {
+        // speed tests show loops & slice is 3x faster than JSON parse/stringify
+        return a.map((p => p.slice()));
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/geometry/MultiPolygon.ts
+++ b/packages/ramp-geoapi/src/api/geometry/MultiPolygon.ts
@@ -1,0 +1,110 @@
+// TODO add proper documentation
+
+import BaseGeometry from './BaseGeometry';
+import Point from './Point';
+import MultiPoint from './MultiPoint';
+import LineString from './LineString';
+import LinearRing from './LinearRing';
+import MultiLineString from './MultiLineString';
+import Polygon from './Polygon';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class MultiPolygon extends BaseGeometry {
+
+    // for now, keeping raw for efficiency (not having object padding around every vertex)
+    // TODO think later on pros/cons of changing this to Array<Polygon>
+    protected rawArray: Array<Array<Array<Array<number>>>>;
+
+    /**
+     * Constructs a MultiPolygon from the given source of polygons.
+     *
+     * @param {String | Integer} id An identifier for the MultiPolygon
+     * @param {Array | Polygon | MultiLineString | LineString | MultiPoint} geometry A geometry that equates to a line or set of lines, or an array of things that equate to a set of lines. Each array element must be parseable as a line.
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the geometry. Defaults to Lat/Long if not provided
+     * @param {Boolean} [raw] An efficiency flag. If set, it means the verticies is in the pure format of [[[number, number],...,[samenumber, samenumber]],...] and we can skip data validations and parsing.
+     */
+    // from existing geometry that can be interpreted as a multi polygon
+    constructor(id: IdDef, multiPolygon: MultiPolygon)
+    // from existing geometry that can be interpreted as a single polygon
+    constructor(id: IdDef, polygon: Polygon)
+    constructor(id: IdDef, multiLine: MultiLineString)
+    constructor(id: IdDef, linearRing: LinearRing)
+    constructor(id: IdDef, line: LineString)
+    constructor(id: IdDef, multiPoint: MultiPoint)
+    // from arrays of arrays of single line structures that can be interpreted as a multi polygon
+    constructor(id: IdDef, listOflistOfListOfCoords: Array<Array<Array<Array<number>>>>, sr?: SrDef, raw?: boolean)
+    constructor(id: IdDef, listOflistOfListOfPoints: Array<Array<Array<Point>>>, sr?: SrDef)
+    constructor(id: IdDef, listOflistOfListOfXY: Array<Array<Array<object>>>, sr?: SrDef)
+    constructor(id: IdDef, listOfPolygons: Array<Polygon>, sr?: SrDef)
+    constructor(id: IdDef, listOflistOfLinearRings: Array<Array<LinearRing>>, sr?: SrDef)
+    constructor(id: IdDef, listOflistOfLines: Array<Array<LineString>>, sr?: SrDef)
+    constructor(id: IdDef, listOflistOfMultiPoints: Array<Array<MultiPoint>>, sr?: SrDef)
+    constructor(id: IdDef, listOfMixedFormats: Array<any>, sr?: SrDef)
+    constructor(id: IdDef, geometry: any, sr?: SrDef, raw?: boolean) {
+        super(id, geometry.sr || sr);
+
+        // TODO update all the geometry signatures to have a listOfMixedFormats Array<any> to indicate we can mix & match
+
+        if (raw) {
+            this.rawArray = MultiPolygon.arrayDeepCopy(geometry);
+        } else {
+            this.rawArray = MultiPolygon.parseMultiPolygon(geometry);
+        }
+    }
+
+    addPolygon(polygon: Polygon): void {
+        // TODO consider to make this of any of the wacky types and apply the parser
+        this.rawArray.push(polygon.toArray());
+    }
+
+    // TODO make a .getAt, .updateAt for polygons?
+    // TODO make a .removePolygon?
+
+    /** Returns an array of the contained polygons. A new array is returned each time this is called. */
+    get polygonArray(): Array<Polygon> {
+        return this.rawArray.map((p, i) => new Polygon(this.childIdGenerator(i), p, this.sr, true));
+    }
+
+    /** Returns the string 'MultiPolygon'. */
+    get type(): GeometryType {
+        return GeometryType.MULTIPOLYGON;
+    }
+
+    /**
+     * Returns an array of polygon arrays (e.g. [[[[x1, y1], [x2, y2], [x3, y3], [x1, y1]], [<another ring>]], [<another polygon>]] )
+     */
+    toArray(): Array<Array<Array<Array<number>>>> {
+        return MultiPolygon.arrayDeepCopy(this.rawArray);
+    }
+
+    static parseMultiPolygon(input: any): Array<Array<Array<Array<number>>>> {
+
+        if (input instanceof MultiPolygon) {
+            // fast return, it's already pure
+            return input.toArray();
+        } else if (input instanceof Polygon) {
+            // fast return, it's already pure
+            return [input.toArray()];
+        } else if ((input instanceof MultiLineString) || (input instanceof MultiPoint)) {
+            // MultiPoint will also be true for LineString and LinearRing
+            // use polygon parser to ensure rings are closed
+            return [Polygon.parsePolygon(input)];
+        } else if (Array.isArray(input)) {
+            if (input.length === 0) {
+                throw new Error('no polygons provided');
+            }
+            return input.map(p => Polygon.parsePolygon(p));
+        } else {
+            throw new Error('invalid input format for parseMultiPolygon');
+        }
+
+    }
+
+    // sing this function definition. epic chorus.
+    static arrayDeepCopy(a: Array<Array<Array<Array<number>>>>): Array<Array<Array<Array<number>>>> {
+        // speed tests show loops & slice is 3x faster than JSON parse/stringify
+        // array of polyGons to array of Lines(rings) to array of Points, copy each point
+        return a.map(g => g.map(l => l.map(p => p.slice())));
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/geometry/Point.ts
+++ b/packages/ramp-geoapi/src/api/geometry/Point.ts
@@ -1,0 +1,116 @@
+// TODO add proper documentation
+
+import BaseGeometry from './BaseGeometry';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class Point extends BaseGeometry {
+
+    // for now, trying out storing raw geometry in array format.
+    // thinking is that it will be in native format for geojson and for
+    // feeding into other ramp geometry types (i.e. arrays of points like [[x1,y1],[x2,y2]])
+    protected rawArray: Array<number>;
+
+    /**
+     * Constructs a Point from the given XY or XYLiteral.
+     *
+     * @param {String | Integer} id An identifier for the Point
+     * @param {Array | Object} geometry An encoding of the co-ordinate values. Supported formats of [xVal, yVal], {x: xVal, y: yVal}, or Point
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the co-ordinates. Defaults to Lat/Long if not provided
+     * @param {Boolean} [raw] An efficiency flag. If set, it means the xy value is in the pure format of [number, number] and we can skip data validations and parsing.
+     */
+    constructor(id: IdDef, point: Point)
+    constructor(id: IdDef, coords: Array<number>, sr?: SrDef, raw?: boolean)
+    constructor(id: IdDef, xy: object, sr?: SrDef)
+    constructor(id: IdDef, geometry: any, sr?: SrDef, raw?: boolean) {
+        super(id, geometry.sr || sr);
+
+        if (raw) {
+            this.rawArray = geometry.slice();
+        } else {
+            this.rawArray = Point.parseXY(geometry);
+        }
+    }
+
+    /** Returns the string 'Point'. */
+    get type(): GeometryType {
+        return GeometryType.POINT;
+    }
+
+    get x(): number {
+        return this.rawArray[0];
+    }
+    set x(val: number) {
+        // TODO some kind of 'i updated' event?
+        this.rawArray[0] = val;
+    }
+    get y(): number {
+        return this.rawArray[1];
+    }
+    set y(val: number) {
+        // TODO some kind of 'i updated' event?
+        this.rawArray[1] = val;
+    }
+
+    /**
+     * Returns a 2-element array with values x and y (i.e. [x, y])
+     */
+    toArray(): Array<number> {
+        // this makes a copy
+        // TODO decide if it should be a copy. document choice
+        return this.rawArray.slice();
+    }
+
+    static parseXY(input: any): Array<number> {
+
+        let buffer: Array<any>;
+
+        // test for various supported formats
+        // do array first, as it's fastest. also use arrays are recommended syntax and use in samples
+        if (Array.isArray(input) && input.length === 2) {
+            // two element array
+            buffer = input;
+
+        /*
+        // TODO for the moment, favoring offloading the geojson support to a converter function in geoapi.
+        //      would make everything much more efficient (i.e. not checking every input; the geojson converter will expect proper input)
+        } else if (input.type === 'Feature' && input.geometry && input.geometry.type === 'Point') {
+            // geojson point feature
+            buffer = input.geometry.coordinates;
+        } else if (input.type === 'Point') {
+            // geojson point geometry
+            buffer = input.coordinates;
+        */
+        } else if (input instanceof Point) {
+            // fast return, it's already pure
+            return input.toArray();
+        } else {
+            // attempt to find x and y properties
+            buffer = [input.x, input.y];
+        }
+
+        // check that point values are numeric
+        if (isNaN(buffer[0]) || isNaN(buffer[1])) {
+            // TODO once converter endpoints for esri, geojson are available, add those to the error message
+            throw new Error('Unsupported point format detected. Supported formats are two element array of numbers, or object with x and y properties containing numbers');
+        } else {
+            // TODO if we find things are slow, consider dropping the "text number to number number" casting we provide here. add more errors
+            // TODO see if testing if buffer val is string first prior to parseFloating it is more efficient than parseFloating everything
+            return [parseFloat(buffer[0]), parseFloat(buffer[1])];
+        }
+    }
+
+    /* // this is passing the contents of raw array by reference, thus linking stuff we dont want linked
+    // purely for efficiency.
+    // we can often have the use case in other geometry items where the input is an array of points (e.g. a polygon ring).
+    // since we want to encode these minimally, in number arrays, we want to convert from fancy objects to raw data.
+    // this function lives here so we can access the protected raw guts and just use them, instead of
+    // having to go through .x and .y and constructing arrays for every point.
+    static fastArray(listOfPoints: Array<Point>): Array<Array<number>> {
+        // the error trick here is to detect impure arrays. hiding it in a function lets us tack it on the back
+        // of a || operator, so standard case should be nice and fast as there will always be a raw array.
+        // caller should handle the error and use a slower conversion.
+        const trick = () => { throw new Error('non-point element found'); };
+        return listOfPoints.map(p => p.rawArray || trick());
+    }
+    */
+}

--- a/packages/ramp-geoapi/src/api/geometry/Polygon.ts
+++ b/packages/ramp-geoapi/src/api/geometry/Polygon.ts
@@ -1,0 +1,113 @@
+// TODO add proper documentation
+
+import BaseGeometry from './BaseGeometry';
+import Point from './Point';
+import MultiPoint from './MultiPoint';
+import LineString from './LineString';
+import LinearRing from './LinearRing';
+import MultiLineString from './MultiLineString';
+import { GeometryType, SrDef, IdDef } from '../apiDefs';
+
+export default class Polygon extends BaseGeometry {
+
+    // for now, keeping raw for efficiency (not having object padding around every vertex)
+    // TODO think later on pros/cons of changing this to Array<LinearRing>
+    protected rawArray: Array<Array<Array<number>>>;
+
+    /**
+     * Constructs a LinearRing from the given source of a line. Will close the line if it's not already closed
+     *
+     * @param {String | Integer} id An identifier for the LineString
+     * @param {Array | Polygon | MultiLineString | LineString | MultiPoint} geometry A geometry that equates to a line or set of lines, or an array of things that equate to a set of lines. Each array element must be parseable as a line.
+     * @param {SpatialReference | number | string} [sr] A spatial reference for the geometry. Defaults to Lat/Long if not provided
+     * @param {Boolean} [raw] An efficiency flag. If set, it means the verticies is in the pure format of [[[number, number],...,[samenumber, samenumber]],...] and we can skip data validations and parsing.
+     */
+    // from existing geometry that can be interpreted as a multi-ring polygon
+    constructor(id: IdDef, polygon: Polygon)
+    constructor(id: IdDef, multiLine: MultiLineString)
+    // from existing geometry that can be interpreted as a single-ring polygon
+    constructor(id: IdDef, linearRing: LinearRing)
+    constructor(id: IdDef, line: LineString)
+    constructor(id: IdDef, multiPoint: MultiPoint)
+    // from arrays of single line structures that can be interpreted as a multi-ring polygon
+    constructor(id: IdDef, listOfListOfCoords: Array<Array<Array<number>>>, sr?: SrDef, raw?: boolean)
+    constructor(id: IdDef, listOfListOfPoints: Array<Array<Point>>, sr?: SrDef)
+    constructor(id: IdDef, listOfListOfXY: Array<Array<object>>, sr?: SrDef)
+    constructor(id: IdDef, listOfLinearRings: Array<LinearRing>, sr?: SrDef)
+    constructor(id: IdDef, listOfLines: Array<LineString>, sr?: SrDef)
+    constructor(id: IdDef, listOfMultiPoints: Array<MultiPoint>, sr?: SrDef)
+    constructor(id: IdDef, listOfMixedFormats: Array<any>, sr?: SrDef)
+    // from arrays of verticies (i.e. one line) that can be interpreted as a single-ring polygon
+    // TODO for now, not allowing these as it increases parsing logic quite a bit.
+    // constructor(id: IdDef, polygon: Array<Point>, sr?: SpatialReference)
+    // constructor(id: IdDef, polygon: Array<Array<number>>, sr?: SpatialReference)
+    // constructor(id: IdDef, polygon: Array<object>, sr?: SpatialReference)
+    constructor(id: IdDef, geometry: any, sr?: SrDef, raw?: boolean) {
+        super(id, geometry.sr || sr);
+
+        if (raw) {
+            this.rawArray = Polygon.arrayDeepCopy(geometry);
+        } else {
+            this.rawArray = Polygon.parsePolygon(geometry);
+        }
+    }
+
+    addLinearRings(linearRings: Array<LinearRing>): void {
+        // TODO consider to make this of any of the wacky types and apply the parser
+        linearRings.forEach(lr => this.rawArray.push(lr.toArray()));
+    }
+
+    // TODO make a .getAt, .updateAt for rings?
+    // TODO make a .removeLinearRings?
+
+    /** Returns an array of the contained rings. A new array is returned each time this is called. */
+    get ringArray(): Array<LinearRing> {
+        return this.rawArray.map((lra, i) => new LinearRing(this.childIdGenerator(i), lra, this.sr, true));
+    }
+
+    /** Returns the string 'Polygon'. */
+    get type(): GeometryType {
+        return GeometryType.POLYGON;
+    }
+
+    /**
+     * Returns an array of ring arrays (e.g. [[[x1, y1], [x2, y2], [x3, y3], [x1, y1]], [<another ring>]] )
+     */
+    toArray(): Array<Array<Array<number>>> {
+        return Polygon.arrayDeepCopy(this.rawArray);
+    }
+
+    static parsePolygon(input: any): Array<Array<Array<number>>> {
+
+        let arrOfLines = [];
+
+        if (input instanceof Polygon) {
+            // fast return, it's already pure
+            return input.toArray();
+        } else if (input instanceof LinearRing) {
+            return [input.toArray()];
+        } else if (input instanceof MultiLineString) {
+            arrOfLines = input.toArray();
+        } else if (input instanceof MultiPoint) {
+            // will also handle LineString
+            arrOfLines = [input.toArray()];
+        } else if (Array.isArray(input)) {
+            if (input.length === 0) {
+                throw new Error('no rings provided');
+            }
+            arrOfLines = input.map(l => MultiPoint.parsePointSet(l));
+        } else {
+            throw new Error('invalid input format for parsePolygon');
+        }
+
+        // ensure each line in our collection of lines is closed
+        arrOfLines.forEach(l => LinearRing.closeRing(l));
+        return arrOfLines;
+    }
+
+    static arrayDeepCopy(a: Array<Array<Array<number>>>): Array<Array<Array<number>>> {
+        // speed tests show loops & slice is 3x faster than JSON parse/stringify
+        return a.map(l => l.map(p => p.slice()));
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/geometry/SpatialReference.ts
+++ b/packages/ramp-geoapi/src/api/geometry/SpatialReference.ts
@@ -1,0 +1,79 @@
+// TODO add proper documentation
+
+/**
+ * Represents a geographical spatial reference.
+ */
+export default class SpatialReference {
+
+    /** Well known id. This generally corresponds to an EPSG code or an ESRI wkid number */
+    wkid: number;
+
+    /** Latest well known id. This optional property allows updated wkid values to be leveraged when standards change */
+    latestWkid: number;
+
+    /** Well known type. */
+    wkt: string;
+
+    constructor(wkid: number)
+    constructor(wkid: number, latestWkid: number)
+    constructor(wkt: string)
+    constructor(wkidOrWkt: number | string, latestWkid?: number) {
+        if (typeof wkidOrWkt === 'string') {
+            this.wkt = wkidOrWkt;
+        } else {
+            this.wkid = wkidOrWkt;
+            this.latestWkid = latestWkid;
+        }
+
+        // TODO consider adding a quack if someone attempts to pass a latestWkid with a wkt
+        // TODO consider checking for falsy input on the first parameter and quacking
+    }
+
+    /**
+     * Returns the another spatial reference is the same as this one
+     *
+     * @method isEqual
+     * @param {SpatialReference} otherSR spatial reference to compare to
+     * @returns {Boolean} result of the comparison
+     */
+    isEqual(otherSR: SpatialReference): boolean {
+        return (this.wkid === otherSR.wkid) &&
+            (this.wkt === otherSR.wkt) &&
+            (this.latestWkid === otherSR.latestWkid);
+    }
+
+    clone(): SpatialReference {
+        const sr = new SpatialReference('');
+        sr.latestWkid = this.latestWkid;
+        sr.wkid = this.wkid;
+        sr.wkt = this.wkt;
+        return sr;
+    }
+
+    lean(): object {
+        // returns a stripped down untyped clone that only has valid properties.
+        // useful for feeding constructors.
+
+        const l: any = {};
+        if (this.wkt) {
+            l.wkt = this.wkt;
+        } else {
+            l.wkid = this.wkid;
+            if (this.latestWkid) {
+                l.latestWkid = this.latestWkid;
+            }
+        }
+        return l;
+    }
+
+    /**
+     * Returns a spatial reference for Lat Long projection
+     *
+     * @static
+     * @method latLongSR
+     * @returns {SpatialReference} the initialized spatial reference
+     */
+    static latLongSR(): SpatialReference {
+        return new SpatialReference(4326);
+    }
+}

--- a/packages/ramp-geoapi/src/api/style/LineStyleOptions.ts
+++ b/packages/ramp-geoapi/src/api/style/LineStyleOptions.ts
@@ -1,0 +1,22 @@
+// TODO add proper documentation
+
+import StyleOptions from './StyleOptions';
+import { LineStyle, LineStyleParams } from '../apiDefs';
+
+export default class LineStyleOptions extends StyleOptions {
+
+    constructor(opts?: LineStyleParams) {
+        opts = opts || {}; // If opts is undefined set it to an empty obj
+        super(opts);
+
+        // defaulting
+        if (!opts.style) {
+            this._style = LineStyle.SOLID;
+        }
+
+        if (!opts.width || opts.width < 0) {
+            this._width = 2;
+        }
+
+    }
+}

--- a/packages/ramp-geoapi/src/api/style/PointStyleOptions.ts
+++ b/packages/ramp-geoapi/src/api/style/PointStyleOptions.ts
@@ -1,0 +1,49 @@
+// TODO add proper documentation
+
+import StyleOptions from './StyleOptions';
+import { PointStyle, PointStyleParams } from '../apiDefs';
+
+export default class PointStyleOptions extends StyleOptions {
+
+    // TODO support outlines? can we even do that, or is that a composite symbol?
+
+    protected _height: number;
+    protected _xOffset: number;
+    protected _yOffset: number;
+    protected _icon: string;
+
+    constructor(opts?: PointStyleParams) {
+        opts = opts || {}; // If opts is undefined set it to an empty obj
+        super(opts);
+
+        this._icon = opts.icon || '';
+        this._style = opts.icon ? 'ICON' : this._style || PointStyle.CIRCLE;
+
+        this._xOffset = opts.xOffset || 0;
+        this._yOffset = opts.yOffset || 0;
+
+        // TODO add negative checks?
+        this._height = opts.height || 16.5;
+        this._width = opts.width || 16.5;
+    }
+
+        /** Returns the specified height */
+        get height(): number {
+            return this._height;
+        }
+
+        /** Returns the specified x offset */
+        get xOffset(): number {
+            return this._xOffset;
+        }
+
+        /** Returns the specified y offset */
+        get yOffset(): number {
+            return this._yOffset;
+        }
+
+        /** Returns the specified icon */ // TODO figure out format, document format
+        get icon(): string {
+            return this._icon;
+        }
+}

--- a/packages/ramp-geoapi/src/api/style/PolygonStyleOptions.ts
+++ b/packages/ramp-geoapi/src/api/style/PolygonStyleOptions.ts
@@ -1,0 +1,54 @@
+// TODO add proper documentation
+
+import StyleOptions from './StyleOptions';
+import LineStyleOptions from './LineStyleOptions';
+import { FillStyle, PolygonStyleParams, LineStyleParams  } from '../apiDefs';
+
+export default class PolygonStyleOptions extends StyleOptions {
+
+    protected _outlineStyle: LineStyleOptions;
+    protected _fillColor: Array<number>;
+    protected _fillStyle: string;
+
+    constructor(opts?: PolygonStyleParams) {
+        opts = opts || {}; // If opts is undefined set it to an empty obj
+        super(opts);
+
+        // dee-faults
+
+        // THE FILL
+        if (opts.fillColor) {
+            this._fillColor = StyleOptions.parseColour(opts.fillColor);
+        } else {
+            // if someone provided a colour on the base param, use it. if both were empty, this will already be defaulted due to super()
+            this._fillColor = this._colour;
+        }
+
+        if (!isNaN(opts.fillOpacity)) {
+            // possible we have 0-1 decimals coming in, need to translate to 0-255
+            if (opts.fillOpacity <= 0) {
+                this._fillColor[3] = 0;
+            } else if (opts.fillOpacity <= 1) {
+                // we take a risk if someone sets value of 1 being 1 of 255 opacity. WHO PICKS 1/255th OPACITY???
+                this._fillColor[3] = Math.floor(opts.fillOpacity * 255.0);
+            } else {
+                this._fillColor[3] = Math.min((Math.floor(opts.fillOpacity), 255));
+            }
+        }
+
+        this._fillStyle = opts.fillStyle || opts.style || FillStyle.SOLID;
+
+        // THE OUTLINE
+        let paramooo: LineStyleParams;
+        if (opts.outlineParams) {
+            paramooo = opts.outlineParams;
+        } else {
+            paramooo.colour = opts.outlineColor;
+            paramooo.style = opts.outlineStyle;
+            paramooo.width = opts.outlineWidth;
+        }
+        this._outlineStyle = new LineStyleOptions(paramooo);
+
+    }
+
+}

--- a/packages/ramp-geoapi/src/api/style/StyleOptions.ts
+++ b/packages/ramp-geoapi/src/api/style/StyleOptions.ts
@@ -1,0 +1,77 @@
+// TODO add proper documentation
+
+import { StyleParams, ColourParams } from '../apiDefs';
+
+export default class StyleOptions {
+
+    protected _width: number;
+    protected _colour: Array<number>;
+    protected _style: string;
+
+    constructor(opts?: StyleParams) {
+        opts = opts || {}; // If opts is undefined set it to an empty obj
+
+        // if an attribute is not defined set it to a default
+        this._style = opts.style;
+        this._colour = StyleOptions.parseColour(opts.colour);
+        this._width = opts.width;
+    }
+
+    /** Returns the specified width */
+    get width(): number {
+        return this._width;
+    }
+
+    /** Returns the specified colour */
+    get colour(): Array<number> {
+        return this._colour;
+    }
+
+    /** Returns the specified colour as a hex string */
+    get colourHex(): string {
+        return StyleOptions.colourToHex(this._colour);
+    }
+
+    /** Returns the specified style */
+    get style(): string {
+        return this._style;
+    }
+
+    static parseColour(c: Array<number> | Array<string> | string | ColourParams): Array<number> {
+
+        if (!c) {
+            return [0, 0, 0, 255];
+        }
+
+        let arr: Array<number>;
+        if (Array.isArray(c)) {
+            arr = (<Array<any>>c).map(n => parseInt(n));
+            if (arr.length === 3) {
+                arr.push(255); // no opacity given. make opaque
+            }
+        } else if (typeof c === 'string') {
+
+            // trim # if its there
+            let s: string = c.substr(0, 1) === '#' ? c.substr(1) : c;
+            arr = [0, 2, 4, 6].map(i => {
+                const hex = s.substr(i, 2);
+                return hex.length === 0 ? 255 : parseInt(hex, 16);
+            });
+        } else {
+            arr = [c.r, c.g, c.b, typeof c.a === 'undefined' ? 255 : c.a];
+        }
+
+        return arr;
+
+    }
+
+    protected static colourToHex(colourArray: Array<number>): string {
+        const toHex = (i: number) => {
+            let s: string = i.toString(16);
+            return s.length === 1 ? `0${s}` : s;
+        };
+
+        return `#${colourArray.map(i => toHex(i)).join('')}`;
+    }
+
+}

--- a/packages/ramp-geoapi/src/gapiTypes.ts
+++ b/packages/ramp-geoapi/src/gapiTypes.ts
@@ -2,6 +2,8 @@
 // TODO after all the stuff has been dumped in here, re-organize the order into logical sections
 
 import esri = __esri; // magic command to get ESRI JS API type definitions.
+import BaseGeometry from './api/geometry/BaseGeometry'; // this is a bit wonky. could expose on RampAPI, but dont want clients using the baseclass
+import { Attributes } from './api/apiDefs';
 import MapModule from './map/MapModule';
 import Map from './map/Map';
 import LayerModule from './layer/LayerModule';
@@ -17,7 +19,7 @@ export interface EpsgLookup {
 
 export interface GeoApiOptions {
     apiUrl?: string;
-    epsgLookup?: EpsgLookup
+    epsgLookup?: EpsgLookup;
 }
 
 export interface DojoWindow extends Window {
@@ -129,8 +131,11 @@ export enum IdentifyResultFormat {
 }
 
 // a collection of attributes
+// TODO consider changin .features to .attributes or .attribs.
+//      features would be back-compatible, but it's confusing as we now have a Graphic class, which would be more
+//      aligned with the word "feature"
 export interface AttributeSet {
-    features: Array<any>;
+    features: Array<Attributes>;
     oidIndex: {[key: number]: number};
 }
 
@@ -173,12 +178,14 @@ export interface GetGraphicResult {
     //      stuff tricky if it's not valid.
     //      perhaps we get very fancy with a wrapper, that can have hidden internals if valid,
     //      and error checking if people say request just attributes then attempt to change visibility
-    attributes?: any;
-    geometry?: any;
+    // TODO replace all this with a RAMPAPI.Graphic?
+    attributes?: Attributes;
+    geometry?: BaseGeometry;
 }
 
+// TODO convert the SR param to our API SR class?
 export interface QueryFeaturesParams {
-    filterGeometry?: esri.Geometry; // filter by geometry
+    filterGeometry?: BaseGeometry; // filter by geometry
     filterSql?: string; // filter by sql query
     includeGeometry?: boolean; // if geometry should be included in the result
     outFields?: string; // comma separated list of attributes to restrict what is downloaded
@@ -197,7 +204,7 @@ export interface QueryFeaturesGeoJsonParams extends QueryFeaturesParams {
 export interface IdentifyParameters {
     // TODO will need a larger thinking session on how we expose any esri native types on our interfaces.
     //      if not esri, needs to be converted inside geoapi to esri, so we need some type of strict interface.
-    geometry: any; // esri.Geometry; // TODO figure out how to manage this. typescript gets angry about supertypes.
+    geometry: BaseGeometry; // esri.Geometry; // TODO figure out how to manage this. typescript gets angry about supertypes.
     map: Map;
     tolerance?: number;
     returnGeometry?: boolean;

--- a/packages/ramp-geoapi/src/layer/AttribFC.ts
+++ b/packages/ramp-geoapi/src/layer/AttribFC.ts
@@ -428,7 +428,7 @@ export default class AttribFC extends BaseFC {
      * @param options {Object} options to provide filters and helpful information.
      * @returns {Array} set of features that satisfy the criteria
      */
-    queryFeatures(options: QueryFeaturesParams): Promise<Array<GetGraphicResult>>{
+    queryFeatures(options: QueryFeaturesParams): Promise<Array<GetGraphicResult>> {
         // NOTE this assumes a server based layer
         //      local based layers should override this function
 

--- a/packages/ramp-geoapi/src/layer/FeatureLayer.ts
+++ b/packages/ramp-geoapi/src/layer/FeatureLayer.ts
@@ -240,14 +240,14 @@ export class FeatureLayer extends AttribLayer {
         //      might consider having an IdentifyUtils class (or use the queryservice) to help with these common things
         //      (e.g. this, buffer creation, etc)
         //      using Geometry.fromJSON does not work well, it won't figure out the type and cast-up
-        const realGeom: esri.Geometry = this.esriBundle.Point.fromJSON(options.geometry);
+        // const realGeom: esri.Geometry = this.esriBundle.Point.fromJSON(options.geometry);
         if (myFC.geomType === 'polygon') {
-            qOpts.filterGeometry = realGeom;
+            qOpts.filterGeometry = options.geometry;
         } else {
             // TODO investigate why we are using opts.clickEvent.mapPoint and not opts.geometry
             // TODO add buffer back once we have buffer tech ready
             // qOpts.filterGeometry = this.makeClickBuffer(opts.clickEvent.mapPoint, opts.map, tolerance);
-            qOpts.filterGeometry = realGeom; // TODO remove me after buffer tech
+            qOpts.filterGeometry = options.geometry; // TODO remove me after buffer tech
         }
 
         result.done = myFC.queryFeatures(qOpts).then(results => {

--- a/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
@@ -112,7 +112,7 @@ export default class GeoJsonFC extends AttribFC {
      * @param options {Object} options to provide filters and helpful information.
      * @returns {Array} set of features that satisfy the criteria
      */
-    queryFeatures(options: QueryFeaturesParams): Promise<Array<GetGraphicResult>>{
+    queryFeatures(options: QueryFeaturesParams): Promise<Array<GetGraphicResult>> {
 
         const gjOpt: QueryFeaturesGeoJsonParams = {
             layer: (<GeoJsonLayer>this.parentLayer),

--- a/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
@@ -249,14 +249,14 @@ export class GeoJsonLayer extends AttribLayer {
         //      might consider having an IdentifyUtils class (or use the queryservice) to help with these common things
         //      (e.g. this, buffer creation, etc)
         //      using Geometry.fromJSON does not work well, it won't figure out the type and cast-up
-        const realGeom: esri.Geometry = this.esriBundle.Point.fromJSON(options.geometry);
+        // const realGeom: esri.Geometry = this.esriBundle.Point.fromJSON(options.geometry);
         if (myFC.geomType === 'polygon') {
-            qOpts.filterGeometry = realGeom;
+            qOpts.filterGeometry = options.geometry;
         } else {
             // TODO investigate why we are using opts.clickEvent.mapPoint and not opts.geometry
             // TODO add buffer back once we have buffer tech ready
             // qOpts.filterGeometry = this.makeClickBuffer(opts.clickEvent.mapPoint, opts.map, tolerance);
-            qOpts.filterGeometry = realGeom; // TODO remove me after buffer tech
+            qOpts.filterGeometry = options.geometry; // TODO remove me after buffer tech
         }
 
         result.done = myFC.queryFeatures(qOpts).then(results => {

--- a/packages/ramp-geoapi/src/layer/MapImageLayer.ts
+++ b/packages/ramp-geoapi/src/layer/MapImageLayer.ts
@@ -525,8 +525,8 @@ export class MapImageLayer extends AttribLayer {
         //      buffer will only be applied to point layers, so need some in-loop checking
         //      see comments in featurelayer identify for issues and ways to share this code
         // right now just do assumed point, FIX LATER
-        const realGeom: esri.Geometry = this.esriBundle.Point.fromJSON(options.geometry);
-        qOpts.filterGeometry = realGeom;
+        // const realGeom: esri.Geometry = this.esriBundle.Point.fromJSON(options.geometry);
+        qOpts.filterGeometry = options.geometry;
         /*
         if (myFC.geomType === 'polygon') {
             qOpts.filterGeometry = realGeom;

--- a/packages/ramp-geoapi/src/main.ts
+++ b/packages/ramp-geoapi/src/main.ts
@@ -7,6 +7,8 @@ import MapModule from './map/MapModule';
 
 import LayerModule from './layer/LayerModule';
 import UtilModule from './util/UtilModule';
+import * as apiDefs from './api/apiDefs';
+import * as apiClasses from './api/api';
 
 export * from './gapiTypes';
 export { Map } from './map/Map';
@@ -15,8 +17,10 @@ export { WmsLayer } from './layer/WmsLayer';
 export { MapImageLayer } from './layer/MapImageLayer';
 export { GeoJsonLayer } from './layer/GeoJsonLayer';
 export { HighlightLayer } from './layer/HighlightLayer';
-export * from './api/apiDefs';
-export * from './api/api';
+export const ApiBundle = {
+    ...apiClasses,
+    ...apiDefs
+};
 
 // TODO figure out best way to export * from './api/api' so it can be consumed by whatever
 //      on the client is making the actual API that gets exposed to everyone.

--- a/packages/ramp-geoapi/src/main.ts
+++ b/packages/ramp-geoapi/src/main.ts
@@ -15,6 +15,11 @@ export { WmsLayer } from './layer/WmsLayer';
 export { MapImageLayer } from './layer/MapImageLayer';
 export { GeoJsonLayer } from './layer/GeoJsonLayer';
 export { HighlightLayer } from './layer/HighlightLayer';
+export * from './api/apiDefs';
+export * from './api/api';
+
+// TODO figure out best way to export * from './api/api' so it can be consumed by whatever
+//      on the client is making the actual API that gets exposed to everyone.
 
 // TODO once working, try to use asynch / await keywords
 

--- a/packages/ramp-geoapi/src/map/Map.ts
+++ b/packages/ramp-geoapi/src/map/Map.ts
@@ -23,7 +23,7 @@ export class Map extends MapBase {
             constraints: {
                 lods: <Array<esri.LOD>>config.lods
             },
-            spatialReference: config.extent.spatialReference,
+            spatialReference: config.extent.spatialReference, // TODO use utils.geom.convSrToEsriSr?
             extent: config.extent,
 
             // TODO remove these once starting extent is working

--- a/packages/ramp-geoapi/src/util/GeometryService.ts
+++ b/packages/ramp-geoapi/src/util/GeometryService.ts
@@ -1,0 +1,173 @@
+// TODO fancy up the docs
+
+import esri = __esri;
+import { InfoBundle, QueryFeaturesArcServerParams, QueryFeaturesGeoJsonParams, GetGraphicResult } from '../gapiTypes';
+import * as RampAPI from '../api/api';
+import BaseGeometry from '../api/geometry/BaseGeometry'; // this is a bit wonky. could expose on RampAPI, but dont want clients using the baseclass
+import BaseBase from '../BaseBase';
+import { GeometryType } from '../api/apiDefs';
+
+export default class GeometryService extends BaseBase {
+    constructor (infoBundle: InfoBundle) {
+        super(infoBundle);
+    }
+
+    // these converters are public, but we should discourage use by 3rd party individuals for the ESRI specific stuff
+    // TODO doc this in docs.
+
+    // converts any ramp api geom to corresponding esri geometry
+    geomRampToEsri(rampApiGeom: BaseGeometry): esri.Geometry {
+
+        switch (rampApiGeom.type) {
+            case GeometryType.POINT:
+                return this.convPointToEsri(<RampAPI.Point>rampApiGeom);
+            case GeometryType.LINESTRING:
+                return this.convLineToEsri(<RampAPI.LineString>rampApiGeom);
+            case GeometryType.POLYGON:
+                return this.convPolygonToEsri(<RampAPI.Polygon>rampApiGeom);
+            case GeometryType.EXTENT:
+                return this.convExtentToEsri(<RampAPI.Extent>rampApiGeom);
+            case GeometryType.MULTIPOINT:
+                return this.convMultiPointToEsri(<RampAPI.MultiPoint>rampApiGeom);
+            case GeometryType.MULTILINESTRING:
+                return this.convMultiLineToEsri(<RampAPI.MultiLineString>rampApiGeom);
+            case GeometryType.MULTIPOLYGON:
+                return this.convMultiPolygonToEsri(<RampAPI.MultiPolygon>rampApiGeom);
+            case GeometryType.LINEARRING:
+                return this.convLinearRingToEsri(<RampAPI.LinearRing>rampApiGeom);
+            default:
+                throw new Error(`Encountered unhandled geometry type ${rampApiGeom.type}`);
+        }
+    }
+
+    // converts any esri geometry to corresponding ramp api geom
+    geomEsriToRamp(esriGeometry: esri.Geometry, id?: number | string): BaseGeometry {
+
+        switch (esriGeometry.type) {
+            case 'point':
+                return this.convEsriPointToRamp(<esri.Point>esriGeometry, id);
+            case 'polyline':
+                return this.convEsriLineToRamp(<esri.Polyline>esriGeometry, id);
+            case 'polygon':
+                return this.convEsriPolygonToRamp(<esri.Polygon>esriGeometry, id);
+            case 'extent':
+                return this.convEsriExtentToRamp(<esri.Extent>esriGeometry, id);
+            case 'multipoint':
+                return this.convEsriMultiPointToRamp(<esri.Multipoint>esriGeometry, id);
+            default:
+                throw new Error(`Encountered unhandled geometry type ${esriGeometry.type}`);
+        }
+    }
+
+    convSrToEsri(rampSR: RampAPI.SpatialReference): esri.SpatialReference {
+        return new this.esriBundle.SpatialReference(rampSR.lean());
+    }
+
+    convPointToEsri(rampPoint: RampAPI.Point): esri.Point {
+        return new this.esriBundle.Point({
+            x: rampPoint.x,
+            y: rampPoint.y,
+            spatialReference: this.convSrToEsri(rampPoint.sr)
+        });
+    }
+
+    convMultiPointToEsri(rampMultiPoint: RampAPI.MultiPoint): esri.Multipoint {
+        return new this.esriBundle.Multipoint({
+            points: rampMultiPoint.toArray(),
+            spatialReference: this.convSrToEsri(rampMultiPoint.sr)
+        });
+    }
+
+    private polylineFactory(coords: Array<Array<Array<number>>>, sr: RampAPI.SpatialReference): esri.Polyline {
+        return new this.esriBundle.Polyline({
+            paths: coords,
+            spatialReference: this.convSrToEsri(sr)
+        });
+    }
+
+    convLineToEsri(rampLine: RampAPI.LineString): esri.Polyline {
+        return this.polylineFactory([rampLine.toArray()], rampLine.sr);
+    }
+
+    convMultiLineToEsri(rampMultiLine: RampAPI.MultiLineString): esri.Polyline {
+        return this.polylineFactory(rampMultiLine.toArray(), rampMultiLine.sr);
+    }
+
+    private polygonFactory(coords: Array<Array<Array<number>>>, sr: RampAPI.SpatialReference): esri.Polygon {
+        return new this.esriBundle.Polygon({
+            rings: coords,
+            spatialReference: this.convSrToEsri(sr)
+        });
+    }
+
+    convLinearRingToEsri(rampRing: RampAPI.LinearRing): esri.Polygon {
+        return this.polygonFactory([rampRing.toArray()], rampRing.sr);
+    }
+
+    convPolygonToEsri(rampPolygon: RampAPI.Polygon): esri.Polygon {
+        return this.polygonFactory(rampPolygon.toArray(), rampPolygon.sr);
+    }
+
+    convMultiPolygonToEsri(rampMultiPolygon: RampAPI.MultiPolygon): esri.Polygon {
+        // esri doesn't support multipolygons. instead all polygons become one polygon that has all the rings in it
+        const ringMerger: Array<Array<Array<number>>> = [];
+
+        // TODO is there a more efficient way to do this than with pushes? use concats?
+        // concat will keep re-copying all known rings with each new polygon encountered, so probably worse
+        rampMultiPolygon.toArray().forEach(poly => {
+            poly.forEach(ring => ringMerger.push(ring));
+        });
+        return this.polygonFactory(ringMerger, rampMultiPolygon.sr);
+    }
+
+    convExtentToEsri(rampExtent: RampAPI.Extent): esri.Extent {
+        return new this.esriBundle.Extent({
+            xmin: rampExtent.xmin,
+            ymin: rampExtent.ymin,
+            xmax: rampExtent.xmax,
+            ymax: rampExtent.ymax,
+            spatialReference: this.convSrToEsri(rampExtent.sr)
+        });
+    }
+
+    // TODO add geojson conversion fun
+
+    convEsriSrToSr(esriSR: esri.SpatialReference): RampAPI.SpatialReference {
+        if (esriSR.wkt) {
+            return new RampAPI.SpatialReference(esriSR.wkt);
+        } else {
+            // TODO lol well looks like esri is now pretending latestWkid doesnt exist.
+            //      so will need to look into what this actually means, and maybe we have to support
+            //      some type of hardcoded mapping of values to stop things from breaking.
+            // TODO run some basic in-browser tests, see what the SR guts of 102100 look like, if it still has latestWkid lurking inside it
+            return new RampAPI.SpatialReference(esriSR.wkid);
+        }
+    }
+
+    convEsriPointToRamp(esriPoint: esri.Point, id?: number | string): RampAPI.Point {
+        return new RampAPI.Point(id, [esriPoint.x, esriPoint.y], this.convEsriSrToSr(esriPoint.spatialReference), true);
+    }
+
+    // this will shoot back a LineString or MultiLineString, depending on the guts
+    convEsriLineToRamp(esriLine: esri.Polyline, id?: number | string): BaseGeometry {
+        const sr: RampAPI.SpatialReference = this.convEsriSrToSr(esriLine.spatialReference);
+        if (esriLine.paths.length === 1) {
+            return new RampAPI.LineString(id, esriLine.paths[0], sr, true);
+        } else {
+            return new RampAPI.MultiLineString(id, esriLine.paths, sr, true);
+        }
+    }
+
+    convEsriPolygonToRamp(esriPoly: esri.Polygon, id?: number | string): RampAPI.Polygon {
+        return new RampAPI.Polygon(id, esriPoly.rings, this.convEsriSrToSr(esriPoly.spatialReference), true);
+    }
+
+    convEsriExtentToRamp(esriExtent: esri.Extent, id?: number | string): RampAPI.Extent {
+        return RampAPI.Extent.fromParams(id, esriExtent.xmin, esriExtent.ymin,
+            esriExtent.xmax, esriExtent.ymin, this.convEsriSrToSr(esriExtent.spatialReference));
+    }
+
+    convEsriMultiPointToRamp(esriMultiPoint: esri.Multipoint, id?: number | string): RampAPI.MultiPoint {
+        return new RampAPI.MultiPoint(id, esriMultiPoint.points, this.convEsriSrToSr(esriMultiPoint.spatialReference), true);
+    }
+}

--- a/packages/ramp-geoapi/src/util/SymbologyService.ts
+++ b/packages/ramp-geoapi/src/util/SymbologyService.ts
@@ -1,9 +1,10 @@
 import esri = __esri;
 import { InfoBundle, LegendSymbology } from '../gapiTypes';
 import BaseBase from '../BaseBase';
-
-import svgjs from 'svg.js';
 import { BaseRenderer, BaseSymbolUnit, SimpleRenderer, ClassBreaksRenderer, UniqueValueRenderer } from './Renderers';
+import { LineStyle } from '../api/apiDefs';
+import svgjs from 'svg.js';
+
 
 // Functions for turning ESRI Renderers into images
 // Specifically, converting ESRI "Simple" symbols into images,
@@ -273,6 +274,7 @@ export default class SymbologyService extends BaseBase {
             .size(this.CONTAINER_SIZE, this.CONTAINER_SIZE)
             .viewbox(0, 0, this.CONTAINER_SIZE, this.CONTAINER_SIZE);
 
+        // TODO use enums here if we can (functions, tricky)
         // functions to draw esri simple marker symbols
         // jscs doesn't like enhanced object notation
         // jscs:disable requireSpacesInAnonymousFunctionExpression
@@ -303,19 +305,20 @@ export default class SymbologyService extends BaseBase {
         // jscs:enable requireSpacesInAnonymousFunctionExpression
 
         // line dash styles
+        // if we need to revist the svg numbers, can see esri 4 styles at https://developers.arcgis.com/javascript/latest/sample-code/playground/live/index.html#/config=symbols/2d/SimpleLineSymbol.json
         const ESRI_DASH_MAPS = {
-            solid: 'none', // esriSLSSolid
-            none: 'none', // esriSLSNull
-            dash: '5.333,4', // esriSLSDash
-            dot: '1.333,4', // esriSLSDot
-            'dash-dot': '5.333,4,1.333,4', // esriSLSDashDot
-            'long-dash': '10.666,4', // esriSLSLongDash
-            'long-dash-dot': '10.666,4,1.333,4', // esriSLSLongDashDot
-            'long-dash-dot-dot': '10.666,4,1.333,4,1.333,4', // esriSLSLongDashDotDot
-            'short-dot': '1.333,1.333', // esriSLSShortDot
-            'short-dash': '5.333,1.333', // esriSLSShortDash
-            'short-dash-dot': '5.333,1.333,1.333,1.333', // esriSLSShortDashDot
-            'short-dash-dot-dot': '5.333,1.333,1.333,1.333,1.333,1.333' // esriSLSShortDashDotDot
+            [LineStyle.SOLID]: 'none', // esriSLSSolid
+            [LineStyle.NONE]: 'none', // esriSLSNull
+            [LineStyle.DASH]: '5.333,4', // esriSLSDash
+            [LineStyle.DOT]: '1.333,4', // esriSLSDot
+            [LineStyle.DASHDOT]: '5.333,4,1.333,4', // esriSLSDashDot
+            [LineStyle.LONGDASH]: '10.666,4', // esriSLSLongDash
+            [LineStyle.LONGDASHDOT]: '10.666,4,1.333,4', // esriSLSLongDashDot
+            [LineStyle.LONGDASHDOTDOT]: '10.666,4,1.333,4,1.333,4', // esriSLSLongDashDotDot
+            [LineStyle.SHORTDOT]: '1.333,1.333', // esriSLSShortDot
+            [LineStyle.SHORTDASH]: '5.333,1.333', // esriSLSShortDash
+            [LineStyle.SHORTDASHDOT]: '5.333,1.333,1.333,1.333', // esriSLSShortDashDot
+            [LineStyle.SHORTDASHDOTDOT]: '5.333,1.333,1.333,1.333,1.333,1.333' // esriSLSShortDashDotDot
         };
 
         // default stroke style

--- a/packages/ramp-geoapi/src/util/UtilModule.ts
+++ b/packages/ramp-geoapi/src/util/UtilModule.ts
@@ -12,6 +12,7 @@ import QueryService from './QueryService';
 import HighlightService from './HighlightService';
 import ProjectionService from './ProjectionService';
 import SymbologyService from './SymbologyService';
+import GeometryService from './GeometryService';
 
 export default class UtilModule extends BaseBase {
 
@@ -21,6 +22,7 @@ export default class UtilModule extends BaseBase {
     highlight: HighlightService;
     proj: ProjectionService;
     symbology: SymbologyService;
+    geom: GeometryService;
 
     constructor (infoBundle: InfoBundle, epsgFunction: EpsgLookup = undefined) {
         super(infoBundle);
@@ -30,6 +32,7 @@ export default class UtilModule extends BaseBase {
         this.highlight = new HighlightService(infoBundle);
         this.proj = new ProjectionService(infoBundle, epsgFunction);
         this.symbology = new SymbologyService(infoBundle);
+        this.geom = new GeometryService(infoBundle);
     }
 
 }


### PR DESCRIPTION
First cut.
The main question will be what is the best way to expose all these classes to the core so they can be added into whatever becomes the main RAMP API (like old `window.RAMP.x` stuff).

Still updating documentation, want to add a few more helper functions and a set of GeoJSON to RAMP Geom converter functions.

Have fun reviewing every file in detail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/47)
<!-- Reviewable:end -->
