### PR TITLE
chore: simplify loading locale messages in panel screen components

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -22,18 +22,18 @@ dependencies:
   '@vue/cli-plugin-babel': 4.3.1_@vue+cli-service@4.3.1
   '@vue/cli-plugin-e2e-cypress': 4.3.1_26b4135a6a7ea6e5db753560c48793ec
   '@vue/cli-plugin-eslint': 4.3.1_26b4135a6a7ea6e5db753560c48793ec
-  '@vue/cli-plugin-typescript': 4.3.1_4393d990a4a77a4ef1a94eecd7abd551
+  '@vue/cli-plugin-typescript': 4.3.1_22122c1b335748d34772818bd2671b9d
   '@vue/cli-plugin-unit-jest': 4.3.1_26ec19d41106f6887b12594fc4613ed9
   '@vue/cli-plugin-vuex': 4.3.1_@vue+cli-service@4.3.1
-  '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+  '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
   '@vue/eslint-config-prettier': 5.1.0_484a2925e2c2b62f874c20a5d1f8a049
-  '@vue/eslint-config-typescript': 4.0.0_eslint@5.16.0+typescript@3.5.3
+  '@vue/eslint-config-typescript': 4.0.0_eslint@5.16.0+typescript@3.8.3
   '@vue/test-utils': 1.0.0-beta.29_d81dac297579cfd5597855dabf60f13b
   ag-grid-community: 22.1.1
   ag-grid-vue: 22.1.1_1dc7f8a466c694e72b2b9eba2d4b7b31
   animejs: 3.2.0
   await-to-js: 2.1.1
-  awesome-typescript-loader: 5.2.1_typescript@3.5.3
+  awesome-typescript-loader: 5.2.1_typescript@3.8.3
   axios: 0.19.2
   css-loader: 3.5.2_webpack@4.41.3
   debounce: 1.2.0
@@ -57,11 +57,11 @@ dependencies:
   terraformer: 1.0.9
   terraformer-arcgis-parser: 1.1.0
   ts-jest: 23.10.5_jest@23.6.0
-  ts-loader: 7.0.1_typescript@3.5.3
+  ts-loader: 7.0.1_typescript@3.8.3
   tslib: 1.10.0
-  tslint: 5.17.0_typescript@3.5.3
+  tslint: 5.17.0_typescript@3.8.3
   tslint-loader: 3.6.0_tslint@5.17.0
-  typescript: 3.5.3
+  typescript: 3.8.3
   vue: 2.6.11
   vue-class-component: 7.2.3_vue@2.6.11
   vue-i18n: 8.16.0
@@ -1450,7 +1450,7 @@ packages:
     dev: false
     resolution:
       integrity: sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
-  /@typescript-eslint/eslint-plugin/1.13.0_0b5e999c52a893676e7127c05369c7b6:
+  /@typescript-eslint/eslint-plugin/1.13.0_01b5b14c201fc628df6ec486d97f4eb6:
     dependencies:
       '@typescript-eslint/experimental-utils': 1.13.0_eslint@5.16.0
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
@@ -1458,7 +1458,7 @@ packages:
       eslint-utils: 1.4.3
       functional-red-black-tree: 1.0.1
       regexpp: 2.0.1
-      tsutils: 3.17.1_typescript@3.5.3
+      tsutils: 3.17.1_typescript@3.8.3
     dev: false
     engines:
       node: ^6.14.0 || ^8.10.0 || >=9.10.0
@@ -1606,7 +1606,7 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@vue/babel-preset-app': 4.3.1
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
       '@vue/cli-shared-utils': 4.3.1
       babel-loader: 8.1.0_@babel+core@7.9.0+webpack@4.41.3
       cache-loader: 4.1.0_webpack@4.41.3
@@ -1619,7 +1619,7 @@ packages:
       integrity: sha512-tBqu0v1l4LfWX8xuJmofpp+8xQzKddFNxdLmeVDOX/omDBQX0qaVDeMUtRxxSTazI06SKr605SnUQoa35qwbvw==
   /@vue/cli-plugin-e2e-cypress/4.3.1_26b4135a6a7ea6e5db753560c48793ec:
     dependencies:
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
       '@vue/cli-shared-utils': 4.3.1
       cypress: 3.8.3
       eslint-plugin-cypress: 2.10.3_eslint@5.16.0
@@ -1631,7 +1631,7 @@ packages:
       integrity: sha512-/7V2jCLBkwPDKLVkkaWZMEBfecQ2W3B8IWk4JI4MTHK2yenIMNsciMotS8XxtpGkNF3HsxDr2LI+onBd6xHDFQ==
   /@vue/cli-plugin-eslint/4.3.1_26b4135a6a7ea6e5db753560c48793ec:
     dependencies:
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
       '@vue/cli-shared-utils': 4.3.1
       eslint: 5.16.0
       eslint-loader: 2.2.1_eslint@5.16.0+webpack@4.41.3
@@ -1647,25 +1647,25 @@ packages:
       integrity: sha512-5UEP93b8C/JQs9Rnuldsu8jMz0XO4wNXG0lL/GdChYBEheKCyXJXzan7qzEbIuvUwG3I+qlUkGsiyNokIgXejg==
   /@vue/cli-plugin-router/4.3.1_@vue+cli-service@4.3.1:
     dependencies:
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
       '@vue/cli-shared-utils': 4.3.1
     dev: false
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     resolution:
       integrity: sha512-m0ntr5R6q62oNMODgoyHAVAd/sDtsH15GdBrScZsPNeyHxmzmNBDlsNM38yYGGY064zDRRWif15d1yaTREybrA==
-  /@vue/cli-plugin-typescript/4.3.1_4393d990a4a77a4ef1a94eecd7abd551:
+  /@vue/cli-plugin-typescript/4.3.1_22122c1b335748d34772818bd2671b9d:
     dependencies:
       '@types/webpack-env': 1.15.1
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
       '@vue/cli-shared-utils': 4.3.1
       cache-loader: 4.1.0_webpack@4.41.3
       fork-ts-checker-webpack-plugin: 3.1.1
       globby: 9.2.0
       thread-loader: 2.1.3_webpack@4.41.3
