### PR TITLE
Details Panel: Custom Template Implementation

### DIFF
--- a/packages/ramp-core/host/index.html
+++ b/packages/ramp-core/host/index.html
@@ -127,7 +127,112 @@
                                 'divider'
                             ]
                         },
-                        mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] }
+                        mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                        details: {
+                            items: [
+                                {
+                                    id: 'WaterQuantity',
+                                    template: 'Water-Quantity-Template'
+                                },
+                                {
+                                    id: 'WFSLayer',
+                                    template: 'WFSLayer-Custom'
+                                }
+                            ]
+                        }
+                    }
+                });
+
+                // Register some custom templates. I'm sure there's a way to add these from a separate file...
+
+                Vue.component('WFSLayer-Custom', {
+                    props: ['identifyData'],
+                    render: function(h) {
+                        return h('div', [
+                            h('span', 'This is an example template that contains an image.'),
+                            h('span', { 
+                                domProps: { innerHTML: '<img src="https://i.imgur.com/WtY0tdC.gif" />' }
+                            })
+                        ])
+                    }
+                })
+
+                Vue.component('Water-Quantity-Template', {
+                    props: ['identifyData'],
+                    render: function(h) {
+
+                        // Demonstrates that you can display different components in a template depending on an attribute value.
+                        let renderHeader = () => {
+                            if(this.identifyData.data['Symbol'] === "3") {
+                                return h('span', {
+                                    style: 'display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;'
+                                }, this.identifyData.data['StationName']);
+                            } else {
+                                return h('span', {
+                                    style: 'display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;'
+                                }, this.identifyData.data['StationName']);
+                            }
+                        }
+
+                        let createSection = (title, id) => {
+                            return h('div', {
+                                style: 'display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;'
+                            }, [
+                                h('span', {
+                                    style: 'color: #a0aec0; font-weight: bold;'
+                                }, title),
+                                h('span', this.identifyData.data[id])
+                            ])
+                        }
+
+                        return h('div', { style: 'align-items: center; justify-content: center; font-size: .875rem; font-family: "Arial", sans-serif;' }, [
+                            renderHeader(),
+                            createSection('Station ID', 'StationID'),
+                            createSection('Province', 'E_Province'),
+                            createSection('Report Year', 'Report_Year'),
+                            h('div', {
+                                style: 'display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;'
+                            }, [
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, 'Latitude'),
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, 'Longitude')
+                            ]),
+                            h('div', {
+                                style: 'display: flex; flex-direction: row;'
+                            }, [
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, this.identifyData.data['Latitude']),
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, this.identifyData.data['Longitude'])
+                            ]),
+                            h('div', {
+                                style: 'display: flex; flex-direction: column; padding-top: 5px; color: #4299e1;'
+                            }, [
+                                h('span', {
+                                    style: 'font-weight: bold; color: #a0aec0;'
+                                }, 'Links'),
+                                h('span', {
+                                    domProps: {
+                                        innerHTML: this.identifyData.data['E_DetailPageURL']
+                                    }
+                                }),
+                                h('span', {
+                                    domProps: {
+                                        innerHTML: this.identifyData.data['E_URL_Historical']
+                                    }
+                                }),
+                                h('span', {
+                                    domProps: {
+                                        innerHTML: this.identifyData.data['E_URL_RealTime']
+                                    }
+                                })
+                            ])
+                        ]);
                     }
                 });
 
@@ -141,6 +246,7 @@
                 rInstance.fixture.add('basemap');
                 rInstance.fixture.add('legend');
                 rInstance.fixture.add('grid');
+                rInstance.fixture.add('details');
                 rInstance.fixture.add('help');
 
                 rInstance.fixture.add('diligord', window.hostFixtures.diligord);

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -140,7 +140,113 @@
                                 'divider'
                             ]
                         },
