### PR TITLE
Geoapi Enhancement Medley

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11,7 +11,7 @@ dependencies:
   '@rush-temp/ramp-sample-fixtures': 'file:projects/ramp-sample-fixtures.tgz'
   '@tailwindcss/custom-forms': 0.2.1_tailwindcss@1.1.4
   '@types/animejs': 3.1.0
-  '@types/arcgis-js-api': 4.14.0
+  '@types/arcgis-js-api': 4.15.0
   '@types/clone-deep': 4.0.1
   '@types/debounce': 1.2.0
   '@types/dojo': 1.9.42
@@ -1292,10 +1292,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-OOOQ11ylW8GeFY85yM3HrprR5wZl1R1KsxrxNLMpE9l24zs+4yXAu4WsDESWcCAf5+PxvPNsLV9W/PB3J+XGMQ==
-  /@types/arcgis-js-api/4.14.0:
+  /@types/arcgis-js-api/4.15.0:
     dev: false
     resolution:
-      integrity: sha512-TGOfVtEpC5mIVqHwZRGS2OLx8D47AsPfUgDw/Z4IdTOOjMY+7/Hd25mu8xPkoEYNKy88jFYD/7eUIZWDBPUvKQ==
+      integrity: sha512-8k3izWm6TBuNgYjYr7k5S9aXpzJ6R51g3HMecQvB4CAD5tgO+kUFn3i1BPnfweAPnrURei9ponU9QL1N5o0BhA==
   /@types/babel__core/7.1.7:
     dependencies:
       '@babel/parser': 7.9.4
@@ -13469,7 +13469,7 @@ packages:
       '@babel/plugin-proposal-object-rest-spread': 7.9.5_@babel+core@7.9.0
       '@babel/preset-env': 7.9.5_@babel+core@7.9.0
       '@babel/preset-typescript': 7.9.0_@babel+core@7.9.0
-      '@types/arcgis-js-api': 4.14.0
+      '@types/arcgis-js-api': 4.15.0
       '@types/dojo': 1.9.42
       '@types/geojson': 1.0.6
       '@types/node': 7.0.0
@@ -13490,7 +13490,7 @@ packages:
     dev: false
     name: '@rush-temp/ramp-geoapi'
     resolution:
-      integrity: sha512-Aj91IWDw3RhVYp6cI4T4P9y5s4rvgWwE0bkZQo1jIKxaC5seIKQvwyJv4EmSwOaOGClqVfSkScWw4qhotGzMlA==
+      integrity: sha512-1MpLXk+hVWjWoo+cATdJA92pIa9e1Ab/Ewfkr6td8XOmoJk5H67gyu/fOxRNtmTbrJh9dl9220isLqdPrx001Q==
       tarball: 'file:projects/ramp-geoapi.tgz'
     version: 0.0.0
   'file:projects/ramp-sample-fixtures.tgz':
@@ -13518,6 +13518,7 @@ packages:
       integrity: sha512-ToEiPhqtC7BzixJ9ChYh69pWhzMHF4HGVpNryHLOXpUCAsTIsw2W2I1T5c8dvv6HztFOLIggNY7gsL2O0fMIUw==
       tarball: 'file:projects/ramp-sample-fixtures.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@babel/cli': ^7.2.3
   '@babel/core': ^7.4.0
@@ -13531,7 +13532,7 @@ specifiers:
   '@rush-temp/ramp-sample-fixtures': 'file:./projects/ramp-sample-fixtures.tgz'
   '@tailwindcss/custom-forms': ^0.2.1
   '@types/animejs': ~3.1.0
-  '@types/arcgis-js-api': ~4.14.0
+  '@types/arcgis-js-api': ~4.15.0
   '@types/clone-deep': ~4.0.1
   '@types/debounce': ^1.2.0
   '@types/dojo': ^1.9.41

--- a/packages/ramp-core/src/api/index.ts
+++ b/packages/ramp-core/src/api/index.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import GapiLoader, { GeoApi } from 'ramp-geoapi';
+import GapiLoader, { GeoApi, ApiBundle } from 'ramp-geoapi';
 
 import { InstanceAPI, AppVersion } from './internal';
 import mixin from './mixin';
@@ -10,6 +10,23 @@ declare const __VERSION__: AppVersion;
 
 // install/register mixin plugin with Vue, so it's available on all Vue instances
 Vue.use(mixin);
