### PR TITLE
OKAY TO MERGE: improve lol-level fixture handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,11 @@
 {
     "cSpell.words": [
+        "Appbar",
         "Proxied",
+        "TABBABLE",
+        "activedescendant",
         "behaviour",
+        "contenteditable",
         "deepmerge",
         "diligord",
         "fullhuman",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "Appbar",
+        "Geosearch",
         "Proxied",
         "TABBABLE",
         "activedescendant",
@@ -8,6 +9,7 @@
         "contenteditable",
         "deepmerge",
         "diligord",
+        "esri",
         "fullhuman",
         "geoapi",
         "pathify",

--- a/packages/ramp-core/public/diligord-fixture.js
+++ b/packages/ramp-core/public/diligord-fixture.js
@@ -85,7 +85,19 @@
                                     this.title = event.target.value;
                                 }
                             }
-                        })
+                        }),
+
+                        this.title === 'fight'
+                            ? h('img', {
+                                  style: {
+                                      width: '300px',
+                                      marginTop: '30px'
+                                  },
+                                  domProps: {
+                                      src: 'https://media.giphy.com/media/sGAlRSaXKjTfq/giphy.gif'
+                                  }
+                              })
+                            : null
                     ])
                 ])
             ]);
@@ -104,22 +116,45 @@
     };
 
     // then, create a fixture config
-    const diligordFixture = {
-        id: 'diligord',
-
-        // `created` function receives a reference to the FixtureItemAPI instance and we need to save it for later
-        // this is only needed when creating external fixtures (ones that are not compiled as part of the R4MP core)
-        // fixtures compiled as part of the core, use a helper class which takes care of this
-        created($iApi) {
-            this.$iApi = $iApi;
-        },
-
+    class DiligordFixture {
         added() {
+            // `this.id` and `this.$iApi` and `this.$vApp` are automatically made available on this object
+            console.log(this.id, this.$iApi, this.$vApp);
+
+            // you can also create a custom component using the `extend` function and put it anywhere on the page, even outside the R4MP container
+            const component = this.extend({
+                render: function(h) {
+                    return h(
+                        'p',
+                        {
+                            style: {
+                                marginTop: '80px',
+                                fontWeight: 'bold',
+                                color: '#34495e',
+                                fontSize: '20pt',
+                                textAlign: 'center'
+                            }
+                        },
+                        [this.firstName, ' ', this.lastName, ' aka ', this.alias]
+                    );
+                },
+                data: function() {
+                    return {
+                        firstName: 'Walter',
+                        lastName: 'White',
+                        alias: 'Heisenberg'
+                    };
+                }
+            });
+
+            // and put it on the page
+            document.querySelector('.ramp-app').after(component.$el);
+
             // this life hook is called when the fixture is added to R4MP, and now it's possible to open our panel
             this.$iApi.panel.open(dPanel1);
         }
-    };
+    }
 
     window.hostFixtures = window.hostFixtures || {};
-    window.hostFixtures[diligordFixture.id] = diligordFixture;
+    window.hostFixtures['diligord'] = DiligordFixture;
 })();

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -112,11 +112,11 @@
                 // TODO: fixtures specified in the config should be loaded first, then fixtures added through the API
                 // TODO: remove
                 rInstance.fixture.add('snowman');
-                rInstance.fixture.add('gazebo');
-                rInstance.fixture.add('geosearch');
+                /* rInstance.fixture.add('gazebo');
+                rInstance.fixture.add('geosearch');*/
                 rInstance.fixture.add('appbar');
-                rInstance.fixture.add('grid');
-                rInstance.fixture.add(window.hostFixtures.diligord);
+                /*rInstance.fixture.add('grid');*/
+                rInstance.fixture.add('diligord', window.hostFixtures.diligord);
             }
         </script>
     </body>

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -112,10 +112,10 @@
                 // TODO: fixtures specified in the config should be loaded first, then fixtures added through the API
                 // TODO: remove
                 rInstance.fixture.add('snowman');
-                rInstance.fixture.add('gazebo'); /*
-                rInstance.fixture.add('geosearch');*/
+                rInstance.fixture.add('gazebo');
+                rInstance.fixture.add('geosearch');
                 rInstance.fixture.add('appbar');
-                /*rInstance.fixture.add('grid');*/
+                rInstance.fixture.add('grid');
                 rInstance.fixture.add('diligord', window.hostFixtures.diligord);
             }
         </script>

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -112,7 +112,7 @@
                 // TODO: fixtures specified in the config should be loaded first, then fixtures added through the API
                 // TODO: remove
                 rInstance.fixture.add('snowman');