-                        mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] }
+                        mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                        details: {
+                            items: [
+                                {
+                                    id: 'WaterQuantity',
+                                    template: 'Water-Quantity-Template'
+                                },
+                                {
+                                    id: 'WFSLayer',
+                                    template: 'WFSLayer-Custom'
+                                }
+                            ]
+                        }
+                    }
+                });
+
+
+                // Load custom templates.
+
+                Vue.component('WFSLayer-Custom', {
+                    props: ['identifyData'],
+                    render: function(h) {
+                        return h('div', [
+                            h('span', 'This is an example template that contains an image.'),
+                            h('span', { 
+                                domProps: { innerHTML: '<img src="https://i.imgur.com/WtY0tdC.gif" />' }
+                            })
+                        ])
+                    }
+                })
+
+                Vue.component('Water-Quantity-Template', {
+                    props: ['identifyData'],
+                    render: function(h) {
+
+                        // Demonstrates that you can display different components in a template depending on an attribute value.
+                        let renderHeader = () => {
+                            if(this.identifyData.data['Symbol'] === "3") {
+                                return h('span', {
+                                    style: 'display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;'
+                                }, this.identifyData.data['StationName']);
+                            } else {
+                                return h('span', {
+                                    style: 'display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;'
+                                }, this.identifyData.data['StationName']);
+                            }
+                        }
+
+                        let createSection = (title, id) => {
+                            return h('div', {
+                                style: 'display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;'
+                            }, [
+                                h('span', {
+                                    style: 'color: #a0aec0; font-weight: bold;'
+                                }, title),
+                                h('span', this.identifyData.data[id])
+                            ])
+                        }
+
+                        return h('div', { style: 'align-items: center; justify-content: center; font-size: .875rem; font-family: "Arial", sans-serif;' }, [
+                            renderHeader(),
+                            createSection('Station ID', 'StationID'),
+                            createSection('Province', 'E_Province'),
+                            createSection('Report Year', 'Report_Year'),
+                            h('div', {
+                                style: 'display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;'
+                            }, [
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, 'Latitude'),
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, 'Longitude')
+                            ]),
+                            h('div', {
+                                style: 'display: flex; flex-direction: row;'
+                            }, [
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, this.identifyData.data['Latitude']),
+                                h('div', {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                }, this.identifyData.data['Longitude'])
+                            ]),
+                            h('div', {
+                                style: 'display: flex; flex-direction: column; padding-top: 5px; color: #4299e1;'
+                            }, [
+                                h('span', {
+                                    style: 'font-weight: bold; color: #a0aec0;'
+                                }, 'Links'),
+                                h('span', {
+                                    domProps: {
+                                        innerHTML: this.identifyData.data['E_DetailPageURL']
+                                    }
+                                }),
+                                h('span', {
+                                    domProps: {
+                                        innerHTML: this.identifyData.data['E_URL_Historical']
+                                    }
+                                }),
+                                h('span', {
+                                    domProps: {
+                                        innerHTML: this.identifyData.data['E_URL_RealTime']
+                                    }
+                                })
+                            ])
+                        ]);
                     }
                 });
 

--- a/packages/ramp-core/src/fixtures/details/details-layers.vue
+++ b/packages/ramp-core/src/fixtures/details/details-layers.vue
@@ -17,8 +17,7 @@
                 @click="openResult(idx)"
             >
                 <div class="truncate">
-                    <!-- TODO: Change this later. If there's a way to retrieve the layer name, we should use that here. -->
-                    {{ item.uid }}
+                    {{ layerInfo(idx) }}
                 </div>
                 <div class="flex-auto"></div>
                 <div class="text-gray-400 px-5">{{ item.items.length }}</div>
@@ -34,17 +33,41 @@ import { DetailsStore } from './store';
 
 import { PanelInstance } from '@/api';
 import { IdentifyResult } from 'ramp-geoapi';
