### PR TITLE
Move map identify code to core and expose identify modes

### DIFF
--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -10,10 +10,12 @@ import { createStore, RootState } from '@/store';
 import { ConfigStore } from '@/store/modules/config';
 
 import { FixtureAPI, PanelAPI, GlobalEvents } from './internal';
+import { MapAPI } from './map';
 
 export class InstanceAPI {
     fixture: FixtureAPI;
     panel: PanelAPI;
+    mapActions: MapAPI;
 
     // FIXME: temporarily store map in global, remove line below when map API is complete
     // set by the `map/esri-map.vue` file
@@ -45,6 +47,7 @@ export class InstanceAPI {
 
         this.fixture = new FixtureAPI(this); // pass the iApi reference to the FixtureAPI
         this.panel = new PanelAPI(this);
+        this.mapActions = new MapAPI(this);
 
         // TODO: decide whether to move to src/main.ts:createApp
         // TODO: store a reference to the even bus in the global store [?]

--- a/packages/ramp-core/src/api/internal.ts
+++ b/packages/ramp-core/src/api/internal.ts
@@ -6,3 +6,4 @@ export * from './fixture';
 export * from './instance';
 export * from './panel';
 export * from './panel-instance';
+export * from './map';

--- a/packages/ramp-core/src/api/map.ts
+++ b/packages/ramp-core/src/api/map.ts
@@ -1,0 +1,79 @@
+import { APIScope } from './internal';
+import { IdentifyResult, IdentifyResultSet, IdentifyItem, IdentifyResultFormat, IdentifyParameters, MapClick } from 'ramp-geoapi';
+import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
+import { LayerStore, layer } from '@/store/modules/layer';
+import { DetailsAPI } from '@/fixtures/details/api/details';
+
+export class MapAPI extends APIScope {
+    _identifyMode: IdentifyMode[] = [
+        IdentifyMode.Query,
+        IdentifyMode.Marker,
+        IdentifyMode.Highlight,
+        IdentifyMode.Haze,
+        IdentifyMode.Details
+    ];
+
+    /**
+     * Performs an identify request on all layers that support identify, and combines the results into an object that is readable by the details panel.
+     *
+     * @param {*} payload
+     * @memberof DetailsFixture
+     */
+    identify(payload: MapClick) {
+        let layers: BaseLayer[] | undefined = this.$vApp.$store.get(LayerStore.layers);
+
+        // Don't perform an identify request if the layers array hasn't been established yet.
+        if (layers === undefined) return;
+
+        let p: IdentifyParameters = {
+            geometry: payload.mapPoint
+        };
+
+        // Perform an identify request on each layer. Does not perform the request on layers that do not have an identify function (layers that do not support identify).
+        const identifyInstances: IdentifyResultSet[] = layers
+            .filter(layer => layer.supportsIdentify)
+            .map(layer => {
+                return layer.identify(p);
+            });
+
+        // Merge all results received by the identify into one array.
+        const identifyResults: IdentifyResult[] = ([] as IdentifyResult[]).concat(...identifyInstances.map(({ results }) => results));
+
+        // Open the details panel if the details fixture is present and the `Details` mode is set.
+        if(this.$iApi.fixture.get('details')) {
+          this.$iApi.fixture.get<DetailsAPI>('details').openDetails(identifyResults);
+        }
+    }
+}
+
+
+export enum IdentifyMode {
+
+    /**
+     * Runs the identify query and pipes the available results through the `identify` API endpoint.
+     */
+    Query = 'query',
+
+    /**
+     * Display the identify results in the details panel.
+     * This option only works in conjunction with the `Query` option. Without `Query`, there will be no results to display in the details panel.
+     */
+    Details = 'details',
+
+    /**
+     * Highlight the identify results on the map. If the `Marker` mode is set, highlighted features will replace the marker.
+     * Only works when `Query` is set.
+     */
+    Highlight = 'highlight',
+
+    /**
+     * Adds a graphic marker at the point of a mouse click. The marker will be set on the map even if the `Query` option is not set.
+     */
+    Marker = 'marker',
+
+    /**
+     * Dehighlights all other layers and features except the identify results (if `Highlight` is set) or the marker (if `Marker` is set`).
+     * The haze will not be applied if neither `Marker` nor `Highlight` is set.
+     */
+    Haze = 'haze'
+}

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -35,38 +35,8 @@ class DetailsFixture extends DetailsAPI {
         // Add map click handler for global map identify.
         // TODO: come back to this later, it will most likely be moved to the Event API (https://github.com/ramp4-pcar4/r4design/issues/14)
         this.$iApi.map.mapClicked.listen((payload: MapClick) => {
-            return this.identify(payload);
+            return this.$iApi.mapActions.identify(payload);
         });
-    }
-
-    /**
-     * Performs an identify request on all layers that support identify, and combines the results into an object that is readable by the details panel.
-     *
-     * @param {*} payload
-     * @memberof DetailsFixture
-     */
-    identify(payload: MapClick) {
-        let layers: BaseLayer[] | undefined = this.$vApp.$store.get(LayerStore.layers);
-
-        // Don't perform an identify request if the layers array hasn't been established yet.
-        if (layers === undefined) return;
-
-        let p: IdentifyParameters = {
-            geometry: payload.mapPoint
-        };
-
-        // Perform an identify request on each layer. Does not perform the request on layers that do not have an identify function (layers that do not support identify).
-        const identifyInstances: IdentifyResultSet[] = layers
-            .filter(layer => layer.supportsIdentify)
-            .map(layer => {
-                return layer.identify(p);
-            });
-
-        // Merge all results received by the identify into one array.
-        const identifyResults: IdentifyResult[] = ([] as IdentifyResult[]).concat(...identifyInstances.map(({ results }) => results));
-
-        // Open the details panel.
-        this.openDetails(identifyResults);
     }
 
     removed() {


### PR DESCRIPTION
This PR moves the map identify code to the core. It's currently exposed on the global API under `mapActions`, but this is just temporary and will be re-named (recommendations would be appreciated 😄)

This PR also exposes the five identify modes to the API, but they haven't been implemented yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/106)
<!-- Reviewable:end -->
