### PR TITLE
added initial legend store/state + some API functionality

### DIFF
--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -131,6 +131,21 @@
                             }
                         ],
                         fixtures: {
+                            legend: {
+                                reorderable: true,
+                                root: {
+                                    children: [
+                                        {
+                                            layerId: "WaterQuantity",
+                                            name: "Water Quantity"
+                                        },
+                                        {
+                                            layerId: "CleanAir",
+                                            name: "Clean Air"
+                                        }
+                                    ]
+                                }
+                            },
                             appbar: {
                                 items: [
                                     { id: 'gazebo', options: { colour: '#54a0ff' } },

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -31,7 +31,6 @@ class DetailsFixture extends DetailsAPI {
             () => this.config,
             value => this._parseConfig(value)
         );
-
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -1,0 +1,53 @@
+import { FixtureInstance } from '@/api';
+import { LegendConfig, LegendElement } from '../store';
+import { LayerStore } from '@/store/modules/layer';
+
+export class LegendAPI extends FixtureInstance {
+    /**
+     * Returns `LegendConfig` section of the global config file.
+     *
+     * @readonly
+     * @type {LegendConfig}
+     * @memberof LegendFixture
+     */
+    get config(): LegendConfig | undefined {
+        return super.config;
+    }
+
+    /**
+     * Parses the legend config JSON snippet from the config file and save resulting objects to the fixture store.
+     *
+     * @param {LegendConfig} [legendConfig]
+     * @returns
+     * @memberof LegendAPI
+     */
+    _parseConfig(legendConfig?: LegendConfig) {
+        if (!legendConfig || !legendConfig.root.children) {
+            return;
+        }
+
+        let legendEntries: Array<LegendElement> = [];
+        let stack: Array<any> = [];
+        // initialize stack
+        legendConfig.root.children.forEach(legendItem => stack.push(legendItem));
+
+        // parse children from legend root structure through traversal
+        while (stack.length > 0) {
+            // pop legend entry in stack and check if it has a corresponding layer
+            const lastEntry = stack.pop();
+            // TODO: create legend wrapper object once class definitions implemented and bind to legend object
+            if (lastEntry.layerId !== undefined) {
+                // TODO: figure out a good approach to wait and map layerId to uid then call `getLayerById` to bind GeoApi BaseLayer to legend object
+                // lastEntry.layer = this.$vApp.$store.get('layer/getLayerById', lastEntry.layerId);
+            }
+            legendEntries.push(lastEntry);
+            // push all children in current legend node back onto stack
+            if (lastEntry?.children !== undefined && lastEntry.children.length > 0) {
+                lastEntry?.children.forEach((child: any) => stack.push(child));
+            }
+        }
+
+        this.$vApp.$store.set('legend/children', legendEntries);
+        // TODO: validate legend items?
+    }
+}

--- a/packages/ramp-core/src/fixtures/legend/store/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/index.ts
@@ -1,0 +1,2 @@
+export * from './legend-state';
+export * from './legend-store';

--- a/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
@@ -1,0 +1,42 @@
+import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
+
+export class LegendState {
+    legendConfig: LegendConfig | undefined = undefined;
+    children: Array<LegendElement> = [];
+}
+
+export interface LegendConfig {
+    isOpen: boolean;
+    reorderable: boolean;
+    root: { name: string; children: Array<LegendElement> };
+}
+
+// TODO: following should be ported over from separate legend item object definitions file
+export interface LegendElement {
+    id: string;
+    name: string;
+    type: 'LegendEntry' | 'LegendGroup' | 'VisibilitySet' | 'InfoSection';
+    controls: Array<string>;
+    visibility: boolean;
+    opacity: number;
+    // symbologyExpanded: boolean;
+    children: Array<LegendElement> | [];
+    expanded: boolean | undefined;
+    layer: BaseLayer;
+    parent: LegendElement | undefined;
+}
+
+interface LegendEntry extends LegendElement {
+    children: [];
+    layer: BaseLayer;
+}
+
+interface LegendGroup extends LegendElement {
+    children: Array<LegendEntry | LegendGroup | VisibilitySet>;
+    expanded: boolean;
+}
+
+interface VisibilitySet extends LegendElement {
+    children: Array<LegendElement | LegendGroup>;
+    expanded: boolean;
+}

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -1,0 +1,154 @@
+import { ActionContext, Action } from 'vuex';
+import { make } from 'vuex-pathify';
+
+import { LegendState, LegendConfig, LegendElement } from './legend-state';
+import { ConfigStore } from '@/store/modules/config';
+import { RootState } from '@/store';
+
+// use for actions
+type LegendContext = ActionContext<LegendState, RootState>;
+
+const getters = {
+    getChildById: (state: LegendState, id: string): LegendElement | undefined => {
+        return state.children.find((entry: LegendElement) => entry.type === 'LegendEntry' && entry.layer.uid === id);
+    },
+    getAllToggled: (state: LegendState, expanded: boolean): boolean => {
+        return state.children.every(entry => entry.type !== 'LegendGroup' || entry.expanded === expanded);
+    },
+    getAllVisibility: function(state: LegendState, visible: boolean): boolean {
+        return state.children.every(
+            entry => entry.visibility === visible || (entry.parent !== undefined && entry.parent.visibility === visible)
+        );
+    }
+};
+
+const mutations = {};
+
+const actions = {
+    expandGroups: function(this: any, context: LegendContext): void {
+        context.state.children.forEach(entry => {
+            if (entry.type === 'LegendGroup' && !entry.expanded) {
+                // TODO: call function to expand legend group once implemented
+            }
+        });
+    },
+    collapseGroups: function(this: any, context: LegendContext): void {
+        context.state.children.forEach(entry => {
+            if (entry.type === 'LegendGroup' && entry.expanded) {
+                // TODO: call function to collapse legend group once implemented
+            }
+        });
+    },
+    showAll: function(this: any, context: LegendContext): void {
+        context.state.children.forEach(entry => {
+            if (!entry.visibility) {
+                // TODO: call function to toggle visibility on for legend entry once implemented
+                // implementations will differ significantly for groups, sets and single entries
+            }
+        });
+    },
+    hideAll: function(this: any, context: LegendContext): void {
+        context.state.children.forEach(entry => {
+            if (entry.visibility) {
+                // TODO: call function to toggle visibility off for legend entry once implemented
+            }
+        });
+    },
+    updateLegendConfig: function(this: any, context: LegendContext, config: LegendConfig): void {
+        this.$vApp.$store.set(ConfigStore.updateConfig, config);
+        const newLegendConfig = this.$vApp.$store.get(ConfigStore.getFixtureConfig, 'legend');
+        context.commit('SET_LEGEND_CONFIG', newLegendConfig);
+    }
+};
+
+// commented out functions below were initially used if legend entries were stored in config tree structure
+/**
+ * Helper function that checks if all entries are visible/not visible.
+ *
+ * @function checkVisibility
+ * @param {LegendElement}   child Current legend item that is being checked
+ * @param {boolean}         visible Specifies whether visibility or expand/collapse functionality is to be changed
+ */
+// function checkVisibility(child: LegendElement, visible: boolean): boolean {
+//     // traverse tree to check if all legend items have visibility toggled on/off
+//     if (child.children && child.children.length > 0) {
+//         child.children.forEach(ch => {
+//             if (!checkVisibility(ch, visible)) {
+//                 return false;
+//             }
+//         });
+//     }
+//     if (child.type === 'legendEntry' && child.visibility === visible) {
+//         return false;
+//     }
+//     return true;
+// }
+
+/**
+ * Helper function that checks if all entries are expanded/collapsed.
+ *
+ * @function checkExpanded
+ * @param {LegendElement} child Current legend item that is being checked
+ * @param {Object}        expanded Specifies whether visibility or expand/collapse functionality is to be changed
+ */
+// function checkExpanded(child: LegendElement, expanded: boolean): boolean {
+//     // traverse tree to check if all legend groups are expanded/collapsed
+//     if (child.children && child.children.length > 0) {
+//         child.children.forEach(ch => {
+//             if (!checkExpanded(ch, expanded)) {
+//                 return false;
+//             }
+//         });
+//     }
+//     if (child.type === 'legendGroup' && child.expanded === expanded) {
+//         return false;
+//     }
+//     return true;
+// }
+
+/**
+ * Helper function that toggles visibility for all entries or expands/collapses all groups.
+ *
+ * @function toggle
+ * @param {LegendElement}   child Current legend item that is being checked
+ * @param {Object}          options Specifies whether visibility or expand/collapse functionality is to be changed
+ */
+// function toggle(child: LegendElement, options: any) {
+//     const visibility = options.visibility;
+//     const expand = options.expand;
+//     // traverse the tree and make recursive calls
+//     if (child.children && child.children.length > 0) {
+//         child.children.forEach(ch => {
+//             // level order traversal
+//             toggle(ch, options);
+//         });
+//     }
+//     // for current legend child toggle properties if possible, check for appropriate legend element type
+//     if (visibility && child.type === 'legendEntry') {
+//         // TODO: call functions to toggle visibility on/off for legend entry once implemented
+//         // e.g. visibility ? child.toggleVisibility(true) : child.toggleVisibility(false);
+//     }
+//     if (expand && child.type === 'legendGroup') {
+//         // TODO: call functions to expand/collapse group for legend group once implemented
+//         // e.g. expand ? child.expand(true) : child.expand(false);
+//     }
+// }
+
+export enum LegendStore {
+    /**
+     * (State) children: Array<LegendElement>
+     */
+    children = 'legend/children'
+}
+
+export function legend() {
+    const state = new LegendState();
+
+    return {
+        namespaced: true,
+        state,
+        getters: { ...getters },
+        actions: { ...actions, ...make.actions(state) },
+        mutations: { ...mutations, ...make.mutations(state) }
+    };
+}

--- a/packages/ramp-core/src/store/modules/config/config-store.ts
+++ b/packages/ramp-core/src/store/modules/config/config-store.ts
@@ -135,7 +135,15 @@ export enum ConfigStore {
      *
      * `@returns` <RampMapConfig> The map portion of the current config
      */
-    getMapConfig = 'config/getMapConfig'
+    getMapConfig = 'config/getMapConfig',
+    /**
+     * getFixtureConfig
+     *
+     * `@remarks` Getter - use `@Get`
+     *
+     * `@returns` <any> A particular fixture config
+     */
+    getFixtureConfig = 'config/getFixtureConfig'
 }
 
 export function config() {

--- a/packages/ramp-core/src/store/store.ts
+++ b/packages/ramp-core/src/store/store.ts
@@ -5,7 +5,7 @@ import pathify from 'vuex-pathify';
 import { config } from '@/store/modules/config';
 import { fixture } from '@/store/modules/fixture';
 import { layer } from '@/store/modules/layer';
-import { legend } from '@/store/modules/legend';
+// import { legend } from '@/store/modules/legend';
 import { panel } from '@/store/modules/panel';
 import { RootState } from '@/store/state';
 
@@ -20,7 +20,7 @@ export const createStore = () =>
             config: config(),
             fixture: fixture(),
             layer: layer(),
-            legend: legend(),
+            // legend: legend(),
             panel: panel()
         }
     });


### PR DESCRIPTION
Initial draft of Legend Store + State according to this [doc](https://hackmd.io/7dI2VIMaSRa8ANxHTgi89A). 

Wrote a parsing function in API to extract legend items from config snippet, still need to figure out a good approach to obtain `uid` and interact with layers store to connect GeoApi layers to legend items. 

Other things on the menu: 
- add to API 
- legend Vue components 
- legend wrapper object definitions 
- add events/watchers
- link to datatable on click 
- settings fixture + link 
- metadata fixture + link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/112)
<!-- Reviewable:end -->
