### PR TITLE
set up e2e testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ The alphabetic order makes sense because the `serve` command explicitly ignores 
 
 Due to this technicality, `ramp-core` package should remain the first package on the list as its output is the main indication of the `serve` task progress (`geoapi` and `sample-fixtures` compile very quickly compared to `core`). When adding a new package to the monorepo, its name should not alphabetically precede `ramp-core`.
 
+## Testing
+
+`rush test:e2e` will run a UI-less (headless) version of cypress that will provide output saying which tests passed/failed.
+
+If you want to have a UI or have the tests react to changes in either the code or testing files, you should run `npm run test:e2e` from inside `packages/ramp-core`.
+
 ## Building a prod library
 
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Due to this technicality, `ramp-core` package should remain the first package on
 
 `rush test:e2e` will run a UI-less (headless) version of cypress that will provide output saying which tests passed/failed.
 
-If you want to have a UI or have the tests react to changes in either the code or testing files, you should run `npm run test:e2e` from inside `packages/ramp-core`.
+If you want to have a UI or have the tests react to changes in either the code or testing files, you should run `rush test:e2e-ui`.
 
 ## Building a prod library
 

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -4,7 +4,6 @@
  */
 {
     "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/command-line.schema.json",
-
     /**
      * Custom "commands" introduce new verbs for the command-line.  To see the help for these
      * example commands, try "rush --help", "rush my-bulk-command --help", or
@@ -23,6 +22,12 @@
             "name": "host",
             "summary": "Serves the production build from the `host` folder in `ramp-core`. This can be used to test the final library build.",
             "shellCommand": "npm run --prefix packages/ramp-core host"
+        },
+        {
+            "commandKind": "global",
+            "name": "test:e2e",
+            "summary": "Runs e2e tests on ramp-core",
+            "shellCommand": "npm run --prefix packages/ramp-core test:e2e -- --headless"
         }
         // {
         //   /**
@@ -136,7 +141,6 @@
         //   "shellCommand": "node common/scripts/my-global-command.js"
         // }
     ],
-
     /**
      * Custom "parameters" introduce new parameters for specified Rush command-line commands.
      * For example, you might define a "--production" parameter for the "rush build" command.

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -28,6 +28,12 @@
             "name": "test:e2e",
             "summary": "Runs e2e tests on ramp-core",
             "shellCommand": "npm run --prefix packages/ramp-core test:e2e -- --headless"
+        },
+        {
+            "commandKind": "global",
+            "name": "test:e2e-ui",
+            "summary": "Runs e2e tests on ramp-core",
+            "shellCommand": "npm run --prefix packages/ramp-core test:e2e"
         }
         // {
         //   /**

--- a/packages/ramp-core/cypress.json
+++ b/packages/ramp-core/cypress.json
@@ -1,3 +1,7 @@
 {
-  "pluginsFile": "tests/e2e/plugins/index.js"
+  "pluginsFile": "tests/e2e/plugins/index.js",
+  "testFiles": [
+    "./tests/e2e/specs/*.*",
+    "./src/fixtures/**/tests/e2e/**/*.*"
+  ]
 }

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -7,6 +7,8 @@
         <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
         <title>ramp-core</title>
 
+        <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+
         <!-- these two fixtures will load before either RAMP is loaded -->
         <script src="../sample-fixtures/mouruge-fixture.js"></script>
         <script src="../sample-fixtures/diligord-fixture.js"></script>
@@ -34,7 +36,7 @@
         <!-- built files will be auto injected -->
 
         <script>
