### PR TITLE
Scrub complex attribs from wfs

### DIFF
--- a/packages/ramp-geoapi/src/layer/FileUtils.ts
+++ b/packages/ramp-geoapi/src/layer/FileUtils.ts
@@ -251,8 +251,15 @@ export default class FileUtils extends BaseBase {
                 esriJson.forEach(gr => {
                     gr.geometry.spatialReference = fancySR;
                     gr.geometry.type = defRender.geometryType;
-                });
 
+                    // TEMPORARY hunt any complex datatypes and replace with a string
+                    // TODO figure out how to actually handle arrays or objects as attribute values
+                    Object.keys(gr.attributes).forEach(attName => {
+                        if (Array.isArray(gr.attributes[attName]) || typeof gr.attributes[attName] === 'object') {
+                            gr.attributes[attName] = '[Complex Value Removed]';
+                        }
+                    });
+                });
 
                 configPackage.source = <any>esriJson; // TODO see if this needs to become esriJson.features
                 configPackage.spatialReference = fancySR;


### PR DESCRIPTION
Temporarily scrub complex attribute values like arrays and objects from services that are too fancy for their own good.
Will stop the torrent of warnings in the console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/95)
<!-- Reviewable:end -->
