### PR TITLE
Details Part 1: details panel, map identify request

### DIFF
--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -106,19 +106,19 @@
                             customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                         },
                         {
-                            id: 'HydrometricStations',
+                            id: 'WFSLayer',
                             layerType: 'ogcWfs',
-                            url: 'http://geo.wxod-dev.cmc.ec.gc.ca/geomet/features/collections/hydrometric-stations/items?startindex=7500',
+                            url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=6000',
                             state: {
                                 visibility: true
                             },
-                            customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                            customRenderer: {}
                         },
                         {
                             id: 'Happy',
                             layerType: 'esriFeature',
                             fileType: 'geojson',
-                            url: 'http://fgpv.cloudapp.net/demo/__assets__/Sample%20Data/happy.json',
+                            url: 'http://fgpv-app.azureedge.net/demo/assets/sample_data/happy.json',
                             state: {
                                 visibility: true
                             },
@@ -149,7 +149,7 @@
                 rInstance.fixture.add('basemap');
                 rInstance.fixture.add('legend');
                 rInstance.fixture.add('grid');
-
+                rInstance.fixture.add('details');
                 rInstance.fixture.add('diligord', window.hostFixtures.diligord);
                 rInstance.fixture.add('mouruge', window.hostFixtures.mouruge);
             }

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -1,0 +1,22 @@
+<template>
+    <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
+        <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-16 h-16" viewBox="0 0 16 16">
+            <path
+                d="M20.485784919653916,7.578491965389372h-14.170000000000005l3.5800000000000054,-3.589999999999997l-1.409999999999993,-1.4099999999999984l-6.000000000000008,6.0000000000000275l6.000000000000008,6l1.409999999999993,-1.4100000000000001l-3.58,-3.59h14.170000000000007Z"
+                transform="matrix(0.865803 0 0 0.865803 -1.99071 0.638058)"
+            />
+        </svg>
+    </button>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+@Component
+export default class CloseV extends Vue {
+    @Prop() active!: boolean;
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -18,12 +18,14 @@ import anime from 'animejs';
 import PanelScreenV from './panel-screen.vue';
 import PinV from './controls/pin.vue';
 import CloseV from './controls/close.vue';
+import BackV from './controls/back.vue';
 import PanelOptionsMenuV from './controls/panel-options-menu.vue';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
 Vue.component('panel-screen', PanelScreenV);
 Vue.component('pin', PinV);
 Vue.component('close', CloseV);
+Vue.component('back', BackV)
 Vue.component('panel-options-menu', PanelOptionsMenuV);
 Vue.component('dropdown-menu', DropdownMenuV);
 

--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -1,0 +1,40 @@
+import { FixtureInstance } from '@/api';
+import { IdentifyResult, IdentifyItem } from 'ramp-geoapi';
+
+export class DetailsAPI extends FixtureInstance {
+    /**
+     * Updates the identify result in the store, and then opens the details panel.
+     *
+     * @param {IdentifyResult[]} payload
+     * @memberof DetailsAPI
+     */
+    openDetails(payload: IdentifyResult[]): void {
+        // Save the provided identify result in the store.
+        this.$vApp.$store.set('details/setPayload!', payload);
+
+        // Open the details panel.
+        if (!this.$iApi.panel.get('details-panel').isOpen) {
+            this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-layers' });
+        }
+    }
+
+    /**
+     * Provided with the data for a single feature, open the details panel directly to the feature screen.
+     *
+     * @param {IdentifyItem} payload
+     * @memberof DetailsAPI
+     */
+    openFeature(payload: IdentifyItem) {
+        // Save the provided identify result in the store.
+        this.$vApp.$store.set('details/setPayload!', payload);
+
+        // Open the details panel.
+        if (!this.$iApi.panel.get('details-panel').isOpen) {
+            this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-item', props: { isFeature: true } });
+        }
+    }
+}
+
+export interface DetailsAPI {
+    openDetails(payload: IdentifyResult[]): void;
+}

--- a/packages/ramp-core/src/fixtures/details/details-item.vue
+++ b/packages/ramp-core/src/fixtures/details/details-item.vue
@@ -1,0 +1,72 @@
+<template>
+    <panel-screen>
+        <template #header>
+            Details
+        </template>
+        <template #controls>
+            <back @click="panel.show({ screen: 'details-screen-result', props: { layerIndex: layerIndex } })" v-if="!isFeature"></back>
+            <close @click="panel.close()"></close>
+        </template>
+        <template #content>
+            <!-- ESRI Format -->
+            <div v-if="identifyItem.format === identifyTypes.ESRI">
+                <div
+                    class="p-5 pl-3 flex justify-end flex-wrap even:bg-gray-300"
+                    v-for="(val, name, itemIdx) in identifyItem.data"
+                    :key="itemIdx"
+                >
+                    <span class="inline font-bold">{{ name }}</span>
+                    <span class="flex-auto"></span>
+                    <span class="inline" v-html="val"></span>
+                </div>
+            </div>
+
+            <!-- Others... for now. -->
+            <div v-else>
+                <div v-html="item.data"></div>
+            </div>
+        </template>
+    </panel-screen>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+import { DetailsStore } from './store';
+
+import { PanelInstance } from '@/api';
+import { IdentifyResult, IdentifyResultSet, IdentifyItem, IdentifyResultFormat } from 'ramp-geoapi';
+
+@Component({})
+export default class DetailsItemV extends Vue {
+    @Prop() panel!: PanelInstance;
+
+    // the index of the details item we want to display
+    @Prop() layerIndex!: number;
+    @Prop() itemIndex!: number;
+
+    // true if the current payload is a single IdentifyItem
+    @Prop() isFeature!: boolean;
+
+    // retrieve the identify payload from the store
+    @Get(DetailsStore.payload) payload!: IdentifyResult[];
+
+    identifyTypes: any = IdentifyResultFormat;
+
+    beforeMount() {
+        if (this.isFeature) {
+            this.identifyItem = this.payload;
+        } else {
+            this.identifyResult = this.payload[this.layerIndex];
+            this.identifyItem = this.identifyResult.items[this.itemIndex];
+        }
+    }
+}
+
+export default interface DetailsItemV {
+    identifyResult: IdentifyResult;
+    identifyItem: IdentifyResult[] | IdentifyItem;
+}
+</script>
+
+<style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/details/details-layers.vue
+++ b/packages/ramp-core/src/fixtures/details/details-layers.vue
@@ -1,0 +1,59 @@
+<template>
+    <panel-screen>
+        <template #header>
+            Details
+        </template>
+        <template #controls>
+            <close @click="panel.close()"></close>
+        </template>
+        <template #content>
+            <div class="p-5">
+                Found {{ payloadResults }} results in {{ payload.length }} layer{{ payload.length !== 1 ? 's' : '' }}
+            </div>
+            <div
+                class="px-20 py-10 text-md flex hover:bg-gray-200 cursor-pointer"
+                v-for="(item, idx) in payload"
+                :key="idx"
+                @click="openResult(idx)"
+            >
+                <div class="truncate">
+                    <!-- TODO: Change this later. If there's a way to retrieve the layer name, we should use that here. -->
+                    {{ item.uid }}
+                </div>
+                <div class="flex-auto"></div>
+                <div class="text-gray-400 px-5">{{ item.items.length }}</div>
+            </div>
+        </template>
+    </panel-screen>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+import { DetailsStore } from './store';
+
+import { PanelInstance } from '@/api';
+import { IdentifyResult } from 'ramp-geoapi';
+
+@Component({})
+export default class DetailsLayersV extends Vue {
+    @Prop() panel!: PanelInstance;
+    @Get(DetailsStore.payload) payload!: IdentifyResult[];
+
+    /**
+     * Switches the panel screen to display the data for a given result.
+     */
+    openResult(index: number) {
+        this.panel.show({ screen: 'details-screen-result', props: { layerIndex: index } });
+    }
+
+    /**
+     * Calculates the total number of results received by identify.
+     */
+    get payloadResults(): number {
+        return this.payload.map(r => r.items.length).reduce((a, b) => a + b, 0);
+    }
+}
+</script>
+
+<style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/details/details-result.vue
+++ b/packages/ramp-core/src/fixtures/details/details-result.vue
@@ -1,0 +1,57 @@
+<template>
+    <panel-screen>
+        <template #header>
+            Details
+        </template>
+        <template #controls>
+            <back @click="panel.show('details-screen-layers')"></back>
+            <close @click="panel.close()"></close>
+        </template>
+        <template #content>
+            <div
+                class="px-20 py-10 text-md truncate hover:bg-gray-200 cursor-pointer"
+                v-for="(item, idx) in identifyResult.items"
+                :key="idx"
+                @click="openResult(idx)"
+                v-focus-item
+            >
+                <!-- TODO: Change this later. If the name attribute is added to the IdentifyItem class, that can be used. -->
+                {{ item.data.Name || item.data.OBJECTID || 'Identify Result ' + (idx + 1) }}
+            </div>
+        </template>
+    </panel-screen>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+import { DetailsStore } from './store';
+
+import { PanelInstance } from '@/api';
+import { IdentifyResult } from 'ramp-geoapi';
+
+@Component({})
+export default class DetailsResultV extends Vue {
+    @Prop() panel!: PanelInstance;
+    @Prop() layerIndex!: number;
+
+    @Get(DetailsStore.payload) payload!: IdentifyResult[];
+
+    beforeMount() {
+        this.identifyResult = this.payload[this.layerIndex];
+    }
+
+    /**
+     * Switches the panel screen to display the data for a given result. Provides the currently selected layer index and the currently selected feature index as props.
+     */
+    openResult(itemIndex: number) {
+        this.panel.show({ screen: 'details-screen-item', props: { layerIndex: this.layerIndex, itemIndex: itemIndex } });
+    }
+}
+
+export default interface DetailsResultV {
+    identifyResult: IdentifyResult;
+}
+</script>
+
+<style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -1,0 +1,71 @@
+import { DetailsAPI } from './api/details';
+import { details } from './store';
+import DetailsLayerV from './details-layers.vue';
+import DetailsResultV from './details-result.vue';
+import DetailsItemV from './details-item.vue';
+import { LayerStore, layer } from '@/store/modules/layer';
+import { IdentifyResult, IdentifyResultSet, IdentifyItem, IdentifyResultFormat, MapClick } from 'ramp-geoapi';
+import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
+
+class DetailsFixture extends DetailsAPI {
+    async added() {
+        this.$iApi.panel.register({
+            'details-panel': {
+                screens: {
+                    'details-screen-layers': DetailsLayerV,
+                    'details-screen-result': DetailsResultV,
+                    'details-screen-item': DetailsItemV
+                },
+                style: {
+                    width: '350px',
+                    'overflow-y': 'auto'
+                }
+            }
+        });
+
+        this.$vApp.$store.registerModule('details', details());
+
+        // Add map click handler for global map identify.
+        // TODO: come back to this later, it will most likely be moved to the Event API (https://github.com/ramp4-pcar4/r4design/issues/14)
+        this.$iApi.map.mapClicked.listen((payload: MapClick) => {
+            return this.identify(payload);
+        });
+    }
+
+    /**
+     * Performs an identify request on all layers that support identify, and combines the results into an object that is readable by the details panel.
+     *
+     * @param {*} payload
+     * @memberof DetailsFixture
+     */
+    identify(payload: MapClick) {
+        let layers: BaseLayer[] | undefined = this.$vApp.$store.get(LayerStore.layers);
+
+        // Don't perform an identify request if the layers array hasn't been established yet.
+        if (layers === undefined) return;
+
+        let p = {
+            map: this.$iApi.map,
+            geometry: payload.mapPoint
+        };
+
+        // Perform an identify request on each layer. Does not perform the request on layers that do not have an identify function (layers that do not support identify).
+        const identifyInstances: IdentifyResultSet[] = layers
+            .filter(layer => typeof layer.identify !== 'undefined')
+            .map(layer => {
+                return layer.identify(p);
+            });
+
+        // Merge all results received by the identify into one array.
+        const identifyResults: IdentifyResult[] = ([] as IdentifyResult[]).concat(...identifyInstances.map(({ results }) => results));
+
+        // Open the details panel.
+        this.openDetails(identifyResults);
+    }
+
+    removed() {
+        this.$vApp.$store.unregisterModule('details');
+    }
+}
+
+export default DetailsFixture;

--- a/packages/ramp-core/src/fixtures/details/store/details-state.ts
+++ b/packages/ramp-core/src/fixtures/details/store/details-state.ts
@@ -1,0 +1,13 @@
+import { PanelConfig } from '@/store/modules/panel';
+import { IdentifyResult, IdentifyItem, IdentifyResultFormat, IdentifyResultSet } from 'ramp-geoapi';
+
+export class DetailsState {
+    /**
+     * An object containing a features attributes.
+     *
+     * @type IdentifyResult[] | IdentifyItem
+     * @memberof DetailsState
+     */
+
+    payload: IdentifyResult[] | IdentifyItem = [];
+}

--- a/packages/ramp-core/src/fixtures/details/store/details-store.ts
+++ b/packages/ramp-core/src/fixtures/details/store/details-store.ts
@@ -1,0 +1,44 @@
+import { ActionContext, Action, Mutation } from 'vuex';
+import { make } from 'vuex-pathify';
+
+import { DetailsState } from './details-state';
+import { RootState } from '@/store/state';
+
+type DetailsContext = ActionContext<DetailsState, RootState>;
+
+export enum DetailsAction {
+    setPayload = 'setPayload'
+}
+
+export enum DetailsMutation {
+    SET_PAYLOAD = 'SET_PAYLOAD'
+}
+
+const getters = {};
+
+const actions = {
+    [DetailsAction.setPayload](context: DetailsContext, value: any): void {
+        context.commit(DetailsMutation.SET_PAYLOAD, value);
+    }
+};
+const mutations = {
+    [DetailsMutation.SET_PAYLOAD](state: DetailsState, value: any): void {
+        state.payload = value;
+    }
+};
+
+export enum DetailsStore {
+    payload = 'details/payload'
+}
+
+export function details() {
+    const state = new DetailsState();
+
+    return {
+        namespaced: true,
+        state,
+        getters: { ...getters },
+        actions: { ...actions },
+        mutations: { ...mutations, ...make.mutations([]) }
+    };
+}

--- a/packages/ramp-core/src/fixtures/details/store/index.ts
+++ b/packages/ramp-core/src/fixtures/details/store/index.ts
@@ -1,0 +1,2 @@
+export * from './details-state';
+export * from './details-store';

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -31,7 +31,7 @@ module.exports = {
         alignSelf: ['responsive', 'container-query'],
         appearance: ['responsive', 'container-query'],
         backgroundAttachment: ['responsive', 'container-query'],
-        backgroundColor: ['responsive', 'container-query', 'hover', 'focus'],
+        backgroundColor: ['responsive', 'container-query', 'hover', 'focus', 'even'],
         backgroundPosition: ['responsive', 'container-query'],
         backgroundRepeat: ['responsive', 'container-query'],
         backgroundSize: ['responsive', 'container-query'],

--- a/packages/ramp-geoapi/src/util/QueryService.ts
+++ b/packages/ramp-geoapi/src/util/QueryService.ts
@@ -35,7 +35,9 @@ export default class QueryService extends BaseBase {
 
         const queryTask = new this.esriBundle.QueryTask({ url: options.url });
 
-        return queryTask.executeForIds(query);
+        return queryTask.executeForIds(query).then((oids) => {
+            return Array.isArray(oids) ? oids : [];
+        });
     }
 
     // for now, the any is attributes. figure why just return the ids when everything is local;


### PR DESCRIPTION
This PR starts implementing the details panel. There's still stuff to do, but the main functionality of the panel is in this PR.

Notes:
- as of right now, layers are displayed by their `uid`. I'm pretty sure there's a function somewhere that allows me to get the name of a layer from its `uid` but I can't for the life of me find it.
- similarly, individual features don't always have a name attribute associated with them, so I've temporarily added an ordering system for how they're represented in the panel. If there's a `Name` attribute, it's used. Otherwise, it uses the `OBJECTID` attribute. If neither attributes exist, it shows up as `Identify Result #`.
- the panel currently handles `ESRI` format and the `HTML` format. I don't know of any layers that return the other types, so I didn't know how I should implement them 😄

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/90)
<!-- Reviewable:end -->
