### PR TITLE
Grid: add clear filters and fix column filter bug

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -12,11 +12,10 @@
             <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fit=""
-                width="24px"
-                height="24px"
                 preserveAspectRatio="xMidYMid meet"
                 viewBox="0 0 24 24"
                 focusable="false"
+                class="fill-current w-24 h-24"
                 v-if="quicksearch.length < 3"
             >
                 <g id="search_cache224">
@@ -29,7 +28,7 @@
                 data-v-486a0302=""
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 352 512"
-                class="fill-current w-4 h-4 cursor-pointer"
+                class="fill-current w-18 h-18 ml-6 cursor-pointer"
                 @click="resetQuickSearch()"
                 v-else
             >
@@ -39,11 +38,7 @@
                 ></path>
             </svg>
             <panel-options-menu>
-                <a href="#">Item 1 </a>
-                <a href="#">Item 2</a>
-                <a href="#">Item 3</a>
-                <hr />
-                <a href="#">Item 4</a>
+                <a href="#" @click="clearFilters()">Clear Filters</a>
             </panel-options-menu>
             <pin @click="panel.pin()" :active="panel.isPinned"></pin>
             <close @click="panel.close()"></close>
@@ -91,6 +86,11 @@ export default class Screen1 extends Vue {
     resetQuickSearch(): void {
         this.grid.quicksearch = this.quicksearch = '';
         this.grid.updateQuickSearch();
+    }
+
+    clearFilters(): void {
+        this.resetQuickSearch();
+        this.grid.clearFilters();
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/grid/store/table-state-manager.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/table-state-manager.ts
@@ -44,6 +44,15 @@ export default class TableStateManager {
     }
 
     /**
+     * Clears all saved column filters.
+     *
+     * @memberof TableStateManager
+     */
+    clearFilters() {
+        this._columnFilters = {};
+    }
+
+    /**
      * Returns whether column filters are enabled for the table.
      *
      * @memberof TableStateManager

--- a/packages/ramp-core/src/fixtures/grid/table/CustomDateFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomDateFilter.vue
@@ -16,8 +16,8 @@ import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 export default class CustomNumberFilter extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)
-        this.minVal = this.params.minValDefault;
-        this.maxVal = this.params.maxValDefault;
+        this.minVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' min');
+        this.maxVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' max');
 
         // Apply the default values to the column filter.
         this.minValChanged();
@@ -45,7 +45,6 @@ export default class CustomNumberFilter extends Vue {
     }
 
     setFilterModel(instance: any) {
-
         // This is the furthest date supported by JavaScript.
         let maxPossibleDate: Date | String = new Date(8640000000000000);
         maxPossibleDate = `${maxPossibleDate.getFullYear()}-${maxPossibleDate.getMonth() + 1}-${maxPossibleDate.getDate()}`;
@@ -85,7 +84,12 @@ export default class CustomNumberFilter extends Vue {
         this.params.api.onFilterChanged();
     }
 
-    onParentModelChanged(parentModel: any) {}
+    onParentModelChanged(parentModel: any) {
+        if (parentModel === {}) {
+            this.minVal = '';
+            this.maxVal = '';
+        }
+    }
 
     setModel() {
         return {
@@ -114,7 +118,7 @@ export default interface CustomNumberFilter {
 .rv-input {
     @apply m-0 py-1;
 }
-.rv-input[type=date]::-webkit-inner-spin-button {
+.rv-input[type='date']::-webkit-inner-spin-button {
     -webkit-appearance: none;
     display: none;
 }

--- a/packages/ramp-core/src/fixtures/grid/table/CustomNumberFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomNumberFilter.vue
@@ -12,8 +12,8 @@ import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 export default class CustomNumberFilter extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)
-        this.minVal = this.params.minValDefault;
-        this.maxVal = this.params.maxValDefault;
+        this.minVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' min');
+        this.maxVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' max');
 
         // Apply the default values to the column filter.
         this.minValChanged();
@@ -80,7 +80,7 @@ export default class CustomNumberFilter extends Vue {
     }
 
     onParentModelChanged(parentModel: any) {
-        if (parentModel === null) {
+        if (parentModel === {}) {
             this.minVal = '';
             this.maxVal = '';
         }

--- a/packages/ramp-core/src/fixtures/grid/table/CustomSelectorFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomSelectorFilter.vue
@@ -15,7 +15,7 @@ import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 export default class CustomSelectorFilter extends Vue {
     beforeMount() {
         // Load previously stored value (if saved in table state manager)
-        this.selectedOption = this.params.defaultValue;
+        this.selectedOption = this.params.stateManager.getColumnFilter(this.params.column.colDef.field);
 
         let rowData = this.params.rowData;
 
@@ -31,6 +31,8 @@ export default class CustomSelectorFilter extends Vue {
     }
 
     selectionChanged() {
+        this.selectedOption = this.selectedOption ? this.selectedOption : '';
+
         this.params.parentFilterInstance((instance: any) => {
             if (this.selectedOption === '...') {
                 // Clear the selector filter.
@@ -55,7 +57,9 @@ export default class CustomSelectorFilter extends Vue {
     }
 
     onParentModelChanged(parentModel: any) {
-        this.selectedOption = !parentModel ? '' : parentModel.filter;
+        if(parentModel === {}) {
+            this.selectedOption = '';
+        }
     }
 
     setModel() {

--- a/packages/ramp-core/src/fixtures/grid/table/CustomTextFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomTextFilter.vue
@@ -11,7 +11,7 @@ import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 export default class CustomTextFilter extends Vue {
     beforeMount() {
         // Load previously stored value (if saved in table state manager)
-        this.filterValue = this.params.defaultValue;
+        this.filterValue = this.params.stateManager.getColumnFilter(this.params.column.colDef.field);
 
         // Apply the default value to the column filter.
         this.valueChanged();
@@ -19,6 +19,8 @@ export default class CustomTextFilter extends Vue {
 
     valueChanged(): void {
         this.params.parentFilterInstance((instance: any) => {
+            this.filterValue = this.filterValue ? this.filterValue : '';
+
             instance.setModel({
                 filterType: 'text',
                 type: 'contains',
@@ -34,7 +36,9 @@ export default class CustomTextFilter extends Vue {
     }
 
     onParentModelChanged(parentModel: any): void {
-        this.filterValue = !parentModel ? '' : parentModel.filter;
+        if(parentModel === {}) {
+            this.filterValue = '';
+        }
     }
 
     setModel() {

--- a/packages/ramp-core/src/fixtures/grid/table/table.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/table.vue
@@ -214,6 +214,20 @@ export default class TableComponent extends Vue {
         }
     }
 
+    // Clear all table filters.
+    // TODO: In the old version of RAMP we had "static filters". If we re-implement these at some point, this function
+    // needs to be modified to not wipe them.
+    clearFilters() {
+        // Replace the filter model with an empty model.
+        this.gridApi.setFilterModel({});
+
+        // Clear any saved filter state in the table state manager.
+        this.config.state.clearFilters();
+
+        // Refresh the column filters to reset inputs.
+        this.gridApi.refreshHeader();
+    }
+
     // Changes the filter status text in the grid.
     updateFilterStatus() {
         this.filterStatus = `${this.filterInfo.firstRow} - ${this.filterInfo.lastRow} of ${this.filterInfo.visibleRows} entries shown`;
@@ -242,9 +256,7 @@ export default class TableComponent extends Vue {
         colDef.filterParams.inRangeInclusive = true;
         colDef.floatingFilterComponentParams = {
             suppressFilterButton: true,
-            stateManager: state,
-            minValDefault: minVal,
-            maxValDefault: maxVal
+            stateManager: state
         };
     }
 
@@ -257,7 +269,6 @@ export default class TableComponent extends Vue {
         colDef.floatingFilterComponentParams = {
             suppressFilterButton: true,
             stateManager: state,
-            defaultValue: value,
             rowData: rowData
         };
     }
@@ -271,9 +282,7 @@ export default class TableComponent extends Vue {
         colDef.filterParams.inRangeInclusive = true;
         colDef.floatingFilterComponentParams = {
             suppressFilterButton: true,
-            stateManager: state,
-            minValDefault: minVal,
-            maxValDefault: maxVal
+            stateManager: state
         };
     }
 
@@ -284,8 +293,7 @@ export default class TableComponent extends Vue {
         colDef.floatingFilterComponent = 'textFloatingFilter';
         colDef.floatingFilterComponentParams = {
             suppressFilterButton: true,
-            stateManager: state,
-            defaultValue: value
+            stateManager: state
         };
 
         // If we want to add different search methods in the future, consider using some sort of generic search function.


### PR DESCRIPTION
The clear filters button can be found under the `...` button in the panel header. It should clear the global text filter and all column filters.

This PR also fixes a bug where the table wouldn't apply a column filter if the column it was associated with was not visible on the screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/71)
<!-- Reviewable:end -->