-                /* rInstance.fixture.add('gazebo');
+                rInstance.fixture.add('gazebo'); /*
                 rInstance.fixture.add('geosearch');*/
                 rInstance.fixture.add('appbar');
                 /*rInstance.fixture.add('grid');*/

--- a/packages/ramp-core/src/api/common.ts
+++ b/packages/ramp-core/src/api/common.ts
@@ -1,24 +1,29 @@
 import { InstanceAPI } from './internal';
 
+/**
+ * A base class for anything requiring access to the InstanceApi and instance of Vue app controlled by it.
+ *
+ * @export
+ * @class APIScope
+ */
 export class APIScope {
     /**
      * The instance of RampMap API scoped to a single Vue R4MP application.
      *
-     * @protected
      * @type {InstanceAPI}
      * @memberof APIScope
      */
-    protected readonly $iApi: InstanceAPI;
+    readonly $iApi: InstanceAPI;
 
     /**
      * The instance of Vue R4MP application controlled by this InstanceAPI.
+     * This is just a shorthand for `this.$iApi.$vApp`.
      *
      * @readonly
-     * @protected
      * @type {Vue}
      * @memberof APIScope
      */
-    protected get $vApp(): Vue {
+    get $vApp(): Vue {
         return this.$iApi.$vApp;
     }
 

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -1,60 +1,66 @@
+import Vue, { VueConstructor, ComponentOptions } from 'vue';
+
 import { APIScope } from './internal';
-import { FixtureConfig, FixtureMutation } from '@/store/modules/fixture';
+import { FixtureBase, FixtureMutation } from '@/store/modules/fixture';
 import { InstanceAPI } from './instance';
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;
 
-export class FixtureAPI extends APIScope {
-    // TODO: moves this fixture loading function to a separate file
+type IFixtureInstance = new (id: string, iApi: InstanceAPI) => FixtureInstance;
+type IFixtureBase = new () => FixtureBase;
 
+export class FixtureAPI extends APIScope {
     /**
-     * Loads a (built-in) fixture or adds supplied fixture config into the R4MP Vue instance.
+     * Loads a (built-in) fixture or adds supplied fixture into the R4MP Vue instance.
      *
-     * @param {(string | FixtureConfig)} value
-     * @returns {Promise<FixtureItemAPI>}
+     * @param {string} id
+     * @param {IFixtureBase} [constructor]
+     * @returns {Promise<FixtureBase>}
      * @memberof FixtureAPI
      */
-    async add(value: string | FixtureConfig): Promise<FixtureItemAPI> {
-        let fixtureConfig: FixtureConfig;
+    async add(id: string, constructor?: IFixtureBase): Promise<FixtureBase> {
+        let fixture: FixtureBase;
 
-        if (typeof value === 'string') {
-            // perform a dynamic webpack import of a internal fixture (allows for code splitting)
-            fixtureConfig = (await import(/* webpackChunkName: "[request]" */ `@/fixtures/${value}/index.ts`)).default;
+        // only need to provide fixture constructors for external fixtures since internal ones are loaded automatically
+        if (constructor) {
+            if (typeof constructor !== 'function') {
+                throw new Error('malformed fixture constructor');
+            }
+
+            // run the provided constructor and update the resulting object with FixtureInstance functions/properties
+            fixture = FixtureInstance.updateBaseToInstance(new constructor(), id, this.$iApi);
         } else {
-            fixtureConfig = value;
+            // perform a dynamic webpack import of a internal fixture (allows for code splitting)
+            const instanceConstructor: IFixtureInstance = (await import(/* webpackChunkName: "[request]" */ `@/fixtures/${id}/index.ts`))
+                .default;
+
+            fixture = new instanceConstructor(id, this.$iApi);
         }
-
-        // TODO: check if fixtureConfig exists at all
-
-        if (typeof fixtureConfig.created !== 'function') {
-            throw new Error('malformed fixture config; `created` life hook is missing');
-        }
-
-        // pass the reference to the API instance to the fixture config
-        fixtureConfig.created(this.$iApi);
 
         // TODO: calling `ADD_FIXTURE` mutation directly here; might want to switch to calling the action `addFixture`
         // TODO: using this horrible concatenated mixture `fixture/${FixtureMutation.ADD_FIXTURE}!` all the time doesn't seem like a good idea;
-        this.$vApp.$store.set(`fixture/${FixtureMutation.ADD_FIXTURE}!`, { value: fixtureConfig });
+        // fixtures are always stored as objects implementing `FixtureBase` interfaces;
+        this.$vApp.$store.set(`fixture/${FixtureMutation.ADD_FIXTURE}!`, { value: fixture });
 
-        return new FixtureItemAPI(this.$iApi, fixtureConfig);
+        return fixture;
     }
 
     /**
      * Removes the specified fixture from R4MP instance.
      *
-     * @param {(FixtureItemAPI | string)} fixtureOrId
-     * @returns {(FixtureItemAPI | null)}
+     * @template T
+     * @param {(FixtureBase | string)} fixtureOrId
+     * @returns {(T | null)}
      * @memberof FixtureAPI
      */
-    remove(fixtureOrId: FixtureItemAPI | string): FixtureItemAPI | null {
-        const fixture = this.get(fixtureOrId);
+    remove<T extends FixtureBase = FixtureBase>(fixtureOrId: FixtureBase | string): T | null {
+        const fixture = this.get<T>(fixtureOrId);
 
         // TODO: output warning to a log that a fixture with this id cannot be found
         if (!fixture) {
             return null;
         }
 
-        this.$vApp.$store.set(`fixture/${FixtureMutation.REMOVE_FIXTURE}!`, { value: fixture._config });
+        this.$vApp.$store.set(`fixture/${FixtureMutation.REMOVE_FIXTURE}!`, { value: fixture });
 
         return fixture;
     }
@@ -62,31 +68,132 @@ export class FixtureAPI extends APIScope {
     /**
      * Finds and returns a fixture with the id specified.
      *
+     * @template T
      * @param {(string | { id: string })} item
-     * @returns {(FixtureItemAPI | null)}
+     * @returns {(T | null)}
      * @memberof FixtureAPI
      */
-    get(item: string | { id: string }): FixtureItemAPI | null {
+    get<T extends FixtureBase = FixtureBase>(item: string | { id: string }): T | null {
         const id = typeof item === 'string' ? item : item.id;
-        const fixtureConfig = this.$vApp.$store.get<FixtureConfig>(`fixture/items@${id}`);
+        const fixture = this.$vApp.$store.get<T>(`fixture/items@${id}`);
 
         // TODO: output warning to a log that a fixture with this id cannot be found
-        if (!fixtureConfig) {
+        if (!fixture) {
             return null;
         }
 
-        return new FixtureItemAPI(this.$iApi, fixtureConfig);
+        return fixture;
     }
 }
 
+/**
+ * A base class for Fixture subclasses. It provides some utility functions to Fixtures and also gives access to `$iApi` and `$vApp` globals.
+ *
+ * @export
+ * @class FixtureInstance
+ * @extends {APIScope}
+ * @implements {FixtureBase}
+ */
+export class FixtureInstance extends APIScope implements FixtureBase {
+    /**
+     * Adds missing functions and properties to the object implementing FixtureBase interface.
+     * This is only needed for external fixtures as they can't inherit from FixtureInstance.
+     *
+     * TODO: If you know a better way to deep-mixin props/getters/functions from a class into another class instance, please tell me. I honestly don't know 🤷‍♂️.
+     *
+     * @static
+     * @param {FixtureBase} value
+     * @param {string} id
+     * @param {InstanceAPI} $iApi
+     * @returns {FixtureInstance}
+     * @memberof FixtureInstance
+     */
+    static updateBaseToInstance(value: FixtureBase, id: string, $iApi: InstanceAPI): FixtureInstance {
+        const instance = new FixtureInstance(id, $iApi);
+
+        Object.defineProperties(value, {
+            id: { value: id },
+            $iApi: { value: $iApi },
+            $vApp: {
+                get(): Vue {
+                    return instance.$vApp;
+                }
+            },
+            remove: { value: instance.remove },
+            extend: { value: instance.extend }
+        });
+
+        return value as FixtureInstance;
+    }
+
+    /**
+     * ID of this fixture.
+     *
+     * @type {string}
+     * @memberof FixtureInstance
+     */
+    readonly id: string;
+
+    /**
+     * Creates an instance of FixtureItemAPI.
+     */
+    constructor(id: string, iApi: InstanceAPI) {
+        super(iApi);
+
+        this.id = id;
+    }
+
+    /**
+     * Removes the specified fixture from R4MP instance.
+     * This is a proxy to `RAMP.fixture.remove(...)`.
+     *
+     * @returns {this}
+     * @memberof FixtureInstance
+     */
+    remove(): this {
+        this.$iApi.fixture.remove(this);
+        return this;
+    }
+
+    /**
+     *
+     *
+     * @param {VueConstructor<Vue>} vueConstructor
+     * @param {ComponentOptions<Vue>} [options={}]
+     * @param {boolean} [mount=true]
+     * @returns {Vue}
+     * @memberof FixtureInstance
+     */
+    extend(vueConstructor: VueConstructor<Vue>, options: ComponentOptions<Vue> = {}, mount: boolean = true): Vue {
+        const component = new (Vue.extend(vueConstructor))({
+            iApi: this.$iApi,
+            ...options,
+            propsData: {
+                ...options.propsData,
+                fixture: this
+            }
+        });
+
+        component.$mount();
+
+        return component;
+    }
+
+    added?(): void;
+    removed?(): void;
+    initialized?(): void;
+    terminated?(): void;
+}
+
+// TODO: deprecated;
 export class FixtureItemAPI extends APIScope {
     /**
      * The original `FixtureConfig` object. Kept for reference.
      *
-     * @type {FixtureConfig}
+     * @type {FixtureBase}
      * @memberof FixtureItemAPI
      */
-    readonly _config: FixtureConfig;
+    readonly _config: FixtureBase;
 
     /**
      * ID of this fixture.
@@ -96,17 +203,17 @@ export class FixtureItemAPI extends APIScope {
      * @memberof FixtureItemAPI
      */
     get id(): string {
-        return this._config.id;
+        return this._config.id!;
     }
 
     /**
      * Creates an instance of FixtureItemAPI.
      *
      * @param {InstanceAPI} iApi
-     * @param {FixtureConfig} config
+     * @param {FixtureBase} config
      * @memberof FixtureItemAPI
      */
-    constructor(iApi: InstanceAPI, config: FixtureConfig) {
+    constructor(iApi: InstanceAPI, config: FixtureBase) {
         super(iApi);
 
         this._config = config;

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -1,12 +1,19 @@
 import Vue, { VueConstructor, ComponentOptions } from 'vue';
 
-import { APIScope } from './internal';
+import { APIScope, InstanceAPI } from './internal';
 import { FixtureBase, FixtureMutation } from '@/store/modules/fixture';
-import { InstanceAPI } from './instance';
+
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;
 
-type IFixtureInstance = new (id: string, iApi: InstanceAPI) => FixtureInstance;
+/**
+ * A constructor returning an object implementing FixtureBase interface.
+ */
 type IFixtureBase = new () => FixtureBase;
+
+/**
+ * A constructor returning an instance of FixtureInstance class.
+ */
+type IFixtureInstance = new (id: string, iApi: InstanceAPI) => FixtureInstance;
 
 export class FixtureAPI extends APIScope {
     /**
@@ -183,51 +190,4 @@ export class FixtureInstance extends APIScope implements FixtureBase {
     removed?(): void;
     initialized?(): void;
     terminated?(): void;
-}
-
-// TODO: deprecated;
-export class FixtureItemAPI extends APIScope {
-    /**
-     * The original `FixtureConfig` object. Kept for reference.
-     *
-     * @type {FixtureBase}
-     * @memberof FixtureItemAPI
-     */
-    readonly _config: FixtureBase;
-
-    /**
-     * ID of this fixture.
-     *
-     * @readonly
-     * @type {string}
-     * @memberof FixtureItemAPI
-     */
-    get id(): string {
-        return this._config.id!;
-    }
-
-    /**
-     * Creates an instance of FixtureItemAPI.
-     *
-     * @param {InstanceAPI} iApi
-     * @param {FixtureBase} config
-     * @memberof FixtureItemAPI
-     */
-    constructor(iApi: InstanceAPI, config: FixtureBase) {
-        super(iApi);
-
-        this._config = config;
-    }
-
-    /**
-     * Removes the specified fixture from R4MP instance.
-     * This is a proxy to `RAMP.fixture.remove(...)`.
-     *
-     * @returns {this}
-     * @memberof FixtureItemAPI
-     */
-    remove(): this {
-        this.$iApi.fixture.remove(this);
-        return this;
-    }
 }

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -11,8 +11,6 @@ import { FixtureAPI, PanelAPI, APIScope } from './internal';
 export class InstanceAPI {
     fixture: FixtureAPI;
     panel: PanelAPI;
-    // allow fixture apis to be added on, this is solely to make typescript happy
-    [key: string]: any;
 
     /**
      * A public event bus for all events. Can also be used by fixtures to talk to each other.

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -1,16 +1,20 @@
 import Vue from 'vue';
-import { RampMapConfig } from 'ramp-geoapi';
+import { RampMapConfig, RampMap } from 'ramp-geoapi';
 import { Store } from 'vuex';
 
 import App from '@/app.vue';
 import { createStore, RootState } from '@/store';
 import { ConfigStore } from '@/store/modules/config';
 
-import { FixtureAPI, PanelAPI, APIScope } from './internal';
+import { FixtureAPI, PanelAPI } from './internal';
 
 export class InstanceAPI {
     fixture: FixtureAPI;
     panel: PanelAPI;
+
+    // FIXME: temporarily store map in global, remove line below when map API is complete
+    // set by the `map/esri-map.vue` file
+    map!: RampMap;
 
     /**
      * A public event bus for all events. Can also be used by fixtures to talk to each other.

--- a/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
+++ b/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
@@ -1,18 +1,14 @@
 import Vue from 'vue';
 
+import { FixtureInstance } from '@/api';
+
 import { APIScope } from '@/api/common';
 import { InstanceAPI } from '@/api/internal';
 import { AppbarItemConfig } from '../store';
 
 const DIVIDER_ID = 'divider';
 
-export class AppbarAPI extends APIScope {
-    constructor(iApi: InstanceAPI) {
-        super(iApi);
-
-        this.$iApi.appbar = this;
-    }
-
+export class AppbarAPI extends FixtureInstance {
     /**
      * Overwrites the current appbar config
      *
@@ -20,7 +16,7 @@ export class AppbarAPI extends APIScope {
      * @returns {Promise<AppbarItemAPI[]} The list of current Appbar Items in the store, as AppbarItemAPIs
      * @memberof AppbarAPI
      */
-    async set(appbarConfig: any): Promise<AppbarItemAPI[] | AppbarItemAPI | null> {
+    async setConfig(appbarConfig: any): Promise<AppbarItemAPI[] | AppbarItemAPI | null> {
         if (!appbarConfig) {
             return null;
         }
@@ -36,7 +32,7 @@ export class AppbarAPI extends APIScope {
         }
         this.$vApp.$store.set('appbar/items', appbarConfig);
 
-        return this.get()!;
+        return this.getItems()!;
     }
 
     /**
@@ -46,7 +42,7 @@ export class AppbarAPI extends APIScope {
      * @returns {AppbarItemAPI[] | AppbarItemAPI | null}
      * @memberof AppbarAPI
      */
-    get(id?: string): AppbarItemAPI[] | AppbarItemAPI | null {
+    getItems(id?: string): AppbarItemAPI[] | AppbarItemAPI | null {
         if (id) {
             const config = this.$vApp.$store.get<AppbarItemConfig | null>('appbar/getById!', id);
             return config ? new AppbarItemAPI(this.$iApi, config) : null;

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -1,38 +1,30 @@
-import Vue from 'vue';
-
-import { FixtureConfigHelper } from '@/store/modules/fixture';
-
 import AppbarV from './appbar.vue';
 import { AppbarAPI } from './api/appbar';
 import { appbar } from './store/index';
 
-class AppbarFixture extends FixtureConfigHelper {
+class AppbarFixture extends AppbarAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
 
-        const fixture = this.$iApi.fixture.get(this.id)!;
+        this.$vApp.$store.registerModule('appbar', appbar());
 
-        this.vApp.$store.registerModule('appbar', appbar());
+        const appbarInstance = this.extend(AppbarV, { store: this.$vApp.$store });
 
-        this.$iApi.emit('appbarApi', new AppbarAPI(this.$iApi));
-
-        const appbarInstance = new (Vue.extend(AppbarV))({
-            iApi: this.$iApi,
-            propsData: { fixture },
-            store: this.vApp.$store
-        });
-
-        appbarInstance.$mount();
-        const innerShell = this.vApp.$el.getElementsByClassName('inner-shell')[0];
+        const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.insertBefore(appbarInstance.$el, innerShell.children[0]);
 
-        await this.$iApi.appbar.set(this.vApp.$store.get('config/getFixtureConfig', 'appbar'));
+        // when other fixtures need access to appbar API, they can do it directly on the fixture object
+        // `this.$iApi.fixture.get<AppbarFixture>('appbar').setConfig()`
+
+        // this is a bit more complicated than access it directly on the global `$iApi` (`this.$iApi.setConfig()`),
+        // but the above approach doesn't pollute a global, provides an easy way to check if fixture exists and gives you intellisense
+
+        await this.setConfig(this.$vApp.$store.get('config/getFixtureConfig', 'appbar'));
     }
 
     removed() {
-        this.$iApi.appbar = null;
-        this.vApp.$store.unregisterModule('appbar');
+        this.$vApp.$store.unregisterModule('appbar');
     }
 }
 
-export default new AppbarFixture('appbar');
+export default AppbarFixture;

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -1,4 +1,4 @@
-import { FixtureConfigHelper } from '@/store/modules/fixture';
+import { FixtureInstance } from '@/api';
 import { PanelConfig } from '@/store/modules/panel';
 
 import P1Screen1V from './p1-screen-1.vue';
@@ -7,7 +7,7 @@ import P1Screen2V from './p1-screen-2.vue';
 import P2Screen1V from './p2-screen-1.vue';
 import P2Screen2V from './p2-screen-2.vue';
 
-class GazeboFixture extends FixtureConfigHelper {
+class GazeboFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
 
@@ -53,7 +53,7 @@ class GazeboFixture extends FixtureConfigHelper {
     }
 }
 
-export default new GazeboFixture('gazebo');
+export default GazeboFixture;
 
 import GazeboAppbarButton from './gazebo-appbar-button.vue';
 export { GazeboAppbarButton as AppbarButton };

--- a/packages/ramp-core/src/fixtures/geosearch/api/geosearch.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/api/geosearch.ts
@@ -1,9 +1,3 @@
-import { APIScope } from '@/api/common';
-import { InstanceAPI } from '@/api/internal';
+import { FixtureInstance } from '@/api/internal';
 
-export class GeosearchAPI extends APIScope {
-    constructor(iApi: InstanceAPI) {
-        super(iApi);
-        this.$iApi.geosearch = this;
-    }
-}
+export class GeosearchAPI extends FixtureInstance {}

--- a/packages/ramp-core/src/fixtures/geosearch/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/index.ts
@@ -5,14 +5,12 @@ import GeosearchComponent from './geosearch-component.vue';
 import { GeosearchAPI } from './api/geosearch';
 import { geosearch } from './store/index';
 
-class GeosearchFixture extends FixtureConfigHelper {
+class GeosearchFixture extends GeosearchAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
         const geosearchScreen = [{ id: 'geosearch-component', component: GeosearchComponent }];
 
-        this.vApp.$store.registerModule('geosearch', geosearch());
-
-        this.$iApi.emit('geosearchApi', new GeosearchAPI(this.$iApi));
+        this.$vApp.$store.registerModule('geosearch', geosearch());
 
         const geosearchPanel: PanelConfig = {
             id: 'geosearch-panel',
@@ -25,12 +23,11 @@ class GeosearchFixture extends FixtureConfigHelper {
     }
 
     removed() {
-        this.$iApi.geosearch = null;
-        this.vApp.$store.unregisterModule('geosearch');
+        this.$vApp.$store.unregisterModule('geosearch');
     }
 }
 
-export default new GeosearchFixture('geosearch');
+export default GeosearchFixture;
 
 import GeosearchAppbarButton from './geosearch-appbar-button.vue';
 export { GeosearchAppbarButton as AppbarButton };

--- a/packages/ramp-core/src/fixtures/grid/api/grid.ts
+++ b/packages/ramp-core/src/fixtures/grid/api/grid.ts
@@ -1,25 +1,17 @@
-import Vue from 'vue';
-import { APIScope } from '@/api/common';
-import { InstanceAPI } from '@/api/internal';
-import { PanelConfig } from '@/store/modules/panel';
-import { GridStore, GridConfig, GridState } from '../store';
+import { FixtureInstance } from '@/api';
+import { GridConfig } from '../store';
 import TableStateManager from '../store/table-state-manager';
 
-export class GridAPI extends APIScope {
-    constructor(iApi: InstanceAPI, panel: PanelConfig) {
-        super(iApi);
-        this.$iApi.grid = this;
+import GridV from './../grid.vue';
 
-        this.panel = panel;
-    }
-
+export class GridAPI extends FixtureInstance {
     /**
      * Open the grid for the layer with the given uid.
      *
      * @param {string} id
      * @memberof GridAPI
      */
-    open(id: string): void {
+    openGrid(id: string): void {
         // get GridConfig for specified uid
         let gridSettings: GridConfig | undefined = this.$vApp.$store.get(`grid/grids@${id}`);
 
@@ -40,10 +32,20 @@ export class GridAPI extends APIScope {
 
         // open the grid
         this.$vApp.$store.set('grid/open', id ? id : null);
-        this.$iApi.panel.open(this.panel);
-    }
-}
 
-export interface GridAPI {
-    panel: PanelConfig;
+        // FIXME: this is temporary; panel enhancements will fix this; coming soon ™
+        this.$iApi.panel.open({
+            id: 'grid-panel',
+            width: 900,
+            screens: [
+                {
+                    id: 'grid-screen',
+                    component: GridV
+                }
+            ],
+            route: {
+                id: 'grid-screen'
+            }
+        });
+    }
 }

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -1,42 +1,18 @@
-import Vue from 'vue';
-import { FixtureConfigHelper } from '@/store/modules/fixture';
-import { PanelConfig } from '@/store/modules/panel';
-import { ConfigStore } from '@/store/modules/config';
-import { LayerStore, layer } from '@/store/modules/layer';
 import { grid } from './store/index';
 
-import GridV from './grid.vue';
 import { GridAPI } from './api/grid';
 
-class GridFixture extends FixtureConfigHelper {
+class GridFixture extends GridAPI {
     async added() {
-        const screens = [
-            {
-                id: 'grid-screen',
-                component: GridV
-            }
-        ];
-
-        const gridPanel: PanelConfig = {
-            id: 'grid-panel',
-            width: 900,
-            screens: screens,
-            route: {
-                id: 'grid-screen'
-            }
-        };
-
-        this.vApp.$store.registerModule('grid', grid());
-        this.$iApi.emit('gridApi', new GridAPI(this.$iApi, gridPanel));
+        this.$vApp.$store.registerModule('grid', grid());
 
         // temporarily throw the InstanceAPI in console for testing purposes.
         console.log(this.$iApi);
     }
 
     removed() {
-        this.vApp.$store.unregisterModule('grid');
-        this.$iApi.grid = undefined;
+        this.$vApp.$store.unregisterModule('grid');
     }
 }
 
-export default new GridFixture('grid');
+export default GridFixture;

--- a/packages/ramp-core/src/fixtures/snowman/index.ts
+++ b/packages/ramp-core/src/fixtures/snowman/index.ts
@@ -1,31 +1,21 @@
-import Vue from 'vue';
-
-import { FixtureConfigHelper } from '@/store/modules/fixture';
-
 import SnowmanV from './snowman.vue'; // import on-map component
+import { FixtureInstance } from '@/api';
 
-class SnowmanFixture extends FixtureConfigHelper {
+class SnowmanFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
 
-        // instantiate it a new instance of the Snowman component and pass iApi as an option and this fixture reference as a prop
-        // since it's not a child of other R4MP Vue components, it will not have a `iApi` reference automatically
-        // this way, the on-map component has access to these entities
-        const fixture = this.$iApi.fixture.get(this.id)!;
+        // instantiate it a new instance of the Snowman component using a helper function which will add `$iApi` to the component automatically
+        // the component will be auto-mounted as well unless you pass `false` to the `extend` function
+        const snowman = this.extend(SnowmanV, { propsData: { message: "I'm snowman prop." } });
 
-        // NOTE: we are passing `FixtureItemAPI` to the component, not plain `FixtureConfig` object
-        const svInstance = new (Vue.extend(SnowmanV))({ iApi: this.$iApi, propsData: { fixture } });
-
-        // adds the snowman on-map component to the main map instance
-        // TODO: this should be done in the `initialized` life hook
-        svInstance.$mount();
-        this.$iApi.$vApp.$el.appendChild(svInstance.$el);
+        this.$vApp.$el.appendChild(snowman.$el);
 
         // snowman self-terminates from its own component
 
         // NOTE: right now Snowman terminates from inside its own component, but it can be done here as well 👇
         // svInstance.$destroy();
-        // this.$iApi.$vApp.$el.removeChild(this.$el);
+        // this.$vApp.$el.removeChild(this.$el);
         // this.$iApi.fixture.remove(fixture);
     }
 
@@ -34,4 +24,4 @@ class SnowmanFixture extends FixtureConfigHelper {
     }
 }
 
-export default new SnowmanFixture('snowman');
+export default SnowmanFixture;

--- a/packages/ramp-core/src/fixtures/snowman/snowman.vue
+++ b/packages/ramp-core/src/fixtures/snowman/snowman.vue
@@ -7,13 +7,14 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
-import { FixtureItemAPI } from '@/api';
+import { FixtureInstance } from '@/api';
 
 // this is an example of a on-map component (doesn't use panels)
 
 @Component({})
 export default class SnowmanV extends Vue {
-    @Prop() fixture!: FixtureItemAPI; // this prop is passed to this component by its fixture main class
+    @Prop() fixture!: FixtureInstance; // this prop is passed to this component by its fixture main class
+    @Prop() message!: string;
 
     url: string = 'https://i.ya-webdesign.com/images/evil-snowman-png-1.png';
 
@@ -22,6 +23,8 @@ export default class SnowmanV extends Vue {
         // and accessing the parent fixture as well
         this.$iApi;
         this.fixture;
+
+        console.log(this.message);
 
         setTimeout(() => {
             console.log(`[fixture] ${this.fixture.id} self-terminates`);
@@ -39,7 +42,7 @@ export default class SnowmanV extends Vue {
             // 👉 this.$iApi.$vApp.$store.set('fixture/REMOVE_FIXTURE!', { value: this }); ❌
 
             // 👇 this is the correct way ✔
-            this.$iApi.fixture.remove(this.fixture); // remove fixure from R4MP
+            this.fixture.remove(); // or // this.$iApi.fixture.remove(this.fixture);
         }, 6000);
     }
 }

--- a/packages/ramp-core/src/store/modules/fixture/fixture-state.ts
+++ b/packages/ramp-core/src/store/modules/fixture/fixture-state.ts
@@ -1,10 +1,11 @@
+import Vue from 'vue';
 import { InstanceAPI } from '@/api/internal';
 
 export class FixtureState {
-    items: { [name: string]: FixtureConfig } = {};
+    items: { [name: string]: FixtureBase } = {};
 }
 
-export interface FixtureConfig {
+export interface FixtureBase {
     /**
      * ID of this fixture.
      *
@@ -12,24 +13,6 @@ export interface FixtureConfig {
      * @memberof Fixture
      */
     id: string;
-
-    /**
-     * A reference to the InstanceAPI this fixture is running inside.
-     * NOTE: this needs to be populated inside the `init()` life hook.
-     *
-     * @type {InstanceAPI}
-     * @memberof Fixture
-     */
-    $iApi?: InstanceAPI;
-
-    /**
-     * Called at the very beginning of the life cycle with the `iApi` reference.
-     * External fixtures can store this reference manually at `this.$iApi`.
-     *
-     * @param {InstanceAPI} $iApi
-     * @memberof FixtureConfig
-     */
-    created($iApi: InstanceAPI): void;
 
     /**
      * [Optional] Called synchronously when the fixture is added to R4MP.
@@ -64,7 +47,8 @@ export interface FixtureConfig {
     terminated?(): void;
 }
 
-export class FixtureConfigHelper implements FixtureConfig {
+// TODO: deprecated;
+export class FixtureConfigHelper implements FixtureBase {
     id: string;
 
     /**

--- a/packages/ramp-core/src/store/modules/fixture/fixture-store.ts
+++ b/packages/ramp-core/src/store/modules/fixture/fixture-store.ts
@@ -1,7 +1,7 @@
 import { ActionContext, Action, Mutation } from 'vuex';
 import { make } from 'vuex-pathify';
 
-import { FixtureState, FixtureConfig } from './fixture-state';
+import { FixtureState, FixtureBase } from './fixture-state';
 import { RootState } from '@/store/state';
 
 type FixtureContext = ActionContext<FixtureState, RootState>;
@@ -28,9 +28,9 @@ const mutations: StoreMutations = {
      * // TODO: add options for override behaviour as in what to do if a fixture with the same id is already added
      *
      * @param {FixtureState} state
-     * @param {{ value: FixtureConfig }} { value }
+     * @param {{ value: FixtureBase }} { value }
      */
-    [FixtureMutation.ADD_FIXTURE](state: FixtureState, { value }: { value: FixtureConfig }): void {
+    [FixtureMutation.ADD_FIXTURE](state: FixtureState, { value }: { value: FixtureBase }): void {
         state.items = { ...state.items, [value.id]: value };
 
         // call the `added` life hook if available
@@ -43,9 +43,9 @@ const mutations: StoreMutations = {
      * Mutation to remove an existing fixture from the fixture list.
      *
      * @param {FixtureState} state
-     * @param {{ value: FixtureConfig }} { value }
+     * @param {{ value: FixtureBase }} { value }
      */
-    [FixtureMutation.REMOVE_FIXTURE](state: FixtureState, { value }: { value: FixtureConfig }): void {
+    [FixtureMutation.REMOVE_FIXTURE](state: FixtureState, { value }: { value: FixtureBase }): void {
         delete state.items[value.id];
         state.items = { ...state.items };
 


### PR DESCRIPTION
DO NOT MERGE -- looking for feedback

This changes (and hopefully simplifies) how fixtures are handled at the bottom:
- fixtures are no longer wrapped but instead inherit from `FixtureInstance` and get more utility functions from `APIScope` (like automatic access to `$iApi` and `$vApp`);
- external fixtures (since they can't inherit anything) get augmentation treatment with stuff from `FixtureInstance`;
- fixture own API should be defined directly on the body of the fixture (see `appbar` for an example);
- non-panel fixtures should use the `extend` utility function to instantiate their custom Vue components instead of directly using `Vue.extend` (see `snowman` for an example); external fixtures don't have access to `Vue.extend` anyway, so this is a new functionality;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/63)
<!-- Reviewable:end -->