-      ts-loader: 6.2.2_typescript@3.5.3
-      tslint: 5.20.1_typescript@3.5.3
-      typescript: 3.5.3
+      ts-loader: 6.2.2_typescript@3.8.3
+      tslint: 5.20.1_typescript@3.8.3
+      typescript: 3.8.3
       webpack: 4.41.3_webpack@4.41.3
       yorkie: 2.0.0
     dev: false
@@ -1679,7 +1679,7 @@ packages:
       '@babel/core': 7.9.0
       '@babel/plugin-transform-modules-commonjs': 7.9.0_@babel+core@7.9.0
       '@types/jest': 24.9.1
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
       '@vue/cli-shared-utils': 4.3.1
       babel-core: 7.0.0-bridge.0_@babel+core@7.9.0
       babel-jest: 24.9.0_@babel+core@7.9.0
@@ -1701,13 +1701,13 @@ packages:
       integrity: sha512-mhIqwW6UGsPEOlw+rHBQjhlCjSxD9fKuVVVtkl989/bFZA17ZsdDrj/BfMTwX8mvoY5x6pPXb+Ti/opkkAOD7w==
   /@vue/cli-plugin-vuex/4.3.1_@vue+cli-service@4.3.1:
     dependencies:
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
     dev: false
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     resolution:
       integrity: sha512-mukwOlhZGBJhkqO2b3wHFFHjK5aP00b1WUHdrOfLR7M18euhaTyb4kA5nwZwEOmU3EzZx6kHzSFCRy/XaMkLug==
-  /@vue/cli-service/4.3.1_dade6536ab75b4e40cf6bd8a48594f01:
+  /@vue/cli-service/4.3.1_c697b53a0674ec5a6a3e3a567d98b494:
     dependencies:
       '@intervolga/optimize-cssnano-plugin': 1.0.6_webpack@4.41.3
       '@soda/friendly-errors-webpack-plugin': 1.7.1_webpack@4.41.3
@@ -1747,7 +1747,7 @@ packages:
       lodash.transform: 4.6.0
       mini-css-extract-plugin: 0.9.0_webpack@4.41.3
       minimist: 1.2.5
-      pnp-webpack-plugin: 1.6.4_typescript@3.5.3
+      pnp-webpack-plugin: 1.6.4_typescript@3.8.3
       portfinder: 1.0.25
       postcss-loader: 3.0.0
       sass-loader: 8.0.2_sass@1.26.3+webpack@4.41.3
@@ -1838,9 +1838,9 @@ packages:
       prettier: '>= 1.13.0'
     resolution:
       integrity: sha512-LNqBXtM+4XqKz6yW3rrF/frCVZUKyYryiiMc8aCGq3czSXhTR/UNhl89FAtqZcpSwh5u8k2Qh8BvFctva68HUQ==
-  /@vue/eslint-config-typescript/4.0.0_eslint@5.16.0+typescript@3.5.3:
+  /@vue/eslint-config-typescript/4.0.0_eslint@5.16.0+typescript@3.8.3:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 1.13.0_0b5e999c52a893676e7127c05369c7b6
+      '@typescript-eslint/eslint-plugin': 1.13.0_01b5b14c201fc628df6ec486d97f4eb6
       '@typescript-eslint/parser': 1.13.0_eslint@5.16.0
     dev: false
     peerDependencies:
@@ -2432,7 +2432,7 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==
-  /awesome-typescript-loader/5.2.1_typescript@3.5.3:
+  /awesome-typescript-loader/5.2.1_typescript@3.8.3:
     dependencies:
       chalk: 2.4.2
       enhanced-resolve: 4.1.1
@@ -2441,7 +2441,7 @@ packages:
       micromatch: 3.1.10
       mkdirp: 0.5.5
       source-map-support: 0.5.18
-      typescript: 3.5.3
+      typescript: 3.8.3
       webpack-log: 1.2.0
     dev: false
     peerDependencies:
@@ -9651,9 +9651,9 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
-  /pnp-webpack-plugin/1.6.4_typescript@3.5.3:
+  /pnp-webpack-plugin/1.6.4_typescript@3.8.3:
     dependencies:
-      ts-pnp: 1.2.0_typescript@3.5.3
+      ts-pnp: 1.2.0_typescript@3.8.3
     dev: false
     engines:
       node: '>=6'
@@ -12104,14 +12104,14 @@ packages:
       jest: '>=24 <25'
     resolution:
       integrity: sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
-  /ts-loader/6.2.2_typescript@3.5.3:
+  /ts-loader/6.2.2_typescript@3.8.3:
     dependencies:
       chalk: 2.4.2
       enhanced-resolve: 4.1.1
       loader-utils: 1.4.0
       micromatch: 4.0.2
       semver: 6.3.0
-      typescript: 3.5.3
+      typescript: 3.8.3
     dev: false
     engines:
       node: '>=8.6'
@@ -12119,14 +12119,14 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==
-  /ts-loader/7.0.1_typescript@3.5.3:
+  /ts-loader/7.0.1_typescript@3.8.3:
     dependencies:
       chalk: 2.4.2
       enhanced-resolve: 4.1.1
       loader-utils: 1.4.0
       micromatch: 4.0.2
       semver: 6.3.0
-      typescript: 3.5.3
+      typescript: 3.8.3
     dev: false
     engines:
       node: '>=10.0.0'
@@ -12134,9 +12134,9 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-wdGs9xO8UnwASwbluehzXciBtc9HfGlYA8Aiv856etLmdv8mJfAxCkt3YpS4g7G1IsGxaCVKQ102Qh0zycpeZQ==
-  /ts-pnp/1.2.0_typescript@3.5.3:
+  /ts-pnp/1.2.0_typescript@3.8.3:
     dependencies:
-      typescript: 3.5.3
+      typescript: 3.8.3
     dev: false
     engines:
       node: '>=6'
@@ -12167,13 +12167,13 @@ packages:
       object-assign: 4.1.1
       rimraf: 2.7.1
       semver: 5.7.1
