### PR TITLE
Map Level Zoom and Identify Buffer

### DIFF
--- a/packages/ramp-geoapi/src/map/RampMap.ts
+++ b/packages/ramp-geoapi/src/map/RampMap.ts
@@ -170,6 +170,39 @@ export class RampMap extends MapBase {
     }
 
     /**
+     * Zooms the map to a given zoom level. The center point will not change.
+     * In the rare case where there is no basemap, this will likely do nothing
+     *
+     * @param {number} zoomLevel An integer matching the level of detail / zoom level the map should adjust to
+     * @returns {Promise<void>} A promise that resolves when the map has finished zooming
+     */
+    zoomToLevel(zoomLevel: number): Promise<void> {
+        return this._innerView.goTo({ zoom: zoomLevel });
+    }
+
+    /**
+     * Zooms the map to the next zoom level in towards the earth. The center point will not change.
+     * In the rare case where there is no basemap, this will likely do nothing
+     *
+     * @returns {Promise<void>} A promise that resolves when the map has finished zooming
+     */
+    zoomIn(): Promise<void> {
+        // TODO fancy it up and add some bounds checking
+        return this.zoomToLevel(this._innerView.zoom + 1);
+    }
+
+    /**
+     * Zooms the map to the next zoom level out away from the earth. The center point will not change.
+     * In the rare case where there is no basemap, this will likely do nothing
+     *
+     * @returns {Promise<void>} A promise that resolves when the map has finished zooming
+     */
+    zoomOut(): Promise<void> {
+        // TODO fancy it up and add some bounds checking
+        return this.zoomToLevel(this._innerView.zoom - 1);
+    }
+
+    /**
      * Provides the scale of the map (the scale denominator as integer)
      *
      * @returns {number} the map scale

--- a/packages/ramp-geoapi/src/map/RampMap.ts
+++ b/packages/ramp-geoapi/src/map/RampMap.ts
@@ -229,6 +229,24 @@ export class RampMap extends MapBase {
         return this.rampSR.clone();
     }
 
+    /**
+     * Get the height of the map on the screen in pixels
+     *
+     * @returns {Number} pixel height
+     */
+    getPixelHeight(): number {
+        return this._innerView.height;
+    }
+
+    /**
+     * Get the width of the map on the screen in pixels
+     *
+     * @returns {Number} pixel width
+     */
+    getPixelWidth(): number {
+        return this._innerView.width;
+    }
+
     // TODO function to allow a second Map to be shot out, that shares this map but has a different scene
 
     // TODO basemap generation stuff (might need to be delayed due to lack of dojo dijit)

--- a/packages/ramp-geoapi/src/util/QueryService.ts
+++ b/packages/ramp-geoapi/src/util/QueryService.ts
@@ -7,6 +7,8 @@ import BaseBase from '../BaseBase';
 import Aql from './Aql';
 import BaseGeometry from '../api/geometry/BaseGeometry';
 import Extent from '../api/geometry/Extent';
+import Point from '../api/geometry/Point';
+import RampMap from '../map/RampMap';
 import { GeometryType } from '../api/apiDefs';
 
 export default class QueryService extends BaseBase {
@@ -102,6 +104,25 @@ export default class QueryService extends BaseBase {
         }
 
         return finalGeom;
+    }
+
+    /**
+     * Create an extent centered around a point, that is appropriate for the current map scale.
+     *
+     * @function makeClickBuffer
+     * @param {Point} point         point on the map for extent center
+     * @param {RampMap} map         map object the extent is relevant for
+     * @param {Integer} tolerance   optional. distance in pixels from mouse point that qualifies as a hit. default is 5
+     * @return {Extent} an extent of desired size and location
+     */
+    makeClickBuffer(point: Point, map: RampMap, tolerance: number = 5): Extent {
+        // take pixel tolerance, convert to map units at current scale.
+        const mapExt = map.getExtent();
+        const buffSize = tolerance * (mapExt.xmax - mapExt.xmin) / map.getPixelWidth();
+
+        // Build tolerance envelope of correct size
+        return new Extent('ze_buffer', [point.x - buffSize, point.y - buffSize],
+            [point.x + buffSize, point.y + buffSize], point.sr);
     }
 
     // TODO slated for review / removal, as has been made obsolete by functions up above and in the FCs.


### PR DESCRIPTION
Adds public methods on the map to do tile level zooming.

Adds click buffering on identify when a point is the inspection geometry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/88)
<!-- Reviewable:end -->
