### PR TITLE
Zoomies

### DIFF
--- a/packages/ramp-geoapi/src/api/geometry/BaseGeometry.ts
+++ b/packages/ramp-geoapi/src/api/geometry/BaseGeometry.ts
@@ -20,16 +20,7 @@ export default class BaseGeometry {
 
     constructor(id: IdDef, sr?: SrDef) {
         this.id = id.toString();
-
-        // default to lat long if no SR is provided
-        if (!sr) {
-            this.sr = SpatialReference.latLongSR();
-        } else if (sr instanceof SpatialReference) {
-            this.sr = sr.clone();
-        } else {
-            // cheating typescript. this will pass a string wkt or number wkid
-            this.sr = new SpatialReference(<any>sr);
-        }
+        this.sr = SpatialReference.parseSR(sr);
     }
 
     /**

--- a/packages/ramp-geoapi/src/api/geometry/SpatialReference.ts
+++ b/packages/ramp-geoapi/src/api/geometry/SpatialReference.ts
@@ -1,5 +1,7 @@
 // TODO add proper documentation
 
+import { SrDef } from '../apiDefs';
+
 /**
  * Represents a geographical spatial reference.
  */
@@ -37,6 +39,9 @@ export default class SpatialReference {
      * @returns {Boolean} result of the comparison
      */
     isEqual(otherSR: SpatialReference): boolean {
+        // TODO consider improving this logic. might make more sense to do
+        //      some type of cross-matching against wkid and latestWkid.
+        //      e.g. 102100 and 3857 should effectively be considered equal
         return (this.wkid === otherSR.wkid) &&
             (this.wkt === otherSR.wkt) &&
             (this.latestWkid === otherSR.latestWkid);
@@ -76,4 +81,33 @@ export default class SpatialReference {
     static latLongSR(): SpatialReference {
         return new SpatialReference(4326);
     }
+
+    /**
+     * Returns a spatial ref object from a config typed object
+     * @param srObject config spatial reference object
+     * @returns spatial reference object with same settings as input
+     */
+    static fromConfig(srObject: any): SpatialReference {
+        // note using any type on input as this API class wont know about config object interfaces
+        if (srObject.wkt) {
+            return new SpatialReference(<string>srObject.wkt);
+        } else if (srObject.wkid) {
+            return new SpatialReference(srObject.wkid, srObject.latestWkid);
+        } else {
+            throw new Error('Could not parse config spatial reference object');
+        }
+    }
+
+    static parseSR(sr?: SrDef): SpatialReference {
+        if (!sr) {
+             // default to lat long if no SR is provided
+            return SpatialReference.latLongSR();
+        } else if (sr instanceof SpatialReference) {
+            return sr.clone();
+        } else {
+            // cheating typescript. this will pass a string wkt or number wkid
+            return new SpatialReference(<any>sr);
+        }
+    }
+
 }

--- a/packages/ramp-geoapi/src/map/Map.ts
+++ b/packages/ramp-geoapi/src/map/Map.ts
@@ -7,15 +7,22 @@ import { InfoBundle, RampMapConfig } from '../gapiTypes';
 import MapBase from './MapBase';
 import LayerBase from '../layer/BaseLayer';
 import HighlightLayer from '../layer/HighlightLayer';
+import { Extent, Point, SpatialReference } from '../api/api';
+import BaseGeometry from '../api/geometry/BaseGeometry';
+import { GeometryType } from '../api/apiDefs';
 
 export class Map extends MapBase {
 
     // TODO think about how to expose. protected makes sense, but might want to make it public to allow hacking and use by a dev module if we decide to
     innerView: esri.MapView;
 
+    private rampSR: SpatialReference;
+
     constructor (infoBundle: InfoBundle, config: RampMapConfig, targetDiv: string | HTMLDivElement) {
 
         super(infoBundle, config);
+
+        this.rampSR = SpatialReference.fromConfig(config.extent.spatialReference);
 
         const esriViewConfig: esri.MapViewProperties = {
             map: this.innerMap,
@@ -23,7 +30,7 @@ export class Map extends MapBase {
             constraints: {
                 lods: <Array<esri.LOD>>config.lods
             },
-            spatialReference: config.extent.spatialReference, // TODO use utils.geom.convSrToEsriSr?
+            spatialReference: this.gapi.utils.geom.convSrToEsri(this.rampSR),
             extent: config.extent,
 
             // TODO remove these once starting extent is working
@@ -33,9 +40,17 @@ export class Map extends MapBase {
 
         // TODO extract more from config and set appropriate view properties (e.g. intial extent, initial projection, LODs)
         this.innerView = new this.esriBundle.MapView(esriViewConfig);
+
     }
 
-    // TODO implement
+    private geomToMapSR(geom: BaseGeometry): Promise<BaseGeometry> {
+        if (this.rampSR.isEqual(geom.sr)) {
+            return Promise.resolve(geom);
+        } else {
+            return this.gapi.utils.proj.projectGeometry(this.rampSR, geom);
+        }
+    }
+
     // promise resolves when layer gets added to map
     addLayer (layer: LayerBase): Promise<void> {
         return layer.isReadyForMap().then(() => {
@@ -50,6 +65,25 @@ export class Map extends MapBase {
     // TODO passthrough functions, either by aly magic or make them hardcoded
     getScale(): number {
         return this.innerView.scale;
+    }
+
+    zoomMapTo(extent: Extent): Promise<void>;
+    zoomMapTo(centerPoint: Point, mapScale: number): Promise<void>;
+    zoomMapTo(geom: BaseGeometry, scale?: number): Promise<void> {
+        // TODO technically this can accept any geometry. should we open up the suggested signatures to allow various things?
+
+        return this.geomToMapSR(geom).then(g => {
+            const zoomP: any = {
+                target: this.gapi.utils.geom.geomRampToEsri(g)
+            };
+
+            if (g.type === GeometryType.POINT) {
+                zoomP.scale = scale;
+            }
+
+            return this.innerView.goTo(zoomP);
+        });
+
     }
 
     // TODO function to allow a second Map to be shot out, that shares this map but has a different scene


### PR DESCRIPTION
Implements a basic "zoom the map to this area" function on the geoApi's map wrapper. Can take an extent or a point + optional scale. 

No extent warping currently, not sure that even matters that much for this function.

Also added some more plumbing to allow reprojection of RAMP API Geometry objects.

PRing for use in GeoSearch fixture so we can see things in action.

The test code I had temporarily put in `esri-map.vue`

```
// top o file
import { ApiBundle } from 'ramp-geoapi';

// after map got created
this.map.zoomMapTo(new ApiBundle.Point('whitehouse', [-76.77, 44.42]), 30000);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/49)
<!-- Reviewable:end -->