-      tslint: 5.17.0_typescript@3.5.3
+      tslint: 5.17.0_typescript@3.8.3
     dev: false
     peerDependencies:
       tslint: '>=4.0.0'
     resolution:
       integrity: sha512-Me9Qf/87BOfCY8uJJw+J7VMF4U8WiMXKLhKKKugMydF0xMhMOt9wo2mjYTNhwbF9H7SHh8PAIwRG8roisTNekQ==
-  /tslint/5.17.0_typescript@3.5.3:
+  /tslint/5.17.0_typescript@3.8.3:
     dependencies:
       '@babel/code-frame': 7.8.3
       builtin-modules: 1.1.1
@@ -12187,8 +12187,8 @@ packages:
       resolve: 1.16.1
       semver: 5.7.1
       tslib: 1.10.0
-      tsutils: 2.29.0_typescript@3.5.3
-      typescript: 3.5.3
+      tsutils: 2.29.0_typescript@3.8.3
+      typescript: 3.8.3
     dev: false
     engines:
       node: '>=4.8.0'
@@ -12197,7 +12197,7 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
     resolution:
       integrity: sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==
-  /tslint/5.20.1_typescript@3.5.3:
+  /tslint/5.20.1_typescript@3.8.3:
     dependencies:
       '@babel/code-frame': 7.8.3
       builtin-modules: 1.1.1
@@ -12211,8 +12211,8 @@ packages:
       resolve: 1.16.1
       semver: 5.7.1
       tslib: 1.10.0
-      tsutils: 2.29.0_typescript@3.5.3
-      typescript: 3.5.3
+      tsutils: 2.29.0_typescript@3.8.3
+      typescript: 3.8.3
     dev: false
     engines:
       node: '>=4.8.0'
@@ -12221,19 +12221,19 @@ packages:
       typescript: '>=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >=3.0.0-dev || >= 3.1.0-dev || >= 3.2.0-dev'
     resolution:
       integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==
-  /tsutils/2.29.0_typescript@3.5.3:
+  /tsutils/2.29.0_typescript@3.8.3:
     dependencies:
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.8.3
     dev: false
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
       integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  /tsutils/3.17.1_typescript@3.5.3:
+  /tsutils/3.17.1_typescript@3.8.3:
     dependencies:
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.8.3
     dev: false
     engines:
       node: '>= 6'
@@ -12296,13 +12296,13 @@ packages:
     dev: false
     resolution:
       integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-  /typescript/3.5.3:
+  /typescript/3.8.3:
     dev: false
     engines:
       node: '>=4.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+      integrity: sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
   /uglify-js/3.4.10:
     dependencies:
       commander: 2.19.0
@@ -13416,12 +13416,12 @@ packages:
       '@vue/cli-plugin-babel': 4.3.1_@vue+cli-service@4.3.1
       '@vue/cli-plugin-e2e-cypress': 4.3.1_26b4135a6a7ea6e5db753560c48793ec
       '@vue/cli-plugin-eslint': 4.3.1_26b4135a6a7ea6e5db753560c48793ec
-      '@vue/cli-plugin-typescript': 4.3.1_4393d990a4a77a4ef1a94eecd7abd551
+      '@vue/cli-plugin-typescript': 4.3.1_22122c1b335748d34772818bd2671b9d
       '@vue/cli-plugin-unit-jest': 4.3.1_26ec19d41106f6887b12594fc4613ed9
       '@vue/cli-plugin-vuex': 4.3.1_@vue+cli-service@4.3.1
-      '@vue/cli-service': 4.3.1_dade6536ab75b4e40cf6bd8a48594f01
+      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
       '@vue/eslint-config-prettier': 5.1.0_484a2925e2c2b62f874c20a5d1f8a049
-      '@vue/eslint-config-typescript': 4.0.0_eslint@5.16.0+typescript@3.5.3
+      '@vue/eslint-config-typescript': 4.0.0_eslint@5.16.0+typescript@3.8.3
       '@vue/test-utils': 1.0.0-beta.29_d81dac297579cfd5597855dabf60f13b
       ag-grid-community: 22.1.1
       ag-grid-vue: 22.1.1_1dc7f8a466c694e72b2b9eba2d4b7b31
@@ -13442,7 +13442,7 @@ packages:
       sass-loader: 8.0.2_sass@1.26.3+webpack@4.41.3
       tailwindcss: 1.1.4
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.8.3
       vue: 2.6.11
       vue-class-component: 7.2.3_vue@2.6.11
       vue-i18n: 8.16.0
@@ -13458,7 +13458,7 @@ packages:
       webpack: '*'
       webpack-cli: '*'
     resolution:
-      integrity: sha512-rf61t15UphBwf9GTfT9dHxABBQuOW91jBSgKA6ljLUJVRU1cegonbyvdEvwHg7HW3UbOF9/Ct7c9s+tKh//lJQ==
+      integrity: sha512-/iuwRmH5EO+/epOF2YZYWEp4Hfekf28sRHSCBlUUDD4+ADVe5Me7QTgszGRZCpCtjymefgfhmKm+dQiekoKegQ==
       tarball: 'file:projects/ramp-core.tgz'
     version: 0.0.0
   'file:projects/ramp-geoapi.tgz':
@@ -13474,23 +13474,23 @@ packages:
       '@types/geojson': 1.0.6
       '@types/node': 7.0.0
       '@types/proj4': 2.5.0
-      awesome-typescript-loader: 5.2.1_typescript@3.5.3
+      awesome-typescript-loader: 5.2.1_typescript@3.8.3
       js-sql-parser: 1.0.7
       proj4: 2.6.0
       source-map-loader: 0.2.3
       svg.js: 2.7.1
       terraformer: 1.0.9
       terraformer-arcgis-parser: 1.1.0
-      tslint: 5.17.0_typescript@3.5.3
+      tslint: 5.17.0_typescript@3.8.3
       tslint-loader: 3.6.0_tslint@5.17.0
-      typescript: 3.5.3
+      typescript: 3.8.3
       webpack: 4.41.3_webpack@4.41.3
       webpack-cli: 3.3.10_webpack@4.41.3
       webpack-dev-server: 3.9.0_webpack@4.41.3
     dev: false
     name: '@rush-temp/ramp-geoapi'
     resolution:
