### PR TITLE
Grid Part 2: implement grid store, api and config

### DIFF
--- a/packages/ramp-core/postcss.config.js
+++ b/packages/ramp-core/postcss.config.js
@@ -1,7 +1,7 @@
 // purgecss stuff is from https://tailwindcss.com/docs/controlling-file-size
 const purgecss = require('@fullhuman/postcss-purgecss')({
     // Paths to all of the template files in your project
-    content: ['./src/**/*.html', './src/**/*.vue'],
+    content: ['./src/**/*.html', './src/**/*.vue', './node_modules/ag-grid-community/dist/styles/ag-grid.css', './node_modules/ag-grid-community/dist/styles/ag-theme-material.css'],
 
     whitelist: ['xs', 'sm', 'md', 'lg'], // whitelist ramp shell size classes so they are not purged
 

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -21,12 +21,17 @@ export default class EsriMap extends Vue {
     gapi!: GeoApi;
     map!: Map;
 
+    created() {
+        // temporarily print out loaded layers to console for grid testing purposes.
+        console.log(this.layers);
+    }
+
     @Watch('layers')
     onLayerArrayChange(newValue: BaseLayer[], oldValue: BaseLayer[]) {
         newValue.forEach(layer => {
             // TODO add a proper check for this after
             // if (!oldValue.includes(layer)) {
-                this.map.addLayer(layer);
+            this.map.addLayer(layer);
             // }
         });
     }

--- a/packages/ramp-core/src/fixtures/grid/api/grid.ts
+++ b/packages/ramp-core/src/fixtures/grid/api/grid.ts
@@ -1,0 +1,49 @@
+import Vue from 'vue';
+import { APIScope } from '@/api/common';
+import { InstanceAPI } from '@/api/internal';
+import { PanelConfig } from '@/store/modules/panel';
+import { GridStore, GridConfig, GridState } from '../store';
+import TableStateManager from '../store/table-state-manager';
+
+export class GridAPI extends APIScope {
+    constructor(iApi: InstanceAPI, panel: PanelConfig) {
+        super(iApi);
+        this.$iApi.grid = this;
+
+        this.panel = panel;
+    }
+
+    /**
+     * Open the grid for the layer with the given uid.
+     *
+     * @param {string} id
+     * @memberof GridAPI
+     */
+    open(id: string): void {
+        // get GridConfig for specified uid
+        let gridSettings: GridConfig | undefined = this.$vApp.$store.get(`grid/grids@${id}`);
+
+        // if no GridConfig exists for the given uid, create it.
+        if (gridSettings === undefined) {
+            gridSettings = {
+                uid: id,
+                state: new TableStateManager({
+                    table: {
+                        showFilter: true,
+                        filterByExtent: false
+                    }
+                })
+            };
+
+            this.$vApp.$store.set('grid/addGrid!', gridSettings);
+        }
+
+        // open the grid
+        this.$vApp.$store.set('grid/open', id ? id : null);
+        this.$iApi.panel.open(this.panel);
+    }
+}
+
+export interface GridAPI {
+    panel: PanelConfig;
+}

--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -49,7 +49,7 @@
             <close @click="panel.close()"></close>
         </template>
         <template #content>
-            <TableComponent class="rv-grid" ref="rvGrid"></TableComponent>
+            <TableComponent class="rv-grid" ref="rvGrid" :layerUid="open"></TableComponent>
         </template>
     </panel-screen>
 </template>
@@ -61,7 +61,6 @@ import { Get, Sync, Call } from 'vuex-pathify';
 import { PanelItemAPI } from '@/api';
 import TableComponent from '@/fixtures/grid/table/table.vue';
 
-import { ConfigStore } from '@/store/modules/config';
 import { LayerStore, layer } from '@/store/modules/layer';
 import FeatureLayer from 'ramp-geoapi/dist/layer/FeatureLayer';
 
@@ -75,6 +74,7 @@ export default class Screen1 extends Vue {
     @Prop() header!: String;
 
     @Get(LayerStore.layers) layers!: FeatureLayer[];
+    @Get('grid/open') open: any;
 
     quicksearch: String = '';
     grid: any = undefined;

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -3,8 +3,10 @@ import { FixtureConfigHelper } from '@/store/modules/fixture';
 import { PanelConfig } from '@/store/modules/panel';
 import { ConfigStore } from '@/store/modules/config';
 import { LayerStore, layer } from '@/store/modules/layer';
+import { grid } from './store/index';
 
 import GridV from './grid.vue';
+import { GridAPI } from './api/grid';
 
 class GridFixture extends FixtureConfigHelper {
     async added() {
@@ -15,16 +17,25 @@ class GridFixture extends FixtureConfigHelper {
             }
         ];
 
-        const gridPanel = {
-          id: 'grid-panel',
-          width: 900,
-          screens: screens,
-          route: {
-            id: 'grid-screen'
-          }
-        }
+        const gridPanel: PanelConfig = {
+            id: 'grid-panel',
+            width: 900,
+            screens: screens,
+            route: {
+                id: 'grid-screen'
+            }
+        };
 
-        const pApi3 = this.$iApi.panel.open(gridPanel);
+        this.vApp.$store.registerModule('grid', grid());
+        this.$iApi.emit('gridApi', new GridAPI(this.$iApi, gridPanel));
+
+        // temporarily throw the InstanceAPI in console for testing purposes.
+        console.log(this.$iApi);
+    }
+
+    removed() {
+        this.vApp.$store.unregisterModule('grid');
+        this.$iApi.grid = undefined;
     }
 }
 

--- a/packages/ramp-core/src/fixtures/grid/store/grid-state.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/grid-state.ts
@@ -1,0 +1,46 @@
+import TableStateManager from './table-state-manager';
+import { PanelConfig } from '@/store/modules/panel';
+
+export class GridState {
+    /**
+     * A list of all existing grid configuration files.
+     *
+     * @type {{ [uid: string]: GridConfig }}
+     * @memberof GridState
+     */
+    grids: { [uid: string]: GridConfig } = {};
+
+    /**
+     * The grid panel.
+     *
+     * @type {PanelConfig | null}
+     * @memberof GridState
+     */
+    panel: PanelConfig | null = null;
+
+    /**
+     * The uid of the layer that is currently open in the grid.
+     *
+     * @type {(string | null)}
+     * @memberof GridState
+     */
+    open: String | null = null;
+}
+
+export interface GridConfig {
+    /**
+     * The uid for the layer that this grid represents.
+     *
+     * @type {String}
+     * @memberof GridItemConfig
+     */
+    uid: string;
+
+    /**
+     * The state manager for this grid.
+     *
+     * @type {PanelStateManager}
+     * @memberof GridItemConfig
+     */
+    state: TableStateManager;
+}

--- a/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
@@ -1,0 +1,48 @@
+import { ActionContext, Action, Mutation } from 'vuex';
+import { make } from 'vuex-pathify';
+
+import { GridState, GridConfig } from './grid-state';
+import { RootState } from '@/store/state';
+
+type GridContext = ActionContext<GridState, RootState>;
+
+export enum GridAction {
+    addGrid = 'addGrid'
+}
+
+export enum GridMutation {
+    ADD_GRID = 'ADD_GRID'
+}
+
+const getters = {
+    get: (state: GridState) => (id: string): GridConfig | null => {
+        return state.grids[id];
+    }
+};
+
+const actions = {
+    [GridAction.addGrid](context: GridContext, value: GridConfig): void {
+        context.commit(GridMutation.ADD_GRID, value);
+    },
+};
+const mutations = {
+    [GridMutation.ADD_GRID](state: GridState, value: GridConfig): void {
+        state.grids = { ...state.grids, [value.uid]: value};
+    }
+};
+
+export enum GridStore {
+    grids = 'grid/grids'
+}
+
+export function grid() {
+    const state = new GridState();
+
+    return {
+        namespaced: true,
+        state,
+        getters: { ...getters },
+        actions: { ...actions },
+        mutations: { ...mutations, ...make.mutations(['grids', 'open']) }
+    };
+}

--- a/packages/ramp-core/src/fixtures/grid/store/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/index.ts
@@ -1,0 +1,2 @@
+export * from './grid-state';
+export * from './grid-store';

--- a/packages/ramp-core/src/fixtures/grid/store/table-state-manager.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/table-state-manager.ts
@@ -1,0 +1,109 @@
+/**
+ * Saves relevant enhancedTable states so that it can be reset on reload/reopen. A PanelStateManager is linked to a BaseLayer.
+ * setters are called each time enhancedTable states are updated, getters are called each time enhancedTable is reloaded/reopened.
+ * States to save and reset:
+ *      - displayed rows (on symbology and layer visibility updates)
+ *      - column filters
+ *      - whether table maximized is in maximized or split view
+ */
+export default class TableStateManager {
+    constructor(baseLayer: any) {
+        this.baseLayer = baseLayer;
+        this._showFilter = baseLayer.table.showFilter !== undefined ? baseLayer.table.showFilter : true;
+        this._filterByExtent = baseLayer.table.filterByExtent || false;
+        this._columnFilters = {};
+        this._open = true;
+        this._columnState = null;
+    }
+
+    /**
+     * Returns the stored filter value for the given column field.
+     *
+     * @param {*} colDefField
+     * @returns
+     * @memberof TableStateManager
+     */
+    getColumnFilter(colDefField: any) {
+        return this._columnFilters[colDefField];
+    }
+
+    /**
+     * Saves the current value of the filter for the given column field.
+     *
+     * @param {*} colDefField
+     * @param {(string | number)} filterValue
+     * @memberof TableStateManager
+     */
+    setColumnFilter(colDefField: any, filterValue: string | number) {
+        let newFilterValue = filterValue;
+        if (filterValue && typeof filterValue === 'string') {
+            const escRegex = /[(!"#$%&'+,.\\/:;<=>?@[\]^`{|}~)]/g;
+            newFilterValue = filterValue.replace(escRegex, '\\$&');
+        }
+        this._columnFilters[colDefField] = newFilterValue;
+    }
+
+    /**
+     * Returns whether column filters are enabled for the table.
+     *
+     * @memberof TableStateManager
+     */
+    get colFilter() {
+        return this._showFilter;
+    }
+
+    /**
+     * Sets column filters to on or off.
+     *
+     * @memberof TableStateManager
+     */
+    set colFilter(val) {
+        this._showFilter = val;
+    }
+
+    /**
+     * Returns whether the grid is filtering by map extent.
+     *
+     * @memberof TableStateManager
+     */
+    get filterByExtent() {
+        return this._filterByExtent;
+    }
+
+    /**
+     * Sets the extent filter to on or off.
+     *
+     * @memberof TableStateManager
+     */
+    set filterByExtent(val) {
+        this._filterByExtent = val;
+    }
+
+    /**
+     * Returns whether the grid is currently open.
+     *
+     * @memberof TableStateManager
+     */
+    get open() {
+        return this._open;
+    }
+
+    /**
+     * Sets the grid status to open or closed.
+     *
+     * @memberof TableStateManager
+     */
+    set open(val) {
+        this._open = val;
+    }
+
+}
+
+export default interface TableStateManager {
+    baseLayer: any;
+    _showFilter: boolean;
+    _filterByExtent: boolean;
+    _columnFilters: any;
+    _open: boolean;
+    _columnState: any;
+}

--- a/packages/ramp-core/src/fixtures/grid/table/CustomNumberFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomNumberFilter.vue
@@ -10,38 +10,41 @@ import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 
 @Component({})
 export default class CustomNumberFilter extends Vue {
-    data() {
-        return {
-            minVal: 0,
-            maxVal: 0,
-            colDef: {}
-        };
-    }
+    minVal: any = null;
+    maxVal: any = null;
+    colDef: any;
 
     beforeMount() {
         this.colDef = this.params.column.colDef;
+        this.minVal = this.params.minValDefault;
+        this.maxVal = this.params.maxValDefault;
+        this.minValChanged();
+        this.maxValChanged();
     }
 
     minValChanged() {
-        this.minVal = this.minVal !== '' && !isNaN(this.minVal) ? this.minVal : '';
+        this.minVal = this.minVal !== '' && !isNaN(this.minVal) ? this.minVal : null;
         let that = this;
         this.params.parentFilterInstance(function(instance: any) {
             that.setFilterModel(instance);
-            const minKey = that.colDef.field + ' min';
+            that.params.stateManager.setColumnFilter(that.colDef.field + ' min', that.minVal);
         });
     }
 
     maxValChanged() {
-        this.maxVal = this.maxVal !== '' && !isNaN(this.maxVal) ? this.maxVal : '';
+        this.maxVal = this.maxVal !== '' && !isNaN(this.maxVal) ? this.maxVal : null;
         let that = this;
         this.params.parentFilterInstance(function(instance: any) {
             that.setFilterModel(instance);
-            const maxKey = that.colDef.field + ' max';
+            that.params.stateManager.setColumnFilter(that.colDef.field + ' max', that.maxVal);
         });
     }
 
     setFilterModel(instance: any) {
         let that = this;
+        if(isNaN(that.minVal) || that.minVal == null) that.minVal = '';
+        if(isNaN(that.maxVal) || that.maxVal == null) that.maxVal = '';
+
         if (that.maxVal !== '' && that.minVal !== '') {
             instance.setModel({
                 filterType: 'number',
@@ -53,26 +56,26 @@ export default class CustomNumberFilter extends Vue {
             instance.setModel({
                 filterType: 'number',
                 type: 'lessThanOrEqual',
-                filter: that.maxVal,
-                filterTo: null
+                filter: that.maxVal
             });
         } else if (that.maxVal === '') {
             instance.setModel({
                 filterType: 'number',
                 type: 'greaterThanOrEqual',
-                filter: that.minVal,
-                filterTo: null
+                filter: that.minVal
             });
             // otherwise clear filters
         } else {
             instance.setModel(null);
         }
-        instance.onFilterChanged();
+        this.params.api.onFilterChanged();
     }
 
     onParentModelChanged(parentModel: any) {
-        this.minVal = !parentModel ? -Infinity : parentModel.filter;
-        this.maxVal = !parentModel ? Infinity : parentModel.filterTo;
+        if(parentModel == null) {
+            this.minVal = '';
+            this.maxVal = '';
+        }
     }
 
     setModel() {
@@ -97,9 +100,9 @@ export default interface CustomNumberFilter {
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,
 .rv-global-search {
-    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2
+    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2;
 }
 .rv-input {
-    @apply m-0 py-1
+    @apply m-0 py-1;
 }
 </style>

--- a/packages/ramp-core/src/fixtures/grid/table/CustomTextFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomTextFilter.vue
@@ -9,16 +9,14 @@ import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 
 @Component({})
 export default class CustomTextFilter extends Vue {
-    data() {
-        return {
-            filterValue: '',
-            colDef: {}
-        };
-    }
+    filterValue: string = '';
+    colDef: any;
 
     beforeMount() {
         // would like better way to access panel state manager, pass it down as a prop? (didn't know how to do this)
         this.colDef = this.params.column.colDef;
+        this.filterValue = this.params.defaultValue;
+        this.valueChanged();
     }
 
     valueChanged(): void {
@@ -29,7 +27,8 @@ export default class CustomTextFilter extends Vue {
                 type: 'contains',
                 filter: that.filterValue
             });
-            instance.onFilterChanged();
+            that.params.stateManager.setColumnFilter(that.colDef.field, that.filterValue);
+            that.params.api.onFilterChanged();
         });
     }
 
@@ -57,9 +56,9 @@ export default interface CustomTextFilter {
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,
 .rv-global-search {
-    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2
+    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2;
 }
 .rv-input {
-    @apply m-0 py-1
+    @apply m-0 py-1;
 }
 </style>


### PR DESCRIPTION
Implements the grid store, API, and the grid configuration. There's still quite a bit of work to do (selector & date filters, for example), so there will be a part 3 soon.

### Testing

__Note 1__: No grids are open by default, so you need to use one of the two methods below if you want to test.
__Note 2__: I've temporarily printed out InstanceAPI and the layers object for testing purposes.

To test in a browser console, save the InstanceAPI to a temporary variable and then run the following command:
> temp1.grid.open(`<layer uid>`);

A layer uid can be found from any of the layers in the layers object.

\- or -

You can open a grid using other fixtures by using the following code:
> this.$iApi.grid.open(`<layer uid>`);

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/57)
<!-- Reviewable:end -->
