### PR TITLE
Geosearch Part 2

### DIFF
--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -36,6 +36,8 @@ export default class EsriMap extends Vue {
             return;
         }
         this.map = (window as any).RAMP.geoapi.maps.createMap(this.mapConfig, this.$el as HTMLDivElement);
+        // FIXME: temporarily store map in global, remove line below when map API is complete
+        this.$iApi.map = this.map;
         this.onLayerArrayChange(this.layers, []);
     }
 }

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-bar.vue
@@ -4,8 +4,8 @@
             type="search"
             class="form-input flex-grow border-b border-gray-600 mx-8 h-8"
             placeholder="Search text"
-            v-model="mutableSearchTerm"
-            v-on:change="onSearchTermChange(mutableSearchTerm)"
+            :value="searchVal"
+            @change="setSearchTerm($event.target.value)"
         />
 
         <!-- <button class="text-gray-500 cursor-default" disabled>
@@ -29,20 +29,11 @@ import { GeosearchStore } from './store';
 
 @Component({})
 export default class GeosearchBar extends Vue {
-    @Prop() searchTerm!: string;
-    mutableSearchTerm!: string;
+    // fetch geosearch search value from store
+    @Get(GeosearchStore.searchVal) searchVal!: string;
 
+    // import required geosearch actions
     @Call(GeosearchStore.setSearchTerm) setSearchTerm!: (searchTerm: string) => any;
-
-    data() {
-        return {
-            mutableSearchTerm: this.searchTerm
-        };
-    }
-
-    onSearchTermChange(searchTerm: string) {
-        this.setSearchTerm(searchTerm);
-    }
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
@@ -2,12 +2,7 @@
     <div class="rv-geosearch-bottom-filters">
         <label class="inline-flex">
             <div class="bg-white shadow">
-                <input
-                    type="checkbox"
-                    class="form-checkbox border-2 mx-8 border-gray-600"
-                    v-model="mutableVisibleOnly"
-                    v-on:change="updateExtentFilters"
-                />
+                <input type="checkbox" class="form-checkbox border-2 mx-8 border-gray-600" :value="resultsVisible" @change="updateExtentFilters" />
                 <span class="ml-4">Visible on map</span>
             </div>
         </label>
@@ -16,18 +11,13 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+import { GeosearchStore } from './store';
 
 @Component({})
 export default class GeosearchBottomFilters extends Vue {
-    @Prop() visibleOnly!: boolean;
-
-    mutableVisibleOnly!: boolean;
-
-    data() {
-        return {
-            mutableVisibleOnly: this.visibleOnly
-        };
-    }
+    @Get(GeosearchStore.resultsVisible) resultsVisible!: any;
 
     updateExtentFilters(): void {
         // TODO: implement + call geosearch store action

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-top-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-top-filters.vue
@@ -3,8 +3,8 @@
         <div class="inline-block w-128 h-40 mx-12">
             <select
                 class="form-select border-b border-b-gray-600 w-80 h-auto py-0"
-                v-model="mutableSelectedProvince"
-                v-on:change="setNewProvince(mutableSelectedProvince)"
+                :value="queryParams.province"
+                v-on:change="setProvince($event.target.value)"
             >
                 <option value="" disabled hidden>Province</option>
                 <option v-for="province in provinces" v-bind:key="province.code">
@@ -15,8 +15,8 @@
         <div class="inline-block w-96 h-40 mx-12">
             <select
                 class="form-select border-b border-b-gray-600 w-48 h-auto py-0"
-                v-model="mutableSelectedType"
-                v-on:change="setNewType(mutableSelectedType)"
+                :value="queryParams.type"
+                v-on:change="setType($event.target.value)"
             >
                 <option value="" disabled hidden>Type</option>
                 <option v-for="type in types" v-bind:key="type.code">
@@ -26,7 +26,7 @@
         </div>
         <button
             class="inline-block text-gray-500 hover:text-black float-right"
-            :disabled="!mutableSelectedType && !mutableSelectedProvince"
+            :disabled="!queryParams.type && !queryParams.province"
             v-on:click="clearFilters"
         >
             <div class="rv-geosearch-icon">
@@ -54,35 +54,17 @@ import { ConfigStore } from '@/store/modules/config';
 
 @Component({})
 export default class GeosearchTopFilters extends Vue {
-    @Prop() provinces!: Array<any>;
-    @Prop() types!: Array<any>;
-    @Prop() selectedProvince!: string;
-    @Prop() selectedType!: string;
+    // fetch defined province/type filters + filter params from store
+    @Get(GeosearchStore.getProvinces) provinces!: Array<any>;
+    @Get(GeosearchStore.getTypes) types!: Array<any>;
+    @Get(GeosearchStore.queryParams) queryParams!: any;
 
+    // import required geosearch store actions
     @Call(GeosearchStore.setProvince) setProvince!: (prov: any) => any;
     @Call(GeosearchStore.setType) setType!: (type: any) => any;
 
-    mutableSelectedProvince!: string;
-    mutableSelectedType!: string;
-
-    data() {
-        return {
-            mutableSelectedProvince: this.selectedProvince,
-            mutableSelectedType: this.selectedType
-        };
-    }
-
-    setNewProvince(province: string): void {
-        this.setProvince(province);
-    }
-
-    setNewType(type: string): void {
-        this.setType(type);
-    }
-
+    // clear filters by setting filters to undefined
     clearFilters(): void {
-        this.mutableSelectedProvince = '';
-        this.mutableSelectedType = '';
         this.setProvince(undefined);
         this.setType(undefined);
     }

--- a/packages/ramp-core/src/fixtures/geosearch/store/definitions.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/definitions.ts
@@ -2,6 +2,29 @@ export interface GenericObjectType {
     [key: string]: string;
 }
 
+// config object is used by all query classes
+export interface MainConfig {
+    geoNameUrl: string;
+    geoLocateUrl: string;
+    categories: string[];
+    sortOrder: string[];
+    maxResults: number;
+    officialOnly: boolean;
+    language: string;
+    types: Types;
+    provinces: Provinces;
+}
+
+export interface NameResponse {
+    name: string;
+    location: string;
+    province: { code: string };
+    concise: { code: string };
+    latitude: number;
+    longitude: number;
+    bbox: number[];
+}
+
 export interface Types {
     allTypes: GenericObjectType;
     validTypes: GenericObjectType;
@@ -11,3 +34,24 @@ export interface Types {
 export interface Provinces {
     list: GenericObjectType;
 }
+
+export interface LatLon {
+    lat: number;
+    lon: number;
+}
+
+export interface RawNameResult {
+    items: NameResponse[];
+}
+
+// defines results from a geoNames search
+export interface NameResult {
+    name: string;
+    location: string;
+    province: string; // "Ontario"
+    type: string; // "Lake"
+    LatLon: LatLon;
+    bbox: number[];
+}
+
+export type NameResultList = NameResult[];

--- a/packages/ramp-core/src/fixtures/geosearch/store/geosearch-state.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/geosearch-state.ts
@@ -7,6 +7,8 @@ export class GeosearchState {
     lastSearchVal: string;
     searchResults: Array<any>;
     savedResults: Array<any>;
+    resultsVisible: boolean;
+    loadingResults: boolean;
 
     constructor() {
         // initialize geosearch feature service that contains all key geosearch functionality - running queries, fetch initial filters, update filters, etc.
@@ -16,57 +18,15 @@ export class GeosearchState {
         let queryParams: QueryParams = {
             type: '',
             province: '',
-            extent: '',
-            resultsVisible: false
+            extent: ''
         };
         this.queryParams = queryParams;
+        this.resultsVisible = false;
         this.searchVal = '';
         this.lastSearchVal = '';
-        const tempResults = [
-            // hardcoded search results until geosearch feature query function is implemented
-            {
-                name: 'Jasper National Park of Canada',
-                province: 'AB',
-                type: 'Conservation Area'
-            },
-            {
-                name: 'Jaspers Pond',
-                province: 'NL',
-                type: 'Lake'
-            },
-            {
-                name: 'Duncan Woods Creek',
-                province: 'ON',
-                type: 'River'
-            },
-            {
-                name: 'German Mills Creek',
-                province: 'ON',
-                type: 'River'
-            },
-            {
-                name: 'Westmount',
-                province: 'ON',
-                type: 'Unincorporated place'
-            },
-            {
-                name: 'Rainbow Lake',
-                province: 'AB',
-                type: 'Town'
-            },
-            {
-                name: 'Cold Lake',
-                province: 'SK',
-                type: 'City'
-            },
-            {
-                name: 'Good Friday Gulf',
-                province: 'NU',
-                type: 'Bay'
-            }
-        ];
-        this.searchResults = tempResults;
-        this.savedResults = tempResults;
+        this.searchResults = [];
+        this.savedResults = [];
+        this.loadingResults = false;
     }
 }
 
@@ -74,5 +34,4 @@ interface QueryParams {
     type: string;
     province: string;
     extent: string;
-    resultsVisible: boolean;
 }

--- a/packages/ramp-core/src/fixtures/geosearch/store/geosearch.feature.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/geosearch.feature.ts
@@ -3,7 +3,7 @@
  * @description A feature that provides geo location search
  */
 
-import { GeoSearch } from './geosearch';
+import { GeoSearchObj } from './geosearchObj';
 
 const CODE_TO_ABBR = {
     10: 'NL',
@@ -31,7 +31,6 @@ const CODE_TO_ABBR = {
  * {
  *      excludeTypes: string | Array<string>,
  *      language: string,
- *      settings: Object,
  *      geoLocateUrl: string,
  *      geoNameUrl: string
  * }
@@ -39,12 +38,11 @@ const CODE_TO_ABBR = {
 export class GeoSearchUI {
     constructor(config = {}) {
         // initialize geosearch object and default config properties if not provided
-        (<any>this)._geoSearchObj = new GeoSearch(config);
+        (<any>this)._geoSearchObj = new GeoSearchObj(config);
         (<any>this)._lang = (<any>config).language || 'en';
         (<any>this)._provinceList = [];
         (<any>this)._typeList = [];
         (<any>this)._excludedTypes = (<any>config).excludeTypes || [];
-        (<any>this)._settings = (<any>config).settings || {};
     }
 
     get lang() {
@@ -55,9 +53,6 @@ export class GeoSearchUI {
     }
     get typeList() {
         return (<any>this)._typeList;
-    }
-    get settings() {
-        return (<any>this)._settings;
     }
 
     set provinceList(val) {
@@ -86,8 +81,22 @@ export class GeoSearchUI {
      * @return {Promise}
      */
     query(q: string) {
-        // TODO: return empty promise for now
-        return Promise.resolve();
+        return (<any>this)._geoSearchObj.query(q.toUpperCase()).onComplete.then((q: any) => {
+            let featureResult: any[] = [];
+            let queryResult = q.results.map((item: any) => ({
+                name: item.name,
+                bbox: item.bbox,
+                type: item.type,
+                position: [item.LatLon.lon, item.LatLon.lat],
+                location: {
+                    city: item.location,
+                    latitude: item.LatLon.lat,
+                    longitude: item.LatLon.lon,
+                    province: this.findProvinceObj(item.province)
+                }
+            }));
+            return featureResult.concat(queryResult);
+        });
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/geosearch/store/geosearchObj.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/geosearchObj.ts
@@ -1,10 +1,11 @@
 import Provinces from './provinces';
 import Types from './types';
+import * as Q from './query';
 
 const GEO_LOCATE_URL = 'https://geogratis.gc.ca/services/geolocation/@{language}/locate';
 const GEO_NAMES_URL = 'https://geogratis.gc.ca/services/geoname/@{language}/geonames.json';
 
-export class GeoSearch {
+export class GeoSearchObj {
     config: any;
 
     constructor(uConfig?: any) {
@@ -16,17 +17,27 @@ export class GeoSearch {
         geoLocateUrl = geoLocateUrl.replace('@{language}', language);
         geoNameUrl = geoNameUrl.replace('@{language}', language);
 
+        // set default values to be used in query.ts if needed
+        const categories = uConfig.settings ? uConfig.settings.categories : [];
+        const sortOrder = uConfig.settings ? uConfig.settings.sortOrder : [];
+        const maxResults = uConfig.settings ? uConfig.settings.maxResults : 100;
+        const officialOnly = uConfig.settings ? uConfig.settings.officialOnly : false;
+
         this.config = {
             language,
-            types: Types(language),
-            provinces: Provinces(language),
+            types: Types(language), // list of type filter options
+            provinces: Provinces(language), // list of province filter options
+            categories,
+            sortOrder,
+            maxResults,
+            officialOnly,
             geoNameUrl,
             geoLocateUrl
         };
     }
 
-    query(query: string): void {
-        // TODO: implementation
+    query(query: string): Q.Query {
+        return Q.make(this.config, query);
     }
 }
 

--- a/packages/ramp-core/src/fixtures/geosearch/store/query.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/query.ts
@@ -1,0 +1,73 @@
+import * as defs from './definitions';
+
+export function make(config: defs.MainConfig, query: string): Query {
+    // name based search
+    const q = new Query(config, query);
+    q.onComplete = q.search().then(results => {
+        q.results = results;
+        return q;
+    });
+    return q;
+}
+
+// TODO: only keyword search currently, need support for lat/long, FSA, NTS search
+export class Query {
+    config: defs.MainConfig;
+    query: string | undefined;
+    results: defs.NameResultList = [];
+    onComplete: any;
+
+    constructor(config: defs.MainConfig, query?: string) {
+        this.query = query;
+        this.config = config;
+    }
+
+    search(): Promise<defs.NameResultList> {
+        return (<Promise<defs.RawNameResult>>this.jsonRequest(this.getUrl())).then(r => this.normalizeNameItems(r.items));
+    }
+
+    private getUrl(): string {
+        let url = `${this.config.geoNameUrl}?q=${this.query}&num=${this.config.maxResults}`;
+        // add custom filtering params
+        if (this.config.categories.length > 0) {
+            url += `&concise=${this.config.categories.join(',')}`;
+        }
+        if (this.config.officialOnly) {
+            url += '&category=O';
+        }
+        return url;
+    }
+
+    normalizeNameItems(items: defs.NameResponse[]): defs.NameResultList {
+        return items
+            .filter(i => this.config.types.validTypes[i.concise.code])
+            .map(i => {
+                return {
+                    name: i.name,
+                    location: i.location,
+                    province: this.config.provinces.list[i.province.code],
+                    type: this.config.types.allTypes[i.concise.code],
+                    LatLon: { lat: i.latitude, lon: i.longitude },
+                    bbox: i.bbox
+                };
+            });
+    }
+
+    jsonRequest(url: string) {
+        return new Promise((resolve, reject) => {
+            const xobj = new XMLHttpRequest();
+            xobj.open('GET', url, true);
+            xobj.responseType = 'json';
+            xobj.onload = () => {
+                if (xobj.status === 200) {
+                    const rawResponse = typeof xobj.response === 'string' ? JSON.parse(xobj.response) : xobj.response;
+                    // TODO: sort query results?
+                    resolve(rawResponse);
+                } else {
+                    reject('Could not load results from remote service.');
+                }
+            };
+            xobj.send();
+        });
+    }
+}


### PR DESCRIPTION
Main additions: adds run query (obtain results from search term using proper services) and zoom (clicking on a result) functionality with minor code structure changes. Temporarily store created map object in global object (`this.$iApi`) that needs to be replaced later. Other minor additions include highlighting the search term for each individual result + style changes to geosearch results list items.

Things to do: 
- replace map interactions and Point object creation with proper API calls later
- map extent filters 
- FSA/LAT-LONG/NTA search modes (only search mode usable currently is keyword search)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/51)
<!-- Reviewable:end -->
