### PR TITLE
Appbar upgrade

### DIFF
--- a/common/docs/app/appbar.md
+++ b/common/docs/app/appbar.md
@@ -4,62 +4,67 @@ The Appbar is used as a starting point for functionality in the app. Its main us
 
 ## Configuration
 
-Any arbitrary vue component can be added to the appbar, the config for an item is
+Any arbitrary vue component can be added to the appbar, the config for appbar is as follows:
 
 ```json
 {
-    "id": "my-appbar-button",
-    "component": MyAppbarButton
+    "items": ["my-appbar-button"]
 }
 ```
 
-If an item is supplied without a component it is assumed to be a fixture (that we've developed), and will pull the appbar button from the named fixture folder.
+An item can be supplied as simply a component name or as an object indicating the component's name and any options to be passed to that component as props:
 
 ```json
 {
-    "id": "legend"
+    "items": [{ "id": "my-other-appbar-button-with-options", "options": { "colour": "red" } }]
 }
 ```
 
-The above pulls in the appbar button from `legend` and registers it under `legend-appbar-button`.
+The `-appbar-button` suffix is optional and can be omitted. If a `gazebo` id is provided, the Appbar will automatically check if a `gazebo-appbar-button` component exist and use that one instead. This is a convenience feature to make config less verbose:
+
+````json
+{
+    "items": [
+        "gazebo"
+    ]
+}
 
 Using what we've learned, the whole config for an appbar could be:
 
 ```json
-[
-    {
-        id: "my-appbar-button",
-        component: MyAppbarButton
-    },
-    {
-        id: "legend"
-    },
-    {
-        id: "my-second-button"
-        component: FancyButton
-    }
-]
-```
+{
+    "items": [
+        "my-appbar-button",
+        { "id": "my-other-appbar-button-with-options", "options": { "colour": "red" } },
+        "gazebo"
+    ]
+}
+````
 
 Lastly, there is a Divider component that can be used by specifying an item with the `divider` id. As its name suggests, this component just adds a divider in between groups of appbar buttons.
 
-Lets say we want to separate the `legend` button from the other two;
+Lets say we want to separate the `gazebo` button from the other two:
 
 ```json
-[
-    {
-        id: "legend"
-    },
-    {
-        id: "divider"
-    },
-    {
-        id: "my-appbar-button",
-        component: MyAppbarButton
-    },
-    {
-        id: "my-second-button"
-        component: FancyButton
-    }
-]
+{
+    "items": [
+        "my-appbar-button",
+        { "id": "my-other-appbar-button-with-options", "options": { "colour": "red" } },
+        "divider",
+        "gazebo"
+    ]
+}
+```
+
+And, you guessed it, you can register your own `my-fancy-divider` component and use it instead:
+
+```json
+{
+    "items": [
+        "my-appbar-button",
+        { "id": "my-other-appbar-button-with-options", "options": { "colour": "red" } },
+        "my-fancy-divider",
+        "gazebo"
+    ]
+}
 ```

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -96,27 +96,32 @@
                         }
                     ],
                     fixtures: {
-                        appbar: [
-                            { id: 'gazebo' },
-                            { id: 'divider' },
-                            { id: 'legend' },
-                            { id: 'gazebo' },
-                            { id: 'geosearch' },
-                            { id: 'legend' },
-                            { id: 'divider' }
-                        ]
+                        appbar: {
+                            items: [
+                                { id: 'gazebo', options: { colour: '#54a0ff' } },
+                                'divider',
+                                'snowman-appbar-button'
+                                /* ,
+                                { id: 'divider' },
+                                { id: 'legend' },
+                                { id: 'gazebo' },
+                                { id: 'geosearch' },
+                                { id: 'legend' },
+                                { id: 'divider' } */
+                            ]
+                        }
                     }
                 });
 
                 // start loading fixtures; this is just an example
-                // TODO: fixtures specified in the config should be loaded first, then fixtures added through the API
-                // TODO: remove
+
+                rInstance.fixture.add('appbar');
                 rInstance.fixture.add('snowman');
                 rInstance.fixture.add('gazebo');
