### PR TITLE
Focus list directive (keyboard navigation/accessibility)

### DIFF
--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -64,7 +64,14 @@
                         }
                     ],
                     fixtures: {
-                        appbar: [{ id: 'gazebo' }, { id: 'divider' }, { id: 'legend' }, { id: 'divider' }]
+                        appbar: [
+                            { id: 'gazebo' },
+                            { id: 'divider' },
+                            { id: 'legend' },
+                            { id: 'gazebo' },
+                            { id: 'legend' },
+                            { id: 'divider' }
+                        ]
                     }
                 });
 

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -11,6 +11,9 @@ import Shell from '@/components/shell.vue';
 
 import ro from '@/scripts/resize-observer.js';
 
+import { FocusList } from '@/directives/focus-list';
+Vue.directive('focus-list', FocusList);
+
 @Component({
     components: {
         Shell

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -29,11 +29,16 @@ export default class App extends Vue {
 </script>
 
 <style lang="scss">
-@import './styles/main.css';
+// APP-WIDE STYLES
+@use 'styles/main';
+@use 'directives/focus-list/focus-list';
+.ramp-app {
+    @include focus-list.default-focused-styling;
+    height: 700px;
+}
 </style>
 
 <style lang="scss" scoped>
 .ramp-app {
-    height: 700px;
 }
 </style>

--- a/packages/ramp-core/src/components/panel-stack/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/dropdown-menu.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <button class="text-gray-500 hover:text-black p-2" @click="open = !open">
+        <button class="text-gray-500 hover:text-black p-8" @click="open = !open">
             <slot name="header"></slot>
         </button>
         <button
@@ -9,7 +9,11 @@
             tabindex="-1"
             class="fixed inset-0 h-full w-full bg-black opacity-0 cursor-default"
         ></button>
-        <div v-if="open" class="rv-dropdown shadow-md border border-gray:200 absolute mt-2 py-2 w-64 bg-white rounded z-10">
+        <div
+            v-if="open"
+            @blur="open = false"
+            class="rv-dropdown shadow-md border border-gray:200 absolute py-8 w-256 bg-white rounded z-10"
+        >
             <slot></slot>
         </div>
     </div>

--- a/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
@@ -1,7 +1,7 @@
 <template>
     <dropdown-menu>
         <template #header>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-5 h-5">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-20 h-20">
                 <path
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                 />

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="shadow-tm bg-white w-350 h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto">
+    <div class="shadow-tm bg-white w-350 h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto" :tabindex="0" v-focus-list>
         <!-- this renders a panel screen which is currently in view -->
         <!-- TODO: add animation transition animation here -->
         <component :is="panelConfig.route.id" v-bind="panelConfig.route.props" :panel="panel"></component>

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="h-full w-full flex flex-col items-stretch">
-        <header class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48" focus-item>
+        <header class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48 default-focus-style" focus-item>
             <h2 class="flex-grow text-lg py-16 pl-8">
                 <slot name="header"></slot>
             </h2>
@@ -8,7 +8,7 @@
             <slot name="controls"></slot>
         </header>
 
-        <div class="p-8 flex-grow" focus-item>
+        <div class="p-8 flex-grow default-focus-style" focus-item>
             <slot name="content"></slot>
         </div>
     </div>
@@ -22,8 +22,4 @@ import { Get, Sync, Call } from 'vuex-pathify';
 export default class PanelScreenV extends Vue {}
 </script>
 
-<style lang="scss" scoped>
-.focused {
-    @apply border border-black #{!important};
-}
-</style>
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -1,6 +1,6 @@
 <template>
-    <div>
-        <header class="flex items-center border-b border-solid border-gray-600 px-8 h-48">
+    <div class="h-full w-full flex flex-col items-stretch">
+        <header class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48" focus-item>
             <h2 class="flex-grow text-lg py-16 pl-8">
                 <slot name="header"></slot>
             </h2>
@@ -8,7 +8,7 @@
             <slot name="controls"></slot>
         </header>
 
-        <div class="m-8">
+        <div class="p-8 flex-grow" focus-item>
             <slot name="content"></slot>
         </div>
     </div>
@@ -22,4 +22,8 @@ import { Get, Sync, Call } from 'vuex-pathify';
 export default class PanelScreenV extends Vue {}
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.focused {
+    @apply border border-black #{!important};
+}
+</style>

--- a/packages/ramp-core/src/directives/focus-list/focus-list.scss
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.scss
@@ -1,0 +1,28 @@
+$focus-outline-width: 2px;
+
+@mixin blue-outline {
+    outline: $focus-outline-width rgba(5, 141, 232, 0.8) solid;
+    outline-offset: -$focus-outline-width;
+}
+
+@mixin grey-outline {
+    outline: $focus-outline-width rgba(150, 150, 150, 0.8) solid;
+    outline-offset: -$focus-outline-width;
+}
+
+@mixin default-focused-styling {
+    [focus-list] {
+        &[aria-activedescendant] {
+            outline: 0 !important;
+        }
+        [focus-item].focused.default-focus-style {
+            @include grey-outline;
+        }
+        &:focus {
+            @include blue-outline;
+            [focus-item].focused.default-focus-style {
+                @include blue-outline;
+            }
+        }
+    }
+}

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -18,6 +18,8 @@ const FOCUSED_CLASS = 'focused';
 const FOCUSED_ID = 'focusedItem';
 const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}]`;
 
+// TODO: Figure out a way to put the control scheme into the description of the focus-list for screen readers (hidden text?), or see if the help file would be sufficient.
+
 /**
  * The FocusList Directive
  *
@@ -27,7 +29,7 @@ const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_
  * **Example**:
  *
  * ```
- * <div v-focus-list="horizontal">
+ * <div v-focus-list="'horizontal'">
  *     <button focus-item></button>
  *     <button focus-item></button>
  *     <button focus-item></button>
@@ -112,6 +114,9 @@ class FocusListManager {
         });
         element.addEventListener('click', function(event: MouseEvent) {
             focusManager.onClick(event);
+        });
+        element.addEventListener('focus', function(event: FocusEvent) {
+            focusManager.onFocus();
         });
     }
 