-      integrity: sha512-1MpLXk+hVWjWoo+cATdJA92pIa9e1Ab/Ewfkr6td8XOmoJk5H67gyu/fOxRNtmTbrJh9dl9220isLqdPrx001Q==
+      integrity: sha512-zYcrm0ny7ACGR9lKpTX6srNwF2INTZhs/qqbcBqE439RKJMWSZWBS3/O1KGA77ad2Gh83YyKKcx1WfGvQDHjUA==
       tarball: 'file:projects/ramp-geoapi.tgz'
     version: 0.0.0
   'file:projects/ramp-sample-fixtures.tgz':
@@ -13501,9 +13501,9 @@ packages:
       jest: 23.6.0
       prettier: 1.19.1
       ts-jest: 23.10.5_jest@23.6.0
-      ts-loader: 7.0.1_typescript@3.5.3
+      ts-loader: 7.0.1_typescript@3.8.3
       tslib: 1.10.0
-      typescript: 3.5.3
+      typescript: 3.8.3
       vue: 2.6.11
       vue-class-component: 7.2.3_vue@2.6.11
       vue-jest: 2.6.0_d81dac297579cfd5597855dabf60f13b
@@ -13515,7 +13515,7 @@ packages:
     dev: false
     name: '@rush-temp/ramp-sample-fixtures'
     resolution:
-      integrity: sha512-ToEiPhqtC7BzixJ9ChYh69pWhzMHF4HGVpNryHLOXpUCAsTIsw2W2I1T5c8dvv6HztFOLIggNY7gsL2O0fMIUw==
+      integrity: sha512-OguwqMo1M+GWZfRLFMArIJ5GpRgZgpZlCyFD0Tonv6Wi+ttEB0KFoCCeVgweGn8Tnil0lIfjgfKgtap2oMr8nw==
       tarball: 'file:projects/ramp-sample-fixtures.tgz'
     version: 0.0.0
 registry: ''
@@ -13582,7 +13582,7 @@ specifiers:
   tslib: ~1.10.0
   tslint: 5.17.0
   tslint-loader: 3.6.0
-  typescript: ~3.5.3
+  typescript: ~3.8.3
   vue: ^2.6.10
   vue-class-component: ^7.0.2
   vue-i18n: ~8.16.0

--- a/common/docs/app/fixtures.md
+++ b/common/docs/app/fixtures.md
@@ -26,7 +26,7 @@ Provide a function that returns a promise resolving with a Vue component:
 
 ```ts
 screens: {
-    'p-2-screen-1': () => import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`),
+    'p-2-screen-1': () => import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`)
 }
 ```
 

--- a/common/docs/app/panels.md
+++ b/common/docs/app/panels.md
@@ -1,0 +1,121 @@
+# Panels
+
+## TODO
+
+Write other stuff.
+
+## Localization
+
+### Core
+
+[Vue-i18n](https://kazupon.github.io/vue-i18n/) is used to localize the application and the core messages are injected into the RAMP instance when it's first created. All messages are stored in a CSV file of the following format:
+
+| key         | enValue | enValid | frValue  | frValid |
+| ----------- | ------- | ------- | -------- | ------- |
+| lang-native | English | 1       | Français | 1       |
+
+First column is the message key that will be used in component templates, and the rest of the file is split into languages sections, two columns per language. The first of these columns specifies a locale value for the message key and the second indicates if the value has been confirmed to be correct or if it's a mere placeholder (1 - valid; 0 - not valid).
+
+Right now, only two languages are included, but it's possible to add new languages following the same pattern--adding two columns (`xxValue` and `xxValid`) per language where the first two letters are the short, two-letter language code.
+
+### Fixtures
+
+Fixtures themselves do not require localization, but they **must** provide locale messages to panels, screens, and on-map components it creates. There are several ways to do that.
+
+#### Panel Registration Options
+
+Pass locale messages inside a `PanelConfig` when registering a panel:
+
+```ts
+this.$iApi.panel.register({
+    id: 'panel-id',
+    config: {
+        screens: <...>,
+        i18n: messages
+    }
+})
+```
+
+The above will inject `i18n` options into screen components.
+
+Alternatively, pass locale messages as part of the `PanelRegistrationOptions` when registering multiple panels at the same time:
+
+```ts
+// fixture.ts
+this.$iApi.panel.register({
+    'panel-one': {
+        screens: <...>
+    },
+    'panel-two': {
+        screens: <...>
+    },
+    {
+        i18n: messages
+    }
+})
+```
+
+The above will inject `i18n` options into all screen component of all panels being registered.
+
+It's also possible to specify both options, with `PanelConfig` `i18n` options takes precedence of the common `PanelRegistrationOptions`:
+
+```ts
+// fixture.ts
+this.$iApi.panel.register({
+    'panel-one': {
+        screens: <...>,
+        i18n: panelOneSpecificMessages
+    },
+    'panel-two': {
+        screens: <...>
+    },
+    {
+        i18n: commonMessages
+    }
+})
+```
+
+`i18n` messages can be passed as either a `I18nComponentOptions` object or as loaded CSV file in the form used by the core localization (see above).
+
+#### Vue Component Options
+
+Additionally, it's possible to provide locale messages directly to the screen component as follows:
+
+```ts
+// screen-component.vue
+@Component({
+    i18n: {
+        messages: {
+            en: {
+                hello: 'world'
+            }
+        }
+    }
+})
+```
+
+The above requires hardcoding locale string into the component file. If using a CSV file of locale messages needs to be folded first before passing to the component constructor:
+
+```ts
+// screen-component.vue
+import row from './lang.csv'
+import { fold } from '@/lang';
+
+@Component({
+    i18n: {
+        messages: fold(rows)
+    }
+})
+```
+
+If all three method of passing locale messages are used, more specific `i18n` options take precedence:
+
+-   component file options
+-   panel registration options
+-   common panel registration options
+
+If the string key cannot be found there, `i18n` falls back to the core strings, so it's possible to use any of the common core strings in any screen components without specifying any locale messages at all.
+
+### Non-Fixture Components
+
+A fixture is not required for registering panels or creating on-map components--this can be done directly on the RAMP API. The ways of providing localization in such cases are exactly the same as when using a fixture.

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -58,7 +58,7 @@
         "sass-loader": "^8.0.0",
         "tailwindcss": "~1.1.4",
         "tslib": "~1.10.0",
-        "typescript": "~3.5.3",
+        "typescript": "~3.8.3",
         "vue-template-compiler": "^2.6.10",
         "wrapper-webpack-plugin": "2.1.0"
     }

