### PR TITLE
focus-item ID generation, aria-activedescendant

### DIFF
--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -11,8 +11,9 @@ import Shell from '@/components/shell.vue';
 
 import ro from '@/scripts/resize-observer.js';
 
-import { FocusList } from '@/directives/focus-list';
+import { FocusList, FocusItem } from '@/directives/focus-list';
 Vue.directive('focus-list', FocusList);
+Vue.directive('focus-item', FocusItem);
 
 @Component({
     components: {

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="h-full flex flex-col items-stretch">
-        <header class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48 default-focus-style" focus-item>
+        <header class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48 default-focus-style" v-focus-item>
             <h2 class="flex-grow text-lg py-16 pl-8">
                 <slot name="header"></slot>
             </h2>
@@ -8,7 +8,7 @@
             <slot name="controls"></slot>
         </header>
 
-        <div class="p-8 flex-grow default-focus-style" focus-item>
+        <div class="p-8 flex-grow default-focus-style" v-focus-item>
             <slot name="content"></slot>
         </div>
     </div>

--- a/packages/ramp-core/src/directives/focus-list/focus-item.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-item.ts
@@ -16,8 +16,8 @@ const ITEM_ATTR = 'focus-item';
  * </div>
  * ```
  */
-export const FocusItem = {
-    bind(el: HTMLElement, binding: any /*, vnode: any */) {
+export const FocusItem: Vue.DirectiveOptions = {
+    bind(el: HTMLElement /*, binding: Vue.VNodeDirective , vnode: Vue.VNode */) {
         if (!el.hasAttribute('id')) {
             el.setAttribute('id', generateID());
         }

--- a/packages/ramp-core/src/directives/focus-list/focus-item.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-item.ts
@@ -1,0 +1,40 @@
+const ITEM_ATTR = 'focus-item';
+
+/**
+ * The FocusItem Directive
+ *
+ * This is to be used within `FocusList`s. Add this to every element you want to traverse between using the arrow keys (see FocusList for more info).
+ * This directive adds an id for accessibility if there isn't one on the element already.
+ *
+ * **Example**:
+ *
+ * ```
+ * <div v-focus-list="'horizontal'">
+ *     <button v-focus-item></button>
+ *     <button v-focus-item></button>
+ *     <button v-focus-item></button>
+ * </div>
+ * ```
+ */
+export const FocusItem = {
+    bind(el: HTMLElement, binding: any /*, vnode: any */) {
+        if (!el.hasAttribute('id')) {
+            el.setAttribute('id', generateID());
+        }
+        // add the focus item attribute since the directive attribute will only stick around if its bound (i.e. :v-focus-item=...)
+        el.toggleAttribute(ITEM_ATTR, true);
+    }
+};
+
+function generateID(): string {
+    let newID;
+    do {
+        newID =
+            'focus-item-' +
+            Math.random()
+                .toString(36)
+                .substring(2, 9);
+    } while (document.getElementById(newID) !== null);
+
+    return newID;
+}

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -35,8 +35,8 @@ const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_
  * </div>
  * ```
  */
-export const FocusList = {
-    bind(el: HTMLElement, binding: any /*, vnode: any */) {
+export const FocusList: Vue.DirectiveOptions = {
+    bind(el: HTMLElement, binding: Vue.VNodeDirective /*, vnode: Vue.VNode */) {
         // make it tabbable if it isn't
         // NOTE: +<string> = the string as a number, +<null> = 0
         if (+el.getAttribute('tabindex')! <= 0) {

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -15,7 +15,6 @@ enum KEYS {
 const LIST_ATTR = 'focus-list';
 const ITEM_ATTR = 'focus-item';
 const FOCUSED_CLASS = 'focused';
-const FOCUSED_ID = 'focusedItem';
 const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}]`;
 
 // TODO: Figure out a way to put the control scheme into the description of the focus-list for screen readers (hidden text?), or see if the help file would be sufficient.
@@ -23,16 +22,16 @@ const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_
 /**
  * The FocusList Directive
  *
- * To use; add `v-focus-list` to your main element and `focus-item` to sub-items you want to be selectable
+ * To use; add `v-focus-list` to your main element and `v-focus-item` to sub-items you want to be selectable
  * The directive will assume your list is vertical. To force it to be horizontal set the attribute to have a value of 'horizontal'.
  *
  * **Example**:
  *
  * ```
  * <div v-focus-list="'horizontal'">
- *     <button focus-item></button>
- *     <button focus-item></button>
- *     <button focus-item></button>
+ *     <button v-focus-item></button>
+ *     <button v-focus-item></button>
+ *     <button v-focus-item></button>
  * </div>
  * ```
  */
@@ -163,24 +162,12 @@ class FocusListManager {
     }
 
     /**
-     * Clears the focused element ID from any element that has it, removing it's ancestors `aria-activedescendant` as well.
-     * It then moves the focus to `item` and updates the lists `aria-activedescendant`
+     * Updates the list's `aria-activedescendant` to be `item`
      *
      * @param item The element that should be the active descendant
      */
     setAriaActiveDescendant(item: HTMLElement) {
-        // if theres an element with FOCUSED_ID somewhere else on the page, remove it (and its list's aria-activedescendant)
-        // so that we can put it on our element.
-        const focusedElement = document.getElementById(FOCUSED_ID);
-        if (focusedElement) {
-            focusedElement.removeAttribute('id');
-            const closestList = focusedElement.closest(`[${LIST_ATTR}]`)!;
-            if (closestList !== this.element) {
-                closestList.removeAttribute('aria-activedescendant');
-            }
-        }
-        item.setAttribute('id', FOCUSED_ID);
-        this.element.setAttribute('aria-activedescendant', FOCUSED_ID);
+        this.element.setAttribute('aria-activedescendant', item.getAttribute('id')!);
     }
 
     /**

--- a/packages/ramp-core/src/directives/focus-list/index.ts
+++ b/packages/ramp-core/src/directives/focus-list/index.ts
@@ -1,1 +1,2 @@
 export * from './focus-list';
+export * from './focus-item';

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -6,7 +6,7 @@
             :key="`${item.id}-${index}`"
             class="h-24 my-4 first:mt-8 text-gray-400 hover:text-white"
             :class="{ 'py-12': item.id !== DIVIDER }"
-            :focus-item="item.id !== DIVIDER"
+            :v-focus-item="item.id !== DIVIDER"
         ></component>
     </div>
 </template>

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
@@ -23,7 +23,11 @@
                 v-if="searchResults.length > 0"
             >
                 <li class="relative h-48" v-for="(result, idx) in searchResults" v-bind:key="idx">
-                    <button class="absolute inset-0 h-full w-full hover:bg-gray-300 default-focus-style" @click="zoomIn(result)" focus-item>
+                    <button
+                        class="absolute inset-0 h-full w-full hover:bg-gray-300 default-focus-style"
+                        @click="zoomIn(result)"
+                        v-focus-item
+                    >
                         <div class="rv-result-description flex px-8">
                             <div class="flex-1 text-left truncate">
                                 <span v-html="highlightSearchTerm(result.name) + ','"></span>


### PR DESCRIPTION
Adds the focus item directive which generates IDs as needed. `aria-activedescendant` on focus-lists now sticks around even if a different list is currently in use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/67)
<!-- Reviewable:end -->