-                rInstance.fixture.add('geosearch');
-                rInstance.fixture.add('appbar');
+
+                /* rInstance.fixture.add('geosearch');
                 rInstance.fixture.add('grid');
-                rInstance.fixture.add('diligord', window.hostFixtures.diligord);
+                rInstance.fixture.add('diligord', window.hostFixtures.diligord); */
             }
         </script>
     </body>

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -100,14 +100,10 @@
                             items: [
                                 { id: 'gazebo', options: { colour: '#54a0ff' } },
                                 'divider',
-                                'snowman-appbar-button'
-                                /* ,
-                                { id: 'divider' },
-                                { id: 'legend' },
-                                { id: 'gazebo' },
-                                { id: 'geosearch' },
-                                { id: 'legend' },
-                                { id: 'divider' } */
+                                'snowman-appbar-button',
+                                'legend',
+                                'geosearch',
+                                'divider'
                             ]
                         }
                     }
@@ -118,10 +114,10 @@
                 rInstance.fixture.add('appbar');
                 rInstance.fixture.add('snowman');
                 rInstance.fixture.add('gazebo');
-
-                /* rInstance.fixture.add('geosearch');
+                rInstance.fixture.add('geosearch');
+                rInstance.fixture.add('legend');
                 rInstance.fixture.add('grid');
-                rInstance.fixture.add('diligord', window.hostFixtures.diligord); */
+                rInstance.fixture.add('diligord', window.hostFixtures.diligord);
             }
         </script>
     </body>

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -1,0 +1,7 @@
+export enum GlobalEvents {
+    /**
+     * Fires when a Vue component is registered with `rInstance.component(...)`.
+     * Payload: `(id: string)`
+     */
+    COMPONENT = 'r4/component'
+}

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -28,6 +28,11 @@ export class FixtureAPI extends APIScope {
     async add(id: string, constructor?: IFixtureBase): Promise<FixtureBase> {
         let fixture: FixtureBase;
 
+        // if the fixture already exist, do nothing and just return it
+        if (id in this.$vApp.$store.get<{ [name: string]: FixtureBase }>(`fixture/items`)!) {
+            return this.get(id);
+        }
+
         // only need to provide fixture constructors for external fixtures since internal ones are loaded automatically
         if (constructor) {
             if (typeof constructor !== 'function') {
@@ -189,7 +194,7 @@ export class FixtureInstance extends APIScope implements FixtureBase {
     }
 
     /**
-     *
+     * A helper function to create a "subclass" of the base Vue constructor
      *
      * @param {VueConstructor<Vue>} vueConstructor
      * @param {ComponentOptions<Vue>} [options={}]
@@ -216,4 +221,15 @@ export class FixtureInstance extends APIScope implements FixtureBase {
     removed?(): void;
     initialized?(): void;
     terminated?(): void;
+
+    /**
+     * Returns the fixture config section (JSON) taken from the global config.
+     *
+     * @readonly
+     * @type {*}
+     * @memberof FixtureInstance
+     */
+    get config(): any {
+        return this.$vApp.$store.get('config/getFixtureConfig', this.id);
+    }
 }

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -154,7 +154,12 @@ export class FixtureInstance extends APIScope implements FixtureBase {
                 }
             },
             remove: { value: instance.remove },
-            extend: { value: instance.extend }
+            extend: { value: instance.extend },
+            config: {
+                get(): any {
+                    return instance.config;
+                }
+            }
         });
 
         return value as FixtureInstance;

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -1,7 +1,7 @@
 import Vue, { VueConstructor, ComponentOptions } from 'vue';
 
 import { APIScope, InstanceAPI } from './internal';
-import { FixtureBase, FixtureMutation } from '@/store/modules/fixture';
+import { FixtureBase, FixtureMutation, FixtureBaseSet } from '@/store/modules/fixture';
 
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;
 