--- a/packages/ramp-core/src/api/common.ts
+++ b/packages/ramp-core/src/api/common.ts
@@ -1,3 +1,4 @@
+import Vue, { ComponentOptions, VueConstructor } from 'vue';
 import { InstanceAPI } from './internal';
 
 /**
@@ -50,4 +51,41 @@ export interface AppVersion {
     minor: number;
     patch: number;
     timestamp: string;
+}
+
+/**
+ * Checks if the provided value is a `VueConstructor`.
+ *
+ * @param {(VueConstructor | any)} value
+ * @returns {value is VueConstructor}
+ */
+export function isVueConstructor(value: VueConstructor | any): value is VueConstructor {
+    // check if the value itself is a function (it's not possible to tell if it's a constructor function or not)
+    // check if value's prototype is an instance of Vue--this is the important check
+    return typeof value === 'function' && value.prototype instanceof Vue;
+}
+
+/**
+ * Checks if the provided value is Vue `ComponentsOptions` object.
+ *
+ * @param {(ComponentOptions<Vue> | any)} value
+ * @returns {value is ComponentOptions<Vue>}
+ */
+export function isComponentOptions(value: ComponentOptions<Vue> | any): value is ComponentOptions<Vue> {
+    // `ComponentOptions` is just an object with all optional properties
+    // check for the most common ones to see if any are present
+    // functional component are ignored since a panel screen shouldn't not be a functional component
+    const names = ['data', 'props', 'propsData', 'computed', 'methods', 'watch', 'template', 'render', 'components', 'model'];
+
+    return typeof value === 'object' && !value.functional && names.some(name => value[name] !== undefined);
+}
+
+/**
+ * Checks if the provided value is a dynamically imported `*.vue` file.
+ *
+ * @param {(typeof import('*.vue') | any)} value
+ * @returns {value is typeof import('*.vue')}
+ */
+export function isTypeofImportVue(value: typeof import('*.vue') | any): value is typeof import('*.vue') {
+    return typeof value === 'object' && value.default !== undefined;
 }

--- a/packages/ramp-core/src/api/internal.ts
+++ b/packages/ramp-core/src/api/internal.ts
@@ -5,3 +5,4 @@ export * from './event';
 export * from './fixture';
 export * from './instance';
 export * from './panel';
