### PR TITLE
Map events, doc cleanup

### DIFF
--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
@@ -34,8 +34,7 @@ export default class GeosearchBottomFilters extends Vue {
     @Call(GeosearchStore.setMapExtent) setMapExtent!: (mapExtent: any) => void;
 
     created() {
-        // TODO: temp call to watch for map extent changes, replace later?
-        this.$iApi.map.innerView.watch('extent', this.onMapExtentChange);
+        this.$iApi.map.extentChanged.listen(this.onMapExtentChange);
     }
 
     // update geosearch results to match those in current view if visible is checked
@@ -47,13 +46,11 @@ export default class GeosearchBottomFilters extends Vue {
     }
 
     // update store map extent and geosearch results on map view change with debounce
-    onMapExtentChange = debounce((newExtent: any, oldExtent: any) => {
-        if (newExtent !== oldExtent) {
-            this.setMapExtent({
-                extent: this.$iApi.map.getExtent(),
-                visible: this.resultsVisible
-            });
-        }
+    onMapExtentChange = debounce((newExtent: any) => {
+        this.setMapExtent({
+            extent: newExtent,
+            visible: this.resultsVisible
+        });
     }, 300);
 }
 </script>

--- a/packages/ramp-geoapi/src/layer/AttribFC.ts
+++ b/packages/ramp-geoapi/src/layer/AttribFC.ts
@@ -335,7 +335,7 @@ export default class AttribFC extends BaseFC {
         }
 
         if (opts.getGeom) {
-            scale = opts.map.innerView.scale;
+            scale = opts.map.getScale();
 
             // first locate the appropriate cache due to simplifications.
             let gCache = this.quickCache.getGeom(objectId, scale);
@@ -350,11 +350,11 @@ export default class AttribFC extends BaseFC {
             //              the esri layer object to exploit.
             //              for now, will just skip this optimization.
 
-            } else if (this.parentLayer.innerLayer.type === 'feature') {
+            } else if (this.parentLayer._innerLayer.type === 'feature') {
                 // it is a feature layer. we can attempt to extract info from it.
                 // but remember the feature may not exist on the client currently
 
-                let localGraphic =  (<esri.FeatureLayer>this.parentLayer.innerLayer).graphics.find(g =>
+                let localGraphic =  (<esri.FeatureLayer>this.parentLayer._innerLayer).graphics.find(g =>
                     g.attributes[this.oidField] === objectId);
 
 
@@ -384,9 +384,9 @@ export default class AttribFC extends BaseFC {
             };
 
             if (needWebGeom) {
-                serviceParams.mapSR = JSON.stringify(opts.map.innerView.spatialReference); // TODO test; stringify might include all the esri wrapper garbage. if so, make a custom jsonifier in proj utils
+                serviceParams.mapSR = JSON.stringify(opts.map._innerView.spatialReference); // TODO test; stringify might include all the esri wrapper garbage. if so, make a custom jsonifier in proj utils
                 if (!this.quickCache.isPoint) {
-                    serviceParams.maxOffset = opts.map.innerView.resolution;
+                    serviceParams.maxOffset = opts.map._innerView.resolution;
                 }
             }
 

--- a/packages/ramp-geoapi/src/layer/BaseFC.ts
+++ b/packages/ramp-geoapi/src/layer/BaseFC.ts
@@ -38,7 +38,7 @@ export default class BaseFC extends BaseBase {
      */
     getVisibility (): boolean {
         // basic case - fc vis === layer vis
-        return this.parentLayer.innerLayer.visible;
+        return this.parentLayer._innerLayer.visible;
     }
 
     /**
@@ -49,7 +49,7 @@ export default class BaseFC extends BaseBase {
      */
     setVisibility (value: boolean): void {
         // basic case - set layer visibility
-        this.parentLayer.innerLayer.visible = value;
+        this.parentLayer._innerLayer.visible = value;
     }
 
     /**
@@ -60,7 +60,7 @@ export default class BaseFC extends BaseBase {
      */
     getOpacity (): number {
         // basic case - fc opac === layer opac
-        return this.parentLayer.innerLayer.opacity;
+        return this.parentLayer._innerLayer.opacity;
     }
 
     /**
@@ -71,7 +71,7 @@ export default class BaseFC extends BaseBase {
      */
     setOpacity (value: number): void {
         // basic case - set layer opacity
-        this.parentLayer.innerLayer.opacity = value;
+        this.parentLayer._innerLayer.opacity = value;
     }
 
 }

--- a/packages/ramp-geoapi/src/layer/FeatureFC.ts
+++ b/packages/ramp-geoapi/src/layer/FeatureFC.ts
@@ -26,7 +26,7 @@ export default class FeatureFC extends AttribFC {
 
         const sql = this.filter.getCombinedSql(exclusions);
         // feature layer on a server
-        this.parentLayer.innerLayer.definitionExpression = sql;
+        this.parentLayer._innerLayer.definitionExpression = sql;
     }
 
 }

--- a/packages/ramp-geoapi/src/layer/FeatureLayer.ts
+++ b/packages/ramp-geoapi/src/layer/FeatureLayer.ts
@@ -9,12 +9,12 @@ import FeatureFC from './FeatureFC';
 
 export class FeatureLayer extends AttribLayer {
 
-    innerLayer: esri.FeatureLayer;
+    _innerLayer: esri.FeatureLayer;
 
     constructor (infoBundle: InfoBundle, config: RampLayerConfig, reloadTree?: TreeNode) {
         super(infoBundle, config, reloadTree);
 
-        this.innerLayer = new this.esriBundle.FeatureLayer(this.makeEsriLayerConfig(config));
+        this._innerLayer = new this.esriBundle.FeatureLayer(this.makeEsriLayerConfig(config));
         this.initLayer();
 
     }
@@ -101,8 +101,8 @@ export class FeatureLayer extends AttribLayer {
 
         // TODO .url seems to not have the /index ending.  there is parsedUrl.path, but thats not on official definition
         //      can also consider changing logic to use origRampConfig.url;
-        // const layerUrl: string = (<esri.FeatureLayer>this.innerLayer).url;
-        const layerUrl: string = (<any>this.innerLayer).parsedUrl.path;
+        // const layerUrl: string = (<esri.FeatureLayer>this._innerLayer).url;
+        const layerUrl: string = (<any>this._innerLayer).parsedUrl.path;
         const urlData: ArcGisServerUrl = this.gapi.utils.shared.parseUrlIndex(layerUrl);
         const featIdx: number =  urlData.index;
 

--- a/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
@@ -20,7 +20,7 @@ export default class GeoJsonFC extends AttribFC {
     // TODO consider moving a bulk of this out to LayerModule; the wizard may have use for running this (e.g. getting field list for a service url)
     extractLayerMetadata(): void {
 
-        const l = this.parentLayer.innerLayer;
+        const l = this.parentLayer._innerLayer;
 
         // properties for all endpoints
         this.layerType = 'Feature Layer'; // TODO validate this matches server string. TODO validate we don't want to change to a different value. TODO define an Enum for layerType?
@@ -163,7 +163,7 @@ export default class GeoJsonFC extends AttribFC {
         //      Attempts to manually update things did not work
         //      e.g. (this.parent.innerLayer as any).source.items[0].visible = false;
 
-        this.parentLayer.innerLayer.queryFeatures().then(fs => {
+        this.parentLayer._innerLayer.queryFeatures().then(fs => {
             console.warn('Request to filter geometry on the map of local layer will not work at this time');
             this.gapi.utils.query.sqlEsriGraphicsVisibility(fs.features, sql);
         });

--- a/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
@@ -34,7 +34,7 @@ function fieldValidator(fields: Array<esri.Field>, targetName: string): string {
 // TODO i think we need to change the extends to AttribLayer, as FeatureLayer constructor will attempt to make its own feature layer
 export class GeoJsonLayer extends AttribLayer {
 
-    innerLayer: esri.FeatureLayer;
+    _innerLayer: esri.FeatureLayer;
     private esriJson: esri.FeatureLayerProperties; // used as temp var to get around typescript parameter grousing. will be undefined after initLayer()
 
     constructor (infoBundle: InfoBundle, rampLayerConfig: RampLayerConfig, geoJson: any, systemOptions: any, reloadTree?: TreeNode) {
@@ -66,7 +66,7 @@ export class GeoJsonLayer extends AttribLayer {
 
             this.esriJson = eJson;
             // this will be asynch, triggered after the reprojection of the geojson
-            this.innerLayer = new this.esriBundle.FeatureLayer(this.makeEsriLayerConfig(rampLayerConfig));
+            this._innerLayer = new this.esriBundle.FeatureLayer(this.makeEsriLayerConfig(rampLayerConfig));
 
             this.esriJson = undefined;
             this.initLayer();
@@ -185,7 +185,7 @@ export class GeoJsonLayer extends AttribLayer {
 
         */
 
-        gjFC.featureCount = this.innerLayer.source.length;
+        gjFC.featureCount = this._innerLayer.source.length;
 
         // if file based (or server extent was fried), calculate extent based on geometry
         // TODO implement this. may need a manual loop to calculate graphicsExtent since ESRI torpedo'd the function

--- a/packages/ramp-geoapi/src/layer/HighlightLayer.ts
+++ b/packages/ramp-geoapi/src/layer/HighlightLayer.ts
@@ -13,7 +13,7 @@ import defaultSymbols from './defaulthighlightSymbols.json';
  */
 export class HighlightLayer extends BaseBase {
 
-    innerLayer: esri.GraphicsLayer;
+    _innerLayer: esri.GraphicsLayer;
     protected markerSymbol: esri.PictureMarkerSymbol;
 
     // TODO make types for options
@@ -38,7 +38,7 @@ export class HighlightLayer extends BaseBase {
         }
 
         // need to make type 'any' to allow for the adding of custom functions below
-        this.innerLayer = new this.esriBundle.GraphicsLayer({ id, visible: true });
+        this._innerLayer = new this.esriBundle.GraphicsLayer({ id, visible: true });
         this.markerSymbol = markerSymbol;
     }
 
@@ -50,11 +50,11 @@ export class HighlightLayer extends BaseBase {
      */
     addMarker (point: esri.Point, clearLayer: boolean = false): void {
         if (clearLayer) {
-            this.innerLayer.removeAll();
+            this._innerLayer.removeAll();
         }
 
         const marker = new this.esriBundle.Graphic({ geometry: point, symbol: this.markerSymbol });
-        this.innerLayer.add(marker);
+        this._innerLayer.add(marker);
     }
 
     // TODO looking at RAMP2 code there is a lot of the following:
@@ -72,13 +72,13 @@ export class HighlightLayer extends BaseBase {
      */
     addHighlight (graphic: esri.Graphic | Array<esri.Graphic>, clearLayer: boolean = false): void {
         if (clearLayer) {
-            this.innerLayer.removeAll();
+            this._innerLayer.removeAll();
         }
 
         const graphics = Array.isArray(graphic) ? graphic : [graphic];
 
         // add new highlight graphics
-       this.innerLayer.addMany(graphics);
+       this._innerLayer.addMany(graphics);
     }
 
     /**
@@ -86,7 +86,7 @@ export class HighlightLayer extends BaseBase {
      * @method clearhighlight
      */
     clearHighlight(): void {
-        this.innerLayer.removeAll();
+        this._innerLayer.removeAll();
     }
 
 }

--- a/packages/ramp-geoapi/src/layer/MapImageFC.ts
+++ b/packages/ramp-geoapi/src/layer/MapImageFC.ts
@@ -13,7 +13,7 @@ export default class MapImageFC extends AttribFC {
 
     constructor (infoBundle: InfoBundle, parent: BaseLayer, layerIdx: number = 0) {
         super(infoBundle, parent, layerIdx);
-        this.innerSubLayer = this.parentLayer.innerLayer.allSublayers.find((s: esri.Sublayer) => {
+        this.innerSubLayer = this.parentLayer._innerLayer.allSublayers.find((s: esri.Sublayer) => {
             return s.id === layerIdx;
         });
     }

--- a/packages/ramp-geoapi/src/layer/WmsLayer.ts
+++ b/packages/ramp-geoapi/src/layer/WmsLayer.ts
@@ -11,7 +11,7 @@ import TreeNode from './TreeNode';
 
 export class WmsLayer extends BaseLayer {
 
-    innerLayer: esri.WMSLayer;
+    _innerLayer: esri.WMSLayer;
     sublayerNames: Array<string>;
     readonly mimeType: string;
 
@@ -20,7 +20,7 @@ export class WmsLayer extends BaseLayer {
         this.supportsIdentify = true;
         this.mimeType = config.featureInfoMimeType; // TODO is there a default? will that be in the config defaulting?
 
-        this.innerLayer = new this.esriBundle.WMSLayer(this.makeEsriLayerConfig(config));
+        this._innerLayer = new this.esriBundle.WMSLayer(this.makeEsriLayerConfig(config));
         this.initLayer();
     }
 
@@ -49,7 +49,7 @@ export class WmsLayer extends BaseLayer {
         esriConfig.sublayers = this.sublayerNames.map(sln => {
             return {
                 name: sln
-            }
+            };
         });
 
         const styles = lEntries.map(e => e.currentStyle).join();
@@ -112,7 +112,7 @@ export class WmsLayer extends BaseLayer {
             });
         };
 
-        crawlSublayers(this.innerLayer.sublayers);
+        crawlSublayers(this._innerLayer.sublayers);
         */
 
         // TODO implement symbology load
@@ -222,9 +222,9 @@ export class WmsLayer extends BaseLayer {
      * @param {Boolean} forceRefresh show the new fancy version of the layer or not
      */
     setCustomParameter(key: string, value: string, forceRefresh: boolean = true): void {
-        this.innerLayer.customLayerParameters[key] = value;
+        this._innerLayer.customLayerParameters[key] = value;
         if (forceRefresh) {
-            this.innerLayer.refresh();
+            this._innerLayer.refresh();
         }
     }
 }

--- a/packages/ramp-geoapi/src/map/MapBase.ts
+++ b/packages/ramp-geoapi/src/map/MapBase.ts
@@ -12,7 +12,7 @@ import Basemap from './Basemap';
 export default class MapBase extends BaseBase {
 
     // TODO think about how to expose. protected makes sense, but might want to make it public to allow hacking and use by a dev module if we decide to
-    innerMap: esri.Map;
+    _innerMap: esri.Map;
     protected basemapStore: Array<Basemap>;
 
     protected constructor (infoBundle: InfoBundle, config: RampMapConfig) {
@@ -24,7 +24,7 @@ export default class MapBase extends BaseBase {
         if (config.initialBasemapId) {
             esriConfig.basemap = this.findBasemap(config.initialBasemapId).innerBasemap;
         }
-        this.innerMap = new this.esriBundle.Map(esriConfig);
+        this._innerMap = new this.esriBundle.Map(esriConfig);
 
     }
 
@@ -45,10 +45,10 @@ export default class MapBase extends BaseBase {
             //      would need to back out of this function call and trigger something else if we
             //      detect here.
 
-            this.innerMap.basemap = bm.innerBasemap;
+            this._innerMap.basemap = bm.innerBasemap;
         } else {
             // blank basemap case
-            this.innerMap.basemap = undefined;
+            this._innerMap.basemap = undefined;
         }
     }
 

--- a/packages/ramp-geoapi/src/map/RampMap.ts
+++ b/packages/ramp-geoapi/src/map/RampMap.ts
@@ -36,7 +36,7 @@ export class RampMap extends MapBase {
      * The internal esri map view. Avoid referencing outside of geoapi.
      * @private
      */
-    innerView: esri.MapView;
+    _innerView: esri.MapView;
 
     /**
      * The map spatial reference in RAMP API Spatial Reference format.
@@ -58,7 +58,7 @@ export class RampMap extends MapBase {
         this.rampSR = SpatialReference.fromConfig(config.extent.spatialReference);
 
         const esriViewConfig: esri.MapViewProperties = {
-            map: this.innerMap,
+            map: this._innerMap,
             container: targetDiv,
             constraints: {
                 lods: <Array<esri.LOD>>config.lods
@@ -72,13 +72,13 @@ export class RampMap extends MapBase {
         };
 
         // TODO extract more from config and set appropriate view properties (e.g. intial extent, initial projection, LODs)
-        this.innerView = new this.esriBundle.MapView(esriViewConfig);
+        this._innerView = new this.esriBundle.MapView(esriViewConfig);
 
-        this.innerView.watch('extent', (newval: esri.Extent) => {
+        this._innerView.watch('extent', (newval: esri.Extent) => {
             this.extentChanged.fireEvent(<Extent>this.gapi.utils.geom.geomEsriToRamp(newval, 'map_extent_event'));
         });
 
-        this.innerView.watch('scale', (newval: number) => {
+        this._innerView.watch('scale', (newval: number) => {
             this.scaleChanged.fireEvent(newval);
         });
     }
@@ -106,7 +106,7 @@ export class RampMap extends MapBase {
      */
     async addLayer (layer: LayerBase): Promise<void> {
         await layer.isReadyForMap();
-        this.innerMap.add(layer.innerLayer);
+        this._innerMap.add(layer._innerLayer);
     }
 
     /**
@@ -115,7 +115,7 @@ export class RampMap extends MapBase {
      * @param {HighlightLayer} highlightLayer the highlight
      */
     addHighlightLayer (highlightLayer: HighlightLayer): void {
-        this.innerMap.add(highlightLayer.innerLayer);
+        this._innerMap.add(highlightLayer._innerLayer);
     }
 
     // TODO passthrough functions, either by aly magic or make them hardcoded
@@ -148,7 +148,7 @@ export class RampMap extends MapBase {
                 zoomP.scale = scale;
             }
 
-            return this.innerView.goTo(zoomP);
+            return this._innerView.goTo(zoomP);
         });
 
     }
@@ -159,7 +159,7 @@ export class RampMap extends MapBase {
      * @returns {number} the map scale
      */
     getScale(): number {
-        return this.innerView.scale;
+        return this._innerView.scale;
     }
 
     /**
@@ -168,7 +168,7 @@ export class RampMap extends MapBase {
      * @returns {Extent} the map extent in RAMP API Extent format
      */
     getExtent(): Extent {
-        return this.gapi.utils.geom.convEsriExtentToRamp(this.innerView.extent);
+        return this.gapi.utils.geom.convEsriExtentToRamp(this._innerView.extent);
     }
 
     /**

--- a/packages/ramp-geoapi/src/map/RampMap.ts
+++ b/packages/ramp-geoapi/src/map/RampMap.ts
@@ -1,6 +1,5 @@
-// a 2D esri map
+// wraps and represents a 2D esri map
 // TODO add proper comments
-
 
 import esri = __esri;
 import { InfoBundle, RampMapConfig } from '../gapiTypes';
@@ -12,15 +11,46 @@ import Point from '../api/geometry/Point';
 import SpatialReference from '../api/geometry/SpatialReference';
 import BaseGeometry from '../api/geometry/BaseGeometry';
 import { GeometryType } from '../api/apiDefs';
+import { TypedEvent } from '../Event';
 
 // NOTE naming this RampMap, to avoid collisions with javascript object `Map`
 export class RampMap extends MapBase {
 
-    // TODO think about how to expose. protected makes sense, but might want to make it public to allow hacking and use by a dev module if we decide to
+    // NOTE unlike ESRI3, the map view doesnt have a custom event, it uses property watches.
+    //      so if we want to detect scale change we'll need to have another event, it won't be
+    //      a big bundle of properties like ESRI3 provided
+
+    /**
+     * Event that fires when the map extent changes. Event parameter is the extent in RAMP API Extent format.
+     */
+    extentChanged: TypedEvent<Extent>;
+
+    /**
+     * Event that fires when the map scale changes. Event parameter is the scale denominator integer.
+     */
+    scaleChanged: TypedEvent<number>;
+
+    // TODO think about how to expose. protected makes sense, but might want to make it public to allow hacking and use by a dev module if we decide to.
+    //      there are also cases where other parts of the geoapi need to access this.
+    /**
+     * The internal esri map view. Avoid referencing outside of geoapi.
+     * @private
+     */
     innerView: esri.MapView;
 
+    /**
+     * The map spatial reference in RAMP API Spatial Reference format.
+     * Saves us from converting from ESRI format every time it is needed
+     * @private
+     */
     private rampSR: SpatialReference;
 
+    /**
+     * @constructor
+     * @param {InfoBundle} infoBundle provides the common shared linkages to geoapi
+     * @param {RampMapConfig} config configuration data for the map
+     * @param {string | HTMLDivElement} targetDiv the page div or the div id that the map should be created in
+     */
     constructor (infoBundle: InfoBundle, config: RampMapConfig, targetDiv: string | HTMLDivElement) {
 
         super(infoBundle, config);
@@ -44,8 +74,22 @@ export class RampMap extends MapBase {
         // TODO extract more from config and set appropriate view properties (e.g. intial extent, initial projection, LODs)
         this.innerView = new this.esriBundle.MapView(esriViewConfig);
 
+        this.innerView.watch('extent', (newval: esri.Extent) => {
+            this.extentChanged.fireEvent(<Extent>this.gapi.utils.geom.geomEsriToRamp(newval, 'map_extent_event'));
+        });
+
+        this.innerView.watch('scale', (newval: number) => {
+            this.scaleChanged.fireEvent(newval);
+        });
     }
 
+    /**
+     * Projects a geometry to the map's spatial reference
+     *
+     * @private
+     * @param {BaseGeometry} geom the RAMP API geometry to project
+     * @returns {Promise<BaseGeometry>} the geometry projected to the map's projection, in RAMP API Geometry format
+     */
     private geomToMapSR(geom: BaseGeometry): Promise<BaseGeometry> {
         if (this.rampSR.isEqual(geom.sr)) {
             return Promise.resolve(geom);
@@ -54,27 +98,48 @@ export class RampMap extends MapBase {
         }
     }
 
-    // promise resolves when layer gets added to map
+    /**
+     * Adds a layer to the map
+     *
+     * @param {LayerBase} layer the GeoAPI layer to add
+     * @returns {Promise<void>} a promise that resolves when the layer has been added to the map
+     */
     async addLayer (layer: LayerBase): Promise<void> {
         await layer.isReadyForMap();
         this.innerMap.add(layer.innerLayer);
     }
 
+    /**
+     * Adds a highlight layer to the map
+     *
+     * @param {HighlightLayer} highlightLayer the highlight
+     */
     addHighlightLayer (highlightLayer: HighlightLayer): void {
         this.innerMap.add(highlightLayer.innerLayer);
     }
 
     // TODO passthrough functions, either by aly magic or make them hardcoded
-    getScale(): number {
-        return this.innerView.scale;
-    }
 
+    /**
+     * Zooms the map to a given extent.
+     *
+     * @param {Extent} extent A RAMP API Extent to zoom the map to
+     * @returns {Promise<void>} A promise that resolves when the map has finished zooming
+     */
     zoomMapTo(extent: Extent): Promise<void>;
+    /**
+     * Zooms the map to a given center point, at a given scale.
+     *
+     * @param {Point} extent A RAMP API Point to center the map at
+     * @param {number} mapScale An integer defining the scale the map should be at
+     * @returns {Promise<void>} A promise that resolves when the map has finished zooming
+     */
     zoomMapTo(centerPoint: Point, mapScale: number): Promise<void>;
     zoomMapTo(geom: BaseGeometry, scale?: number): Promise<void> {
         // TODO technically this can accept any geometry. should we open up the suggested signatures to allow various things?
-
         return this.geomToMapSR(geom).then(g => {
+            // TODO investigate the `snapTo` parameter if we have an extent / poly coming in
+            //      see how it compares to the old "fit to view" parameter of ESRI3
             const zoomP: any = {
                 target: this.gapi.utils.geom.geomRampToEsri(g)
             };
@@ -88,14 +153,29 @@ export class RampMap extends MapBase {
 
     }
 
+    /**
+     * Provides the scale of the map (the scale denominator as integer)
+     *
+     * @returns {number} the map scale
+     */
+    getScale(): number {
+        return this.innerView.scale;
+    }
+
+    /**
+     * Provides the extent of the map
+     *
+     * @returns {Extent} the map extent in RAMP API Extent format
+     */
     getExtent(): Extent {
         return this.gapi.utils.geom.convEsriExtentToRamp(this.innerView.extent);
     }
 
-    setExtent(newExt: Extent): Promise<void> {
-        return this.zoomMapTo(newExt);
-    }
-
+    /**
+     * Provides the spatial reference of the map
+     *
+     * @returns {SpatialReference} the map spatial reference in RAMP API format
+     */
     getSR(): SpatialReference {
         return this.rampSR.clone();
     }

--- a/packages/ramp-geoapi/src/map/RampMap3D.ts
+++ b/packages/ramp-geoapi/src/map/RampMap3D.ts
@@ -9,7 +9,7 @@ import MapBase from './MapBase';
 // naming RampMap3D, to align with calling the 2D version RampMap
 export class RampMap3D extends MapBase {
 
-    innerView: esri.SceneView;
+    _innerView: esri.SceneView;
 
     constructor (infoBundle: InfoBundle, config: any, targetDiv: string) {
         // TODO massage incoming config to something that conforms to esri.MapProperties interface
@@ -19,8 +19,8 @@ export class RampMap3D extends MapBase {
 
         // TODO extract more from config and set appropriate view properties (e.g. intial extent, initial projection, LODs)
         /* // need to add SceneView to our bundle for this to work. later!
-        this.innerView = new esriBundle.SceneView({
-            map: this.innerMap,
+        this._innerView = new esriBundle.SceneView({
+            map: this._innerMap,
             container: targetDiv,
             center: [-76.772, 44.423],
             zoom: 10

--- a/packages/ramp-geoapi/src/util/OgcService.ts
+++ b/packages/ramp-geoapi/src/util/OgcService.ts
@@ -33,7 +33,7 @@ export default class OgcService extends BaseBase {
         //            now that we have API and fixtures, a person can write their own fancy
         //            requests if they need it.
 
-        const esriLayer = wmsLayer.innerLayer;
+        const esriLayer = wmsLayer._innerLayer;
         let wkid: number;
         let req: any;
         const ext = map.getExtent();
@@ -41,7 +41,7 @@ export default class OgcService extends BaseBase {
         const layers = layerList.join(',');
 
         // tear off any decimals from the screenpoint coords.
-        const screenPoint = map.innerView.toScreen(this.gapi.utils.geom.convPointToEsri(point));
+        const screenPoint = map._innerView.toScreen(this.gapi.utils.geom.convPointToEsri(point));
         const intX = Math.floor(screenPoint.x);
         const intY = Math.floor(screenPoint.y);
 
@@ -102,8 +102,8 @@ export default class OgcService extends BaseBase {
             SERVICE: 'WMS',
             REQUEST: 'GetFeatureInfo',
             VERSION: esriLayer.version,
-            WIDTH: map.innerView.width,
-            HEIGHT: map.innerView.height,
+            WIDTH: map._innerView.width,
+            HEIGHT: map._innerView.height,
             QUERY_LAYERS: layers,
             LAYERS: layers,
             INFO_FORMAT: mimeType
@@ -273,7 +273,7 @@ export default class OgcService extends BaseBase {
         };
 
         const slMap = new Map();
-        crawlSublayers(wmsLayer.innerLayer.sublayers, slMap);
+        crawlSublayers(wmsLayer._innerLayer.sublayers, slMap);
 
         // NOTE currently this logic (from ramp 2) seems out of sycnh with the config schema
         //      WMSLayerEntryNode does not appear to have .styleToURL or .currentStyle

--- a/packages/ramp-geoapi/src/util/QueryService.ts
+++ b/packages/ramp-geoapi/src/util/QueryService.ts
@@ -49,7 +49,7 @@ export default class QueryService extends BaseBase {
             query.spatialRelationship = 'intersects';
         }
 
-        return (<esri.FeatureLayer>options.layer.innerLayer).queryFeatures(query).then(featSet => {
+        return (<esri.FeatureLayer>options.layer._innerLayer).queryFeatures(query).then(featSet => {
             let feats: any = featSet.features;
             if (options.filterSql && feats.length > 0) {
                 // aql


### PR DESCRIPTION
Added some events to allow GeoSearch cleaner access to the map.

Removed a public method that was essentially a duplication of function (`setExtent`).

Added some nicer JSDoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/75)
<!-- Reviewable:end -->
