### PR TITLE
Panel logic

### DIFF
--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -12,7 +12,7 @@ export class PanelAPI extends APIScope {
      * @memberof PanelAPI
      */
     open(config: PanelConfig): PanelItemAPI {
-        this.$vApp.$store.set('panel/ADD_PANEL!', { value: config });
+        this.$vApp.$store.set('panel/addPanel!', config);
 
         const panel = this.get(config.id)!;
 
@@ -44,7 +44,7 @@ export class PanelAPI extends APIScope {
             panel.pin(false);
         }
 
-        this.$vApp.$store.set(`panel/REMOVE_PANEL!`, { value: panel._config });
+        this.$vApp.$store.set(`panel/removePanel!`, panel._config);
 
         return panel;
     }

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -1,5 +1,13 @@
 <template>
-    <div :style="{'width': (panelConfig.width || 350) + 'px'}" class="shadow-tm bg-white h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto" :tabindex="0" v-focus-list>
+    <div
+        class="shadow-tm bg-white h-full xs:mr-0 xs:flex-grow sm:mr-12 last:mr-0 pointer-events-auto"
+        :style="{
+            'flex-basis': panelConfig.width ? panelConfig.width + 'px' : '350px',
+            'max-width': panelConfig.width ? Math.max(panelConfig.width, 500) + 'px' : '500px'
+        }"
+        :tabindex="0"
+        v-focus-list
+    >
         <!-- this renders a panel screen which is currently in view -->
         <!-- TODO: add animation transition animation here -->
         <component :is="panelConfig.route.id" v-bind="panelConfig.route.props" :panel="panel"></component>

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -12,6 +12,13 @@ import { PanelConfig } from '@/store/modules/panel';
 
 import PanelV from './panel-container.vue';
 