+export * from './panel-instance';

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -1,0 +1,336 @@
+import Vue, { Component, ComponentOptions, VueConstructor } from 'vue';
+import merge from 'deepmerge';
+
+import { APIScope, InstanceAPI, isVueConstructor, isComponentOptions, isTypeofImportVue } from './internal';
+
+import {
+    PanelConfig,
+    PanelConfigRoute,
+    PanelConfigScreens,
+    PanelConfigStyle,
+    AsyncComponentFactoryEh,
+    AsyncComponentEh
+} from '@/store/modules/panel';
+
+import ScreenSpinnerV from '@/components/panel-stack/screen-spinner.vue';
+
+import { I18nComponentOptions, fold } from '@/lang';
+import { PanelRegistrationOptions } from './panel';
+
+export class PanelInstance extends APIScope {
+    /**
+     * ID of this panel.
+     *
+     * @type {string}
+     * @memberof PanelInstance
+     */
+    readonly id: string;
+
+    /**
+     * A collection of panel screens to be displayed inside the panel.
+     *
+     * @type {PanelConfigScreens}
+     * @memberof PanelInstance
+     */
+    readonly screens: PanelConfigScreens;
+
+    /**
+     * A list of screen component ids which are loaded and ready to be rendered.
+     *
+     * @private
+     * @type {string[]}
+     * @memberof PanelInstance
+     */
+    private readonly loadedScreens: string[] = [];
+
+    /**
+     * A collection of i18n locale messages that will be passed to any screen opened inside this panel.
+     *
+     * @type {I18nComponentOptions}
+     * @memberof PanelInstance
+     */
+    readonly i18n: I18nComponentOptions = {};
+
+    /**
+     * Checks if a given screen component id is already loaded and ready to render.
+     *
+     * @param {string} id
+     * @returns {boolean}
+     * @memberof PanelInstance
+     */
+    isScreenLoaded(id: string): boolean {
+        return this.loadedScreens.indexOf(id) !== -1;
+    }
+
+    /**
+     * Loads and register panel screen components.
+     * This function should be called just before the screen is to be shown; this will avoid needlessly loading components upfront
+     * (sometimes certain screens might not get used at all).
+     *
+     * @param {string} id
+     * @memberof PanelInstance
+     */
+    registerScreen(id: string): void {
+        const screen = this.screens[id];
+
+        let payload: AsyncComponentFactoryEh | VueConstructor | Component;
+
+        // the `screen` value can be either a `string` component file path, an component `object`, a component constructor function, or an `AsynComponentFunction`
+        // - `object` or `VueConstructor` => use as is as all the component code is already loaded
+        // - `string` => load fixture file, pass as `component` in `AsyncComponentFactory` function
+        // - `AsyncComponentFunction` => execute as it returns a promise, pass the output as `component` in `AsyncComponentFactory` function
+        // https://vuejs.org/v2/guide/components-dynamic-async.html#Handling-Loading-State
+
+        if (isComponentOptions(screen) || isVueConstructor(screen)) {
+            // patch in panel's i18n messages into the Vue constructor or options object
+            payload = patchI18nMessages(screen, this.i18n);
+
+            this.loadedScreens.push(id); // mark this screen immediately as loaded
+        } else {
+            let asyncComponent: Promise<AsyncComponentEh>;
+
+            if (typeof screen === 'string') {
+                asyncComponent = import(/* webpackChunkName: "[request]" */ `./../../src/fixtures/${screen}`);
+            } else {
+                asyncComponent = screen(); // execute the async component function to get the promise
+            }
+
+            // for async components, wait until they are resolved and patch in panel's i18n messages
+            const component = new Promise<Component>((resolve, reject) => {
+                asyncComponent.then(data => {
+                    // wait until the component promise is resolved and mark it as loaded
+                    this.loadedScreens.push(id);
+
+                    // if data is a `*.vue` file, use its `default` export
+                    resolve(patchI18nMessages(isTypeofImportVue(data) ? data.default : data, this.i18n));
+                });
+                asyncComponent.catch(error => reject(error));
+            });
+
+            payload = () => ({
+                // The component to load (should be a Promise)
+                component,
+                // A component to use while the async component is loading
+                loading: ScreenSpinnerV,
+                // A component to use if the load fails
+                // TODO: add error component
+                // error: ErrorComponent,
+                // Delay before showing the loading component. Default: 200ms.
+                delay: 200
+                // The error component will be displayed if a timeout is
+                // provided and exceeded. Default: Infinity.
+                // TODO: restore the error timeout
+                // timeout: 3000
+            });
+        }
+
+        Vue.component(id, payload);
+    }
+
+    /**
+     * The style object to apply to the panel.
+     *
+     * @type {PanelConfigStyle}
+     * @memberof PanelConfig
+     */
+    style: PanelConfigStyle;
+
+    /**
+     * Returns the width of the panel in pixels or undefined if not set.
+     *
+     * @readonly
+     * @type {(number | undefined)}
+     * @memberof PanelInstance
+     */
+    get width(): number | undefined {
+        if (!this.style.width || this.style.width.slice(-2) !== 'px') {
+            return undefined;
+        }
+
+        return parseInt(this.style.width);
+    }
+
+    /**
+     * Specifies which panel screen to display and optional props to be passed to the screen panel component.
+     *
+     * @type {PanelConfigRoute}
+     * @memberof PanelConfig
+     */
+    route: PanelConfigRoute;
+
+    /**
+     * Creates an instance of PanelInstance.
+     *
+     * @param {InstanceAPI} iApi
+     * @param {string} id
+     * @param {PanelConfig} config
+     * @param {PanelRegistrationOptions} [options={}]
+     * @memberof PanelInstance
+     */
+    constructor(iApi: InstanceAPI, id: string, config: PanelConfig, options: PanelRegistrationOptions = {}) {
+        super(iApi);
+
+        // copy values from the config adding `style` default
+        ({ id: this.id, screens: this.screens, style: this.style } = { id, style: {}, ...config });
+
+        // both the panel config nad panel registration options can specify locale messages as either i18n options or CSV rows
+        // fold CSV rows and merge messages with panel config messages overriding same-key messages supplied in the registration options
+        this.i18n = [options.i18n, config.i18n].reduce<I18nComponentOptions>((map, value = {}) => {
+            const i18n = { messages: Array.isArray(value) ? fold(value) : {}, ...(!Array.isArray(value) ? value : {}) };
+            return merge(map, i18n);
+        }, {});
+
+        // check if this panel has at least a single screen
+        if (Object.keys(this.screens).length === 0) {
+            throw new Error('panel must have at least a single screen');
+        }
+
+        // set the first screen as the default route
+        this.route = { screen: Object.keys(this.screens).pop()! };
+
+        // auto-set `flex-basis` value on the panel if not already set
+        if (!this.style['flex-basis']) {
+            this.style['flex-basis'] = this.style.width || '350px';
+        }
+    }
+
+    /**
+     * Opens a registered panel in the panel stack.
+     * This is a proxy to `RAMP.panel.open(...)`.
+     *
+     *  - `somePanel.open()` -- opens the panel on the first screen in the set
+     *  - `somePanel.open('screen-id')` -- opens the panel on the 'screen-id' screen
+     *  - `somePanel.open({ screen: 'screen-id', props: {... } })` -- opens the panel on the 'screen-id' screen passing supplied `props` to it
+     *
+     * @param {(string | { screen: string; props?: object })} value a screen id, or an object of the form `{ screen: <id>, props: <object> }`.
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    open(value?: string | { screen: string; props?: object }): this {
+        if (typeof value === 'undefined') {
+            // if no screen id is provided, open the panel using the default value
+            this.$iApi.panel.open(this);
+        } else {
+            // pass the screen id and props, if given, to the `open` function
+            this.$iApi.panel.open({ id: this.id, ...(typeof value === 'string' ? { screen: value } : value) });
+        }
+
+        return this;
+    }
+
+    /**
+     * Checks if the panel is open or not.
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof PanelInstance
+     */
+    get isOpen(): boolean {
+        return this.$iApi.panel.opened.indexOf(this) !== -1;
+    }
+
+    /**
+     * Close this panel.
+     * This is a proxy to `RAMP.panel.close(...)`.
+     *
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    close(): this {
+        this.$iApi.panel.close(this);
+
+        return this;
+    }
+
+    /**
+     * Pin/unpin/toggle (if no value provided) pin status of this panel. When pinning, automatically unpins any previous pinned panel if exists.
+     * This is a proxy to `RAMP.panel.pin(...)`.
+     *
+     *
+     * @param {boolean} [value]
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    pin(value?: boolean): this {
+        // use the provided value or negate the existing `isPinned` status of this panel
+        value = typeof value !== 'undefined' ? value : !this.isPinned;
+
+        // TODO: change to toggle the pin status
+        this.$iApi.panel.pin(this, value);
+
+        return this;
+    }
+
+    /**
+     * Checks if this panel is pinned or not.
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof PanelInstance
+     */
+    get isPinned(): boolean {
+        return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.id;
+    }
+
+    /**
+     * Sets route to the specified screen id and pass props to the panel screen components.
+     * This is a proxy to `RAMP.panel.route(...)`.
+     *
+     * @param {(string | PanelConfigRoute)} value
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    show(value: string | PanelConfigRoute): this {
+        const route = typeof value === 'string' ? { screen: value } : value;
+
+        this.$iApi.panel.show(this, route);
+
+        return this;
+    }
+
+    /**
+     * Sets the styles of the specified panel by using a provided CSS styles object.
+     * This is a proxy to `RAMP.panel.setStyles(...)`.
+     *
+     * @param {object} style
+     * @param {boolean} [replace=false]
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    setStyles(style: object, replace: boolean = false): this {
+        this.$iApi.panel.setStyle(this, style, replace);
+
+        return this;
+    }
+}
+
+/**
+ * A helper function to patch i18n locale options/messages into the Vue construction or Vue component options.
+ * The messages will be merged with any already specified on the constructor/options.
+ *
+ * @param {(VueConstructor | ComponentOptions<Vue>)} value
+ * @param {I18nComponentOptions} i18n
+ * @returns {(VueConstructor | ComponentOptions<Vue>)}
+ */
+function patchI18nMessages(
+    value: VueConstructor | ComponentOptions<Vue>,
+    i18n: I18nComponentOptions
+): VueConstructor | ComponentOptions<Vue> {
+    if (!i18n) {
+        return value;
+    }
+
+    let options: ComponentOptions<Vue>;
+
+    if (isComponentOptions(value)) {
+        options = value;
+    } else {
+        // a Vue constructor has a `options` property although it's not present in types
+        // see here how constructor options are resolved: https://github.com/vuejs/vue/blob/b9de23b1008b52deca7e7df40843e318a42f3f53/src/core/instance/init.js#L93
+        options = (value as any).options;
+    }
+
+    options.i18n = merge(options.i18n || {}, i18n);
+
+    return value;
+}

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -243,6 +243,34 @@ export class PanelInstance extends APIScope {
     }
 
     /**
+     * Toggle panel.
+     * This is a proxy to `RAMP.panel.toggle(...)`.
+     *
+     * @param {(boolean | { screen: string; props?: object; toggle?: boolean })} [value]
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    toggle(value?: boolean | { screen: string; props?: object; toggle?: boolean }): this {
+        // toggle panel if no value provided, force toggle panel if value specified, or toggle panel on specified screen if provided
+        // ensure that a toggle value must be provided to panel API toggle if called
+        if (typeof value === 'undefined') {
+            this.$iApi.panel.toggle(this, !this.isOpen);
+        } else if (typeof value === 'boolean') {
+            // only call forced toggle if it is possible to do so
+            if (value !== this.isOpen) {
+                this.$iApi.panel.toggle(this, value);
+            }
+        } else {
+            this.$iApi.panel.toggle(
+                { id: this.id, screen: value.screen, props: value.props },
+                typeof value.toggle !== 'undefined' ? value.toggle : !this.isOpen
+            );
+        }
+
+        return this;
+    }
+
+    /**
      * Pin/unpin/toggle (if no value provided) pin status of this panel. When pinning, automatically unpins any previous pinned panel if exists.
      * This is a proxy to `RAMP.panel.pin(...)`.
      *

--- a/packages/ramp-core/src/fixtures/gazebo/lang/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/lang/index.ts
@@ -1,4 +1,0 @@
-import { fold } from '@/lang';
-import rows from './lang.csv';
-
-export default fold(rows);

--- a/packages/ramp-core/src/fixtures/gazebo/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/gazebo/lang/lang.csv
@@ -1,2 +1,3 @@
 key,enValue,enValid,frValue,frValid
 hello,"I'm a simple panel. but from a locale file",1,"Bonjour. Je suis un panel.",0
+hello2,"I'm a simple panel.",1,"Bonjour. Je suis un panel.",0

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
@@ -41,13 +41,8 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
-import messages from './lang';
 
-@Component({
-    i18n: {
-        messages
-    }
-})
+@Component
 export default class P2Screen1V extends Vue {
     // ✔ this prop is always present and it's set by the panel-container component
     @Prop() panel!: PanelInstance;

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
@@ -16,7 +16,7 @@
         </template>
 
         <template #content>
-            I'm a simple panel.
+            {{ $t('hello2') }}
 
             <div class="flex flex-row justify-center items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
@@ -1,8 +1,6 @@
 <template>
     <panel-screen>
-        <template #header>
-            Gazebo/Panel 2/Screen C
-        </template>
+        <template #header> Gazebo/Panel 2/Screen C </template>
 
         <template #controls>
             <!-- <pin> is a global button component that any fixture/panel/screen can reuse -->
@@ -26,6 +24,18 @@
                 </button>
 
                 <img width="250px" class="my-16" src="https://media.giphy.com/media/iWkHDNtcHpB5e/giphy.gif" alt="" srcset="" />
+
+                <p>Locale merging:</p>
+                <dl>
+                    <dt>global locale:</dt>
+                    <dd class="ml-32 font-bold">{{ $t('lang-native') }}</dd>
+                    <dt>fixture locale:</dt>
+                    <dd class="ml-32 font-bold">{{ $t('hello') }}</dd>
+                    <dt>specific panel locale:</dt>
+                    <dd class="ml-32 font-bold">{{ $t('spec') }}</dd>
+                    <dt>common panels locale:</dt>
+                    <dd class="ml-32 font-bold">{{ $t('who') }}</dd>
+                </dl>
             </div>
         </template>
     </panel-screen>
@@ -37,7 +47,15 @@ import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
 
-@Component({})
+@Component({
+    i18n: {
+        messages: {
+            en: {
+                who: '[me cat]'
+            }
+        }
+    }
+})
 export default class P2Screen3V extends Vue {
     // ✔ this prop is always present and it's set by the panel-container component
     @Prop() panel!: PanelInstance;

--- a/packages/ramp-core/src/lang/index.ts
+++ b/packages/ramp-core/src/lang/index.ts
@@ -4,10 +4,14 @@ import rows from './lang.csv';
 
 Vue.use(VueI18n);
 
-type csvRows = { key: string; enValue: string; frValue: string }[];
-interface LocaleMessages {
-    [key: string]: { [name: string]: string };
-}
+export type CsvRows = { key: string; enValue: string; frValue: string }[];
+
+export type I18nComponentOptions = {
+    messages?: VueI18n.LocaleMessages;
+    dateTimeFormats?: VueI18n.DateTimeFormats;
+    numberFormats?: VueI18n.NumberFormats;
+    sharedMessages?: VueI18n.LocaleMessages;
+};
 
 const fallbackLocale: string = 'en';
 
@@ -17,17 +21,18 @@ const locale: string = document.documentElement!.getAttribute('lang') || fallbac
 /**
  * Fold the imported CSV file in the form of `{ key: string, enValue: string, frValue: string }[]` to the form understood by VueI18n: `{ en: { [name: string]: string }, fr: { [name: string]: string } }`.
  *
- * @param {csvRows} rows
- * @returns {LocaleMessages}
+ * @param {CsvRows} rows
+ * @returns {VueI18n.LocaleMessages}
  */
-export function fold(rows: csvRows): LocaleMessages {
+// TODO: enhance to accept any number of languages
+export function fold(rows: CsvRows): VueI18n.LocaleMessages {
     return rows.reduce(
         (map, item) => {
             map.en[item.key] = item.enValue;
             map.fr[item.key] = item.frValue;
             return map;
         },
-        { en: {}, fr: {} } as LocaleMessages
+        { en: {}, fr: {} } as VueI18n.LocaleMessages
     );
 }
 

--- a/packages/ramp-geoapi/package.json
+++ b/packages/ramp-geoapi/package.json
@@ -1,46 +1,46 @@
 {
-  "name": "ramp-geoapi",
-  "version": "0.0.1",
-  "description": "A simple Webpack 4 starter with TypeScript transpilation",
-  "main": "dist/main.js",
-  "types": "dist/main.d.ts",
-  "scripts": {
-    "build": "webpack --mode=production",
-    "serve": "webpack --watch"
-  },
-  "keywords": [
-    "webpack",
-    "webpack4",
-    "typescript"
-  ],
-  "author": "Good ol James & Jahid, with scaffold from our fine buddy Juri Strumpflohner",
-  "license": "ISC",
-  "dependencies": {
-    "js-sql-parser": "1.0.7",
-    "proj4": "2.6.0",
-    "svg.js": "2.7.1",
-    "terraformer": "1.0.9",
-    "terraformer-arcgis-parser": "1.1.0"
-  },
-  "devDependencies": {
-    "@babel/cli": "^7.2.3",
-    "@babel/core": "^7.4.0",
-    "@babel/plugin-proposal-class-properties": "^7.4.0",
-    "@babel/plugin-proposal-object-rest-spread": "^7.4.0",
-    "@babel/preset-env": "^7.4.1",
-    "@babel/preset-typescript": "^7.3.3",
-    "@types/arcgis-js-api": "~4.15.0",
-    "@types/dojo": "^1.9.41",
-    "@types/geojson": "^1.0.0",
-    "@types/node": "7.0.0",
-    "@types/proj4": "2.5.0",
-    "awesome-typescript-loader": "5.2.1",
-    "source-map-loader": "0.2.3",
-    "tslint": "5.17.0",
-    "tslint-loader": "3.6.0",
-    "typescript": "~3.5.3",
-    "webpack": "4.41.3",
-    "webpack-cli": "3.3.10",
-    "webpack-dev-server": "3.9.0"
-  }
+    "name": "ramp-geoapi",
+    "version": "0.0.1",
+    "description": "A simple Webpack 4 starter with TypeScript transpilation",
+    "main": "dist/main.js",
+    "types": "dist/main.d.ts",
+    "scripts": {
+        "build": "webpack --mode=production",
+        "serve": "webpack --watch"
+    },
+    "keywords": [
+        "webpack",
+        "webpack4",
+        "typescript"
+    ],
+    "author": "Good ol James & Jahid, with scaffold from our fine buddy Juri Strumpflohner",
+    "license": "ISC",
+    "dependencies": {
+        "js-sql-parser": "1.0.7",
+        "proj4": "2.6.0",
+        "svg.js": "2.7.1",
+        "terraformer": "1.0.9",
+        "terraformer-arcgis-parser": "1.1.0"
+    },
+    "devDependencies": {
+        "@babel/cli": "^7.2.3",
+        "@babel/core": "^7.4.0",
+        "@babel/plugin-proposal-class-properties": "^7.4.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.4.0",
+        "@babel/preset-env": "^7.4.1",
+        "@babel/preset-typescript": "^7.3.3",
+        "@types/arcgis-js-api": "~4.15.0",
+        "@types/dojo": "^1.9.41",
+        "@types/geojson": "^1.0.0",
+        "@types/node": "7.0.0",
+        "@types/proj4": "2.5.0",
+        "awesome-typescript-loader": "5.2.1",
+        "source-map-loader": "0.2.3",
+        "tslint": "5.17.0",
+        "tslint-loader": "3.6.0",
+        "typescript": "~3.8.3",
+        "webpack": "4.41.3",
+        "webpack-cli": "3.3.10",
+        "webpack-dev-server": "3.9.0"
+    }
 }

--- a/packages/ramp-sample-fixtures/package.json
+++ b/packages/ramp-sample-fixtures/package.json
@@ -17,7 +17,7 @@
         "ts-jest": "^23.10.3",
         "tslib": "~1.10.0",
         "ts-loader": "^7.0.1",
-        "typescript": "~3.5.3",
+        "typescript": "~3.8.3",
         "vue-jest": "^2.6.0",
         "vue-loader": "^15.7.2",
         "vue-style-loader": "^4.1.2",

--- a/packages/ramp-sample-fixtures/src/diligord/diligord-fixture.js
+++ b/packages/ramp-sample-fixtures/src/diligord/diligord-fixture.js
@@ -132,7 +132,8 @@
             // `this.id` and `this.$iApi` and `this.$vApp` are automatically made available on this object
             console.log(this.id, this.$iApi, this.$vApp);
 
-            // you can also create a custom component using the `extend` function and put it anywhere on the page, even outside the R4MP container
+            // you can also create a custom component using the helper `extend` function and put it anywhere on the page, even outside the R4MP container
+            // the helper function will add references to this fixture and `$iApi` to the extended component
             const component = this.extend({
                 render: function(h) {
                     return h(


### PR DESCRIPTION
See the doc file for details on how this works now.

I moved the `Panelnstance` class into its own file because it was growing too big. The `registerScreen` and the constructor have changed significantly in it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/86)
<!-- Reviewable:end -->
