### PR TITLE
chore: overload get to fetch several fixtures at a time 

### DIFF
--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -57,7 +57,7 @@ export class FixtureAPI extends APIScope {
      *
      * @template T
      * @param {(FixtureBase | string)} fixtureOrId
-     * @returns {(T | null)}
+     * @returns {T}
      * @memberof FixtureAPI
      */
     remove<T extends FixtureBase = FixtureBase>(fixtureOrId: FixtureBase | string): T {

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -24,6 +24,7 @@ export class FixtureAPI extends APIScope {
      * @returns {Promise<FixtureBase>}
      * @memberof FixtureAPI
      */
+    // TODO: implement overload to add a list of features
     async add(id: string, constructor?: IFixtureBase): Promise<FixtureBase> {
         let fixture: FixtureBase;
 
@@ -59,13 +60,8 @@ export class FixtureAPI extends APIScope {
      * @returns {(T | null)}
      * @memberof FixtureAPI
      */
-    remove<T extends FixtureBase = FixtureBase>(fixtureOrId: FixtureBase | string): T | null {
+    remove<T extends FixtureBase = FixtureBase>(fixtureOrId: FixtureBase | string): T {
         const fixture = this.get<T>(fixtureOrId);
-
-        // TODO: output warning to a log that a fixture with this id cannot be found
-        if (!fixture) {
-            return null;
-        }
 
         this.$vApp.$store.set(`fixture/${FixtureMutation.REMOVE_FIXTURE}!`, { value: fixture });
 
@@ -73,23 +69,49 @@ export class FixtureAPI extends APIScope {
     }
 
     /**
-     * Finds and returns a fixture with the id specified.
+     * Finds and returns a `FixtureBase` object with the id specified.
      *
-     * @template T
-     * @param {(string | { id: string })} item
-     * @returns {(T | null)}
+     * @template T subclass of the `FixtureBase`; defaults to `FixtureBase`
+     * @param {(string | FixtureBase)} item fixture id or `FixtureBase` item
+     * @returns {T}
      * @memberof FixtureAPI
      */
-    get<T extends FixtureBase = FixtureBase>(item: string | { id: string }): T | null {
-        const id = typeof item === 'string' ? item : item.id;
-        const fixture = this.$vApp.$store.get<T>(`fixture/items@${id}`);
+    get<T extends FixtureBase = FixtureBase>(item: string | FixtureBase): T;
+    /**
+     * Finds and returns a collection of `FixtureBase` objects given a list of ids.
+     * This can be useful when retrieving several fixtures at one time as follows:
+     * ```ts
+     * const [one, two, three] = RAMP.fixture.get(['fixture-one', 'fixture-two', 'fixture-three']);
+     * ```
+     *
+     * @template T subclass of the `FixtureBase`; defaults to `FixtureBase`
+     * @param {string[]} item a list of fixture ids
+     * @returns {T[]}
+     * @memberof FixtureAPI
+     */
+    get<T extends FixtureBase = FixtureBase>(item: string[]): T[];
+    get<T extends FixtureBase = FixtureBase>(item: string | FixtureBase | string[]): T | T[] {
+        const ids: string[] = [];
 
-        // TODO: output warning to a log that a fixture with this id cannot be found
-        if (!fixture) {
-            return null;
+        // parse the input and figure our what it is
+        if (typeof item === 'string') {
+            ids.push(item);
+        } else if (Array.isArray(item)) {
+            ids.push(...item);
+        } else {
+            ids.push(item.id);
         }
 
-        return fixture;
+        const fixtures = ids.map(id => {
+            const fixture = this.$vApp.$store.get<T>(`fixture/items@${id}`);
+            if (!fixture) {
+                throw new Error("fixture doesn't exist");
+            }
+
+            return fixture;
+        });
+
+        return fixtures.length === 1 ? fixtures[0] : fixtures;
     }
 }
 

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -5,14 +5,22 @@ import { PanelConfig, PanelConfigRoute, PanelMutation, PanelConfigScreens, Panel
 
 export class PanelAPI extends APIScope {
     /**
-     * Register provided panel object (could be several of just one) and return the resulting `PanelInstance` objects.
+     * Registers a provided panel object and returns the resulting `PanelInstance` objects.
      * When the panel is registered, all its screens are added to the Vue as components right away.
      *
-     * @param {(PanelConfigPair | PanelConfigSet)} value
-     * @returns {(PanelInstance | PanelInstanceSet)}
+     * @param {PanelConfigPair} value a PanelConfig/id pair in the form of `{ id: string, config: PanelConfig }`
+     * @returns {PanelInstance}
      * @memberof PanelAPI
      */
     register(value: PanelConfigPair): PanelInstance;
+    /**
+     * Registers a set of provided panel objects and returns the resulting `PanelInstance` object set.
+     * When the panel is registered, all its screens are added to the Vue as components right away.
+     *
+     * @param {PanelConfigSet} value a set of PanelConfig objects in the form of `{ [name: string]: PanelConfig }` where keys assumed to be ids
+     * @returns {PanelInstanceSet}
+     * @memberof PanelAPI
+     */
     register(value: PanelConfigSet): PanelInstanceSet;
     register(value: PanelConfigPair | PanelConfigSet): PanelInstance | PanelInstanceSet {
         const panels: PanelInstance[] = [];
@@ -48,6 +56,7 @@ export class PanelAPI extends APIScope {
      * @returns {PanelInstance}
      * @memberof PanelAPI
      */
+    // TODO: implement overload to get a list of panels, similar to `feature.get([...])`
     get(value: string | PanelInstance): PanelInstance {
         const id = typeof value === 'string' ? value : value.id;
         const panel = this.$vApp.$store.get<PanelInstance>(`panel/items@${id}`);


### PR DESCRIPTION
Add an overload to `feature.get` that lets you fetch several fixtures at once like this:
```ts
const [one, two, three] = RAMP.fixture.get(['fixture-one', 'fixture-two', 'fixture-three']);
```

Added some other comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/68)
<!-- Reviewable:end -->