@@ -205,6 +210,8 @@ class FocusListManager {
                 this.highlightedItem = listOfItems[index + 1] || listOfItems[0];
             }
         }
+        // moves focus from any sub-items
+        this.element.focus();
         this.focusItem(this.highlightedItem);
     }
 
@@ -319,5 +326,20 @@ class FocusListManager {
         } else {
             this.element.removeAttribute('aria-activedescendant');
         }
+    }
+
+    /**
+     * Callback for the focus event listener on the focus list element.
+     * NOTE: this is only called when the LIST ELEMENT is focused, not any descendant
+     *
+     * This is used to pull back the `focusedItem` id and the aria-activedescendant attribute when a list is focused
+     */
+    onFocus() {
+        // if the element already has the attribute, or the highlighted element is the list there is nothing to do
+        if (this.element.hasAttribute('aria-activedescendant') || this.highlightedItem === this.element) {
+            return;
+        }
+        // otherwise set the active descendant
+        this.setAriaActiveDescendant(this.highlightedItem);
     }
 }

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -1,0 +1,313 @@
+enum KEYS {
+    ArrowDown = 'ArrowDown',
+    ArrowDownIE = 'Down',
+    ArrowLeft = 'ArrowLeft',
+    ArrowLeftIE = 'Left',
+    ArrowUp = 'ArrowUp',
+    ArrowUpIE = 'Up',
+    ArrowRight = 'ArrowRight',
+    ArrowRightIE = 'Right',
+    Escape = 'Escape',
+    EscapeIE = 'Esc',
+    Enter = 'Enter'
+}
+
+const LIST_ATTR = 'focus-list';
+const ITEM_ATTR = 'focus-item';
+const FOCUSED_CLASS = 'focused';
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}]`;
+
+/**
+ * The FocusList Directive
+ *
+ * To use; add `v-focus-list` to your main element and `focus-item` to sub-items you want to be selectable
+ * The directive will assume your list is vertical. To force it to be horizontal set the attribute to have a value of 'horizontal'.
+ *
+ * **Example**:
+ *
+ * ```
+ * <div v-focus-list="horizontal">
+ *     <button focus-item></button>
+ *     <button focus-item></button>
+ *     <button focus-item></button>
+ * </div>
+ * ```
+ */
+export const FocusList = {
+    bind(el: HTMLElement, binding: any /*, vnode: any */) {
+        // make it tabbable if it isn't
+        // NOTE: +<string> = the string as a number, +<null> = 0
+        if (+el.getAttribute('tabindex')! <= 0) {
+            el.setAttribute('tabindex', '0');
+        }
+        // add the focus list attribute since the directive attribute will only stick around if its bound (i.e. :v-focus-list=...)
+        el.toggleAttribute(LIST_ATTR, true);
+        // create a focus list manager for this element ONLY on the first time its focused
+        // this helps prevent any weird DOM race condition where tabindex is being changed
+        // before the element is on screen and populated, etc. etc.
+        new FocusListManager(el, binding.value);
+    },
+    componentUpdated(el: HTMLElement) {
+        syncTabIndex(el);
+    }
+};
+
+/**
+ * Makes sure every "tabbable" element under `element` has the correct tab index. Used when the focus list element is updated.
+ *
+ * @param {Element} element the element containing the tabbable items
+ */
+function syncTabIndex(element: HTMLElement) {
+    let tabbable = element.querySelectorAll(TABBABLE_TAGS);
+    //const tempFocusManager = this;
+    tabbable.forEach((el: Element) => {
+        // make sure its not part of a sub-list
+        if (
+            el.closest(`[${LIST_ATTR}]`) === element ||
+            (el.closest(`[${LIST_ATTR}]`) === el && el.parentElement!.closest(`[${LIST_ATTR}]`) === element)
+        ) {
+            // if this element is under a `focused` element in this class list then we dont want to set tabindex to -1
+            // this checks if an ancestor with the class `focused` comes before an ancestor that is a `focus-list`
+            // ELSE if it is under a `focused` element, set it to 0 in case it was just added to the list
+            if (!el.closest(`[${LIST_ATTR}],.${FOCUSED_CLASS}`)!.classList.contains(FOCUSED_CLASS)) {
+                el.setAttribute('tabindex', '-1');
+                return;
+            } else {
+                el.setAttribute('tabindex', '0');
+            }
+        }
+    });
+}
+
+/**
+ * The FocusListManager class
+ *
+ * Each instance of this class is tied to an element. These are created in the bind function for the `FocusList` directive.
+ * This class manages the focus within the element, mainly moving between `focus-item`s with arrow keys.
+ */
+class FocusListManager {
+    element: HTMLElement;
+    highlightedItem: HTMLElement;
+    isHorizontal: boolean;
+
+    /**
+     * Creates an instance of FocusListManager
+     *
+     * @param {HTMLElement} element The focus list's element
+     * @param {string} attributeValue The value of the `v-focus-list` attribute which tells the focus list manager the orientation of the list. 'horizontal' means the list should be traversed horizontally, and other value will make the list vertical (including no value).
+     */
+    constructor(element: HTMLElement, attributeValue: string) {
+        this.element = element;
+        this.highlightedItem = this.element;
+
+        this.isHorizontal = attributeValue === 'horizontal';
+
+        // remove the ability to tab to sub-items
+        this.setTabIndex(-1);
+
+        const focusManager = this;
+        element.addEventListener('keydown', function(event: KeyboardEvent) {
+            focusManager.onKeydown(event);
+        });
+        element.addEventListener('click', function(event: MouseEvent) {
+            focusManager.onClick(event);
+        });
+    }
+
+    /**
+     * Tries to figure out if the list is horizontal or vertical
+     * This function doesn't worry too much about "edge cases" for list layouts as list orientation can be specified
+     *
+     * @returns `true` iff list is thought to be horizontal
+     */
+    /* private guessHorizontal() {
+        const tempFocusManager = this;
+        const items: HTMLElement[] = Array.prototype.filter.call(this.element.querySelectorAll(`[${ITEM_ATTR}]`), (el: Element) => {
+            return el.closest(`[${LIST_ATTR}]`) === tempFocusManager.element;
+        });
+        for (let i = 1; i < items.length; i++) {
+            const currPosition = items[i].getBoundingClientRect();
+            const prevPosition = items[i - 1].getBoundingClientRect();
+            // if the items overlap in y axis and are item 2 is completely to the right of item 1, assume horizontal
+            if (currPosition.top < prevPosition.bottom && currPosition.left >= prevPosition.right) {
+                return true;
+            }
+        }
+        return false;
+    } */
+
+    /**
+     * Sets `tabindex` to `value` for every tabbable thing under `focusItem` (or the list if not specified)
+     *
+     * @param {Number} value the value to give `tabindex` on each tabbable item
+     * @param {Element} focusItem the element containing the tabbable items, defaults to the focus list
+     */
+    setTabIndex(value: number, focusItem: Element = this.element) {
+        let tabbable = focusItem.querySelectorAll(TABBABLE_TAGS);
+        //const tempFocusManager = this;
+        tabbable.forEach((el: Element) => {
+            // make sure its not part of a sub-list
+            if (
+                el.closest(`[${LIST_ATTR}]`) === this.element ||
+                (el.closest(`[${LIST_ATTR}]`) === el && el.parentElement!.closest(`[${LIST_ATTR}]`) === this.element)
+            ) {
+                el.setAttribute('tabindex', value.toString());
+            }
+        });
+    }
+
+    /**
+     * Removes 'focused' to the class list of `item` then updates the tabIndex on subitems (setting them to -1).
+     *
+     * @param {Element} item The element to defocus
+     */
+    defocusItem(item: Element) {
+        item.classList.remove(FOCUSED_CLASS);
+        //this.element.focus();
+        this.setTabIndex(-1, item);
+    }
+
+    /**
+     * Adds 'focused' to the class list of `item` then updates the tabIndex on subitems (setting them to 0).
+     *
+     * @param {Element} item The element to focus
+     */
+    focusItem(item: Element) {
+        item.classList.add(FOCUSED_CLASS);
+        this.setTabIndex(0, item);
+    }
+
+    /**
+     * Moves the highlight through the `listOfItems` forward (or backward) 1 spot
+     *
+     * @param {HTMLElement[]}listOfItems The list of items being moved through
+     * @param {boolean} reverse true iff the highlight should move back one spot
+     */
+    shiftHighlight(listOfItems: HTMLElement[], reverse: boolean = false) {
+        this.defocusItem(this.highlightedItem);
+        if (reverse) {
+            // if the main element is highlighted, move it to the last sub-item
+            // otherwise move the highlight "back" one item (wrapping if needed)
+            if (this.highlightedItem === this.element) {
+                this.highlightedItem = listOfItems[listOfItems.length - 1];
+            } else {
+                let index = Array.prototype.indexOf.call(listOfItems, this.highlightedItem);
+                this.highlightedItem = listOfItems[index - 1] || listOfItems[listOfItems.length - 1];
+            }
+        } else {
+            // if the main element is highlighted, move it to the first sub-item
+            // otherwise move the highlight "forward" one item (wrapping if needed)
+            if (this.highlightedItem === this.element) {
+                this.highlightedItem = listOfItems[0];
+            } else {
+                let index = Array.prototype.indexOf.call(listOfItems, this.highlightedItem);
+                this.highlightedItem = listOfItems[index + 1] || listOfItems[0];
+            }
+        }
+        this.focusItem(this.highlightedItem);
+    }
+
+    /**
+     * Callback for the keydown event listener on the focus list element
+     *
+     * @param {KeyboardEvent} event keydown event
+     */
+    onKeydown(event: KeyboardEvent) {
+        const tempFocusManager = this;
+        const listOfItems: HTMLElement[] = Array.prototype.filter.call(this.element.querySelectorAll(`[${ITEM_ATTR}]`), (el: Element) => {
+            return el.closest(`[${LIST_ATTR}]`) === tempFocusManager.element;
+        });
+
+        if (listOfItems.length === 0) {
+            return;
+        }
+
+        switch (event.key) {
+            case KEYS.ArrowUpIE:
+            case KEYS.ArrowUp:
+                if (this.isHorizontal) {
+                    break;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                // shift highlight ⬆ (backwards)
+                this.shiftHighlight(listOfItems, true);
+                break;
+            case KEYS.ArrowDownIE:
+            case KEYS.ArrowDown:
+                if (this.isHorizontal) {
+                    break;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                // shift highlight ⬇
+                this.shiftHighlight(listOfItems);
+                break;
+            case KEYS.ArrowLeftIE:
+            case KEYS.ArrowLeft:
+                if (!this.isHorizontal) {
+                    break;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                // shift highlight ⬅ (backwards)
+                this.shiftHighlight(listOfItems, true);
+                break;
+            case KEYS.ArrowRightIE:
+            case KEYS.ArrowRight:
+                if (!this.isHorizontal) {
+                    break;
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                // shift highlight ➡
+                this.shiftHighlight(listOfItems);
+                break;
+            case KEYS.EscapeIE:
+            case KEYS.Escape:
+                // we only care about escape presses if the highlighted item isnt the list
+                if (this.highlightedItem !== this.element) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    // defocus current item, move focus to the list
+                    this.defocusItem(this.highlightedItem);
+                    this.highlightedItem = this.element;
+                    this.element.focus();
+                }
+                break;
+            case KEYS.Enter:
+                // if the the list is the target then it has focus, meaning the user is traversing this list
+                // and not a list farther down the tree (or a tabbable button, etc.)
+                // however if the list is the highlighted item we let the default behaviour through (as it has regular focus)
+                if ((event.target as HTMLElement) === this.element && this.highlightedItem !== this.element) {
+                    // dont click on the list
+                    event.preventDefault();
+                    event.stopPropagation();
+                    // click on the highlighted focus-item
+                    this.highlightedItem.click();
+                }
+        }
+    }
+
+    /**
+     * Callback for the click event listener on the focus list element
+     *
+     * @param {MouseEvent} event click event
+     */
+    onClick(event: MouseEvent) {
+        event.stopPropagation();
+        this.defocusItem(this.highlightedItem);
+
+        const targetElement = event.target as HTMLElement;
+        this.highlightedItem = (targetElement.closest(`[${ITEM_ATTR}],[${LIST_ATTR}]`) as HTMLElement) || this.highlightedItem;
+
+        // if target element is a focus item then focus the list
+        if (targetElement.hasAttribute(`${ITEM_ATTR}`)) {
+            this.element.focus();
+        }
+
+        if (this.highlightedItem !== this.element) {
+            this.focusItem(this.highlightedItem);
+        }
+    }
+}

--- a/packages/ramp-core/src/directives/focus-list/index.ts
+++ b/packages/ramp-core/src/directives/focus-list/index.ts
@@ -1,0 +1,1 @@
+export * from './focus-list';

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -1,6 +1,13 @@
 <template>
-    <div class="absolute top-0 left-0 flex flex-col items-center bg-black opacity-75 h-full w-40 md:w-64 pointer-events-auto">
-        <component v-for="(item, index) in items" :is="item.id" :key="`${item.id}-${index}`" class="h-16 mt-8 mb-8 first:mt-16"></component>
+    <div class="absolute top-0 left-0 flex flex-col items-stretch bg-black-75 h-full w-40 md:w-64 pointer-events-auto" v-focus-list>
+        <component
+            v-for="(item, index) in items"
+            :is="item.id"
+            :key="`${item.id}-${index}`"
+            class="h-24 my-4 first:mt-8 text-gray-400 hover:text-white"
+            :class="{ 'py-12': item.id !== DIVIDER }"
+            :focus-item="item.id !== DIVIDER"
+        ></component>
     </div>
 </template>
 
@@ -10,14 +17,23 @@ import { Get, Sync, Call } from 'vuex-pathify';
 import { AppbarItemConfig } from './store';
 import DividerV from './divider.vue';
 
-Vue.component('divider', DividerV);
+const DIVIDER_ID = 'divider';
+
+Vue.component(DIVIDER_ID, DividerV);
 
 @Component
 export default class AppbarV extends Vue {
+    // to use in the template
+    DIVIDER = DIVIDER_ID;
+
     get items() {
         return this.$iApi.$vApp.$store.get('appbar/items');
     }
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.focused {
+    @apply bg-blue-900 text-white;
+}
+</style>

--- a/packages/ramp-core/src/fixtures/appbar/divider.vue
+++ b/packages/ramp-core/src/fixtures/appbar/divider.vue
@@ -1,5 +1,5 @@
 <template>
-    <span class="border-b pl-24 md:pl-48"></span>
+    <span class="border-b p-0 self-center w-2/3"></span>
 </template>
 
 <script lang="ts">

--- a/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
@@ -1,5 +1,5 @@
 <template>
-    <button class="text-green-600 hover:text-green-200 p-6" @click="togglePanel()">
+    <button class="py-6" @click="togglePanel()">
         G
     </button>
 </template>

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
@@ -5,13 +5,15 @@
         </template>
 
         <template #controls>
-            <!-- this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes -->
-            <panel-options-menu>
-                <a href="#">Option 1</a>
-                <a href="#">Option 2</a>
-                <a href="#">Option 3</a>
-            </panel-options-menu>
-            <pin :active="pinned && pinned.id === 'p1'" @click="pinPanel"></pin>
+            <div v-focus-list class="flex">
+                <!-- this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes -->
+                <panel-options-menu focus-item>
+                    <a href="#">Option 1</a>
+                    <a href="#">Option 2</a>
+                    <a href="#">Option 3</a>
+                </panel-options-menu>
+                <pin :active="pinned && pinned.id === 'p1'" @click="pinPanel" focus-item></pin>
+            </div>
         </template>
 
         <template #content>

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
@@ -5,14 +5,14 @@
         </template>
 
         <template #controls>
-            <div v-focus-list class="flex">
+            <div class="flex">
                 <!-- this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes -->
-                <panel-options-menu focus-item>
+                <panel-options-menu>
                     <a href="#">Option 1</a>
                     <a href="#">Option 2</a>
                     <a href="#">Option 3</a>
                 </panel-options-menu>
-                <pin :active="pinned && pinned.id === 'p1'" @click="pinPanel" focus-item></pin>
+                <pin :active="pinned && pinned.id === 'p1'" @click="pinPanel"></pin>
             </div>
         </template>
 

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
@@ -16,9 +16,9 @@
                 :selectedProvince="queryParams.province"
                 :selectedType="queryParams.type"
             ></geosearch-top-filters>
-            <ul class="rv-results-list">
+            <ul class="rv-results-list" v-focus-list>
                 <li class="relative h-48" v-for="(result, idx) in searchResults" v-bind:key="idx">
-                    <button class="absolute inset-0 h-full w-full hover:bg-gray-300" @click="zoomIn(result)">
+                    <button class="absolute inset-0 h-full w-full hover:bg-gray-300 default-focus-style" @click="zoomIn(result)" focus-item>
                         <div class="rv-result-description flex px-32">
                             <div class="flex-1 text-left truncate">
                                 <span>{{ result.name }},</span>

--- a/packages/ramp-core/src/fixtures/legend/legend-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend-appbar-button.vue
@@ -1,7 +1,7 @@
 <template>
-    <button class="text-gray-400 hover:text-white hover: p-6" @click="onClick()">
+    <button @click="onClick()">
         <!-- https://material.io/resources/icons/?icon=layers&style=baseline -->
-        <svg class="fill-current w-24 h-24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <svg class="fill-current w-24 h-24 ml-8 md:ml-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path d="M0 0h24v24H0z" fill="none" />
             <path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z" />
         </svg>

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -13,10 +13,15 @@ module.exports = {
         screens: {
             // sm: '640px'
         },
-        boxShadow: {
-            tm: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 3px 0 rgba(0, 0, 0, 0.1)'
-        },
-        spacing: spacingConfig
+        spacing: spacingConfig,
+        extend: {
+            colors: {
+                'black-75': 'rgba(0, 0, 0, 0.75)'
+            },
+            boxShadow: {
+                tm: '0 0 0 1px rgba(0, 0, 0, 0.05), 0 2px 3px 0 rgba(0, 0, 0, 0.1)'
+            }
+        }
     },
     variants: {
         // https://tailwindcss.com/docs/pseudo-class-variants


### PR DESCRIPTION
This is a Vue directive for focus-lists based on https://jsfiddle.net/ouroborosDragon/dae1h5nb/ and http://fgpv-vpgf.github.io/fgpv-vpgf/v3.2.0/#/developer/accessibility_guidelines

Usage:

`v-focus-list` goes on the list element
`focus-item` goes on each item in the list
If you want the "default" styling for `focus-item`s you add the class `default-focus-styling` to the item elements

The directive will assume lists are vertical. To force it to be horizontal set the attribute to have a value of `'horizontal'`.

 **Example**:
 
 ```
 <div v-focus-list="'horizontal'">
     <button focus-item></button>
     <button focus-item></button>
     <button focus-item></button>
 </div>
```

The directive also manages `aria-activedescendant` on the lists, to help screen readers know which list item has the fake focus.

It also handles setting fake focus on clicks, lists within lists, clicking/tabbing through sub-items...

Actual documentation coming soon (not just comments/function headers) along with better appbar docs to be put in the docs folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/50)
<!-- Reviewable:end -->