+declare class ResizeObserver {
+    constructor(callback: Function);
+    observe(target: Element): void;
+    unobserve(target: Element): void;
+    disconnect(): void;
+}
+
 @Component({
     components: {
         'panel-container': PanelV
@@ -19,6 +26,15 @@ import PanelV from './panel-container.vue';
 })
 export default class PanelStackV extends Vue {
     @Get('panel/visible') visible!: PanelConfig[];
+    @Sync('panel/width') width!: number;
+
+    mounted() {
+        const resizeObserver = new ResizeObserver((entries: any) => {
+            this.width = entries[0].contentRect.width;
+        });
+
+        resizeObserver.observe(this.$el);
+    }
 }
 </script>
 

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -4,7 +4,7 @@
 
         <!-- TODO: should inner shell be a separate component? -->
         <div class="inner-shell absolute top-0 left-0 h-full w-full pointer-events-none">
-            <panel-stack class="absolute inset-0 xs:pl-48 md:p-12 md:pl-80 lg:p-12"></panel-stack>
+            <panel-stack class="absolute inset-0 overflow-hidden xs:pl-40 sm:pl-48 md:p-12 md:pl-80 lg:p-12"></panel-stack>
         </div>
     </div>
 </template>

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -26,9 +26,7 @@ export default class AppbarV extends Vue {
     // to use in the template
     DIVIDER = DIVIDER_ID;
 
-    get items() {
-        return this.$iApi.$vApp.$store.get('appbar/items');
-    }
+    @Get('appbar/items') items!: AppbarItemConfig[];
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -18,7 +18,8 @@ class AppbarFixture extends FixtureConfigHelper {
 
         const appbarInstance = new (Vue.extend(AppbarV))({
             iApi: this.$iApi,
-            propsData: { fixture }
+            propsData: { fixture },
+            store: this.vApp.$store
         });
 
         appbarInstance.$mount();

--- a/packages/ramp-core/src/store/modules/panel/panel-state.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-state.ts
@@ -9,6 +9,12 @@ export class PanelState {
      */
     items: { [name: string]: PanelConfig } = {};
 
+    width: number = 0;
+
+    visible: PanelConfig[] = [];
+
+    orderedItems: PanelConfig[] = [];
+
     /**
      * Indicates a pinned panel.
      *
@@ -16,6 +22,8 @@ export class PanelState {
      * @memberof PanelState
      */
     pinned: PanelConfig | null = null;
+
+    priority: PanelConfig | null = null;
 }
 
 export type PanelConfigScreen = { id: string; component: VueConstructor<Vue> };

--- a/packages/ramp-core/src/store/modules/panel/panel-state.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-state.ts
@@ -9,10 +9,14 @@ export class PanelState {
      */
     items: { [name: string]: PanelConfig } = {};
 
-    width: number = 0;
-
-    visible: PanelConfig[] = [];
-
+    /**
+     * A list of all panels in the arrangement they would be put on screen.
+     * The last item will be the first on screen (rightmost, therefore rightmost in array).
+     * Note: The `visible` array is used for whats actually on screen, this is used for calculating `visible`.
+     *
+     * @type {PanelConfig[]}
+     * @memberof PanelState
+     */
     orderedItems: PanelConfig[] = [];
 
     /**
@@ -23,7 +27,30 @@ export class PanelState {
      */
     pinned: PanelConfig | null = null;
 
+    /**
+     * Indicates the most recently opened panel has priority
+     * This is given the value of that recent panel in order to check on removal
+     *
+     * @type {PanelConfig | null}
+     * @memberof PanelState
+     */
     priority: PanelConfig | null = null;
+
+    /**
+     * The panels that are displayed on the screen
+     *
+     * @type {PanelConfig[]}
+     * @memberof PanelState
+     */
+    visible: PanelConfig[] = [];
+
+    /**
+     * The screen width that the visible panels are allowed to use.
+     *
+     * @type {number}
+     * @memberof PanelState
+     */
+    width: number = 0;
 }
 
 export type PanelConfigScreen = { id: string; component: VueConstructor<Vue> };

--- a/packages/ramp-core/src/store/modules/panel/panel-store.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-store.ts
@@ -9,37 +9,101 @@ type PanelContext = ActionContext<PanelState, RootState>;
 type StoreActions = { [key: string]: Action<PanelState, RootState> };
 type StoreMutations = { [key: string]: Mutation<PanelState> };
 
-export enum PanelAction {}
-// addPanel = 'addPanel'
+export enum PanelAction {
+    addPanel = 'addPanel',
+    removePanel = 'removePanel',
+    setWidth = 'setWidth',
+    updateVisible = 'updateVisible'
+}
 
 export enum PanelMutation {
     ADD_PANEL = 'ADD_PANEL',
-    REMOVE_PANEL = 'REMOVE_PANEL'
+    ADD_TO_PANEL_ORDER = 'ADD_TO_PANEL_ORDER',
+    REMOVE_PANEL = 'REMOVE_PANEL',
+    SET_ORDERED_ITEMS = 'SET_ORDERED_ITEMS',
+    SET_PRIORITY = 'SET_PRIORITY',
+    SET_VISIBLE = 'SET_VISIBLE',
+    SET_WIDTH = 'SET_WIDTH'
 }
 
-const getters = {
-    visible(state: PanelState): PanelConfig[] {
-        // get first three panels; it's a dud
-        // TODO: need to write proper logic for select visible panels based on the number of allowed panels for the current layout and if there is a pinned panel
-        return Object.keys(state.items)
-            .slice(-3)
-            .map(key => state.items[key]);
+const getters = {};
+
+const actions = {
+    [PanelAction.addPanel](context: PanelContext, value: PanelConfig): void {
+        context.commit(PanelMutation.ADD_PANEL, value);
+        context.commit(PanelMutation.SET_PRIORITY, value);
+        context.dispatch(PanelAction.updateVisible);
+    },
+    [PanelAction.removePanel](context: PanelContext, value: PanelConfig): void {
+        if (context.state.priority === value) {
+            context.commit(PanelMutation.SET_PRIORITY, null);
+        }
+        context.commit(PanelMutation.REMOVE_PANEL, value);
+        context.dispatch(PanelAction.updateVisible);
+    },
+    [PanelAction.setWidth](context: PanelContext, value: number): void {
+        context.commit(PanelMutation.SET_WIDTH, value);
+        context.dispatch(PanelAction.updateVisible);
+    },
+    [PanelAction.updateVisible](context: PanelContext): void {
+        //TODO: update when panel width system is in place
+        let remainingWidth = context.state.width;
+        let nowVisible: PanelConfig[] = [];
+
+        // add panels until theres no space in the stack
+        for (let i = context.state.orderedItems.length - 1; i >= 0 && remainingWidth >= (context.state.orderedItems[i].width || 350); i--) {
+            remainingWidth -= context.state.orderedItems[i].width || 350;
+            nowVisible.unshift(context.state.orderedItems[i]);
+        }
+
+        // if pinned isn't visible we need to change the order of the panels (to make it visble)
+        if (context.state.pinned && !nowVisible.includes(context.state.pinned)) {
+            let lastElement: PanelConfig;
+
+            // remove elements from visible until theres room for pinned
+            for (let i = 0; i < nowVisible.length - 1 && remainingWidth < (context.state.pinned.width || 350); i++) {
+                lastElement = nowVisible.shift()!;
+                remainingWidth += lastElement.width || 350;
+            }
+
+            if (remainingWidth >= (context.state.pinned.width || 350)) {
+                // if theres room insert pinned element
+                nowVisible.unshift(context.state.pinned);
+            } else {
+                // otherwise there is only one element in `nowVisible` (loop invariant fun)
+                // if there is no priority, the one element should be pinned
+                // otherwise the priority element stays as the only visible
+                if (!context.state.priority) {
+                    lastElement = nowVisible.shift()!;
+                    nowVisible.unshift(context.state.pinned);
+                }
+            }
+
+            const pinnedIndex = context.state.orderedItems.indexOf(context.state.pinned);
+            const lastRemovedIndex = context.state.orderedItems.indexOf(lastElement!);
+            // clone the current order, splice out the pinned item, insert it back in after the last element we removed from visible
+            const newPanelOrder = context.state.orderedItems.slice();
+            newPanelOrder.splice(pinnedIndex, 1);
+            newPanelOrder.splice(lastRemovedIndex, 0, context.state.pinned);
+
+            context.commit(PanelMutation.SET_ORDERED_ITEMS, newPanelOrder);
+        } else {
+            context.commit(PanelMutation.SET_PRIORITY, null);
+        }
+
+        context.commit(PanelMutation.SET_VISIBLE, nowVisible);
     }
 };
 
-const actions = {
-    /* [PanelAction.addPanel](context: PanelContext, { value }: { value: Panel }): void {
-        context.commit(PanelMutation.ADD_PANEL, { value });
-    } */
-};
-
 const mutations = {
-    [PanelMutation.ADD_PANEL](state: PanelState, { value }: { value: PanelConfig }): void {
-        // TODO: find out what is better in terms of performance and use the better one: `object spread` or `Vue.set()`
+    [PanelMutation.ADD_PANEL](state: PanelState, value: PanelConfig): void {
+        state.orderedItems = [...state.orderedItems, value];
         state.items = { ...state.items, [value.id]: value };
     },
 
-    [PanelMutation.REMOVE_PANEL](state: PanelState, { value }: { value: PanelConfig }): void {
+    [PanelMutation.REMOVE_PANEL](state: PanelState, value: PanelConfig): void {
+        const index = state.orderedItems.indexOf(value);
+        state.orderedItems = [...state.orderedItems.slice(0, index), ...state.orderedItems.slice(index + 1)];
         delete state.items[value.id];
         state.items = { ...state.items };
     }
@@ -53,6 +117,6 @@ export function panel() {
         state,
         getters: { ...getters },
         actions: { ...actions },
-        mutations: { ...mutations, ...make.mutations(['items', 'pinned']) }
+        mutations: { ...mutations, ...make.mutations(state) }
     };
 }


### PR DESCRIPTION
Now calculates which panels should be visible on the screen and not just "first 3 panels".
Pinned panels move up the order as needed, and remain in their position when unpinned.

Essentially the logic is:
- As many panels as can fit
- If pinned isn't in that group move it up the order until it is
- If a panel was just opened (and as such has priority), do not hide it to move pinned up

As such pinned should always be on screen unless opening a panel bumps it off screen (in which case it should be the first to come back after there is room).

In the next PR:
- Proper panel width settings
- Better handling of styles on mobile/extra small screens

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/55)
<!-- Reviewable:end -->