+
+interface RampGeo {
+    Extent: typeof ApiBundle.Extent;
+    Graphic: typeof ApiBundle.Graphic;
+    Hover: typeof ApiBundle.Hover;
+    LineString: typeof ApiBundle.LineString;
+    LineStyleOptions: typeof ApiBundle.LineStyleOptions;
+    LinearRing: typeof ApiBundle.LinearRing;
+    MultiLineString: typeof ApiBundle.MultiLineString;
+    MultiPoint: typeof ApiBundle.MultiPoint;
+    MultiPolygon: typeof ApiBundle.MultiPolygon;
+    Point: typeof ApiBundle.Point;
+    PointStyleOptions: typeof ApiBundle.PointStyleOptions;
+    Polygon: typeof ApiBundle.Polygon;
+    PolygonStyleOptions: typeof ApiBundle.PolygonStyleOptions;
+    SpatialReference: typeof ApiBundle.SpatialReference;
+}
 
 export interface APIInterface {
     Instance: typeof InstanceAPI;
@@ -23,14 +40,33 @@ export interface APIInterface {
      * @memberof APIInterface
      */
     version: AppVersion;
+
+    GEO: RampGeo;
 }
 
 // Load geoapi
 // moved from `main-build` since it was being attached to the api object anyways
 let geoapi: GeoApi;
+let rampgeo: RampGeo;
 const gapiPromise = GapiLoader(window);
 gapiPromise.then((gapi: GeoApi) => {
     geoapi = gapi;
+    rampgeo = {
+        Extent: ApiBundle.Extent,
+        Graphic: ApiBundle.Graphic,
+        Hover: ApiBundle.Hover,
+        LineString: ApiBundle.LineString,
+        LineStyleOptions: ApiBundle.LineStyleOptions,
+        LinearRing: ApiBundle.LinearRing,
+        MultiLineString: ApiBundle.MultiLineString,
+        MultiPoint: ApiBundle.MultiPoint,
+        MultiPolygon: ApiBundle.MultiPolygon,
+        Point: ApiBundle.Point,
+        PointStyleOptions: ApiBundle.PointStyleOptions,
+        Polygon: ApiBundle.Polygon,
+        PolygonStyleOptions: ApiBundle.PolygonStyleOptions,
+        SpatialReference: ApiBundle.SpatialReference
+    };
 });
 
 const api: APIInterface = {
@@ -43,7 +79,15 @@ const api: APIInterface = {
 
         return geoapi;
     },
-    version: __VERSION__ // this is populated by the build process; see `vue.config.js`
+    version: __VERSION__, // this is populated by the build process; see `vue.config.js`
+
+    get GEO(): RampGeo {
+        if (typeof rampgeo === 'undefined') {
+            throw new Error("Attempting to access `GEO` before it's resolved. Use `initRamp` global function instead.");
+        }
+
+        return rampgeo;
+    }
 };
 
 // export `InstanceApi` as `Instance` on global RAMP interface

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
@@ -65,9 +65,6 @@ import GeosearchBottomFilters from './geosearch-bottom-filters.vue';
 import LoadingBar from './loading-bar.vue';
 import messages from './lang';
 
-// TODO: temporary import for map zoom call
-import { ApiBundle } from 'ramp-geoapi';
-
 @Component({
     components: {
         GeosearchBar,
@@ -92,8 +89,7 @@ export default class GeosearchComponent extends Vue {
 
     // zoom in to a clicked result
     zoomIn(result: any): void {
-        // TODO: replace with ramp api once complete - RAMP.GEO.Point()?
-        let zoomPoint = new ApiBundle.Point('zoomies', result.position);
+        let zoomPoint = new (window as any).RAMP.GEO.Point('zoomies', result.position);
         this.$iApi.map.zoomMapTo(zoomPoint, 50000);
     }
 

--- a/packages/ramp-geoapi/package.json
+++ b/packages/ramp-geoapi/package.json
@@ -29,7 +29,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.4.0",
     "@babel/preset-env": "^7.4.1",
     "@babel/preset-typescript": "^7.3.3",
-    "@types/arcgis-js-api": "~4.14.0",
+    "@types/arcgis-js-api": "~4.15.0",
     "@types/dojo": "^1.9.41",
     "@types/geojson": "^1.0.0",
     "@types/node": "7.0.0",

--- a/packages/ramp-geoapi/src/api/apiDefs.ts
+++ b/packages/ramp-geoapi/src/api/apiDefs.ts
@@ -11,16 +11,11 @@ export enum LayerType {
     FEATURE = 'esriFeature',
     MAPIMAGE = 'esriMapImage',
     TILE = 'esriTile',
+    // TODO add esri image server type when/if we decide to support it?
 
     // OGS
     WMS = 'ogcWms',
-    WFS = 'ogcWfs',
-
-    // FILE
-    // TODO need to think about these, as RAMP2 config schema used featurelayer plus second fileType property
-    CSV = '',
-    SHAPEFILE = '',
-    GEOJSON = '',
+    WFS = 'ogcWfs', // TODO proposing this should not be a part of this enum. WFS = Feature
 }
 
 export enum GeometryType {

--- a/packages/ramp-geoapi/src/api/apiDefs.ts
+++ b/packages/ramp-geoapi/src/api/apiDefs.ts
@@ -18,6 +18,15 @@ export enum LayerType {
     WFS = 'ogcWfs', // TODO proposing this should not be a part of this enum. WFS = Feature
 }
 
+// Format indicates what form the spatial data is encoded in.
+// TODO add more as we support more formats
+export enum DataFormat {
+    ESRI_FEATURE = 'esriFeature',
+    ESRI_RASTER = 'esriRaster',
+    ESRI_TILE = 'esriTile',
+    OGC_RASTER = 'ogcRaster'
+}
+
 export enum GeometryType {
     POINT = 'Point',
     MULTIPOINT = 'MultiPoint',

--- a/packages/ramp-geoapi/src/gapiTypes.ts
+++ b/packages/ramp-geoapi/src/gapiTypes.ts
@@ -7,6 +7,7 @@
 
 import esri = __esri; // magic command to get ESRI JS API type definitions.
 import BaseGeometry from './api/geometry/BaseGeometry'; // this is a bit wonky. could expose on RampAPI, but dont want clients using the baseclass
+import Point from './api/geometry/Point';
 import { Attributes } from './api/apiDefs';
 import MapModule from './map/MapModule';
 import RampMap from './map/RampMap';
@@ -132,6 +133,14 @@ export enum IdentifyResultFormat {
     XML = 'xml',
     JSON = 'json',
     UNKNOWN = 'unknown'
+}
+
+export interface MapClick {
+    mapPoint: Point;
+    screenX: number;
+    screenY: number;
+    button: number;
+    clickTime: number;
 }
 
 // a collection of attributes

--- a/packages/ramp-geoapi/src/layer/AttribFC.ts
+++ b/packages/ramp-geoapi/src/layer/AttribFC.ts
@@ -14,7 +14,7 @@ import Extent from '../api/geometry/Extent';
 export default class AttribFC extends BaseFC {
 
     geomType: string;
-    layerType: string; // TODO revisit this. is value still useful?
+    layerType: string; // TODO revisit this. is value still useful? // NOTE this can fuel the new dataformat function being proposed
     oidField: string;
     fields: Array<esri.Field>;
     nameField: string;

--- a/packages/ramp-geoapi/src/layer/AttribFC.ts
+++ b/packages/ramp-geoapi/src/layer/AttribFC.ts
@@ -10,11 +10,11 @@ import { BaseRenderer } from '../util/Renderers';
 import QuickCache from './QuickCache';
 import Filter from './Filter';
 import Extent from '../api/geometry/Extent';
+import { DataFormat } from '../api/apiDefs';
 
 export default class AttribFC extends BaseFC {
 
     geomType: string;
-    layerType: string; // TODO revisit this. is value still useful? // NOTE this can fuel the new dataformat function being proposed
     oidField: string;
     fields: Array<esri.Field>;
     nameField: string;
@@ -60,7 +60,7 @@ export default class AttribFC extends BaseFC {
                     const sData: any = serviceResult.data;
 
                     // properties for all endpoints
-                    this.layerType = sData.type;
+
                     // TODO need to decide what propert default is. Raster Layer has null gt.
                     this.geomType = this.gapi.utils.shared.serverGeomTypeToClientGeomType(sData.geometryType) || 'none';
                     this.quickCache = new QuickCache(this.geomType);
@@ -71,6 +71,7 @@ export default class AttribFC extends BaseFC {
 
                     if (sData.type === 'Feature Layer') {
                         this.supportsFeatures = true;
+                        this.dataFormat = DataFormat.ESRI_FEATURE;
                         this.fields = sData.fields.map((f: any) => this.esriBundle.Field.fromJSON(f)); // TODO need to use Field.fromJSON() to make things correct
                         this.nameField = sData.displayField;
 
@@ -123,6 +124,8 @@ export default class AttribFC extends BaseFC {
                             attribs: '*' // TODO re-align with our attribs decision above
                         };
                         this.attLoader = new ArcServerAttributeLoader(this.infoBundle(), loadData);
+                    } else {
+                        this.dataFormat = DataFormat.ESRI_RASTER;
                     }
 
                     // tell caller we are donethanks
@@ -208,9 +211,7 @@ export default class AttribFC extends BaseFC {
         }
 
         // TODO after refactor, consider changing this to a warning and just return some dummy value
-        // TODO make a layertype constant / enum?
-        //      adopt the esri layer.type values would be a good idea
-        if (this.layerType === 'Raster Layer') {
+        if (this.dataFormat === DataFormat.ESRI_RASTER) {
             throw new Error('Attempting to get attributes on a raster layer.');
         }
 

--- a/packages/ramp-geoapi/src/layer/BaseFC.ts
+++ b/packages/ramp-geoapi/src/layer/BaseFC.ts
@@ -3,6 +3,7 @@
 
 import esri = __esri;
 import { InfoBundle, LegendSymbology } from '../gapiTypes';
+import { DataFormat } from '../api/apiDefs';
 import BaseBase from '../BaseBase';
 import BaseLayer from './BaseLayer';
 import ScaleSet from './ScaleSet';
@@ -10,6 +11,7 @@ import ScaleSet from './ScaleSet';
 export default class BaseFC extends BaseBase {
 
     protected parentLayer: BaseLayer;
+    dataFormat: DataFormat;
     layerIdx: number; // final name TBD
     name: string;
     uid: string;

--- a/packages/ramp-geoapi/src/layer/BaseLayer.ts
+++ b/packages/ramp-geoapi/src/layer/BaseLayer.ts
@@ -292,7 +292,7 @@ export default class BaseLayer extends BaseBase {
     /**
      * The type of the physical layer
      */
-    get layerType(): LayerType { return this._layerType}
+    get layerType(): LayerType { return this._layerType; }
 
     /**
      * Provides a tree structure describing the layer and any sublayers,

--- a/packages/ramp-geoapi/src/layer/BaseLayer.ts
+++ b/packages/ramp-geoapi/src/layer/BaseLayer.ts
@@ -2,15 +2,14 @@
 // TODO add proper comments
 
 import esri = __esri;
-import { InfoBundle, LayerState, RampLayerConfig, LegendSymbology, IdentifyParameters, IdentifyResultSet, FilterEventParam } from '../gapiTypes';
+import { InfoBundle, LayerState, RampLayerConfig, LegendSymbology, IdentifyParameters, IdentifyResultSet, FilterEventParam, IdentifyResult } from '../gapiTypes';
 import BaseBase from '../BaseBase';
 import { TypedEvent } from '../Event';
 import BaseFC from './BaseFC';
 import TreeNode from './TreeNode';
 import NaughtyPromise from '../util/NaughtyPromise';
 import ScaleSet from './ScaleSet';
-
-
+import { LayerType } from '../api/apiDefs';
 
 export default class BaseLayer extends BaseBase {
 
@@ -41,6 +40,7 @@ export default class BaseLayer extends BaseBase {
     protected sawRefresh: boolean;
     protected name: string; // TODO re-evaluate this. using protected property here to store name until FCs get created. might be smarter way
     protected origRampConfig: RampLayerConfig;
+    protected _layerType: LayerType;
 
     // TODO consider also having a loaded boolean property, allowing a synch check if layer has loaded or not. state can flip around to update, etc.
     //      alternately implement something like function layerLoaded() from old geoApi
@@ -289,6 +289,18 @@ export default class BaseLayer extends BaseBase {
 
     // ----------- LAYER MANAGEMENT -----------
 
+    /**
+     * The type of the physical layer
+     */
+    get layerType(): LayerType { return this._layerType}
+
+    /**
+     * Provides a tree structure describing the layer and any sublayers,
+     * including uid values. Should only be called after isLayerLoaded resolves.
+     *
+     * @method getLayerTree
+     * @returns {TreeNode} the root of the layer tree
+     */
     getLayerTree(): TreeNode {
 
         // TODO throw error if called too early? may want to standardize that error for other properties
@@ -296,8 +308,14 @@ export default class BaseLayer extends BaseBase {
         return this.layerTree;
     }
 
-    // finds an index corresponding to the uid.
-    // -1 indicates the uid targets the root layer
+    /**
+     * Finds an FC index corresponding to the given uid.
+     * -1 indicates the uid targets the root layer
+     *
+     * @private
+     * @param {string} uid the uid we want the index for
+     * @returns {number} the integer index of the uid
+     */
     protected uidToIdx(uid: string): number {
         if (uid === this.uid) {
             return -1;
@@ -312,10 +330,19 @@ export default class BaseLayer extends BaseBase {
         }
     }
 
-    // attempts to get an FC based on the index or uid passed.
-    // will return undefined if a valid root request is made.
-    // missing layerIdx will be treated as root request if validRoot, otherwise treated as first valid FC child.
-    // will throw error if specific parameters cannot be found
+    /**
+     * Attempts to get an FC based on the index or uid provided.
+     * Will return undefined if a valid root request is made.
+     * A missing layerIdx will be interpreted as root request if validRoot is true,
+     * otherwise it will interpret as a request for the first valid FC child.
+     * An index of -1 will be interpreted as a root request.
+     * Will throw error if specific parameters cannot be matched to items in the layer
+     *
+     * @private
+     * @param {number | string} layerIdx the uid or numeric index of the item we are interested in
+     * @param {boolean} [validRoot=false] indicates if asking for the layer root is a valid request
+     * @returns {BaseFC} the matching feature class object, or undefined if the root was requested
+     */
     protected getFC(layerIdx: number | string, validRoot: boolean = false): BaseFC {
         // highscool cs IF party
 
@@ -357,6 +384,13 @@ export default class BaseLayer extends BaseBase {
         }
     }
 
+    /**
+     * Returns the name of the layer/sublayer.
+     *
+     * @function getName
+     * @param {Integer | String} [layerIdx] targets a layer index or uid to get the name for. Uses first/only if omitted.
+     * @returns {String} name of the layer/sublayer
+     */
     getName(layerIdx: number | string = undefined): string {
         return this.getFC(layerIdx).name;
     }
@@ -433,6 +467,13 @@ export default class BaseLayer extends BaseBase {
 
     // ----------- LAYER ACTIONS -----------
 
+    /**
+     * Baseline identify function for layers that do not support identify.
+     * Will return an empty result. Layers that support identify should override this method.
+     *
+     * @param options not used, present for nice signature of overrided function
+     * @returns {IdentifyResultSet} an empty result set
+     */
     identify(options: IdentifyParameters): IdentifyResultSet {
         // returns an empty set.
         // serves as a fallback incase someone tries to identify on a non-identifiyable layer

--- a/packages/ramp-geoapi/src/layer/BaseLayer.ts
+++ b/packages/ramp-geoapi/src/layer/BaseLayer.ts
@@ -9,7 +9,7 @@ import BaseFC from './BaseFC';
 import TreeNode from './TreeNode';
 import NaughtyPromise from '../util/NaughtyPromise';
 import ScaleSet from './ScaleSet';
-import { LayerType } from '../api/apiDefs';
+import { LayerType, DataFormat } from '../api/apiDefs';
 
 export default class BaseLayer extends BaseBase {
 
@@ -393,6 +393,17 @@ export default class BaseLayer extends BaseBase {
      */
     getName(layerIdx: number | string = undefined): string {
         return this.getFC(layerIdx).name;
+    }
+
+    /**
+     * Returns the data format of a sublayer.
+     *
+     * @function dataFormat
+     * @param {Integer | String} [layerIdx] targets a sublayer index or uid to get the data format for. Uses first/only if omitted.
+     * @returns {String} format type of the sublayer
+     */
+    dataFormat(layerIdx: number | string = undefined): DataFormat {
+        return this.getFC(layerIdx).dataFormat;
     }
 
     /**

--- a/packages/ramp-geoapi/src/layer/FeatureFC.ts
+++ b/packages/ramp-geoapi/src/layer/FeatureFC.ts
@@ -5,6 +5,7 @@ import { InfoBundle } from '../gapiTypes';
 import BaseLayer from './BaseLayer';
 import AttribFC from './AttribFC';
 import FeatureLayer from './FeatureLayer';
+import { DataFormat } from '../api/apiDefs';
 
 export default class FeatureFC extends AttribFC {
 
@@ -13,6 +14,7 @@ export default class FeatureFC extends AttribFC {
 
     constructor (infoBundle: InfoBundle, parent: BaseLayer, layerIdx: number = 0) {
         super(infoBundle, parent, layerIdx);
+        this.dataFormat = DataFormat.ESRI_FEATURE;
     }
 
     /**

--- a/packages/ramp-geoapi/src/layer/FeatureLayer.ts
+++ b/packages/ramp-geoapi/src/layer/FeatureLayer.ts
@@ -6,6 +6,7 @@ import { InfoBundle, LayerState, RampLayerConfig, ArcGisServerUrl, IdentifyParam
 import AttribLayer from './AttribLayer';
 import TreeNode from './TreeNode';
 import FeatureFC from './FeatureFC';
+import { LayerType } from '../api/apiDefs';
 
 export class FeatureLayer extends AttribLayer {
 
@@ -13,7 +14,7 @@ export class FeatureLayer extends AttribLayer {
 
     constructor (infoBundle: InfoBundle, config: RampLayerConfig, reloadTree?: TreeNode) {
         super(infoBundle, config, reloadTree);
-
+        this._layerType = LayerType.FEATURE;
         this._innerLayer = new this.esriBundle.FeatureLayer(this.makeEsriLayerConfig(config));
         this.initLayer();
 

--- a/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
@@ -7,6 +7,7 @@ import AttribFC from './AttribFC';
 import { AttributeLoaderDetails, FileLayerAttributeLoader } from '../util/AttributeLoader';
 import QuickCache from './QuickCache';
 import GeoJsonLayer from './GeoJsonLayer';
+import { DataFormat } from '../api/apiDefs';
 
 export default class GeoJsonFC extends AttribFC {
 
@@ -15,6 +16,7 @@ export default class GeoJsonFC extends AttribFC {
 
     constructor (infoBundle: InfoBundle, parent: BaseLayer, layerIdx: number = 0) {
         super(infoBundle, parent, layerIdx);
+        this.dataFormat = DataFormat.ESRI_FEATURE;
     }
 
     // TODO consider moving a bulk of this out to LayerModule; the wizard may have use for running this (e.g. getting field list for a service url)

--- a/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonFC.ts
@@ -25,7 +25,6 @@ export default class GeoJsonFC extends AttribFC {
         const l = this.parentLayer._innerLayer;
 
         // properties for all endpoints
-        this.layerType = 'Feature Layer'; // TODO validate this matches server string. TODO validate we don't want to change to a different value. TODO define an Enum for layerType?
         this.supportsFeatures = true;
 
         this.geomType = l.geometryType;

--- a/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
@@ -6,6 +6,7 @@ import { InfoBundle, LayerState, RampLayerConfig, IdentifyParameters, IdentifyRe
 import AttribLayer from './AttribLayer';
 import TreeNode from './TreeNode';
 import GeoJsonFC from './GeoJsonFC';
+import { LayerType } from '../api/apiDefs';
 
 
 // util function to manage trickery. file layer can have field names that are bad keys.
@@ -41,6 +42,7 @@ export class GeoJsonLayer extends AttribLayer {
 
         super(infoBundle, rampLayerConfig, reloadTree);
         this.isFile = true;
+        this._layerType = LayerType.FEATURE;
 
         // NOTE: file based layers can require reprojection.
         //       that is an asynchronous action. and has to happen before the esri layer

--- a/packages/ramp-geoapi/src/layer/HighlightLayer.ts
+++ b/packages/ramp-geoapi/src/layer/HighlightLayer.ts
@@ -20,6 +20,7 @@ export class HighlightLayer extends BaseBase {
     constructor (infoBundle: InfoBundle, options: any) {
         super(infoBundle);
 
+        // TODO determine if we are setting a layer type for highlight layers.
         let id: string = 'rv_highlight';
         let markerSymbol: esri.PictureMarkerSymbol = this.esriBundle.PictureMarkerSymbol.fromJSON(defaultSymbols.markerSymbol);
 

--- a/packages/ramp-geoapi/src/layer/MapImageLayer.ts
+++ b/packages/ramp-geoapi/src/layer/MapImageLayer.ts
@@ -7,7 +7,7 @@ import AttribLayer from './AttribLayer';
 import TreeNode from './TreeNode';
 import MapImageFC from './MapImageFC';
 import ScaleSet from './ScaleSet';
-import { LayerType } from '../api/apiDefs';
+import { LayerType, DataFormat } from '../api/apiDefs';
 
 // Formerly known as DynamicLayer
 export class MapImageLayer extends AttribLayer {
@@ -256,6 +256,7 @@ export class MapImageLayer extends AttribLayer {
                     const miFC = new MapImageFC(this.infoBundle(), this, sid);
                     const lName = (subC ? subC.name : '') || subLayer.title || ''; // config if exists, else server, else none
                     miFC.name = lName;
+                    miFC.dataFormat = subLayer.objectIdField === null ? DataFormat.ESRI_RASTER : DataFormat.ESRI_FEATURE;
                     this.fcs[sid] = miFC;
                     leafsToInit.push(miFC);
                 }

--- a/packages/ramp-geoapi/src/layer/MapImageLayer.ts
+++ b/packages/ramp-geoapi/src/layer/MapImageLayer.ts
@@ -256,7 +256,6 @@ export class MapImageLayer extends AttribLayer {
                     const miFC = new MapImageFC(this.infoBundle(), this, sid);
                     const lName = (subC ? subC.name : '') || subLayer.title || ''; // config if exists, else server, else none
                     miFC.name = lName;
-                    miFC.dataFormat = subLayer.objectIdField === null ? DataFormat.ESRI_RASTER : DataFormat.ESRI_FEATURE;
                     this.fcs[sid] = miFC;
                     leafsToInit.push(miFC);
                 }

--- a/packages/ramp-geoapi/src/layer/MapImageLayer.ts
+++ b/packages/ramp-geoapi/src/layer/MapImageLayer.ts
@@ -7,6 +7,7 @@ import AttribLayer from './AttribLayer';
 import TreeNode from './TreeNode';
 import MapImageFC from './MapImageFC';
 import ScaleSet from './ScaleSet';
+import { LayerType } from '../api/apiDefs';
 
 // Formerly known as DynamicLayer
 export class MapImageLayer extends AttribLayer {
@@ -18,6 +19,7 @@ export class MapImageLayer extends AttribLayer {
     constructor (infoBundle: InfoBundle, config: RampLayerConfig, reloadTree?: TreeNode) {
 
         super(infoBundle, config, reloadTree);
+        this._layerType = LayerType.MAPIMAGE;
 
         this._innerLayer = new this.esriBundle.MapImageLayer(this.makeEsriLayerConfig(config));
 

--- a/packages/ramp-geoapi/src/layer/WmsFC.ts
+++ b/packages/ramp-geoapi/src/layer/WmsFC.ts
@@ -5,6 +5,7 @@ import { InfoBundle } from '../gapiTypes';
 import BaseLayer from './BaseLayer';
 import BaseFC from './BaseFC';
 import WmsLayer from './WmsLayer';
+import { DataFormat } from '../api/apiDefs';
 
 export default class WmsFC extends BaseFC {
 
@@ -12,7 +13,7 @@ export default class WmsFC extends BaseFC {
 
     constructor (infoBundle: InfoBundle, parent: BaseLayer, layerIdx: number = 0) {
         super(infoBundle, parent, layerIdx);
+        this.dataFormat = DataFormat.OGC_RASTER;
     }
 
-    // TODO if nothing goes here, then delete and have WmsLayer use BaseFC refs
 }

--- a/packages/ramp-geoapi/src/layer/WmsLayer.ts
+++ b/packages/ramp-geoapi/src/layer/WmsLayer.ts
@@ -3,7 +3,7 @@
 
 import esri = __esri;
 import { InfoBundle, IdentifyParameters, IdentifyResultSet, IdentifyResult, RampLayerConfig, RampLayerWmsLayerEntryConfig, IdentifyItem, IdentifyResultFormat } from '../gapiTypes';
-import { GeometryType } from '../api/apiDefs';
+import { GeometryType, LayerType } from '../api/apiDefs';
 import BaseLayer from './BaseLayer';
 import Point from '../api/geometry/Point';
 import WmsFC from './WmsFC';
@@ -18,6 +18,7 @@ export class WmsLayer extends BaseLayer {
     constructor (infoBundle: InfoBundle, config: RampLayerConfig, reloadTree?: TreeNode) {
         super(infoBundle, config, reloadTree);
         this.supportsIdentify = true;
+        this._layerType = LayerType.WMS;
         this.mimeType = config.featureInfoMimeType; // TODO is there a default? will that be in the config defaulting?
 
         this._innerLayer = new this.esriBundle.WMSLayer(this.makeEsriLayerConfig(config));

--- a/packages/ramp-geoapi/src/main.ts
+++ b/packages/ramp-geoapi/src/main.ts
@@ -200,7 +200,7 @@ export default async (window: DojoWindow, options: GeoApiOptions = {}): Promise<
         oScript.onerror = (err: any) => reject(err);
         oScript.onload = () => resolve();
         oHead.appendChild(oScript);
-        oScript.src = options.apiUrl || 'https://js.arcgis.com/4.14'; // default value should be used for general testing and be considered our "supported" version
+        oScript.src = options.apiUrl || 'https://js.arcgis.com/4.15'; // default value should be used for general testing and be considered our "supported" version
     });
 
     const esriBundle = await makeDojoRequests(esriDeps, window);

--- a/packages/ramp-geoapi/src/util/SharedUtils.ts
+++ b/packages/ramp-geoapi/src/util/SharedUtils.ts
@@ -9,30 +9,6 @@ export default class SharedUtils extends BaseBase {
         super(infoBundle);
     }
 
-    // TODO figure out grand scheme of layer type strings. use enum? adopt server strings?
-    /**
-     * Will return a string indicating the type of layer a layer object is.
-     * @method getLayerType
-     * @param  {Object} layer an ESRI API layer object
-     * @return {String} layer type
-     */
-    getLayerType(layer: esri.Layer): string {
-
-        if (layer instanceof this.esriBundle.FeatureLayer) {
-            return 'FeatureLayer';
-        } else if (layer instanceof this.esriBundle.WMSLayer) {
-            return 'WmsLayer';
-        } else if (layer instanceof this.esriBundle.MapImageLayer) {
-            return 'MapImageLayer';
-        } else if (layer instanceof this.esriBundle.TileLayer) {
-            return 'TileLayer';
-        } else {
-            // Can add more types above as we support them
-            return 'UNKNOWN';
-        }
-
-    }
-
     /**
      * Get a 'good enough' uuid. For backup purposes if client does not supply its own
      * unique layer id

--- a/packages/ramp-geoapi/src/util/SymbologyService.ts
+++ b/packages/ramp-geoapi/src/util/SymbologyService.ts
@@ -622,7 +622,7 @@ export default class SymbologyService extends BaseBase {
 
     /**
      * Generate a legend object based on an ESRI renderer.
-     * @private
+     *
      * @param  {Object} renderer an ESRI renderer object in server JSON form
      * @return {Array} list of legend symbologies
      */
@@ -645,25 +645,22 @@ export default class SymbologyService extends BaseBase {
             // e.g. a renderer has SU for 'type=X' and 'type=Y', both with label 'Fun Stuff'. This merges the logic into
             // one line on the legend for Fun Stuff!
 
-            const legendCollater: {[key: string]: Array<BaseSymbolUnit>} = {};
+            // using Map will preserve the order things were encountered
+            const legendCollater = new Map<string, Array<BaseSymbolUnit>>();
 
             allRendererSUs.forEach(su => {
-                if (legendCollater[su.label]) {
+                const lblArray = legendCollater.get(su.label);
+                if (lblArray) {
                     // not the first time we hit this label. add to the list
-                    legendCollater[su.label].push(su);
+                    lblArray.push(su);
                 } else {
-                    legendCollater[su.label] = [su];
+                    legendCollater.set(su.label, [su]);
                 }
             });
 
-            // TODO this code will return the legend array in the order that object.keys presents the keys.
-            //      we may need to add some additional logic to enforce a different order.
-            //      e.g. alphabetical by label, with default being last.
-            //           alphabetical by label, default not treated special.
-            //           same order as renderer's array, with default being last.
-
             // iterate through the unique keys in the collater. process each legend item
-            finalSymbols = Object.keys(legendCollater).map((lbl: string) => legendCollater[lbl]);
+            finalSymbols = [];
+            legendCollater.forEach(lblArray => finalSymbols.push(lblArray));
         }
 
         // iterate through the final symbol array. process each legend item


### PR DESCRIPTION
Adds a number of small but stellar updates

- Boosts ESRI JS API to 4.15
- Adds `layerType` and `dataFormat` to geoapi layers
- Fixes ordering issue in legend symbol stack generator
- Adds map click and doubleclick events to geoapi Map
- Puts API geometries on global RAMP object
- JSDoc additions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/84)
<!-- Reviewable:end -->
