### PR TITLE
Panel enhancements

### DIFF
--- a/packages/ramp-core/.eslintrc.js
+++ b/packages/ramp-core/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     rules: {
         'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
         'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-        'no-dupe-class-members': 'off'
+        'no-dupe-class-members': 'off' // `no-dupe-class-members` complains when function overloads are used
     },
     parserOptions: {
         parser: '@typescript-eslint/parser'

--- a/packages/ramp-core/.eslintrc.js
+++ b/packages/ramp-core/.eslintrc.js
@@ -6,7 +6,8 @@ module.exports = {
     extends: ['plugin:vue/essential', '@vue/prettier', '@vue/typescript'],
     rules: {
         'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-        'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+        'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+        'no-dupe-class-members': 'off'
     },
     parserOptions: {
         parser: '@typescript-eslint/parser'

--- a/packages/ramp-core/public/diligord-fixture.js
+++ b/packages/ramp-core/public/diligord-fixture.js
@@ -8,7 +8,7 @@
     // TODO: make an example of a compiled external fixture
     const dScreen1 = {
         // the `panel` prop is automatically passed to all panel screen components by the panel-container
-        // this is the `PanelItemAPI` instance inside which this screen component is displayed, and it exposes panel API functions
+        // this is the `PanelInstance` instance inside which this screen component is displayed, and it exposes panel API functions
         // methods, computed functions and template will have access to the panel as `this.panel`
         props: ['panel'],
 
@@ -105,13 +105,10 @@
     };
 
     // then, create a panel config
-    const dPanel1 = {
+    const dpanel = {
         id: 'diligord-p1',
-        screens: [{ id: 'diligord-s1', component: dScreen1 }],
-
-        // if the route is not specified, the first screen will be used automatically
-        route: {
-            id: 'diligord-s1'
+        config: {
+            screens: { 'diligord-s1': dScreen1 }
         }
     };
 
@@ -151,7 +148,7 @@
             document.querySelector('.ramp-app').after(component.$el);
 
             // this life hook is called when the fixture is added to R4MP, and now it's possible to open our panel
-            this.$iApi.panel.open(dPanel1);
+            this.$iApi.panel.register(dpanel).open();
         }
     }
 

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -142,7 +142,11 @@ export class FixtureInstance extends APIScope implements FixtureBase {
     readonly id: string;
 
     /**
-     * Creates an instance of FixtureItemAPI.
+     * Creates an instance of FixtureInstance.
+     *
+     * @param {string} id
+     * @param {InstanceAPI} iApi
+     * @memberof FixtureInstance
      */
     constructor(id: string, iApi: InstanceAPI) {
         super(iApi);

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -1,26 +1,93 @@
 import Vue from 'vue';
 
 import { APIScope, InstanceAPI } from './internal';
-import { PanelConfig, PanelConfigRoute } from '@/store/modules/panel';
+import { PanelConfig, PanelConfigRoute, PanelMutation, PanelConfigScreens, PanelConfigStyle, PanelAction } from '@/store/modules/panel';
+
+export type PanelConfigSet = { [name: string]: PanelConfig };
+
+export type PanelConfigPair = { id: string; config: PanelConfig };
+
+export type PanelInstanceSet = { [name: string]: PanelInstance };
+
+export type PanelInstancePath = { id: string; screen?: string; props?: object };
 
 export class PanelAPI extends APIScope {
     /**
-     * Adds and automatically opens a new panel in the panel stack.
+     * Register provided panel object (could be several of just one) and return the resulting `PanelInstance` objects.
+     * When the panel is registered, all its screens are added to the Vue as components right away.
      *
-     * @param {PanelConfig} config
-     * @returns {PanelItemAPI}
+     * @param {(PanelConfigPair | PanelConfigSet)} value
+     * @returns {(PanelInstance | PanelInstanceSet)}
      * @memberof PanelAPI
      */
-    open(config: PanelConfig): PanelItemAPI {
-        this.$vApp.$store.set('panel/addPanel!', config);
+    register(value: PanelConfigPair): PanelInstance;
+    register(value: PanelConfigSet): PanelInstanceSet;
+    register(value: PanelConfigPair | PanelConfigSet): PanelInstance | PanelInstanceSet {
+        const panels: PanelInstance[] = [];
 
-        const panel = this.get(config.id)!;
-
-        // TODO: does the condition below constitute business logic? should this be moved to the store mutation?
-        // if the panel route is not defined, set it to the first panel screen automatically
-        if (!panel._config.route) {
-            this.route(panel, { id: panel._config.screens[0].id });
+        if (isPanelConfigPair(value)) {
+            panels.push(new PanelInstance(this.$iApi, value.id, value.config));
+        } else {
+            Object.entries(value).reduce((map, [id, config]) => {
+                map.push(new PanelInstance(this.$iApi, id, config));
+                return map;
+            }, panels);
         }
+
+        panels.forEach(panel => this.$vApp.$store.set(`panel/${PanelMutation.REGISTER_PANEL}!`, { panel }));
+
+        if (panels.length === 1) {
+            return panels[0];
+        } else {
+            return panels.reduce<PanelInstanceSet>((map, panel) => {
+                map[panel.id] = panel;
+                return map;
+            }, {});
+        }
+    }
+
+    /**
+     * Finds and returns a panel with the id specified.
+     *
+     * @param {(string | PanelInstance)} value
+     * @returns {PanelInstance}
+     * @memberof PanelAPI
+     */
+    get(value: string | PanelInstance): PanelInstance {
+        const id = typeof value === 'string' ? value : value.id;
+        const panel = this.$vApp.$store.get<PanelInstance>(`panel/items@${id}`);
+
+        if (!panel) {
+            throw new Error("panel doesn't exist");
+        }
+
+        return panel;
+    }
+
+    /**
+     * Opens a registered panel in the panel stack.
+     *
+     * @param {(string | PanelInstance | PanelInstancePath)} value
+     * @returns {PanelInstance}
+     * @memberof PanelAPI
+     */
+    open(value: string | PanelInstance | PanelInstancePath): PanelInstance {
+        let panel: PanelInstance, screen: string | undefined, props: object | undefined;
+
+        // figure out what is passed to the function and retrieve the panel object
+        if (typeof value === 'string' || value instanceof PanelInstance) {
+            panel = this.get(value);
+        } else {
+            panel = this.get(value.id);
+            ({ screen, props } = value);
+        }
+
+        // if the screen route is not defined, the default is the first screen component
+        if (screen) {
+            this.show(panel, { screen, props });
+        }
+
+        this.$vApp.$store.set(`panel/${PanelAction.openPanel}!`, { panel });
 
         return panel;
     }
@@ -28,23 +95,19 @@ export class PanelAPI extends APIScope {
     /**
      * Closes the panel specified.
      *
-     * @param {(string | PanelItemAPI)} panelOrId
-     * @returns {(PanelItemAPI | null)}
+     * @param {(string | PanelInstance)} value
+     * @returns {PanelInstance}
      * @memberof PanelAPI
      */
-    close(panelOrId: PanelItemAPI | string): PanelItemAPI | null {
-        const panel = this.get(panelOrId);
-
-        if (!panel) {
-            return null;
-        }
+    close(value: string | PanelInstance): PanelInstance {
+        const panel = this.get(value);
 
         // unpin the panel before removing if it was pinned
         if (panel.isPinned) {
             panel.pin(false);
         }
 
-        this.$vApp.$store.set(`panel/removePanel!`, panel._config);
+        this.$vApp.$store.set(`panel/${PanelAction.closePanel}!`, { panel });
 
         return panel;
     }
@@ -52,61 +115,52 @@ export class PanelAPI extends APIScope {
     /**
      * Pin/unpin/toggle (if no value provided) pin status of the provided panel. When pinning, automatically unpins any previous pinned panel if exists.
      *
-     * @param {(string | PanelItemAPI)} panelOrId
-     * @param {boolean} value
-     * @returns {(PanelItemAPI | null)}
+     * @param {(string | PanelInstance)} value
+     * @param {boolean} [pin]
+     * @returns {PanelInstance}
      * @memberof PanelAPI
      */
-    pin(panelOrId: PanelItemAPI | string, value?: boolean): PanelItemAPI | null {
-        const panel = this.get(panelOrId);
-
-        if (!panel) {
-            return null;
-        }
+    pin(value: string | PanelInstance, pin?: boolean): PanelInstance {
+        const panel = this.get(value);
 
         // use the provided value or negate the existing `isPinned` status of this panel
-        value = typeof value !== 'undefined' ? value : !panel.isPinned;
+        pin = typeof pin !== 'undefined' ? pin : !panel.isPinned;
 
         // if the panel is not currently pinned, and the `value` is not `true`, don't do anything,
         // as this might unintentionally unpin a different panel;
         // say `panelA` is pinned and if the following is called `$iApi.panel.pin(panelB, false)`, it should do nothing
-        if (!panel.isPinned && !value) {
+        if (!panel.isPinned && !pin) {
             return panel;
         }
 
-        // NOTE: we store `pinned` in the store as a reference to a panel config object, not a panel id
-        this.$vApp.$store.set('panel/pinned', value ? panel._config : null);
+        // NOTE: we store `pinned` in the store as a reference to a panel instance object
+        this.$vApp.$store.set('panel/pinned', pin ? panel : null);
 
         return panel;
     }
 
     /**
-     * Returns the currently pinned panel API item, if exists.
+     * Returns the currently pinned panel instance, if exists.
      *
      * @readonly
-     * @type {(PanelItemAPI | null)}
+     * @type {(PanelInstance | null)}
      * @memberof PanelAPI
      */
-    get pinned(): PanelItemAPI | null {
-        const config = this.$vApp.$store.get<PanelConfig | null>('panel/pinned');
-
-        return config ? new PanelItemAPI(this.$iApi, config) : null;
+    get pinned(): PanelInstance | null {
+        return this.$vApp.$store.get<PanelInstance>('panel/pinned') || null;
     }
 
     /**
      * Sets route to the specified screen id and pass props to the panel screen components.
      *
-     * @param {(PanelItemAPI | string)} panelOrId
+     * @param {(string | PanelInstance)} value
      * @param {PanelConfigRoute} route
-     * @returns {(PanelItemAPI | null)}
+     * @returns {PanelInstance}
      * @memberof PanelAPI
      */
-    route(panelOrId: PanelItemAPI | string, route: PanelConfigRoute): PanelItemAPI | null {
-        const panel = this.get(panelOrId);
-
-        if (!panel) {
-            return null;
-        }
+    // TODO: implement panel route history
+    show(value: string | PanelInstance, route: PanelConfigRoute): PanelInstance {
+        const panel = this.get(value);
 
         this.$vApp.$store.set(`panel/items@${panel.id}.route`, route);
 
@@ -114,93 +168,147 @@ export class PanelAPI extends APIScope {
     }
 
     /**
-     * Finds and returns a panel with the id specified.
+     * Sets the styles of the specified panel by using a provided CSS styles object.
      *
-     * @param {(string | PanelItemAPI)} item
+     * @param {(string | PanelInstance)} value
+     * @param {object} style
+     * @param {boolean} [replace=false] merge with existing styles if `false`; replace if `true`
      * @returns {(PanelItemAPI | null)}
      * @memberof PanelAPI
      */
-    get(item: string | PanelItemAPI): PanelItemAPI | null {
-        const id = typeof item === 'string' ? item : item.id;
-        const config = this.$vApp.$store.get<PanelConfig>(`panel/items@${id}`);
+    setStyle(value: string | PanelInstance, style: object, replace: boolean = false): PanelItemAPI | null {
+        const panel = this.get(value);
 
-        // TODO: output warning to a log that a fixture with this id cannot be found
-        if (!config) {
-            return null;
-        }
-
-        return new PanelItemAPI(this.$iApi, config);
-    }
-
-    /**
-     * Sets the width of the specified panel
-     *
-     * @param item panel to modify
-     * @param width the width to set
-     * @returns {{PanelItemAPI | null}}
-     * @memberof PanelAPI
-     */
-    setWidth(item: string | PanelItemAPI, width: number | undefined): PanelItemAPI | null {
-        const panel = this.get(item);
-
-        if (!panel) {
-            return null;
-        }
-
-        this.$vApp.$store.set(`panel/items@${panel.id}.width`, width);
+        this.$vApp.$store.set(`panel/items@${panel.id}.style`, replace ? style : { ...panel.style, ...style });
 
         return panel;
     }
 }
 
-export class PanelItemAPI extends APIScope {
+export class PanelInstance extends APIScope {
     /**
-     * The original `PanelConfig` object. Kept for reference.
+     * ID of this panel.
      *
-     * @type {PanelConfig}
-     * @memberof PanelItemAPI
+     * @type {string}
+     * @memberof PanelInstance
      */
-    readonly _config: PanelConfig;
+    readonly id: string;
 
     /**
-     * ID of this fixture.
+     * A collection of panel screens to be displayed inside the panel.
+     *
+     * @type {PanelConfigScreens}
+     * @memberof PanelInstance
+     */
+    readonly screens: PanelConfigScreens;
+
+    /**
+     * The style object to apply to the panel.
+     *
+     * @type {PanelConfigStyle}
+     * @memberof PanelConfig
+     */
+    style: PanelConfigStyle;
+
+    /**
+     * Returns the width of the panel in pixels or undefined if not set.
      *
      * @readonly
-     * @type {string}
-     * @memberof FixtureItemAPI
+     * @type {(number | undefined)}
+     * @memberof PanelInstance
      */
-    get id(): string {
-        return this._config.id;
+    get width(): number | undefined {
+        if (!this.style.width || this.style.width.slice(-2) !== 'px') {
+            return undefined;
+        }
+
+        return parseInt(this.style.width);
     }
 
     /**
-     * Creates an instance of PanelItemAPI.
+     * Specifies which panel screen to display and optional props to be passed to the screen panel component.
+     *
+     * @type {PanelConfigRoute}
+     * @memberof PanelConfig
+     */
+    route: PanelConfigRoute;
+
+    /**
+     * Creates an instance of PanelInstance.
      *
      * @param {InstanceAPI} iApi
+     * @param {string} id
      * @param {PanelConfig} config
-     * @memberof PanelItemAPI
+     * @memberof PanelInstance
      */
-    constructor(iApi: InstanceAPI, config: PanelConfig) {
+    constructor(iApi: InstanceAPI, id: string, config: PanelConfig) {
         super(iApi);
 
-        this._config = config;
+        // copy values from the config adding `style` default
+        ({ id: this.id, screens: this.screens, style: this.style } = { id, style: {}, ...config });
+
+        if (Object.keys(this.screens).length === 0) {
+            throw new Error('panel must have at least a single screen');
+        }
 
         // register all the panel screen components globally
-        this._config.screens.forEach(({ id, component }) => {
+        Object.entries(this.screens).forEach(([id, component]) => {
             // only register if it hasn't been registered before
             if (!(id in this.$vApp.$options.components!)) {
                 Vue.component(id, component);
+            } else {
+                throw new Error('duplicate component');
             }
         });
+
+        // set the first screen as the default route
+        this.route = { screen: Object.keys(this.screens).pop()! };
+
+        // auto-set `flex-basis` value on the panel if not already set
+        if (!this.style['flex-basis']) {
+            this.style['flex-basis'] = this.style.width || '350px';
+        }
+    }
+
+    /**
+     * Opens a registered panel in the panel stack.
+     * This is a proxy to `RAMP.panel.open(...)`.
+     *
+     * @param {(string | { screen: string; props?: object })} value
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    open(value: string | { screen: string; props?: object }): this {
+        if (typeof value === 'string') {
+            this.$iApi.panel.open(this);
+        } else {
+            this.$iApi.panel.open({ id: this.id, ...value });
+        }
+
+        return this;
+    }
+
+    /**
+     * Close this panel.
+     * This is a proxy to `RAMP.panel.close(...)`.
+     *
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    close(): this {
+        this.$iApi.panel.close(this);
+
+        return this;
     }
 
     /**
      * Pin/unpin/toggle (if no value provided) pin status of this panel. When pinning, automatically unpins any previous pinned panel if exists.
      * This is a proxy to `RAMP.panel.pin(...)`.
      *
+     *
      * @param {boolean} [value]
      * @returns {this}
-     * @memberof PanelItemAPI
+     * @memberof PanelInstance
      */
     pin(value?: boolean): this {
         // use the provided value or negate the existing `isPinned` status of this panel
@@ -217,61 +325,93 @@ export class PanelItemAPI extends APIScope {
      *
      * @readonly
      * @type {boolean}
-     * @memberof PanelItemAPI
+     * @memberof PanelInstance
      */
     get isPinned(): boolean {
         return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.id;
     }
 
     /**
-     * Close this panel.
-     * This is a proxy to `RAMP.panel.close(...)`.
-     *
-     * @returns {this}
-     * @memberof PanelItemAPI
-     */
-    close(): this {
-        this.$iApi.panel.close(this);
-
-        return this;
-    }
-
-    /**
      * Sets route to the specified screen id and pass props to the panel screen components.
      * This is a proxy to `RAMP.panel.route(...)`.
      *
-     * @param {PanelConfigRoute} route
+     * @param {(string | PanelConfigRoute)} value
      * @returns {this}
-     * @memberof PanelItemAPI
+     * @memberof PanelInstance
      */
-    route(route: PanelConfigRoute): this {
-        this.$iApi.panel.route(this, route);
+    show(value: string | PanelConfigRoute): this {
+        const route = typeof value === 'string' ? { screen: value } : value;
+
+        this.$iApi.panel.show(this, route);
 
         return this;
     }
 
     /**
-     * Sets width to the specified value.
-     * This is a proxy to `RAMP.panel.setWidth(...)`.
+     * Sets the styles of the specified panel by using a provided CSS styles object.
+     * This is a proxy to `RAMP.panel.setStyles(...)`.
      *
-     * @param width the width to set
+     * @param {object} style
+     * @param {boolean} [replace=false]
      * @returns {this}
-     * @memberof PanelItemAPI
+     * @memberof PanelInstance
      */
-    setWidth(width: number | undefined): this {
-        this.$iApi.panel.setWidth(this, width);
+    setStyles(style: object, replace: boolean = false): this {
+        this.$iApi.panel.setStyle(this, style, replace);
 
         return this;
     }
+}
+
+// TODO: deprecated
+export class PanelItemAPI extends APIScope {
+    /**
+     * The original `PanelConfig` object. Kept for reference.
+     *
+     * @type {PanelConfig}
+     * @memberof PanelItemAPI
+     */
+    /* readonly _config: PanelConfig; */
 
     /**
-     * Returns the width of the panel (as set in the config)
+     * ID of this fixture.
      *
      * @readonly
-     * @type number | undefined
+     * @type {string}
+     * @memberof FixtureItemAPI
+     */
+    /* get id(): string {
+        return this._config.id;
+    } */
+
+    /**
+     * Creates an instance of PanelItemAPI.
+     *
+     * @param {InstanceAPI} iApi
+     * @param {PanelConfig} config
      * @memberof PanelItemAPI
      */
-    get width(): number | undefined {
-        return this._config.width;
+    constructor(iApi: InstanceAPI, config: PanelConfig) {
+        super(iApi);
+
+        /* this._config = config; */
+
+        // register all the panel screen components globally
+        /* this._config.screens.forEach(({ id, component }) => {
+            // only register if it hasn't been registered before
+            if (!(id in this.$vApp.$options.components!)) {
+                Vue.component(id, component);
+            }
+        }); */
     }
+}
+
+/**
+ * Check if the provided value is of `PanelConfigPair` type.
+ *
+ * @param {(PanelConfigPair | PanelConfigSet)} value
+ * @returns {value is PanelConfigPair}
+ */
+function isPanelConfigPair(value: PanelConfigPair | PanelConfigSet): value is PanelConfigPair {
+    return value.id !== undefined && typeof value.id === 'string' && value.config !== undefined;
 }

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -1,14 +1,8 @@
 <template>
-    <div
-        class="shadow-tm bg-white h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto"
-        :style="{
-            'flex-basis': panelConfig.width ? panelConfig.width + 'px' : '350px',
-            ...panelConfig.style
-        }"
-    >
+    <div class="shadow-tm bg-white h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto" :style="panel.style">
         <!-- this renders a panel screen which is currently in view -->
         <!-- TODO: add animation transition animation here -->
-        <component :is="panelConfig.route.id" v-bind="panelConfig.route.props" :panel="panel" v-focus-list></component>
+        <component :is="panel.route.screen" v-bind="panel.route.props" :panel="panel" v-focus-list></component>
     </div>
 </template>
 
@@ -28,17 +22,11 @@ Vue.component('close', CloseV);
 Vue.component('panel-options-menu', PanelOptionsMenuV);
 Vue.component('dropdown-menu', DropdownMenuV);
 
-import { PanelConfig } from '@/store/modules/panel';
-import { PanelItemAPI } from '@/api';
+import { PanelInstance } from '@/api';
 
 @Component
 export default class PanelContainerV extends Vue {
-    @Prop() panelConfig!: PanelConfig;
-
-    get panel(): PanelItemAPI {
-        // wrap a panel config into a PanelItemAPI and pass it to the fixture components that render inside the panel-screen
-        return new PanelItemAPI(this.$iApi, this.panelConfig);
-    }
+    @Prop() panel!: PanelInstance;
 }
 </script>
 

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -1,10 +1,6 @@
 <template>
     <div class="sm:flex">
-        <panel-container
-            v-for="panelConfig in visible($iApi.screenSize)"
-            :key="`${panelConfig.id}`"
-            :panel-config="panelConfig"
-        ></panel-container>
+        <panel-container v-for="panel in visible($iApi.screenSize)" :key="`${panel.id}`" :panel="panel"></panel-container>
     </div>
 </template>
 
@@ -12,7 +8,7 @@
 import { Vue, Component } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelConfig } from '@/store/modules/panel';
+import { PanelInstance } from '@/api';
 
 import PanelV from './panel-container.vue';
 
@@ -29,14 +25,13 @@ declare class ResizeObserver {
     }
 })
 export default class PanelStackV extends Vue {
-    @Get('panel/getVisible!') visible!: (extraSmallScreen: boolean) => PanelConfig[];
-    @Sync('panel/width') width!: number;
-    isExtraSmall: boolean = !this.$root.$el.classList.contains('sm');
+    @Get('panel/getVisible!') visible!: (extraSmallScreen: boolean) => PanelInstance[];
+    @Sync('panel/stackWidth') stackWidth!: number;
 
     mounted() {
+        // sync the `panel-stack` width into the store so that visible can get calculated
         const resizeObserver = new ResizeObserver((entries: any) => {
-            this.width = entries[0].contentRect.width;
-            this.isExtraSmall = !this.$root.$el.classList.contains('sm');
+            this.stackWidth = entries[0].contentRect.width;
         });
 
         resizeObserver.observe(this.$el);

--- a/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
@@ -8,11 +8,16 @@ import { Vue, Component } from 'vue-property-decorator';
 
 import P1Screen1V from './p1-screen-1.vue';
 import P1Screen2V from './p1-screen-2.vue';
+import GazeboFixture from '.';
 
 @Component
 export default class GazeboAppbarButton extends Vue {
     togglePanel(): void {
         const panel = this.$iApi.panel.get('p1');
+
+        this.$iApi.fixture.get<GazeboFixture>('gazebo')!.panels.p1.open();
+
+        panel!.route();
         if (panel) {
             panel.close();
         } else {

--- a/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/gazebo-appbar-button.vue
@@ -6,31 +6,15 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 
-import P1Screen1V from './p1-screen-1.vue';
-import P1Screen2V from './p1-screen-2.vue';
-import GazeboFixture from '.';
-
 @Component
 export default class GazeboAppbarButton extends Vue {
     togglePanel(): void {
         const panel = this.$iApi.panel.get('p1');
 
-        this.$iApi.fixture.get<GazeboFixture>('gazebo')!.panels.p1.open();
-
-        panel!.route();
-        if (panel) {
+        if (panel.isOpen) {
             panel.close();
         } else {
-            this.$iApi.panel.open({
-                id: 'p1',
-                screens: [
-                    { id: 'p-1-screen-1', component: P1Screen1V },
-                    { id: 'p-1-screen-2', component: P1Screen2V }
-                ],
-                route: {
-                    id: 'p-1-screen-1'
-                }
-            });
+            panel.open();
         }
     }
 }

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -11,7 +11,31 @@ class GazeboFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
 
-        const p1screens = [
+        this.$iApi.panel.register({
+            p1: {
+                screens: {
+                    'p-1-screen-1': P1Screen1V,
+                    'p-1-screen-2': P1Screen2V
+                }
+            },
+            p2: {
+                screens: {
+                    'p-2-screen-1': P2Screen1V,
+                    'p-2-screen-2': P2Screen2V
+                },
+                style: {
+                    'flex-grow': '1',
+                    'max-width': '500px'
+                }
+            }
+        });
+
+        this.$iApi.panel.open('p1');
+        this.$iApi.panel.open('p2').pin();
+
+        /* panel2.pin(true); */
+
+        /* const p1screens = [
             { id: 'p-1-screen-1', component: P1Screen1V },
             { id: 'p-1-screen-2', component: P1Screen2V }
         ];
@@ -44,13 +68,68 @@ class GazeboFixture extends FixtureInstance {
                 'flex-grow': '1',
                 'max-width': '500px'
             }
-        };
+        }; */
 
-        const pApi1 = this.$iApi.panel.open(p1);
+        /* const pApi1 = this.$iApi.panel.open(p1);
         const pApi2 = this.$iApi.panel.open(p2);
 
-        pApi2.pin(true);
+        pApi2.pin(true); */
     }
+
+    /* blah() {
+        // panels seem to be awfully awkward to use since to open a panel, you need to submit a panel config every time
+        // what if instead, all the panels and panel screens are registered upfront?
+
+        // a fixture register some panels;
+        // registered panels are stored in the global panel store, but are not yet visible
+        this.panels.register({
+            p1: {
+                screens: {
+                    'p-1-screen-1': { component: P1Screen1V },
+                    'p-1-screen-2': { component: P1Screen2V }
+                }
+            },
+            p2: {
+                screens: {
+                    'p-2-screen-1': { component: P1Screen1V },
+                    'p-2-screen-2': { component: P1Screen2V }
+                },
+                style: {
+                    'flex-grow': '1',
+                    'max-width': '500px'
+                }
+            }
+        });
+
+        this.panels.register({ id: 'p1', { screens: { 'screen-1': { ... } }}}).open('screen-1');
+
+        // getting panel from the global store still works
+        const p1 = this.$iApi.panel.get('p1');
+
+        // the panel can be opened through its reference without having to pass the panel config to `$iApi` every time
+        // this will open the panel with the first screen listed
+        p1.open();
+
+        // or maybe we don't want to do default screen and will require always to provide screen id.
+        p1.open('p-1-screen-2');
+
+        // `open` also doubles up as `route`: if the panel is opened already, just modify the route
+        p1.open({ screen: 'p-1-screen-2', props: { greeting: 'Default greeting!' }})
+
+        // closing the panel, doesn't not mean the panel is unregistered; it's just removed from the visible stack, or marked as not opened
+        p1.close();
+
+        // anyone can open any panel by its id from anywhere
+        // this is useful for in fixture appbar buttons where
+        // any ideas on how to prevent duplicate panel/screen ids?
+        this.$iApi.panel.open('p1');
+
+        // opening and routing the panels while not having a direct panel reference
+        this.$iApi.panel.open({ panel: 'p1', screen: 'p-1-screen-2', props: { greeting: 'Default greeting!' } })
+
+        this.$iApi.panel.close('p1');
+
+    } */
 }
 
 export default GazeboFixture;

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -12,12 +12,16 @@ class GazeboFixture extends FixtureInstance {
         console.log(`[fixture] ${this.id} added`);
 
         this.$iApi.panel.register({
+            // panel-1 has examples of how not to bind things and interact with stuff; bad panel ❌
+            // it generally avoids using API and goes straight to the store; fixtures/panels/screens should not do that;
             p1: {
                 screens: {
                     'p-1-screen-1': P1Screen1V,
                     'p-1-screen-2': P1Screen2V
                 }
             },
+            // panel-2 has examples of how properly bind things and interact with stuff; good panel ✔
+            // use API functions; underlying store structure might change and all the code accessing the store directly will break
             p2: {
                 screens: {
                     'p-2-screen-1': P2Screen1V,
@@ -30,106 +34,12 @@ class GazeboFixture extends FixtureInstance {
             }
         });
 
-        this.$iApi.panel.open('p1');
-        this.$iApi.panel.open('p2').pin();
-
-        /* panel2.pin(true); */
-
-        /* const p1screens = [
-            { id: 'p-1-screen-1', component: P1Screen1V },
-            { id: 'p-1-screen-2', component: P1Screen2V }
-        ];
-
-        const p2screens = [
-            { id: 'p-2-screen-1', component: P2Screen1V },
-            { id: 'p-2-screen-2', component: P2Screen2V }
-        ];
-
-        // panel-1 has examples of how not to bind things and interact with stuff; bad panel ❌
-        // it generally avoids using API and goes straight to the store; fixtures/panels/screens should not do that;
-        const p1: PanelConfig = {
-            id: 'p1',
-            screens: p1screens,
-            route: {
-                id: 'p-1-screen-1'
-            }
-        };
-
-        // panel-2 has examples of how properly bind things and interact with stuff; good panel ✔
-        // use API functions; underlying store structure might change and all the code accessing the store directly will break
-        const p2: PanelConfig = {
-            id: 'p2',
-            screens: p2screens,
-            route: {
-                id: 'p-2-screen-2',
-                props: { greeting: 'Default greeting!' }
-            },
-            style: {
-                'flex-grow': '1',
-                'max-width': '500px'
-            }
-        }; */
-
-        /* const pApi1 = this.$iApi.panel.open(p1);
-        const pApi2 = this.$iApi.panel.open(p2);
-
-        pApi2.pin(true); */
+        this.$iApi.panel.open({ id: 'p1', screen: 'p-1-screen-2' });
+        this.$iApi.panel
+            .get('p2')
+            .open()
+            .pin();
     }
-
-    /* blah() {
-        // panels seem to be awfully awkward to use since to open a panel, you need to submit a panel config every time
-        // what if instead, all the panels and panel screens are registered upfront?
-
-        // a fixture register some panels;
-        // registered panels are stored in the global panel store, but are not yet visible
-        this.panels.register({
-            p1: {
-                screens: {
-                    'p-1-screen-1': { component: P1Screen1V },
-                    'p-1-screen-2': { component: P1Screen2V }
-                }
-            },
-            p2: {
-                screens: {
-                    'p-2-screen-1': { component: P1Screen1V },
-                    'p-2-screen-2': { component: P1Screen2V }
-                },
-                style: {
-                    'flex-grow': '1',
-                    'max-width': '500px'
-                }
-            }
-        });
-
-        this.panels.register({ id: 'p1', { screens: { 'screen-1': { ... } }}}).open('screen-1');
-
-        // getting panel from the global store still works
-        const p1 = this.$iApi.panel.get('p1');
-
-        // the panel can be opened through its reference without having to pass the panel config to `$iApi` every time
-        // this will open the panel with the first screen listed
-        p1.open();
-
-        // or maybe we don't want to do default screen and will require always to provide screen id.
-        p1.open('p-1-screen-2');
-
-        // `open` also doubles up as `route`: if the panel is opened already, just modify the route
-        p1.open({ screen: 'p-1-screen-2', props: { greeting: 'Default greeting!' }})
-
-        // closing the panel, doesn't not mean the panel is unregistered; it's just removed from the visible stack, or marked as not opened
-        p1.close();
-
-        // anyone can open any panel by its id from anywhere
-        // this is useful for in fixture appbar buttons where
-        // any ideas on how to prevent duplicate panel/screen ids?
-        this.$iApi.panel.open('p1');
-
-        // opening and routing the panels while not having a direct panel reference
-        this.$iApi.panel.open({ panel: 'p1', screen: 'p-1-screen-2', props: { greeting: 'Default greeting!' } })
-
-        this.$iApi.panel.close('p1');
-
-    } */
 }
 
 export default GazeboFixture;

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
@@ -19,7 +19,7 @@
         <template #content>
             <div class="flex flex-col items-center">
                 <!-- this is fine -->
-                <button @click="route = { id: 'p-1-screen-2' }" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16">
+                <button @click="route = { screen: 'p-1-screen-2' }" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16">
                     See Gazebo 2
                 </button>
 
@@ -33,7 +33,8 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelConfig, PanelConfigRoute } from '@/store/modules/panel';
+import { PanelConfigRoute } from '@/store/modules/panel';
+import { PanelInstance } from '../../api';
 
 @Component
 export default class Screen1V extends Vue {
@@ -43,14 +44,14 @@ export default class Screen1V extends Vue {
     @Sync('panel/items@p1.route') route!: PanelConfigRoute;
 
     // ❌ also don't do this for the reasons above 👇
-    @Sync('panel/pinned') pinned!: PanelConfig | null;
+    @Sync('panel/pinned') pinned!: PanelInstance | null;
 
     url: string = 'https://i2.wp.com/freepngimages.com/wp-content/uploads/2017/08/wooden-garden-gazebo.png?w=860';
 
     pinPanel(): void {
         // this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes
-        const panelConfig = this.$store.get<PanelConfig>(`panel/items@p1`)!;
-        this.pinned = this.pinned === null || (this.pinned && this.pinned.id) !== 'p1' ? panelConfig : null;
+        const panel = this.$store.get<PanelInstance>(`panel/items@p1`)!;
+        this.pinned = this.pinned === null || (this.pinned && this.pinned.id) !== 'p1' ? panel : null;
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
@@ -25,8 +25,7 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
-import { PanelConfig } from '../../store/modules/panel';
-import { PanelItemAPI } from '../../api';
+import { PanelInstance } from '../../api';
 
 @Component({})
 export default class Scree2V extends Vue {
@@ -34,23 +33,22 @@ export default class Scree2V extends Vue {
 
     // ❌ this is bad because it's tappnig directly into the store circumventing the API
     // this will work, but if the store changes strcture, it might break 👇
-    goToScreen(id: string): void {
-        this.$store.set('panel/items@p1.route', { id });
+    goToScreen(screen: string): void {
+        this.$store.set('panel/items@p1.route', { screen });
     }
 
     // ❌ this is bad because it's tappnig directly into the store circumventing the API
-    // and it also receives back a PanelConfig object, not the PanelItemAPI object
     // this will work, but if the store changes strcture, it might break 👇
     get pinned(): string | null {
-        const panelConfig = this.$store.get<PanelConfig | null>('panel/pinned')!;
-        return panelConfig ? panelConfig.id : null;
+        const panel = this.$store.get<PanelInstance | null>('panel/pinned')!;
+        return panel ? panel.id : null;
     }
 
     pinPanel(): void {
         // ❌ this is bad because it's tappnig directly into the store circumventing the API
         // this will work, but if the store changes structure, it might break 👇
-        const panelConfig = this.$store.get<PanelConfig>(`panel/items@p1`)!;
-        this.$store.set('panel/pinned', this.pinned !== 'p1' ? panelConfig : null);
+        const panel = this.$store.get<PanelInstance>(`panel/items@p1`)!;
+        this.$store.set('panel/pinned', this.pinned !== 'p1' ? panel : null);
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
@@ -36,7 +36,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelItemAPI, PanelInstance } from '@/api';
+import { PanelInstance } from '@/api';
 
 @Component({})
 export default class Scree2V extends Vue {

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
@@ -20,7 +20,7 @@
             <div class="flex flex-col items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->
                 <button
-                    @click="panel.route({ id: 'p-2-screen-2', props: { greeting: 'Howdy?' } })"
+                    @click="panel.show({ screen: 'p-2-screen-2', props: { greeting: 'Howdy?' } })"
                     class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-16"
                 >
                     Go back to B
@@ -36,12 +36,12 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelItemAPI } from '@/api';
+import { PanelItemAPI, PanelInstance } from '@/api';
 
 @Component({})
 export default class Scree2V extends Vue {
     // ✔ this prop is always present and it's set by the panel-container component
-    @Prop() panel!: PanelItemAPI;
+    @Prop() panel!: PanelInstance;
 
     // ✔ this prop is passed to this component as part of the `route` property when switching/rendering this screen
     @Prop() greeting?: string;

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
@@ -21,7 +21,7 @@
             <div class="flex flex-col items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->
                 <button
-                    @click="panel.route({ id: 'p-2-screen-1', props: { greeting: 'Greeting from Screen B' } })"
+                    @click="panel.show({ screen: 'p-2-screen-1', props: { greeting: 'Greeting from Screen B' } })"
                     class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-16"
                 >
                     Switch to Screen A
@@ -37,12 +37,12 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelItemAPI } from '@/api';
+import { PanelInstance } from '@/api';
 
 @Component({})
 export default class Scree2V extends Vue {
     // ✔ this prop is always present and it's set by the panel-container component
-    @Prop() panel!: PanelItemAPI;
+    @Prop() panel!: PanelInstance;
 
     // ✔ this prop is passed to this component as part of the `route` property when switching/rendering this screen
     @Prop() greeting?: string;

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-appbar-button.vue
@@ -18,17 +18,11 @@ import GeosearchComponent from './geosearch-component.vue';
 export default class GeosearchAppbarButton extends Vue {
     togglePanel(): void {
         const panel = this.$iApi.panel.get('geosearch-panel');
-        const geosearchScreen = [{ id: 'geosearch-component', component: GeosearchComponent }];
-        if (panel) {
+
+        if (panel.isOpen) {
             panel.close();
         } else {
-            this.$iApi.panel.open({
-                id: 'geosearch-panel',
-                screens: geosearchScreen,
-                route: {
-                    id: 'geosearch-component'
-                }
-            });
+            panel.open();
         }
     }
 }

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
@@ -48,7 +48,7 @@
 <script lang="ts">
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
-import { PanelItemAPI } from '@/api';
+import { PanelInstance } from '@/api';
 
 import { GeosearchStore } from './store';
 import { RampMap } from 'ramp-geoapi';
@@ -68,7 +68,7 @@ import { ApiBundle } from 'ramp-geoapi';
     }
 })
 export default class GeosearchComponent extends Vue {
-    @Prop() panel!: PanelItemAPI;
+    @Prop() panel!: PanelInstance;
     // fetch store properties/data
     @Get(GeosearchStore.searchVal) searchVal!: string;
     @Get(GeosearchStore.searchResults) searchResults!: Array<any>;

--- a/packages/ramp-core/src/fixtures/geosearch/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/index.ts
@@ -1,6 +1,3 @@
-import { PanelConfig } from '@/store/modules/panel';
-import { FixtureConfigHelper } from '@/store/modules/fixture';
-// import on-map components
 import GeosearchComponent from './geosearch-component.vue';
 import { GeosearchAPI } from './api/geosearch';
 import { geosearch } from './store/index';
@@ -8,18 +5,17 @@ import { geosearch } from './store/index';
 class GeosearchFixture extends GeosearchAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
-        const geosearchScreen = [{ id: 'geosearch-component', component: GeosearchComponent }];
 
         this.$vApp.$store.registerModule('geosearch', geosearch());
 
-        const geosearchPanel: PanelConfig = {
+        this.$iApi.panel.register({
             id: 'geosearch-panel',
-            screens: geosearchScreen,
-            route: {
-                id: 'geosearch-component'
+            config: {
+                screens: { 'geosearch-component': GeosearchComponent }
             }
-        };
-        this.$iApi.panel.open(geosearchPanel);
+        });
+
+        this.$iApi.panel.open('geosearch-panel');
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/grid/api/grid.ts
+++ b/packages/ramp-core/src/fixtures/grid/api/grid.ts
@@ -2,8 +2,6 @@ import { FixtureInstance } from '@/api';
 import { GridConfig } from '../store';
 import TableStateManager from '../store/table-state-manager';
 
-import GridV from './../grid.vue';
-
 export class GridAPI extends FixtureInstance {
     /**
      * Open the grid for the layer with the given uid.
@@ -33,19 +31,6 @@ export class GridAPI extends FixtureInstance {
         // open the grid
         this.$vApp.$store.set('grid/open', id ? id : null);
 
-        // FIXME: this is temporary; panel enhancements will fix this; coming soon ™
-        this.$iApi.panel.open({
-            id: 'grid-panel',
-            width: 900,
-            screens: [
-                {
-                    id: 'grid-screen',
-                    component: GridV
-                }
-            ],
-            route: {
-                id: 'grid-screen'
-            }
-        });
+        this.$iApi.panel.open('grid-panel');
     }
 }

--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -58,7 +58,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelItemAPI } from '@/api';
+import { PanelInstance } from '@/api';
 import TableComponent from '@/fixtures/grid/table/table.vue';
 
 import { LayerStore, layer } from '@/store/modules/layer';
@@ -70,7 +70,7 @@ import FeatureLayer from 'ramp-geoapi/dist/layer/FeatureLayer';
     }
 })
 export default class Screen1 extends Vue {
-    @Prop() panel!: PanelItemAPI;
+    @Prop() panel!: PanelInstance;
     @Prop() header!: String;
 
     @Get(LayerStore.layers) layers!: FeatureLayer[];
@@ -99,9 +99,9 @@ export default class Screen1 extends Vue {
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,
 .rv-global-search {
-    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2
+    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2;
 }
 .rv-input {
-    @apply m-0 py-1
+    @apply m-0 py-1;
 }
 </style>

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -1,9 +1,21 @@
+import { GridAPI } from './api/grid';
 import { grid } from './store/index';
 
-import { GridAPI } from './api/grid';
+import GridV from './grid.vue';
 
 class GridFixture extends GridAPI {
     async added() {
+        this.$iApi.panel.register({
+            'grid-panel': {
+                screens: {
+                    'grid-screen': GridV
+                },
+                style: {
+                    width: '900px'
+                }
+            }
+        });
+
         this.$vApp.$store.registerModule('grid', grid());
 
         // temporarily throw the InstanceAPI in console for testing purposes.

--- a/packages/ramp-core/src/store/modules/panel/panel-state.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-state.ts
@@ -1,48 +1,49 @@
 import Vue, { VueConstructor } from 'vue';
+import { PanelInstance } from '@/api';
 
 export class PanelState {
     /**
      * A list of all open (visible and hidden) panels.
      *
-     * @type {{ [name: string]: PanelConfig }}
+     * @type {{ [name: string]: PanelInstance }}
      * @memberof PanelState
      */
-    items: { [name: string]: PanelConfig } = {};
+    items: { [name: string]: PanelInstance } = {};
 
     /**
      * A list of all panels in the arrangement they would be put on screen.
      * The last item will be the first on screen (rightmost, therefore rightmost in array).
      * Note: The `visible` array is used for whats actually on screen, this is used for calculating `visible`.
      *
-     * @type {PanelConfig[]}
+     * @type {PanelInstance[]}
      * @memberof PanelState
      */
-    orderedItems: PanelConfig[] = [];
+    orderedItems: PanelInstance[] = [];
 
     /**
      * Indicates a pinned panel.
      *
-     * @type {(PanelConfig | null)}
+     * @type {(PanelInstance | null)}
      * @memberof PanelState
      */
-    pinned: PanelConfig | null = null;
+    pinned: PanelInstance | null = null;
 
     /**
      * Indicates the most recently opened panel has priority
      * This is given the value of that recent panel in order to check on removal
      *
-     * @type {PanelConfig | null}
+     * @type {(PanelInstance | null)}
      * @memberof PanelState
      */
-    priority: PanelConfig | null = null;
+    priority: PanelInstance | null = null;
 
     /**
      * The panels that are displayed on the screen
      *
-     * @type {PanelConfig[]}
+     * @type {PanelInstance[]}
      * @memberof PanelState
      */
-    visible: PanelConfig[] = [];
+    visible: PanelInstance[] = [];
 
     /**
      * The screen width that the visible panels are allowed to use.
@@ -50,45 +51,21 @@ export class PanelState {
      * @type {number}
      * @memberof PanelState
      */
-    width: number = 0;
+    stackWidth: number = 0;
 }
 
-export type PanelConfigScreen = { id: string; component: VueConstructor<Vue> };
-export type PanelConfigRoute = { id: string; props?: object };
+export type PanelConfigScreens = { [key: string]: VueConstructor<Vue> };
+export type PanelConfigRoute = { screen: string; props?: object };
 export type PanelConfigStyle = { [key: string]: string };
 
 export interface PanelConfig {
     /**
-     * ID of this panel.
-     *
-     * @type {string}
-     * @memberof Panel
-     */
-    id: string;
-
-    /**
-     * The width of this panel.
-     *
-     * @type {number}
-     * @memberof Panel
-     */
-    width?: number;
-
-    /**
-     * Specifies which panel screen to display and optional props to be passed to the screen panel component.
-     *
-     * @type {PanelConfigRoute}
-     * @memberof PanelConfig
-     */
-    route?: PanelConfigRoute;
-
-    /**
      * A collection of panel screens to be displayed inside the panel.
      *
-     * @type {PanelConfigScreen[]}
+     * @type {{[name: string]: PanelConfigScreen}}
      * @memberof PanelConfig
      */
-    screens: PanelConfigScreen[];
+    screens: PanelConfigScreens;
 
     /**
      * The style object to apply to the panel.

--- a/packages/ramp-core/src/store/modules/panel/panel-store.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-store.ts
@@ -12,7 +12,6 @@ type StoreMutations = { [key: string]: Mutation<PanelState> };
 
 export enum PanelAction {
     openPanel = 'openPanel',
-    /* addPanel = 'addPanel', */
     closePanel = 'removePanel',
     setWidth = 'setWidth',
     updateVisible = 'updateVisible'
@@ -22,7 +21,6 @@ export enum PanelMutation {
     REGISTER_PANEL = 'REGISTER_PANEL',
     OPEN_PANEL = 'OPEN_PANEL',
 
-    ADD_PANEL = 'ADD_PANEL',
     ADD_TO_PANEL_ORDER = 'ADD_TO_PANEL_ORDER',
     CLOSE_PANEL = 'REMOVE_PANEL',
 
@@ -54,12 +52,6 @@ const actions = {
         context.commit(PanelMutation.SET_PRIORITY, value);
         context.dispatch(PanelAction.updateVisible);
     },
-
-    /* [PanelAction.addPanel](context: PanelContext, value: PanelConfig): void {
-        context.commit(PanelMutation.ADD_PANEL, value);
-        context.commit(PanelMutation.SET_PRIORITY, value);
-        context.dispatch(PanelAction.updateVisible);
-    }, */
 
     [PanelAction.closePanel](context: PanelContext, value: { panel: PanelConfig }): void {
         if (context.state.priority === value.panel) {
@@ -133,11 +125,6 @@ const mutations = {
     [PanelMutation.OPEN_PANEL](state: PanelState, { panel }: { panel: PanelInstance }): void {
         state.orderedItems = [...state.orderedItems, panel];
     },
-
-    /* [PanelMutation.ADD_PANEL](state: PanelState, value: PanelConfig): void {
-        state.orderedItems = [...state.orderedItems, value];
-        state.items = { ...state.items, [value.id]: value };
-    }, */
 
     [PanelMutation.CLOSE_PANEL](state: PanelState, { panel }: { panel: PanelInstance }): void {
         const index = state.orderedItems.indexOf(panel);


### PR DESCRIPTION
Panel management improvements from yesterday's post. See below:

```ts
// panels seem to be awfully awkward to use since to open a panel, you need to submit a panel config every time
// what if instead, all the panels and panel screens are registered upfront?

// a fixture register some panels;
// registered panels are stored in the global panel store, but are not yet visible
this.panels.register({
    p1: {
        screens: {
            'p-1-screen-1': { component: P1Screen1V },
            'p-1-screen-2': { component: P1Screen2V }
        }
    },
    p2: {
        screens: {
            'p-2-screen-1': { component: P1Screen1V },
            'p-2-screen-2': { component: P1Screen2V }
        },
        style: {
            'flex-grow': '1',
            'max-width': '500px'
        }
    }
})

// getting panel from the global store still works
const p1 = this.$iApi.panel.get('p1');

// the panel can be opened through its reference without having to pass the panel config to `$iApi` every time
// this will open the panel with the first screen listed
p1.open();

// or maybe we don't want to do default screen and will require always to provide screen id.
p1.open('p-1-screen-2');

// `open` also doubles up as `route`: if the panel is opened already, just modify the route
p1.open({ screen: 'p-1-screen-2', props: { greeting: 'Default greeting!' }})

// closing the panel, doesn't not mean the panel is unregistered; it's just removed from the visible stack, or marked as not opened
p1.close();

// anyone can open any panel by its id from anywhere
// this is useful for in fixture appbar buttons where
// any ideas on how to prevent duplicate panel/screen ids?
this.$iApi.panel.open('p1');

// opening and routing the panels while not having a direct panel reference
this.$iApi.panel.open({ id: 'p1', screen: 'p-1-screen-2', props: { greeting: 'Default greeting!' } })

this.$iApi.panel.close('p1');
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/66)
<!-- Reviewable:end -->