+import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 
 @Component({})
 export default class DetailsLayersV extends Vue {
     @Prop() panel!: PanelInstance;
     @Get(DetailsStore.payload) payload!: IdentifyResult[];
+    @Get('layer/layers') layers!: BaseLayer[];
 
     /**
      * Switches the panel screen to display the data for a given result.
      */
     openResult(index: number) {
         this.panel.show({ screen: 'details-screen-result', props: { layerIndex: index } });
+    }
+
+    layerInfo(idx: number) {
+        const layerInfo = this.payload[idx];
+
+        // Check to see if there is a custom template defined for the selected layer.
+        let item: BaseLayer | undefined = this.layers
+            .map(layer => {
+                let layerNode = layer.getLayerTree();
+
+                if (!layerNode) return;
+
+                // Determine if the selected UID is a child of this layer.
+                if (layerNode.findChildByUid(layerInfo.uid) !== undefined) {
+                    return layer;
+                }
+            })
+            .filter(node => node != undefined)[0];
+
+        if(!item) return;
+
+        return item.getName() ? item.getName() : item.id;
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/details/details-result.vue
+++ b/packages/ramp-core/src/fixtures/details/details-result.vue
@@ -8,16 +8,19 @@
             <close @click="panel.close()"></close>
         </template>
         <template #content>
-            <div
-                class="px-20 py-10 text-md truncate hover:bg-gray-200 cursor-pointer"
-                v-for="(item, idx) in identifyResult.items"
-                :key="idx"
-                @click="openResult(idx)"
-                v-focus-item
-            >
-                <!-- TODO: Change this later. If the name attribute is added to the IdentifyItem class, that can be used. -->
-                {{ item.data.Name || item.data.OBJECTID || 'Identify Result ' + (idx + 1) }}
+            <div v-if="identifyResult.items.length > 0">
+                <div
+                    class="px-20 py-10 text-md truncate hover:bg-gray-200 cursor-pointer"
+                    v-for="(item, idx) in identifyResult.items"
+                    :key="idx"
+                    @click="openResult(idx)"
+                    v-focus-item
+                >
+                    <!-- TODO: Change this later. If the name attribute is added to the IdentifyItem class, that can be used. -->
+                    {{ item.data.Name || item.data.OBJECTID || 'Identify Result ' + (idx + 1) }}
+                </div>
             </div>
+            <div v-else>No results found for the selected layer.</div>
         </template>
     </panel-screen>
 </template>

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -24,6 +24,14 @@ class DetailsFixture extends DetailsAPI {
 
         this.$vApp.$store.registerModule('details', details());
 
+        // Parse the details portion of the configuration file and save any custom
+        // template bindings in the details store.
+        this._parseConfig(this.config);
+        this.$vApp.$watch(
+            () => this.config,
+            value => this._parseConfig(value)
+        );
+
         // Add map click handler for global map identify.
         // TODO: come back to this later, it will most likely be moved to the Event API (https://github.com/ramp4-pcar4/r4design/issues/14)
         this.$iApi.map.mapClicked.listen((payload: MapClick) => {

--- a/packages/ramp-core/src/fixtures/details/store/details-state.ts
+++ b/packages/ramp-core/src/fixtures/details/store/details-state.ts
@@ -1,6 +1,43 @@
 import { PanelConfig } from '@/store/modules/panel';
 import { IdentifyResult, IdentifyItem, IdentifyResultFormat, IdentifyResultSet } from 'ramp-geoapi';
 
+export type DetailsItemSet = { [name: string]: DetailsItemInstance };
+
+export interface DetailsConfig {
+    items: DetailsConfigItem[];
+}
+
+export interface DetailsConfigItem {
+    /**
+     * The layer ID that we want to bind the custom template to.
+     *
+     * @type {string}
+     * @memberof DetailsConfigItem
+     */
+    id: string;
+
+    /**
+     * The component that we would like to use as a template.
+     *
+     * @type {string}
+     * @memberof DetailsConfigItem
+     */
+    template: string;
+}
+
+export class DetailsItemInstance implements DetailsConfigItem {
+    id: string;
+
+    template: string;
+
+    componentId?: string;
+
+    constructor(value: string | DetailsConfigItem) {
+        const params = { ...(typeof value === 'string' ? { id: value, template: '' } : value) };
+        ({ template: this.template, id: this.id } = params);
+    }
+}
+
 export class DetailsState {
     /**
      * An object containing a features attributes.

--- a/packages/ramp-core/src/fixtures/details/store/details-store.ts
+++ b/packages/ramp-core/src/fixtures/details/store/details-store.ts
@@ -39,6 +39,6 @@ export function details() {
         state,
         getters: { ...getters },
         actions: { ...actions },
-        mutations: { ...mutations, ...make.mutations([]) }
+        mutations: { ...mutations, ...make.mutations(['items']) }
     };
 }

--- a/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
@@ -1,0 +1,25 @@
+<template>
+    <div>
+        <div class="p-5 pl-3 flex justify-end flex-wrap even:bg-gray-300" v-for="(val, name, itemIdx) in identifyData.data" :key="itemIdx">
+            <span class="inline font-bold">{{ name }}</span>
+            <span class="flex-auto"></span>
+            <span class="inline" v-html="val"></span>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+import { PanelInstance } from '@/api';
+import { IdentifyResult, IdentifyResultSet, IdentifyItem, IdentifyResultFormat } from 'ramp-geoapi';
+
+@Component({})
+export default class ESRIDefaultV extends Vue {
+    // passed in by the details panel. Contains all of the identify data.
+    @Prop() identifyData!: Object;
+}
+</script>
+
+<style lang="scss"></style>


### PR DESCRIPTION
[Demo Link](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/details-templating-1/host/index.html)

---
This PR implements custom templates for the details panel. It was implemented as explained [here](https://hackmd.io/yoppJbmhS2Gm5U8v6rciIg) (excluding the API functions, which can still be added if we want them to be).

The PR includes two examples of custom components and one default template. The default templates for non-ESRI layers still need to be implemented.

Note: I had to use regular CSS for the custom templates since the tailwind styling didn't seem to work for the them on the host page. I'm assuming it's because the templates are added after everything is loaded.

---
In order to use a custom template, add the following snippet to the config file in the `details` section:
```
{
    id: 'layer-id',
    template: 'custom-component-id'
}
```

The `custom-component-id` should be registered as a Vue component on the host page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/104)
<!-- Reviewable:end -->
