### PR TITLE
chore: merge fixture i18n messages into the global locales

### DIFF
--- a/common/docs/app/panels.md
+++ b/common/docs/app/panels.md
@@ -24,58 +24,60 @@ Fixtures themselves do not require localization, but they **must** provide local
 
 #### Panel Registration Options
 
-Pass locale messages inside a `PanelConfig` when registering a panel:
-
-```ts
-this.$iApi.panel.register({
-    id: 'panel-id',
-    config: {
-        screens: <...>,
-        i18n: messages
-    }
-})
-```
-
-The above will inject `i18n` options into screen components.
-
-Alternatively, pass locale messages as part of the `PanelRegistrationOptions` when registering multiple panels at the same time:
+Pass locale messages as part of the `PanelRegistrationOptions` when registering panels:
 
 ```ts
 // fixture.ts
+
+// with a single panel
 this.$iApi.panel.register({
-    'panel-one': {
-        screens: <...>
-    },
-    'panel-two': {
-        screens: <...>
+        id: 'panel-one',
+        config: {
+            screens: <...>
+        }
     },
     {
-        i18n: messages
+        i18n: <i18nOptions>
     }
-})
-```
+);
 
-The above will inject `i18n` options into all screen component of all panels being registered.
-
-It's also possible to specify both options, with `PanelConfig` `i18n` options takes precedence of the common `PanelRegistrationOptions`:
-
-```ts
-// fixture.ts
+// or several panels
 this.$iApi.panel.register({
-    'panel-one': {
-        screens: <...>,
-        i18n: panelOneSpecificMessages
-    },
-    'panel-two': {
-        screens: <...>
+        'panel-one': {
+            screens: <...>
+        },
+        'panel-two': {
+            screens: <...>
+        },
     },
     {
-        i18n: commonMessages
+        i18n: <i18nOptions>
     }
-})
+);
 ```
 
-`i18n` messages can be passed as either a `I18nComponentOptions` object or as loaded CSV file in the form used by the core localization (see above).
+`i18n` options use the following type:
+
+```
+type I18nComponentOptions = {
+    messages?: VueI18n.LocaleMessages;  // https://kazupon.github.io/vue-i18n/guide/messages.html#structure
+    dateTimeFormats?: VueI18n.DateTimeFormats;  // https://kazupon.github.io/vue-i18n/guide/datetime.html#datetime-localization
+    numberFormats?: VueI18n.NumberFormats;  // https://kazupon.github.io/vue-i18n/guide/number.html#custom-formatting
+    sharedMessages?: VueI18n.LocaleMessages;
+};
+```
+
+The above code will merge `messages`, `dateTimeFormats` and `numberFormats` into the corresponding global locales, while the `sharedMessages` property will be ignored.
+
+> **Important:**
+> Because all values are merged into the global locales, all components--even ones that do not belong to this panel or fixtures--will be able to use these messages. There is a potential for key name collisions.
+>
+> As a rule of thumb, fixture locale keys should be prefixed with the fixture name (or its abbreviation (`basemap` => `bm`) for brevity):
+>
+> | key                 | enValue              | enValid | frValue                       | frValid |
+> | ------------------- | -------------------- | ------- | ----------------------------- | ------- |
+> | **basemap.**refresh | Map refresh required | 1       | Actualiser la carte           | 1       |
+> | **basemap.**select  | Select basemap       | 1       | Sélectionner la carte de base | 1       |
 
 #### Vue Component Options
 

--- a/packages/ramp-core/src/fixtures/basemap/basemap-item.vue
+++ b/packages/ramp-core/src/fixtures/basemap/basemap-item.vue
@@ -42,14 +42,9 @@
 import { Vue, Prop, Component } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import messages from './lang';
 import { BasemapStore } from './store';
 