@@ -29,7 +29,7 @@ export class FixtureAPI extends APIScope {
         let fixture: FixtureBase;
 
         // if the fixture already exist, do nothing and just return it
-        if (id in this.$vApp.$store.get<{ [name: string]: FixtureBase }>(`fixture/items`)!) {
+        if (id in this.$vApp.$store.get<FixtureBaseSet>(`fixture/items`)!) {
             return this.get(id);
         }
 

--- a/packages/ramp-core/src/api/internal.ts
+++ b/packages/ramp-core/src/api/internal.ts
@@ -1,6 +1,7 @@
 // pattern to avoid circular imports
 // https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de
 export * from './common';
+export * from './event';
 export * from './fixture';
 export * from './instance';
 export * from './panel';

--- a/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
+++ b/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
@@ -57,7 +57,7 @@ export class AppbarAPI extends FixtureInstance {
         // get the ordered list of items and see if any of them are registered
         this.$vApp.$store.get<string[]>('appbar/order')!.forEach(id => {
             // appbar check components with the literal id and with a `-appbar-button` suffix;
-            [id, `${id}-appbar-button`].some(v => {
+            [`${id}-appbar-button`, id].some(v => {
                 if (v in this.$vApp.$options.components!) {
                     // if an item is registered globally, save the name of the registered component
                     this.$vApp.$store.set(`appbar/items@${id}.componentId`, v);

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -23,10 +23,6 @@ Vue.component('divider', DividerV);
 @Component
 export default class AppbarV extends Vue {
     @Get('appbar/visible') items!: AppbarItemInstance[];
-
-    get registeredItems(): AppbarItemInstance[] {
-        return this.items.filter(item => item.componentId);
-    }
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -2,11 +2,12 @@
     <div class="absolute top-0 left-0 flex flex-col items-stretch bg-black-75 h-full w-40 sm:w-64 pointer-events-auto" v-focus-list>
         <component
             v-for="(item, index) in items"
-            :is="item.id"
-            :key="`${item.id}-${index}`"
+            :is="item.componentId"
+            :key="`${item}-${index}`"
             class="h-24 my-4 first:mt-8 text-gray-400 hover:text-white"
-            :class="{ 'py-12': item.id !== DIVIDER }"
-            :v-focus-item="item.id !== DIVIDER"
+            :class="{ 'py-12': item.id !== 'divider' }"
+            :focus-item="item.id !== 'divider'"
+            :options="item.options"
         ></component>
     </div>
 </template>
@@ -14,19 +15,18 @@
 <script lang="ts">
 import { Vue, Watch, Component } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
-import { AppbarItemConfig } from './store';
+import { AppbarItemInstance } from './store';
 import DividerV from './divider.vue';
 
-const DIVIDER_ID = 'divider';
-
-Vue.component(DIVIDER_ID, DividerV);
+Vue.component('divider', DividerV);
 
 @Component
 export default class AppbarV extends Vue {
-    // to use in the template
-    DIVIDER = DIVIDER_ID;
+    @Get('appbar/visible') items!: AppbarItemInstance[];
 
-    @Get('appbar/items') items!: AppbarItemConfig[];
+    get registeredItems(): AppbarItemInstance[] {
+        return this.items.filter(item => item.componentId);
+    }
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/appbar/divider.vue
+++ b/packages/ramp-core/src/fixtures/appbar/divider.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
+import { Vue, Watch, Component } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 @Component

--- a/packages/ramp-core/src/fixtures/appbar/divider.vue
+++ b/packages/ramp-core/src/fixtures/appbar/divider.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component } from 'vue-property-decorator';
+import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 @Component

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -1,25 +1,29 @@
 import AppbarV from './appbar.vue';
 import { AppbarAPI } from './api/appbar';
 import { appbar } from './store/index';
+import { GlobalEvents } from '@/api';
 
 class AppbarFixture extends AppbarAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
 
+        // TODO: registering a fixture store module seems like a common action almost every fixture needs; check if this can be automated somehow
         this.$vApp.$store.registerModule('appbar', appbar());
 
         const appbarInstance = this.extend(AppbarV, { store: this.$vApp.$store });
 
+        // TODO: the `innerShell` reference will probably get used more than once; consider creating a dedicated ref on `$iApi`;
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.insertBefore(appbarInstance.$el, innerShell.children[0]);
 
-        // when other fixtures need access to appbar API, they can do it directly on the fixture object
-        // `this.$iApi.fixture.get<AppbarFixture>('appbar').setConfig()`
+        this._parseConfig(this.config);
+        this.$vApp.$watch(
+            () => this.config,
+            value => this._parseConfig(value)
+        );
 
-        // this is a bit more complicated than access it directly on the global `$iApi` (`this.$iApi.setConfig()`),
-        // but the above approach doesn't pollute a global, provides an easy way to check if fixture exists and gives you intellisense
-
-        await this.setConfig(this.$vApp.$store.get('config/getFixtureConfig', 'appbar'));
+        // since components used in appbar can be registered after this point, listen to the global component registration event and re-validate items
+        this.$iApi.on(GlobalEvents.COMPONENT, this._validateItems.bind(this));
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
@@ -43,8 +43,20 @@ export interface AppbarItemConfig {
 export class AppbarItemInstance implements AppbarItemConfig {
     id: string;
 
+    /**
+     * Optional object containing any options to be passed to the appbar component.
+     *
+     * @type {object}
+     * @memberof AppbarItemInstance
+     */
     options: object;
 
+    /**
+     * An actual id of the appbar Vue component to use when rendering in the template.
+     *
+     * @type {string}
+     * @memberof AppbarItemInstance
+     */
     componentId?: string;
 
     constructor(value: string | AppbarItemConfig) {

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
@@ -1,13 +1,25 @@
-import Vue, { VueConstructor } from 'vue';
-
 export class AppbarState {
     /**
-     * A list of all open (visible and hidden) panels.
+     * A set of all open (visible and hidden) panels.
      *
-     * @type {AppbarItemConfig[]}
+     * @type {AppbarItem[]}
      * @memberof AppbarState
      */
-    items: AppbarItemConfig[] = [];
+    items: AppbarItemSet = {};
+
+    /**
+     * An ordered list of appbar item ids.
+     *
+     * @type {string[]}
+     * @memberof AppbarState
+     */
+    order: string[] = [];
+}
+
+export type AppbarItemSet = { [name: string]: AppbarItemInstance };
+
+export interface AppbarFixtureConfig {
+    items: (string | AppbarItemConfig)[];
 }
 
 export interface AppbarItemConfig {
@@ -20,10 +32,26 @@ export interface AppbarItemConfig {
     id: string;
 
     /**
-     * The component to be displayed on the Appbar
+     * The options for the displayed appbar button.
      *
-     * @type {VueConstructor<Vue>}
+     * @type {object}
      * @memberof AppbarItemConfig
      */
-    component?: VueConstructor<Vue>;
+    options?: object;
+}
+
+export class AppbarItemInstance implements AppbarItemConfig {
+    id: string;
+
+    options: object;
+
+    componentId?: string;
+
+    constructor(value: string | AppbarItemConfig) {
+        const params = { options: {}, ...(typeof value === 'string' ? { id: value } : value) };
+        ({ id: this.id, options: this.options } = params);
+
+        // this should work too, but it doesn't;
+        // ({ id: this.id, options: this.options } = { options: {}, ...(typeof value === 'string' ? { id: value} : value) });
+    }
 }

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
@@ -14,10 +14,12 @@ export enum AppbarMutation {
 }
 
 const getters = {
-    /* getById: (state: AppbarState) => (id: string): AppbarItemInstance | null => {
-        return state.items.find(item => item.id === id) || null;
-    } */
-
+    /**
+     * Return a list of appbar items with registered components (ones that can be rendered right now).
+     *
+     * @param {AppbarState} state
+     * @returns {AppbarItemInstance[]}
+     */
     visible(state: AppbarState): AppbarItemInstance[] {
         return state.order.map<AppbarItemInstance>(id => state.items[id]).filter(item => item.componentId);
     }
@@ -25,15 +27,7 @@ const getters = {
 
 const actions = {};
 
-const mutations = {
-    /* [AppbarMutation.ADD_ITEM](state: AppbarState, value: AppbarItemInstance): void {
-        state.items.push(value);
-    },
-
-    [AppbarMutation.REMOVE_ITEM](state: AppbarState, value: AppbarItemInstance): void {
-        state.items.splice(state.items.indexOf(value), 1);
-    } */
-};
+const mutations = {};
 
 export function appbar() {
     const state = new AppbarState();

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
@@ -1,7 +1,7 @@
 import { ActionContext, Action, Mutation } from 'vuex';
 import { make } from 'vuex-pathify';
 
-import { AppbarState, AppbarItemConfig } from './appbar-state';
+import { AppbarState, AppbarItemInstance } from './appbar-state';
 import { RootState } from '@/store/state';
 
 type AppbarContext = ActionContext<AppbarState, RootState>;
@@ -14,21 +14,25 @@ export enum AppbarMutation {
 }
 
 const getters = {
-    getById: (state: AppbarState) => (id: string): AppbarItemConfig | null => {
+    /* getById: (state: AppbarState) => (id: string): AppbarItemInstance | null => {
         return state.items.find(item => item.id === id) || null;
+    } */
+
+    visible(state: AppbarState): AppbarItemInstance[] {
+        return state.order.map<AppbarItemInstance>(id => state.items[id]).filter(item => item.componentId);
     }
 };
 
 const actions = {};
 
 const mutations = {
-    [AppbarMutation.ADD_ITEM](state: AppbarState, value: AppbarItemConfig): void {
+    /* [AppbarMutation.ADD_ITEM](state: AppbarState, value: AppbarItemInstance): void {
         state.items.push(value);
     },
 
-    [AppbarMutation.REMOVE_ITEM](state: AppbarState, value: AppbarItemConfig): void {
+    [AppbarMutation.REMOVE_ITEM](state: AppbarState, value: AppbarItemInstance): void {
         state.items.splice(state.items.indexOf(value), 1);
-    }
+    } */
 };
 
 export function appbar() {
@@ -39,6 +43,6 @@ export function appbar() {
         state,
         getters: { ...getters },
         actions: { ...actions },
-        mutations: { ...mutations, ...make.mutations(['items']) }
+        mutations: { ...mutations, ...make.mutations(['items', 'order']) }
     };
 }

--- a/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
@@ -1,5 +1,5 @@
 <template>
-    <button class="py-6" @click="togglePanel()" :style="{ color: options.colour }">G</button>
+    <button class="py-6" @click="togglePanel()" :style="{ fontWeight: 'bold', color: options.colour }">G</button>
 </template>
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';

--- a/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
@@ -1,0 +1,23 @@
+<template>
+    <button class="py-6" @click="togglePanel()" :style="{ color: options.colour }">G</button>
+</template>
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class GazeboAppbarButton extends Vue {
+    @Prop({ default: { colour: 'auto' } }) options!: { colour: string };
+
+    togglePanel(): void {
+        const panel = this.$iApi.panel.get('p1');
+
+        if (panel.isOpen) {
+            panel.close();
+        } else {
+            panel.open();
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -1,5 +1,6 @@
 import { FixtureInstance } from '@/api';
-import { PanelConfig } from '@/store/modules/panel';
+
+import GazeboAppbarButton from './appbar-button.vue';
 
 import P1Screen1V from './p1-screen-1.vue';
 import P1Screen2V from './p1-screen-2.vue';
@@ -7,9 +8,13 @@ import P1Screen2V from './p1-screen-2.vue';
 import P2Screen1V from './p2-screen-1.vue';
 import P2Screen2V from './p2-screen-2.vue';
 
+import Vue from 'vue';
+
 class GazeboFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
+
+        this.$iApi.component('gazebo-appbar-button', GazeboAppbarButton);
 
         this.$iApi.panel.register({
             // panel-1 has examples of how not to bind things and interact with stuff; bad panel ❌
@@ -43,6 +48,3 @@ class GazeboFixture extends FixtureInstance {
 }
 
 export default GazeboFixture;
-
-import GazeboAppbarButton from './gazebo-appbar-button.vue';
-export { GazeboAppbarButton as AppbarButton };

--- a/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
@@ -15,7 +15,7 @@ import { Vue, Component } from 'vue-property-decorator';
 import GeosearchComponent from './geosearch-component.vue';
 
 @Component
-export default class GeosearchAppbarButton extends Vue {
+export default class GeosearchAppbarButtonV extends Vue {
     togglePanel(): void {
         const panel = this.$iApi.panel.get('geosearch-panel');
 

--- a/packages/ramp-core/src/fixtures/geosearch/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/index.ts
@@ -1,10 +1,14 @@
 import GeosearchComponent from './geosearch-component.vue';
 import { GeosearchAPI } from './api/geosearch';
 import { geosearch } from './store/index';
+import GeosearchAppbarButtonV from './appbar-button.vue';
 
 class GeosearchFixture extends GeosearchAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
+
+        // TODO: this appbar registration also seems like a common action; maybe automate
+        this.$iApi.component('geosearch-appbar-button', GeosearchAppbarButtonV);
 
         this.$vApp.$store.registerModule('geosearch', geosearch());
 
@@ -24,6 +28,3 @@ class GeosearchFixture extends GeosearchAPI {
 }
 
 export default GeosearchFixture;
-
-import GeosearchAppbarButton from './geosearch-appbar-button.vue';
-export { GeosearchAppbarButton as AppbarButton };

--- a/packages/ramp-core/src/fixtures/legend/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/legend/appbar-button.vue
@@ -11,7 +11,7 @@
 import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class LegendAppbarButton extends Vue {
+export default class LegendAppbarButtonV extends Vue {
     onClick() {
         console.log('legend appbar button clicked');
     }

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -1,2 +1,10 @@
-import LegendAppbarButton from './legend-appbar-button.vue';
-export { LegendAppbarButton as AppbarButton };
+import LegendAppbarButtonV from './appbar-button.vue';
+import { FixtureInstance } from '@/api';
+
+class LegendFixture extends FixtureInstance {
+    added() {
+        this.$iApi.component('legend-appbar-button', LegendAppbarButtonV);
+    }
+}
+
+export default LegendFixture;

--- a/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
@@ -11,6 +11,8 @@ export default class SnowmanAppbarButtonV extends Vue {
     togglePanel(): void {
         // summon the SNOWMAN!
         this.$iApi.fixture.add('snowman');
+
+        // the above will re-add the snowman fixture as it was self-terminated
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
@@ -1,21 +1,16 @@
 <template>
     <button class="py-6" @click="togglePanel()">
-        G
+        ⛄
     </button>
 </template>
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class GazeboAppbarButton extends Vue {
+export default class SnowmanAppbarButtonV extends Vue {
     togglePanel(): void {
-        const panel = this.$iApi.panel.get('p1');
-
-        if (panel.isOpen) {
-            panel.close();
-        } else {
-            panel.open();
-        }
+        // summon the SNOWMAN!
+        this.$iApi.fixture.add('snowman');
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/snowman/index.ts
+++ b/packages/ramp-core/src/fixtures/snowman/index.ts
@@ -1,9 +1,13 @@
 import SnowmanV from './snowman.vue'; // import on-map component
+import SnowmanAppbarButtonV from './appbar-button.vue';
+
 import { FixtureInstance } from '@/api';
 
 class SnowmanFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
+
+        this.$iApi.component('snowman-appbar-button', SnowmanAppbarButtonV);
 
         // instantiate it a new instance of the Snowman component using a helper function which will add `$iApi` to the component automatically
         // the component will be auto-mounted as well unless you pass `false` to the `extend` function

--- a/packages/ramp-core/src/fixtures/snowman/index.ts
+++ b/packages/ramp-core/src/fixtures/snowman/index.ts
@@ -7,6 +7,7 @@ class SnowmanFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
 
+        // register snowman appbar button
         this.$iApi.component('snowman-appbar-button', SnowmanAppbarButtonV);
 
         // instantiate it a new instance of the Snowman component using a helper function which will add `$iApi` to the component automatically

--- a/packages/ramp-core/src/store/modules/fixture/fixture-state.ts
+++ b/packages/ramp-core/src/store/modules/fixture/fixture-state.ts
@@ -5,6 +5,8 @@ export class FixtureState {
     items: { [name: string]: FixtureBase } = {};
 }
 
+export type FixtureBaseSet = { [name: string]: FixtureBase };
+
 export interface FixtureBase {
     /**
      * ID of this fixture.


### PR DESCRIPTION
- change the structure of the `appbar` config from a flat array of items to an object with `items` array; this is to future-proof in case we want to add more configuration to the `appbar` lately, and I think it's a good convention to follow with all other fixture configs; see updated docs for details;
- `appbar` will no longer register appbar-button components; this is responsibility of their respective fixtures; if `appbar` is provided with an id of the component that is not registered, the item will be skipped; this results in an initial race condition as appbar-button components might be registered after the `appbar` itself is loaded, but do not despair;
- added a helpful function on the global API for fixtures to register components more easily: `rInstance.component(...)`
- `rInstance.component(...)` will fire an internal `component` event when a new component is registered
- `appbar` listens to the internal `component` event and re-checks if any of the initially specified appbar items can now be rendered; race condition solved without using `setTimeout` 🎉
- added a helper getter to the `FixtureInstance` class that returns fixture's config section from the global config; makes for less typing;
- updated appbar docs;

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/69)
<!-- Reviewable:end -->
