### PR TITLE
add scale and spot for attribution

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -3,5 +3,11 @@ export enum GlobalEvents {
      * Fires when a Vue component is registered with `rInstance.component(...)`.
      * Payload: `(id: string)`
      */
-    COMPONENT = 'r4/component'
+    COMPONENT = 'r4/component',
+
+    /**
+     * Fires when the map is created
+     * Payload: (map)
+     */
+    MAP_CREATED = 'map/created'
 }

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -11,6 +11,7 @@ import GapiLoader, { RampMap, GeoApi, RampMapConfig } from 'ramp-geoapi';
 import { ConfigStore } from '@/store/modules/config';
 import { LayerStore, layer } from '@/store/modules/layer';
 import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
+import { GlobalEvents } from '../../api';
 
 @Component
 export default class EsriMap extends Vue {
@@ -44,6 +45,7 @@ export default class EsriMap extends Vue {
         this.map = RAMP.geoapi.maps.createMap(this.mapConfig, this.$el as HTMLDivElement);
         // FIXME: temporarily store map in global, remove line below when map API is complete
         this.$iApi.map = this.map;
+        this.$iApi.emit(GlobalEvents.MAP_CREATED, this.$iApi.map);
         this.onLayerArrayChange(this.layers, []);
     }
 }

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -1,0 +1,144 @@
+<template>
+    <div class="absolute bottom-0 flex justify-center pointer-events-none text-white bg-black-75 left-64 right-0 py-2">
+        <span class="relative ml-10 truncate top-1">Attribution goes here</span>
+
+        <span class="flex-grow w-15"></span>
+
+        <!-- TODO: find out if any ARIA attributes are needed for the map scale -->
+
+        <!-- TODO: coords -->
+        <!--span class="flex-shrink-0 relative top-1" v-if="cursorPoint.y !== 0 || cursorPoint.x !== 0">
+                {{ cursorPointDMS.y }} {{ $t(`${tPath}.${cursorPoint.y > 0 ? 'north' : 'south'}`) }} | {{ cursorPointDMS.x }}
+                {{ $t(`${tPath}.${0 > cursorPoint.x ? 'west' : 'east'}`) }}
+            </span-->
+
+        <button
+            class="flex-shrink-0 mx-10 pointer-events-auto h-20 cursor-pointer border-none"
+            @click="onScaleClick"
+            :aria-pressed="isImperialScale"
+            :aria-label="$t('map.toggleScaleUnits')"
+        >
+            <span class="border-solid border-2 border-white border-t-0 h-5 mr-2 inline-block" :style="{ width: scale.width }"></span>
+            {{ scale.label }}
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Watch, Prop, Inject } from 'vue-property-decorator';
+import { debounce } from 'debounce';
+
+import { GlobalEvents } from '@/api';
+
+@Component
+export default class MapCaptionV extends Vue {
+    // TODO: use proper type for map instance
+    //@Prop() cursorPoint: MapPoint;
+
+    isImperialScale: boolean = false;
+
+    scale: { label: string; width: string } = { label: '0km', width: '0px' };
+
+    /**
+     * Convert lat/long in decimal degree to degree, minute, second.
+     * Uses the 'formatLatLong' utils function
+     */
+    get cursorPointDMS(): { x: string; y: string } {
+        const { y: lat, x: long } = { y: 0, x: 0 }; // TODO: get cursor location from map
+        return this.formatLatLong(long, lat);
+    }
+
+    mounted() {
+        // When map is created update scale
+        this.$iApi.on(GlobalEvents.MAP_CREATED, () => {
+            this.updateScale();
+            // Listen for scale changes, debounce so that zoom animations don't rapidly call update
+            this.$iApi.map.scaleChanged.listen(
+                debounce(() => {
+                    this.updateScale();
+                }, 300)
+            );
+        });
+    }
+
+    onScaleClick() {
+        this.isImperialScale = !this.isImperialScale;
+        this.updateScale();
+    }
+
+    /**
+     * Calculates a scale bar for the current resolution.
+     */
+    updateScale(): void {
+        // the starting length of the scale line in pixels
+        // reduce the length of the bar on extra small layouts
+        const factor = window.innerWidth > 600 ? 70 : 35;
+
+        // distance in meters
+        const meters = this.$iApi.map._innerView.resolution * factor;
+        console.log(this.$iApi.map._innerView.resolution, 'resolution');
+        console.log(this.$iApi.map.getScale(), 'scale');
+        const metersInAMile = 1609.34;
+
+        // get the distance in units, either miles or kilometers
+        const units = (this.$iApi.map._innerView.resolution * factor) / (this.isImperialScale ? metersInAMile : 1000);
+        const unit = this.isImperialScale ? 'mi' : 'km';
+
+        // length of the distance number
+        const len = Math.round(units).toString().length;
+        const div = Math.pow(10, len - 1);
+
+        // we want to round the distance to the ceiling of the highest position and display a nice number
+        // 45.637km => 50.00km; 4.368km => 5.00km
+        // 28.357mi => 30.00mi; 2.714mi => 3.00mi
+        const distance = Math.ceil(units / div) * div;
+
+        // calcualte length of the scale line in pixels based on the round distance
+        const pixels = (distance * (this.isImperialScale ? metersInAMile : 1000)) / this.$iApi.map._innerView.resolution;
+
+        this.scale = {
+            width: `${pixels}px`,
+            label: `${distance}${unit}`
+        };
+    }
+
+    /**
+     * Formats a latlong into degrees minutes seconds
+     *
+     * Taken from RAMP source
+     *
+     * @param long longitude coordinate
+     * @param lat latitude coordinate
+     */
+    formatLatLong(long: number, lat: number): { x: string; y: string } {
+        const degreeSymbol = String.fromCharCode(176);
+
+        const dy = Math.floor(Math.abs(lat)) * (lat < 0 ? -1 : 1);
+        const my = Math.floor(Math.abs((lat - dy) * 60));
+        const sy = Math.round((Math.abs(lat) - Math.abs(dy) - my / 60) * 3600);
+
+        const dx = Math.floor(Math.abs(long)) * (long < 0 ? -1 : 1);
+        const mx = Math.floor(Math.abs((long - dx) * 60));
+        const sx = Math.round((Math.abs(long) - Math.abs(dx) - mx / 60) * 3600);
+
+        const newY = `${Math.abs(dy)}${degreeSymbol} ${padZero(my)}' ${padZero(sy)}"`;
+        const newX = `${Math.abs(dx)}${degreeSymbol} ${padZero(mx)}' ${padZero(sx)}"`;
+
+        return { x: newX, y: newY };
+
+        /**
+         * Pad value with leading 0 to make sure there is always 2 digits if number is below 10.
+         *
+         * @function padZero
+         * @private
+         * @param {Number} val value to pad with 0
+         * @return {String} string with always 2 characters
+         */
+        function padZero(val: number) {
+            return val >= 10 ? `${val}` : `0${val}`;
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -1,11 +1,12 @@
 <template>
     <div class="h-full relative">
-        <esri-map></esri-map>
-
         <!-- TODO: should inner shell be a separate component? -->
         <div class="inner-shell absolute top-0 left-0 h-full w-full pointer-events-none">
             <panel-stack class="sm:flex absolute inset-0 overflow-hidden xs:pl-40 sm:p-12 sm:pl-80"></panel-stack>
+            <map-caption></map-caption>
         </div>
+
+        <esri-map></esri-map>
     </div>
 </template>
 
@@ -15,11 +16,13 @@ import { Get, Sync, Call } from 'vuex-pathify';
 
 import EsriMap from '@/components/map/esri-map.vue';
 import PanelStackV from '@/components/panel-stack/panel-stack.vue';
+import MapCaptionV from '@/components/map/map-caption.vue';
 
 @Component({
     components: {
         EsriMap,
-        'panel-stack': PanelStackV
+        'panel-stack': PanelStackV,
+        'map-caption': MapCaptionV
     }
 })
 export default class Shell extends Vue {}

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mapnav absolute right-0 bottom-0 pb-12 pr-12">
+    <div class="mapnav absolute right-0 bottom-0 pb-36 pr-12">
         <div class="flex flex-col" v-focus-list>
             <zoom-nav-section class="mapnav-section bg-white-75 hover:bg-white"></zoom-nav-section>
             <span class="py-1"></span>

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -4,3 +4,4 @@ lang-dir,ltr,1,ltr,1
 lang-en,English,1,French,1
 lang-fr,anglais,1,français,1
 lang-native,English,1,Français,1
+map.toggleScaleUnits,Toggle between imperial and metric map scale,1,Basculer entre les échelles métriques et impériales pour la carte,1

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
             // sm: '640px'
         },
         spacing: spacingConfig,
+        inset: spacingConfig,
         extend: {
             colors: {
                 'black-75': 'rgba(0, 0, 0, 0.75)',


### PR DESCRIPTION
CCCS style scale, altered to play nice with how we're doing things.

Mouse/cursor coords to be done later, as far as I could tell there was no simple "heres where the mouse is" function. Let me know if I just can't read ESRI docs properly.

I also don't like the name map caption, but I didn't know what to put there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/109)
<!-- Reviewable:end -->