-            let rInstance;
+            window.rInstance = null;
             function initRAMP() {
                 document.getElementById('ramp-version').innerText =
                     'v.' +

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -7,13 +7,14 @@
         <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
         <title>ramp-core</title>
 
+        <!-- Vue is loaded in dev builds as well because of an issue with Cypress and external fixtures -->
         <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 
         <!-- these two fixtures will load before either RAMP is loaded -->
         <script src="../sample-fixtures/mouruge-fixture.js"></script>
         <script src="../sample-fixtures/diligord-fixture.js"></script>
 
-        <!-- RAMP with bundled-in Vue will be injected here -->
+        <!-- RAMP will be injected here -->
     </head>
     <body>
         <!-- this fixture will load after RAMP (and Vue) are loaded (since Vue is bundled with RAMP in `dev`); `iklob` requires Vue to be exposed on the global scope -->

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -7,7 +7,6 @@
             </svg>
         </button>
         <divider-nav></divider-nav>
-        <!-- slider goes here? -->
         <button @click="zoomOut()" class="zoom-out default-focus-style w-32 h-32 text-gray-600 hover:text-black" v-focus-item>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
                 <path d="M19 13H5v-2h14v2z" />

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <button @click="zoomIn()" class="default-focus-style w-32 h-32 text-gray-600 hover:text-black" v-focus-item>
+        <button @click="zoomIn()" class="zoom-in default-focus-style w-32 h-32 text-gray-600 hover:text-black" v-focus-item>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
                 <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
                 <path d="M0 0h24v24H0z" fill="none" />
@@ -8,7 +8,7 @@
         </button>
         <divider-nav></divider-nav>
         <!-- slider goes here? -->
-        <button @click="zoomOut()" class="default-focus-style w-32 h-32 text-gray-600 hover:text-black" v-focus-item>
+        <button @click="zoomOut()" class="zoom-out default-focus-style w-32 h-32 text-gray-600 hover:text-black" v-focus-item>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
                 <path d="M19 13H5v-2h14v2z" />
                 <path d="M0 0h24v24H0z" fill="none" />

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -1,9 +1,9 @@
 <template>
-    <div class="absolute right-0 bottom-0 pb-12 pr-12">
+    <div class="mapnav absolute right-0 bottom-0 pb-12 pr-12">
         <div class="flex flex-col" v-focus-list>
-            <zoom-nav-section class="map-nav-section bg-white-75 hover:bg-white"></zoom-nav-section>
+            <zoom-nav-section class="mapnav-section bg-white-75 hover:bg-white"></zoom-nav-section>
             <span class="py-1"></span>
-            <div class="map-nav-section bg-white-75 hover:bg-white">
+            <div class="mapnav-section bg-white-75 hover:bg-white">
                 <template v-for="(button, index) in visible">
                     <component
                         :is="button.id + '-nav-button'"
@@ -11,7 +11,7 @@
                         :key="button.id + 'button'"
                         v-focus-item
                     ></component>
-                    <divider-nav class="map-nav-divider" v-if="index !== visible.length - 1" :key="button.id + 'spacer'"></divider-nav>
+                    <divider-nav class="mapnav-divider" v-if="index !== visible.length - 1" :key="button.id + 'spacer'"></divider-nav>
                 </template>
             </div>
         </div>
@@ -44,7 +44,7 @@ export default class MapNavV extends Vue {
 </script>
 
 <style lang="scss" scoped>
-.map-nav-section {
+.mapnav-section {
     @apply flex-col flex shadow-tm pointer-events-auto;
 }
 </style>

--- a/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
+++ b/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
@@ -1,0 +1,33 @@
+describe('Mapnav', () => {
+    beforeEach(() => {
+        cy.visit('/');
+        cy.get('.ramp-app');
+        cy.get('.mapnav');
+    });
+
+    it('has zoom buttons', () => {
+        cy.get('.mapnav .zoom-in');
+    });
+
+    it('has other buttons', () => {
+        cy.get('.mapnav .mapnav-section');
+    });
+
+    it('zoom-in button works', () => {
+        cy.window().then(window => {
+            cy.get('.mapnav .zoom-in').click();
+            /* cy.wrap(window.rInstance.map._innerView)
+                .its('zoom')
+                .should('change'); */
+        });
+    });
+
+    it('zoom-out button works', () => {
+        cy.window().then(window => {
+            cy.get('.mapnav .zoom-out').click();
+            cy.wrap(window.rInstance.map._innerView)
+                .its('zoom')
+                .should('eq', 0);
+        });
+    });
+});

--- a/packages/ramp-core/src/main-serve.ts
+++ b/packages/ramp-core/src/main-serve.ts
@@ -1,19 +1,3 @@
-// this file is used when running `rush serve`
-// when compiled using the `serve` command, the code is treated as an app, not a library,
-// so we need to expose RAMP API on the window manually
-import api from '@/api';
-import Vue from 'vue';
+import { startup } from './main';
 
-// assign RAMP api to global variable
-window.RAMP = api;
-
-// expose Vue to the global scope so fixtures that use Vue have access to it
-// this is only needed in `serve` mode; in `build`, Vue is explicitly loaded by the host page
-window.Vue = Vue;
-
-// execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
-api.gapiPromise.then(() => {
-    if (typeof window.initRAMP === 'function') {
-        window.initRAMP();
-    }
-});
+startup();

--- a/packages/ramp-core/src/main.ts
+++ b/packages/ramp-core/src/main.ts
@@ -1,0 +1,19 @@
+// this file is used when running `rush serve`
+// when compiled using the `serve` command, the code is treated as an app, not a library,
+// so we need to expose RAMP API on the window manually
+import api from '@/api';
+import Vue from 'vue';
+
+// assign RAMP api to global variable
+window.RAMP = api;
+
+// expose Vue to the global scope so fixtures that use Vue have access to it
+// this is only needed in `serve` mode; in `build`, Vue is explicitly loaded by the host page
+window.Vue = Vue;
+
+// execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
+api.gapiPromise.then(() => {
+    if (typeof window.initRAMP === 'function') {
+        window.initRAMP();
+    }
+});

--- a/packages/ramp-core/src/main.ts
+++ b/packages/ramp-core/src/main.ts
@@ -1,19 +1,26 @@
+// We have 3 `main` files as Cypress requires a `main.ts`, `main-serve` is used for serves and `main-build` is used for builds.
+
 // this file is used when running `rush serve`
 // when compiled using the `serve` command, the code is treated as an app, not a library,
 // so we need to expose RAMP API on the window manually
 import api from '@/api';
 import Vue from 'vue';
 
-// assign RAMP api to global variable
-window.RAMP = api;
+export function startup() {
+    // assign RAMP api to global variable
+    window.RAMP = api;
 
-// expose Vue to the global scope so fixtures that use Vue have access to it
-// this is only needed in `serve` mode; in `build`, Vue is explicitly loaded by the host page
-window.Vue = Vue;
+    // expose Vue to the global scope so fixtures that use Vue have access to it
+    // this is only needed in `serve` mode; in `build`, Vue is explicitly loaded by the host page
+    //TODO: there are issues with how Vue is loading when using Cypress
+    window.Vue = Vue;
 
-// execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
-api.gapiPromise.then(() => {
-    if (typeof window.initRAMP === 'function') {
-        window.initRAMP();
-    }
-});
+    // execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
+    api.gapiPromise.then(() => {
+        if (typeof window.initRAMP === 'function') {
+            window.initRAMP();
+        }
+    });
+}
+
+startup();

--- a/packages/ramp-core/tests/e2e/plugins/index.js
+++ b/packages/ramp-core/tests/e2e/plugins/index.js
@@ -9,16 +9,16 @@
 // const webpack = require('@cypress/webpack-preprocessor')
 
 module.exports = (on, config) => {
-  // on('file:preprocessor', webpack({
-  //  webpackOptions: require('@vue/cli-service/webpack.config'),
-  //  watchOptions: {}
-  // }))
+    // on('file:preprocessor', webpack({
+    //  webpackOptions: require('@vue/cli-service/webpack.config'),
+    //  watchOptions: {}
+    // }))
 
-  return Object.assign({}, config, {
-    fixturesFolder: "tests/e2e/fixtures",
-    integrationFolder: "tests/e2e/specs",
-    screenshotsFolder: "tests/e2e/screenshots",
-    videosFolder: "tests/e2e/videos",
-    supportFile: "tests/e2e/support/index.js"
-  });
+    return Object.assign({}, config, {
+        fixturesFolder: 'tests/e2e/fixtures',
+        integrationFolder: './',
+        screenshotsFolder: 'tests/e2e/screenshots',
+        videosFolder: 'tests/e2e/videos',
+        supportFile: 'tests/e2e/support/index.js'
+    });
 };

--- a/packages/ramp-core/tests/e2e/specs/test.js
+++ b/packages/ramp-core/tests/e2e/specs/test.js
@@ -1,8 +1,21 @@
 // https://docs.cypress.io/api/introduction/api.html
 
-describe("My First Test", () => {
-  it("Visits the app root url", () => {
-    cy.visit("/");
-    cy.contains("h1", "Welcome to Your Vue.js + TypeScript App");
-  });
+describe('RAMP', () => {
+    beforeEach(function() {
+        cy.visit('/');
+        cy.get('.ramp-app');
+    });
+
+    it('has global and instance APIs', () => {
+        cy.window().then(window => {
+            expect(window.RAMP);
+            expect(window.rInstance);
+        });
+    });
+
+    it('loads fixtures', () => {
+        cy.window().then(window => {
+            expect(window.rInstance.fixture.get('appbar'));
+        });
+    });
 });


### PR DESCRIPTION
Involves setting up cypress fully and testing the testing.

`rush test:e2e` will run a UI-less (headless) version of cypress that will provide output saying which tests passed/failed.

If you want to have a UI or have the tests react to changes in either the code or testing files, you should run `npm run test:e2e` from inside `packages/ramp-core`.

Tests can be placed either in the `ramp-core/tests/e2e/specs` folder or under `tests/e2e` in any fixture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/101)
<!-- Reviewable:end -->