-@Component({
-    i18n: {
-        messages
-    }
-})
+@Component
 export default class BasemapItem extends Vue {
     @Prop() basemap!: any;
     @Get(BasemapStore.selectedBasemap) selectedBasemap!: any;

--- a/packages/ramp-core/src/fixtures/basemap/basemap.vue
+++ b/packages/ramp-core/src/fixtures/basemap/basemap.vue
@@ -45,14 +45,10 @@ import { PanelInstance } from '@/api';
 
 import { BasemapStore } from './store';
 import BasemapItem from './basemap-item.vue';
-import messages from './lang';
 
 @Component({
     components: {
         BasemapItem
-    },
-    i18n: {
-        messages
     }
 })
 export default class BasemapComponent extends Vue {

--- a/packages/ramp-core/src/fixtures/basemap/index.ts
+++ b/packages/ramp-core/src/fixtures/basemap/index.ts
@@ -3,6 +3,8 @@ import { BasemapAPI } from './api/basemap';
 import { basemap } from './store/index';
 import BasemapAppbarButtonV from './appbar-button.vue';
 
+import messages from './lang/lang.csv';
+
 class BasemapFixture extends BasemapAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
@@ -11,12 +13,15 @@ class BasemapFixture extends BasemapAPI {
 
         this.$vApp.$store.registerModule('basemap', basemap());
 
-        this.$iApi.panel.register({
-            id: 'basemap-panel',
-            config: {
-                screens: { 'basemap-component': BasemapComponent }
-            }
-        });
+        this.$iApi.panel.register(
+            {
+                id: 'basemap-panel',
+                config: {
+                    screens: { 'basemap-component': BasemapComponent }
+                }
+            },
+            { i18n: { messages } }
+        );
 
         this.$iApi.panel.open('basemap-panel');
     }

--- a/packages/ramp-core/src/fixtures/basemap/lang/index.ts
+++ b/packages/ramp-core/src/fixtures/basemap/lang/index.ts
@@ -1,4 +1,0 @@
-import { fold } from '@/lang';
-import rows from './lang.csv';
-
-export default fold(rows);

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -63,13 +63,6 @@ class GazeboFixture extends FixtureInstance {
                     style: {
                         'flex-grow': '1',
                         'max-width': '500px'
-                    },
-                    i18n: {
-                        messages: {
-                            en: {
-                                spec: 'gazebo'
-                            }
-                        }
                     }
                 }
             },

--- a/packages/ramp-core/src/fixtures/gazebo/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/gazebo/lang/lang.csv
@@ -1,3 +1,3 @@
 key,enValue,enValid,frValue,frValid
-hello,"I'm a simple panel. but from a locale file",1,"Bonjour. Je suis un panel.",0
-hello2,"I'm a simple panel.",1,"Bonjour. Je suis un panel.",0
+gz.hello,"I'm a simple panel. but from a locale file",1,"Bonjour. Je suis un panel.",0
+gz.hello2,"I'm a simple panel.",1,"Bonjour. Je suis un panel.",0

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
@@ -15,7 +15,7 @@
         </template>
 
         <template #content>
-            {{ $t('hello') }}
+            {{ $t('gz.hello') }}
 
             <div class="flex flex-row justify-center items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
@@ -16,7 +16,7 @@
         </template>
 
         <template #content>
-            {{ $t('hello2') }}
+            {{ $t('gz.hello2') }}
 
             <div class="flex flex-row justify-center items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
@@ -30,9 +30,7 @@
                     <dt>global locale:</dt>
                     <dd class="ml-32 font-bold">{{ $t('lang-native') }}</dd>
                     <dt>fixture locale:</dt>
-                    <dd class="ml-32 font-bold">{{ $t('hello') }}</dd>
-                    <dt>specific panel locale:</dt>
-                    <dd class="ml-32 font-bold">{{ $t('spec') }}</dd>
+                    <dd class="ml-32 font-bold">{{ $t('gz.hello') }}</dd>
                     <dt>common panels locale:</dt>
                     <dd class="ml-32 font-bold">{{ $t('who') }}</dd>
                 </dl>

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-bar.vue
@@ -16,13 +16,8 @@ import { Get, Sync, Call } from 'vuex-pathify';
 
 import { GeosearchStore } from './store';
 import { debounce } from 'debounce';
-import messages from './lang';
 
-@Component({
-    i18n: {
-        messages
-    }
-})
+@Component
 export default class GeosearchBar extends Vue {
     // fetch geosearch search value from store
     @Get(GeosearchStore.searchVal) searchVal!: string;

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
@@ -20,13 +20,8 @@ import { Get, Sync, Call } from 'vuex-pathify';
 
 import { GeosearchStore } from './store';
 import { debounce } from 'debounce';
-import messages from './lang';
 
-@Component({
-    i18n: {
-        messages
-    }
-})
+@Component
 export default class GeosearchBottomFilters extends Vue {
     @Get(GeosearchStore.resultsVisible) resultsVisible!: any;
 

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
@@ -63,7 +63,6 @@ import GeosearchBar from './geosearch-bar.vue';
 import GeosearchTopFilters from './geosearch-top-filters.vue';
 import GeosearchBottomFilters from './geosearch-bottom-filters.vue';
 import LoadingBar from './loading-bar.vue';
-import messages from './lang';
 
 @Component({
     components: {
@@ -71,9 +70,6 @@ import messages from './lang';
         GeosearchTopFilters,
         GeosearchBottomFilters,
         LoadingBar
-    },
-    i18n: {
-        messages
     }
 })
 export default class GeosearchComponent extends Vue {

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-top-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-top-filters.vue
@@ -50,13 +50,8 @@ import { Get, Sync, Call } from 'vuex-pathify';
 
 import { GeosearchStore } from './store';
 import { ConfigStore } from '@/store/modules/config';
-import messages from './lang';
 
-@Component({
-    i18n: {
-        messages
-    }
-})
+@Component
 export default class GeosearchTopFilters extends Vue {
     // fetch defined province/type filters + filter params from store
     @Get(GeosearchStore.getProvinces) provinces!: Array<any>;

--- a/packages/ramp-core/src/fixtures/geosearch/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/index.ts
@@ -3,6 +3,8 @@ import { GeosearchAPI } from './api/geosearch';
 import { geosearch } from './store/index';
 import GeosearchAppbarButtonV from './appbar-button.vue';
 
+import rows from './lang/lang.csv';
+
 class GeosearchFixture extends GeosearchAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
@@ -12,12 +14,15 @@ class GeosearchFixture extends GeosearchAPI {
 
         this.$vApp.$store.registerModule('geosearch', geosearch());
 
-        this.$iApi.panel.register({
-            id: 'geosearch-panel',
-            config: {
-                screens: { 'geosearch-component': GeosearchComponent }
-            }
-        });
+        this.$iApi.panel.register(
+            {
+                id: 'geosearch-panel',
+                config: {
+                    screens: { 'geosearch-component': GeosearchComponent }
+                }
+            },
+            { i18n: rows }
+        );
 
         this.$iApi.panel.open('geosearch-panel');
     }

--- a/packages/ramp-core/src/fixtures/geosearch/lang/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/lang/index.ts
@@ -1,4 +1,0 @@
-import { fold } from '@/lang';
-import rows from './lang.csv';
-
-export default fold(rows);

--- a/packages/ramp-core/src/fixtures/geosearch/loading-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/loading-bar.vue
@@ -11,7 +11,7 @@
 <script>
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component
 export default class LoadingBar extends Vue {}
 </script>
 

--- a/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
+++ b/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
@@ -46,13 +46,7 @@
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-import messages from './lang';
-
-@Component({
-    i18n: {
-        messages
-    }
-})
+@Component
 export default class ColumnDropdown extends Vue {
     @Prop() columnDefs!: Array<Object>;
     @Prop() columnApi!: Object;

--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -58,14 +58,10 @@ import TableComponent from '@/fixtures/grid/table/table.vue';
 
 import { LayerStore, layer } from '@/store/modules/layer';
 import FeatureLayer from 'ramp-geoapi/dist/layer/FeatureLayer';
-import messages from './lang';
 
 @Component({
     components: {
         TableComponent
-    },
-    i18n: {
-        messages
     }
 })
 export default class Screen1 extends Vue {

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -3,18 +3,23 @@ import { grid } from './store/index';
 
 import GridV from './grid.vue';
 
+import rows from './lang/lang.csv';
+
 class GridFixture extends GridAPI {
     async added() {
-        this.$iApi.panel.register({
-            'grid-panel': {
-                screens: {
-                    'grid-screen': GridV
-                },
-                style: {
-                    width: '900px'
+        this.$iApi.panel.register(
+            {
+                'grid-panel': {
+                    screens: {
+                        'grid-screen': GridV
+                    },
+                    style: {
+                        width: '900px'
+                    }
                 }
-            }
-        });
+            },
+            { i18n: rows }
+        );
 
         this.$vApp.$store.registerModule('grid', grid());
 

--- a/packages/ramp-core/src/fixtures/grid/lang/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/lang/index.ts
@@ -1,4 +1,0 @@
-import { fold } from '@/lang';
-import rows from './lang.csv';
-
-export default fold(rows);

--- a/packages/ramp-core/src/fixtures/grid/table/CustomDateFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomDateFilter.vue
@@ -12,7 +12,7 @@
 <script lang="ts">
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component
 export default class CustomNumberFilter extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)

--- a/packages/ramp-core/src/fixtures/grid/table/CustomHeader.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomHeader.vue
@@ -40,7 +40,7 @@
 <script lang="ts">
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component
 export default class CustomHeader extends Vue {
     data(): Object {
         return {

--- a/packages/ramp-core/src/fixtures/grid/table/CustomNumberFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomNumberFilter.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component
 export default class CustomNumberFilter extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)

--- a/packages/ramp-core/src/fixtures/grid/table/CustomSelectorFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomSelectorFilter.vue
@@ -11,7 +11,7 @@
 <script lang="ts">
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 
-@Component({})
+@Component
 export default class CustomSelectorFilter extends Vue {
     beforeMount() {
         // Load previously stored value (if saved in table state manager)

--- a/packages/ramp-core/src/fixtures/grid/table/CustomTextFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomTextFilter.vue
@@ -12,13 +12,8 @@
 
 <script lang="ts">
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
-import messages from '../lang';
 
-@Component({
-    i18n: {
-        messages
-    }
-})
+@Component
 export default class CustomTextFilter extends Vue {
     beforeMount() {
         // Load previously stored value (if saved in table state manager)

--- a/packages/ramp-core/src/fixtures/grid/table/table.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/table.vue
@@ -77,8 +77,6 @@ import CustomSelectorFilter from './CustomSelectorFilter.vue';
 import CustomDateFilter from './CustomDateFilter.vue';
 import CustomHeader from './CustomHeader.vue';
 
-import messages from '../lang';
-
 // these should match up with the `type` value returned by the attribute promise.
 const NUM_TYPES: string[] = ['oid', 'double', 'integer'];
 const DATE_TYPE: string = 'date';
@@ -93,9 +91,6 @@ const TEXT_TYPE: string = 'string';
         CustomDateFilter,
         CustomTextFilter,
         CustomHeader
-    },
-    i18n: {
-        messages
     }
 })
 export default class TableComponent extends Vue {

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -3,4 +3,4 @@ lang-code,en,1,fr,1
 lang-dir,ltr,1,ltr,1
 lang-en,English,1,French,1
 lang-fr,anglais,1,français,1
-lang-native,English,1,Français,
+lang-native,English,1,Français,1

--- a/packages/ramp-core/src/store/modules/panel/panel-state.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-state.ts
@@ -98,13 +98,4 @@ export interface PanelConfig {
      * @memberof PanelConfig
      */
     style?: PanelConfigStyle;
-
-    /**
-     * Locale messages in the form of either i18n options object or unparsed CSV rows.
-     * These messages will be passed to any screen opened inside this panel.
-     *
-     * @type {(I18nComponentOptions | CsvRows)}
-     * @memberof PanelConfig
-     */
-    i18n?: I18nComponentOptions | CsvRows;
 }

--- a/packages/ramp-core/tsconfig.json
+++ b/packages/ramp-core/tsconfig.json
@@ -13,30 +13,12 @@
         "allowJs": true,
         "sourceMap": true,
         "baseUrl": ".",
-        "types": [
-            "webpack-env",
-            "jest",
-            "node"
-        ],
+        "types": ["jest", "node"],
         "paths": {
-            "@/*": [
-                "src/*"
-            ]
+            "@/*": ["src/*"]
         },
-        "lib": [
-            "esnext",
-            "dom",
-            "dom.iterable",
-            "scripthost"
-        ]
+        "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
     },
-    "include": [
-        "src/**/*.ts",
-        "src/**/*.vue",
-        "tests/**/*.ts"
-    ],
-    "exclude": [
-        "node_modules",
-        "common"
-    ]
+    "include": ["src/**/*.ts", "src/**/*.vue", "tests/**/*.ts"],
+    "exclude": ["node_modules", "common"]
 }


### PR DESCRIPTION
Now panel locale messages are merged into the global locales to avoid needless duplication of message objects to be propagated through fixture components.

- removed half of the fancy stuff I wrote before :/
- updated existing fixture to load locales correctly
- update docs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/89)
<!-- Reviewable:end -->
