### PR TITLE
Implement Metadata Fixture

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -26,7 +26,7 @@ dependencies:
   '@vue/cli-plugin-typescript': 4.3.1_22122c1b335748d34772818bd2671b9d
   '@vue/cli-plugin-unit-jest': 4.3.1_26ec19d41106f6887b12594fc4613ed9
   '@vue/cli-plugin-vuex': 4.3.1_@vue+cli-service@4.3.1
-  '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+  '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
   '@vue/eslint-config-prettier': 5.1.0_484a2925e2c2b62f874c20a5d1f8a049
   '@vue/eslint-config-typescript': 4.0.0_eslint@5.16.0+typescript@3.8.3
   '@vue/test-utils': 1.0.0-beta.29_d81dac297579cfd5597855dabf60f13b
@@ -51,6 +51,7 @@ dependencies:
   postcss-nested: 4.2.1
   prettier: 1.19.1
   proj4: 2.6.0
+  raw-loader: 4.0.1_webpack@4.41.3
   sass: 1.26.3
   sass-loader: 8.0.2_sass@1.26.3+webpack@4.41.3
   screenfull: 5.0.2
@@ -1609,7 +1610,7 @@ packages:
     dependencies:
       '@babel/core': 7.9.0
       '@vue/babel-preset-app': 4.3.1
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
       '@vue/cli-shared-utils': 4.3.1
       babel-loader: 8.1.0_@babel+core@7.9.0+webpack@4.41.3
       cache-loader: 4.1.0_webpack@4.41.3
@@ -1622,7 +1623,7 @@ packages:
       integrity: sha512-tBqu0v1l4LfWX8xuJmofpp+8xQzKddFNxdLmeVDOX/omDBQX0qaVDeMUtRxxSTazI06SKr605SnUQoa35qwbvw==
   /@vue/cli-plugin-e2e-cypress/4.3.1_26b4135a6a7ea6e5db753560c48793ec:
     dependencies:
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
       '@vue/cli-shared-utils': 4.3.1
       cypress: 3.8.3
       eslint-plugin-cypress: 2.10.3_eslint@5.16.0
@@ -1634,7 +1635,7 @@ packages:
       integrity: sha512-/7V2jCLBkwPDKLVkkaWZMEBfecQ2W3B8IWk4JI4MTHK2yenIMNsciMotS8XxtpGkNF3HsxDr2LI+onBd6xHDFQ==
   /@vue/cli-plugin-eslint/4.3.1_26b4135a6a7ea6e5db753560c48793ec:
     dependencies:
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
       '@vue/cli-shared-utils': 4.3.1
       eslint: 5.16.0
       eslint-loader: 2.2.1_eslint@5.16.0+webpack@4.41.3
@@ -1650,7 +1651,7 @@ packages:
       integrity: sha512-5UEP93b8C/JQs9Rnuldsu8jMz0XO4wNXG0lL/GdChYBEheKCyXJXzan7qzEbIuvUwG3I+qlUkGsiyNokIgXejg==
   /@vue/cli-plugin-router/4.3.1_@vue+cli-service@4.3.1:
     dependencies:
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
       '@vue/cli-shared-utils': 4.3.1
     dev: false
     peerDependencies:
@@ -1660,7 +1661,7 @@ packages:
   /@vue/cli-plugin-typescript/4.3.1_22122c1b335748d34772818bd2671b9d:
     dependencies:
       '@types/webpack-env': 1.15.1
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
       '@vue/cli-shared-utils': 4.3.1
       cache-loader: 4.1.0_webpack@4.41.3
       fork-ts-checker-webpack-plugin: 3.1.1
@@ -1682,7 +1683,7 @@ packages:
       '@babel/core': 7.9.0
       '@babel/plugin-transform-modules-commonjs': 7.9.0_@babel+core@7.9.0
       '@types/jest': 24.9.1
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
       '@vue/cli-shared-utils': 4.3.1
       babel-core: 7.0.0-bridge.0_@babel+core@7.9.0
       babel-jest: 24.9.0_@babel+core@7.9.0
@@ -1704,13 +1705,13 @@ packages:
       integrity: sha512-mhIqwW6UGsPEOlw+rHBQjhlCjSxD9fKuVVVtkl989/bFZA17ZsdDrj/BfMTwX8mvoY5x6pPXb+Ti/opkkAOD7w==
   /@vue/cli-plugin-vuex/4.3.1_@vue+cli-service@4.3.1:
     dependencies:
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
     dev: false
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     resolution:
       integrity: sha512-mukwOlhZGBJhkqO2b3wHFFHjK5aP00b1WUHdrOfLR7M18euhaTyb4kA5nwZwEOmU3EzZx6kHzSFCRy/XaMkLug==
-  /@vue/cli-service/4.3.1_c697b53a0674ec5a6a3e3a567d98b494:
+  /@vue/cli-service/4.3.1_a7f726f1764fe8b9df6991b9942a87ff:
     dependencies:
       '@intervolga/optimize-cssnano-plugin': 1.0.6_webpack@4.41.3
       '@soda/friendly-errors-webpack-plugin': 1.7.1_webpack@4.41.3
@@ -1753,6 +1754,7 @@ packages:
       pnp-webpack-plugin: 1.6.4_typescript@3.8.3
       portfinder: 1.0.25
       postcss-loader: 3.0.0
+      raw-loader: 4.0.1_webpack@4.41.3
       sass-loader: 8.0.2_sass@1.26.3+webpack@4.41.3
       ssri: 7.1.0
       terser-webpack-plugin: 2.3.5_webpack@4.41.3
@@ -10399,6 +10401,18 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  /raw-loader/4.0.1_webpack@4.41.3:
+    dependencies:
+      loader-utils: 2.0.0
+      schema-utils: 2.6.6
+      webpack: 4.41.3_webpack@4.41.3
+    dev: false
+    engines:
+      node: '>= 10.13.0'
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    resolution:
+      integrity: sha512-baolhQBSi3iNh1cglJjA0mYzga+wePk7vdEX//1dTFd+v4TsQlQE0jitJSNF1OIP82rdYulH7otaVmdlDaJ64A==
   /react-is/16.13.1:
     dev: false
     resolution:
@@ -13445,7 +13459,7 @@ packages:
       '@vue/cli-plugin-typescript': 4.3.1_22122c1b335748d34772818bd2671b9d
       '@vue/cli-plugin-unit-jest': 4.3.1_26ec19d41106f6887b12594fc4613ed9
       '@vue/cli-plugin-vuex': 4.3.1_@vue+cli-service@4.3.1
-      '@vue/cli-service': 4.3.1_c697b53a0674ec5a6a3e3a567d98b494
+      '@vue/cli-service': 4.3.1_a7f726f1764fe8b9df6991b9942a87ff
       '@vue/eslint-config-prettier': 5.1.0_484a2925e2c2b62f874c20a5d1f8a049
       '@vue/eslint-config-typescript': 4.0.0_eslint@5.16.0+typescript@3.8.3
       '@vue/test-utils': 1.0.0-beta.29_d81dac297579cfd5597855dabf60f13b
@@ -13464,6 +13478,7 @@ packages:
       lodash: 4.17.15
       postcss-nested: 4.2.1
       prettier: 1.19.1
+      raw-loader: 4.0.1_webpack@4.41.3
       sass: 1.26.3
       sass-loader: 8.0.2_sass@1.26.3+webpack@4.41.3
       screenfull: 5.0.2
@@ -13485,7 +13500,7 @@ packages:
       webpack: '*'
       webpack-cli: '*'
     resolution:
-      integrity: sha512-bk1sButiO8cwnuEId0g+LmgxWY+eD+EG3PtafMwdonDaajo7SjC14Aacntetx0vOc6nxyMASBgSDmngg463ZgQ==
+      integrity: sha512-MgYRX3aTp0G3IXYNFu4VtN8saDqd7Hh69brwAi3HmKih21DldP3hxXZiME3amE0fp/l4arOYNaAFrtcO9dHJCw==
       tarball: 'file:projects/ramp-core.tgz'
     version: 0.0.0
   'file:projects/ramp-geoapi.tgz':
@@ -13615,6 +13630,7 @@ specifiers:
   postcss-nested: ~4.2.1
   prettier: ^1.19.1
   proj4: 2.6.0
+  raw-loader: ^4.0.1
   sass: ^1.23.7
   sass-loader: ^8.0.0
   screenfull: ~5.0.2

--- a/common/docs/app/defaults.md
+++ b/common/docs/app/defaults.md
@@ -40,6 +40,10 @@ The `geosearch` is a utility that allows one to search for geographic names and 
 
 The `help` provides a means to display user help for the application. TODO create and hyperlink to `help.md`, or provide any other relevant info here.
 
+### Metadata
+
+The `metadata` provides an interface to view extra information about a layer. TODO create and hyperlink to `metadata.md`, or provide any other relevant info here.
+
 ## Default Events Handlers
 
 Along with the default fixtures, there are default event handlers that are applied to make them react to each other and to the RAMP core. See the examples section below and the LINKTO Events API page for details on how to work with event handlers.

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -22,6 +22,7 @@
         "ramp-geoapi": "0.0.1",
         "ramp-locale-loader": "0.0.1",
         "ramp-sample-fixtures": "0.0.1",
+        "raw-loader": "^4.0.1",
         "screenfull": "~5.0.2",
         "vue": "^2.6.10",
         "vue-class-component": "^7.0.2",

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -133,7 +133,7 @@ export class FixtureAPI extends APIScope {
      */
     addDefaultFixtures(fixtureNames?: Array<string>): Promise<Array<FixtureBase>> {
         if (!Array.isArray(fixtureNames) || fixtureNames.length === 0) {
-            fixtureNames = ['appbar', 'mapnav', 'help', 'details', 'grid', 'basemap', 'geosearch', 'legend'];
+            fixtureNames = ['appbar', 'mapnav', 'help', 'details', 'grid', 'basemap', 'geosearch', 'legend', 'metadata'];
         }
 
         // add all the requested default promises.

--- a/packages/ramp-core/src/fixtures/metadata/api/metadata.ts
+++ b/packages/ramp-core/src/fixtures/metadata/api/metadata.ts
@@ -1,0 +1,12 @@
+import { FixtureInstance } from '@/api';
+import { MetadataPayload } from '../definitions';
+
+export class MetadataAPI extends FixtureInstance {
+    /**
+     * Opens the metadata panel. Provides the given payload as a prop to the panel.
+     * @param payload
+     */
+    openMetadata(payload: MetadataPayload): void {
+        this.$iApi.panel.open({ id: 'metadata-panel', props: { payload: payload } });
+    }
+}

--- a/packages/ramp-core/src/fixtures/metadata/definitions.ts
+++ b/packages/ramp-core/src/fixtures/metadata/definitions.ts
@@ -1,0 +1,15 @@
+export interface MetadataPayload {
+  type: string; // 'xml' or 'html'
+  layer: string;
+  url: string;
+}
+
+export interface MetadataState {
+  status: string;
+  response: DocumentFragment | string | null;
+}
+
+export interface MetadataResult {
+  status: string;
+  response: string;
+}

--- a/packages/ramp-core/src/fixtures/metadata/files/xstyle_default_en.xsl
+++ b/packages/ramp-core/src/fixtures/metadata/files/xstyle_default_en.xsl
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gmdl="http://www.canada.gc.ca/ns/gmdl"
+                xmlns:napec="http://www.ec.gc.ca/data_donnees/standards/schemas/napec"
+                xmlns:gml="http://www.opengis.net/gml"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.ec.gc.ca/data_donnees/standards/schemas/napec/schema.xsd">
+
+  <xsl:param name="catalogue_url" />
+  <xsl:decimal-format NaN=""/>
+
+  <xsl:template match="/">
+
+    <div class="metadata-view">
+
+      <xsl:if test="//gmd:abstract/gco:CharacterString/text() != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Abstract}}</h5>
+        <p>
+          <xsl:value-of select="//gmd:abstract/gco:CharacterString/text()" />
+        </p>
+      </xsl:if>
+
+      <xsl:comment>
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Scope}}</h5>
+        <p>{{metadata.xslt.hereBeScope}}</p>
+      </xsl:comment>
+
+      <xsl:if test="//gml:TimePeriod//* != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.timePeriod}}</h5>
+        <p>
+          <xsl:value-of select="//gml:TimePeriod//gml:beginPosition" />
+          <xsl:if test="//gml:TimePeriod//gml:beginPosition/text() != '' and //gml:TimePeriod//gml:endPosition/text() != ''">
+            -
+          </xsl:if>
+          <xsl:value-of select="//gml:TimePeriod//gml:endPosition" />
+        </p>
+      </xsl:if>
+
+      <xsl:comment>
+        <xsl:if test="//gmd:supplementalInformation/gco:CharacterString/text() != ''">
+          <h5 class="text-xl font-bold mb-3">{{metadata.xslt.supplementalData}}</h5>
+          <p>
+            <xsl:value-of select="//gmd:supplementalInformation/gco:CharacterString/text()" />
+          </p>
+        </xsl:if>
+      </xsl:comment>
+
+      <xsl:if test="//gmd:pointOfContact//gmd:individualName/* != '' 
+              or //gmd:pointOfContact//gmd:organisationName/gco:CharacterString/text() != ''
+              or //gmd:pointOfContact//gmd:positionName/gco:CharacterString/text() != ''
+              or //gmd:pointOfContact//gmd:electronicMailAddress/* != ''
+              or //gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.contactInfo}}</h5>
+        <p>
+          <xsl:value-of select="//gmd:pointOfContact//gmd:individualName" />
+        </p>
+        <p>
+          <xsl:value-of select="//gmd:pointOfContact//gmd:organisationName/gco:CharacterString/text()" />
+        </p>
+        <p>
+          <xsl:value-of select="//gmd:pointOfContact//gmd:positionName/gco:CharacterString/text()" />
+        </p>
+        <p>
+          <a href="mailto:{//gmd:pointOfContact//gmd:electronicMailAddress/gco:CharacterString/text()}?Subject={//gmd:identificationInfo//gmd:title/gco:CharacterString/text()}">
+            <xsl:value-of select="//gmd:pointOfContact//gmd:electronicMailAddress" />
+          </a>
+        </p>
+        <p>
+          <xsl:variable name="roleCode" >
+            <xsl:value-of select="concat(substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue,1,1),
+                        substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue, 2))" />
+          </xsl:variable>
+
+          <xsl:choose>
+            <xsl:when test="$roleCode = 'resourceProvider'">{{metadata.xslt.resourceProvider}}</xsl:when>
+            <xsl:when test="$roleCode = 'custodian'">{{metadata.xslt.custodian}}</xsl:when>
+            <xsl:when test="$roleCode = 'owner'">{{metadata.xslt.owner}}</xsl:when>
+            <xsl:when test="$roleCode = 'user'">{{metadata.xslt.user}}</xsl:when>
+            <xsl:when test="$roleCode = 'distributor'">{{metadata.xslt.distributor}}</xsl:when>
+            <xsl:when test="$roleCode = 'originator'">{{metadata.xslt.originator}}</xsl:when>
+            <xsl:when test="$roleCode = 'pointOfContact'">{{metadata.xslt.pointOfContact}}</xsl:when>
+            <xsl:when test="$roleCode = 'principalInvestigator'">{{metadata.xslt.principalInvestigator}}</xsl:when>
+            <xsl:when test="$roleCode = 'processor'">{{metadata.xslt.processor}}</xsl:when>
+            <xsl:when test="$roleCode = 'publisher'">{{metadata.xslt.publisher}}</xsl:when>
+            <xsl:when test="$roleCode = 'author'">{{metadata.xslt.author}}</xsl:when>
+            <xsl:when test="$roleCode = 'collaborator'">{{metadata.xslt.collaborator}}</xsl:when>
+            <xsl:when test="$roleCode = 'editor'">{{metadata.xslt.editor}}</xsl:when>
+            <xsl:when test="$roleCode = 'mediator'">{{metadata.xslt.mediator}}</xsl:when>
+            <xsl:when test="$roleCode = 'rightsHolder'">{{metadata.xslt.rightsHolder}}</xsl:when>
+          </xsl:choose>
+        </p>
+      </xsl:if>
+
+      <xsl:if test="$catalogue_url != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.cataloguePage}}</h5>
+        <p>
+          <a href="{$catalogue_url}"
+             rel="external" target="_blank" class="ui-link">
+            {{metadata.xslt.metadata}}
+          </a>
+        </p>
+      </xsl:if>
+    </div>
+  </xsl:template>
+</xsl:stylesheet>

--- a/packages/ramp-core/src/fixtures/metadata/files/xstyle_default_fr.xsl
+++ b/packages/ramp-core/src/fixtures/metadata/files/xstyle_default_fr.xsl
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gmdl="http://www.canada.gc.ca/ns/gmdl"
+                xmlns:napec="http://www.ec.gc.ca/data_donnees/standards/schemas/napec"
+                xmlns:gml="http://www.opengis.net/gml"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.ec.gc.ca/data_donnees/standards/schemas/napec/schema.xsd">
+
+  <xsl:param name="catalogue_url" />
+  <xsl:decimal-format NaN=""/>
+
+  <xsl:template match="/">
+
+    <div class="metadata-view">
+
+      <xsl:if test="//gmd:abstract//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Abstract}}</h5>
+        <p>
+          <xsl:value-of select="//gmd:abstract//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
+        </p>
+      </xsl:if>
+
+      <xsl:comment>
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Scope}}</h5>
+        <p>{{metadata.xslt.hereBeScope}}</p>
+      </xsl:comment>
+
+      <xsl:if test="//gml:TimePeriod//* != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.timePeriod}}</h5>
+        <p>
+          <xsl:value-of select="//gml:TimePeriod//gml:beginPosition" />
+          <xsl:if test="//gml:TimePeriod//gml:beginPosition/text() != '' and //gml:TimePeriod//gml:endPosition/text() != ''">
+            -
+          </xsl:if>
+          <xsl:value-of select="//gml:TimePeriod//gml:endPosition" />
+        </p>
+      </xsl:if>
+
+      <xsl:comment>
+        <xsl:if test="//gmd:supplementalInformation//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''">
+          <h5 class="text-xl font-bold mb-3">{{metadata.xslt.supplementalData}}</h5>
+          <p>
+            <xsl:value-of select="//gmd:supplementalInformation//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
+          </p>
+        </xsl:if>
+      </xsl:comment>
+
+      <xsl:if test="//gmd:pointOfContact//gmd:individualName/* != '' 
+              or //gmd:pointOfContact//gmd:organisationName//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''
+              or //gmd:pointOfContact//gmd:positionName//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''
+              or //gmd:pointOfContact//gmd:electronicMailAddress/* != ''
+              or //gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.contactInfo}}</h5>
+        <p>
+          <xsl:value-of select="//gmd:pointOfContact//gmd:individualName" />
+        </p>
+        <p>
+          <xsl:value-of select="//gmd:pointOfContact//gmd:organisationName//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
+        </p>
+        <p>
+          <xsl:value-of select="//gmd:pointOfContact//gmd:positionName//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
+        </p>
+        <p>
+          <a href="mailto:{//gmd:pointOfContact//gmd:electronicMailAddress//gmd:LocalisedCharacterString[@locale='#fra']/text()}?Subject={//gmd:identificationInfo//gmd:title//gmd:LocalisedCharacterString[@locale='#fra']/text()}">
+            <xsl:value-of select="//gmd:pointOfContact//gmd:electronicMailAddress" />
+          </a>
+        </p>
+        <p>
+          <xsl:variable name="roleCode" >
+            <xsl:value-of select="concat(substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue,1,1),
+                        substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue, 2))" />
+          </xsl:variable>
+
+          <xsl:choose>
+            <xsl:when test="$roleCode = 'resourceProvider'">{{metadata.xslt.resourceProvider}}</xsl:when>
+            <xsl:when test="$roleCode = 'custodian'">{{metadata.xslt.custodian}}</xsl:when>
+            <xsl:when test="$roleCode = 'owner'">{{metadata.xslt.owner}}</xsl:when>
+            <xsl:when test="$roleCode = 'user'">{{metadata.xslt.user}}</xsl:when>
+            <xsl:when test="$roleCode = 'distributor'">{{metadata.xslt.distributor}}</xsl:when>
+            <xsl:when test="$roleCode = 'originator'">{{metadata.xslt.originator}}</xsl:when>
+            <xsl:when test="$roleCode = 'pointOfContact'">{{metadata.xslt.pointOfContact}}</xsl:when>
+            <xsl:when test="$roleCode = 'principalInvestigator'">{{metadata.xslt.principalInvestigator}}</xsl:when>
+            <xsl:when test="$roleCode = 'processor'">{{metadata.xslt.processor}}</xsl:when>
+            <xsl:when test="$roleCode = 'publisher'">{{metadata.xslt.publisher}}</xsl:when>
+            <xsl:when test="$roleCode = 'author'">{{metadata.xslt.author}}</xsl:when>
+            <xsl:when test="$roleCode = 'collaborator'">{{metadata.xslt.collaborator}}</xsl:when>
+            <xsl:when test="$roleCode = 'editor'">{{metadata.xslt.editor}}</xsl:when>
+            <xsl:when test="$roleCode = 'mediator'">{{metadata.xslt.mediator}}</xsl:when>
+            <xsl:when test="$roleCode = 'rightsHolder'">{{metadata.xslt.rightsHolder}}</xsl:when>
+          </xsl:choose>
+        </p>
+      </xsl:if>
+
+      <xsl:if test="$catalogue_url != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.cataloguePage}}</h5>
+        <p>
+          <a href="{$catalogue_url}"
+             rel="external" target="_blank" class="ui-link">
+            {{metadata.xslt.metadata}}
+          </a>
+        </p>
+      </xsl:if>
+    </div>
+  </xsl:template>
+</xsl:stylesheet>

--- a/packages/ramp-core/src/fixtures/metadata/index.ts
+++ b/packages/ramp-core/src/fixtures/metadata/index.ts
@@ -1,0 +1,41 @@
+import { MetadataAPI } from './api/metadata';
+
+import ScreenV from './screen.vue';
+
+import messages from './lang/lang.csv';
+
+class MetadataFixture extends MetadataAPI {
+    async added() {
+        this.$iApi.panel.register(
+            {
+                'metadata-panel': {
+                    screens: {
+                        'metadata-screen-content': ScreenV
+                    },
+                    style: {
+                        width: '350px'
+                    }
+                }
+            },
+            { i18n: { messages } }
+        );
+
+        let handler = (payload: any) => {
+            const metadataFixture: MetadataAPI = this.$iApi.fixture.get('metadata');
+            metadataFixture.openMetadata(payload);
+        };
+
+        this.$iApi.event.on('metadata/open', handler, 'metadata_opened_handler');
+
+        // TODO: remove this. Temporarily emits an event to open the metadata panel. In the future, this will be done by
+        // any fixture that wants the metadata panel to open.
+        this.$iApi.event.emit('metadata/open', {
+            type: 'html',
+            layer: 'Sample Layer Name',
+            url:
+                'https://ryan-coulson.com/RAMPMetadataDemo.html'
+        });
+    }
+}
+
+export default MetadataFixture;

--- a/packages/ramp-core/src/fixtures/metadata/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/metadata/lang/lang.csv
@@ -1,0 +1,25 @@
+key,enValue,enValid,frValue,frValid
+metadata.xslt.Abstract,Abstract,1,Résumé,1
+metadata.xslt.Scope,Scope,1,Portée,1
+metadata.xslt.hereBeScope,here be scope,1,la portée jusqu'ici,1
+metadata.xslt.timePeriod,Time Period,1,Période,1
+metadata.xslt.supplementalData,Supplemental Data,1,Données supplémentaires,1
+metadata.xslt.contactInfo,Contact Information,1,Coordonnées,1
+metadata.xslt.resourceProvider,Resource Provider,1,Fournisseur de la ressource,1
+metadata.xslt.custodian,Custodian,1,Dépositaire,1
+metadata.xslt.owner,Owner,1,Propriétaire,1
+metadata.xslt.user,User,1,Utilisateur,1
+metadata.xslt.distributor,Distributor,1,Distributeur,1
+metadata.xslt.originator,Originator,1,Auteur,1
+metadata.xslt.pointOfContact,Point of Contact,1,Point de contact,1
+metadata.xslt.principalInvestigator,Principal Investigator,1,Chercheur principal,1
+metadata.xslt.processor,Processor,1,Préparateur,1
+metadata.xslt.publisher,Publisher,1,Éditeur,1
+metadata.xslt.author,Author,1,Auteur,1
+metadata.xslt.collaborator,Collaborator,1,Collaborateur,1
+metadata.xslt.editor,Editor,1,Éditeur,1
+metadata.xslt.mediator,Mediator,1,Médiateur,1
+metadata.xslt.rightsHolder,Rights Holder,1,Titulaire des droits,1
+metadata.xslt.cataloguePage,Data Catalogue Page,1,Page des données du catalogue,1
+metadata.xslt.metadataPage,Raw Metadata,1,Métadonnées brutes,1
+metadata.xslt.metadata,Metadata,1,Métadonnées,1

--- a/packages/ramp-core/src/fixtures/metadata/screen.vue
+++ b/packages/ramp-core/src/fixtures/metadata/screen.vue
@@ -1,0 +1,168 @@
+<template>
+    <panel-screen>
+        <template #header> Metadata: {{ payload.layer }} </template>
+
+        <template #controls>
+            <close @click="panel.close()" />
+        </template>
+
+        <template #content>
+            <div class="flex justify-center">
+                <!-- Loading Screen -->
+                <div v-if="state.status == 'loading'" class="flex flex-col justify-center text-center">
+                    Loading...
+                </div>
+
+                <!-- Found Screen, XML -->
+                <div v-else-if="payload.type === 'xml' && state.status == 'success'" class="flex flex-col justify-center"></div>
+
+                <!-- Found Screen, HTML -->
+                <div
+                    v-else-if="payload.type === 'html' && state.status == 'success'"
+                    v-html="state.response"
+                    class="flex flex-col justify-center"
+                ></div>
+
+                <!-- Error Screen -->
+                <div v-else class="flex flex-col justify-center text-center">
+                    <img src="https://i.imgur.com/fA5EqV6.png" />
+
+                    <span class="text-xl mt-20">There was an error retrieving this resource. Please try again.</span>
+                </div>
+            </div>
+        </template>
+    </panel-screen>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+import { PanelInstance } from '@/api';
+import { MetadataPayload, MetadataResult, MetadataState } from './definitions';
+
+import XSLT_en from './files/xstyle_default_en.xsl';
+import XSLT_fr from './files/xstyle_default_fr.xsl';
+
+@Component
+export default class MetadataV extends Vue {
+    @Prop() panel!: PanelInstance;
+    @Prop() payload!: MetadataPayload;
+
+    state: MetadataState = {
+        status: 'loading',
+        response: null
+    };
+
+    cache: { [id: string]: string } = {};
+
+    mounted() {
+        if (this.payload.type === 'xml') {
+            // This site prevents CORS errors. Helpful for testing purposes.
+            this.loadFromURL('https://cors-anywhere.herokuapp.com/' + this.payload.url, []).then(r => {
+                this.state.status = 'success';
+
+                // Append the content to the panel.
+                if (r !== null) {
+                    this.$el.childNodes[1].appendChild(r);
+                }
+            });
+        } else if (this.payload.type === 'html') {
+            this.requestContent('https://cors-anywhere.herokuapp.com/' + this.payload.url).then(r => {
+                this.state.status = 'success';
+                this.state.response = (r as MetadataResult).response;
+            });
+        }
+    }
+
+    /**
+     * Applies an XSLT to XML, XML is provided but the XSLT is stored in a string constant.
+     *
+     * @method loadFromURL
+     * @param {String} xmlUrl Location of the xml file
+     * @param {Array} params an array which never seems to be set and is never used
+     * @return {Promise} a promise resolving with an HTML fragment
+     */
+    loadFromURL(xmlUrl: string, params: any[]) {
+        let XSLT = this.$iApi.language === 'en' ? XSLT_en : XSLT_fr;
+
+        // Translate headers.
+        XSLT = XSLT.replace(/\{\{([\w.]+)\}\}/g, (_: string, tag: string) => this.$t(tag));
+
+        if (!this.cache[xmlUrl]) {
+            return this.requestContent(xmlUrl).then(xmlData => {
+                this.cache[xmlUrl] = (xmlData as MetadataResult).response;
+                return this.applyXSLT(this.cache[xmlUrl], XSLT, params);
+            });
+        } else {
+            return Promise.resolve(this.applyXSLT(this.cache[xmlUrl], XSLT, params));
+        }
+    }
+
+    /**
+     * Transform XML using XSLT
+     * @function applyXSLT
+     * @private
+     * @param {string} xmlString text data of the XML document
+     * @param {string} xslString text data of the XSL document
+     * in IE)}
+     * @param {Array} params a list of paramters to apply to the transform
+     * @return {object} transformed document
+     */
+    applyXSLT(xmlString: string, xslString: string, params: any[]) {
+        let output = null;
+
+        if (window.XSLTProcessor) {
+            const xsltProc = new window.XSLTProcessor();
+            const parser = new DOMParser();
+
+            const xmlDoc = parser.parseFromString(xmlString, 'text/xml');
+            const xslDoc = parser.parseFromString(xslString, 'text/xml');
+            xsltProc.importStylesheet(xslDoc);
+            // [patched from ECDMP] Add parameters to xsl document (setParameter = Chrome/FF/Others)
+            if (params) {
+                params.forEach(p => xsltProc.setParameter('', p.key, p.value || ''));
+            }
+            output = xsltProc.transformToFragment(xmlDoc, document);
+        } else if (window.hasOwnProperty('ActiveXObject')) {
+            // IE11 (╯°□°）╯︵ ┻━┻
+            const xslt = new window.ActiveXObject('Msxml2.XSLTemplate');
+            const xmlDoc = new window.ActiveXObject('Msxml2.DOMDocument');
+            const xslDoc = new window.ActiveXObject('Msxml2.FreeThreadedDOMDocument');
+            xmlDoc.loadXML(xmlString);
+            xslDoc.loadXML(xslString);
+            xslt.stylesheet = xslDoc;
+            const xsltProc = xslt.createProcessor();
+            xsltProc.input = xmlDoc;
+            xsltProc.transform();
+            output = document.createRange().createContextualFragment(xsltProc.output);
+        }
+
+        return output;
+    }
+
+    /**
+     * Sends a GET request to the provided URL. Returns a promise containing information received from the webpage.
+     * */
+    requestContent(url: string) {
+        return new Promise((resolve, reject) => {
+            const xobj = new XMLHttpRequest();
+            xobj.open('GET', url, true);
+            xobj.responseType = 'text';
+            xobj.onload = () => {
+                if (xobj.status === 200) {
+                    resolve({ status: 'success', response: xobj.response });
+                } else {
+                    resolve({ status: 'error', response: 'Could not load results from remote service.' });
+                }
+            };
+            xobj.onerror = () => {
+                resolve({ status: 'error', response: 'Could not load results from remote service.' });
+            };
+            xobj.send();
+        });
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/shims-vue.d.ts
+++ b/packages/ramp-core/src/shims-vue.d.ts
@@ -13,3 +13,8 @@ declare module '*.csv' {
     const content: any;
     export default content;
 }
+
+declare module '*.xsl' {
+    const content: any;
+    export default content;
+}

--- a/packages/ramp-core/vue.config.js
+++ b/packages/ramp-core/vue.config.js
@@ -28,11 +28,22 @@ module.exports = {
         config.plugins.delete('prefetch');
 
         // load csv files (used for translations)
-        config.module
-            .rule('dsv')
+        const csvRule = config.module.rule('dsv');
+
+        csvRule.uses.clear();
+        csvRule
             .test(/lang\.csv$/)
             .use('ramp-locale-loader')
-            .loader('ramp-locale-loader');
+            .loader('ramp-locale-loader')
+
+        // load xsl files (for metadata fixture)
+        const xslRule = config.module.rule('loadxsl');
+        xslRule.uses.clear();
+
+        xslRule
+            .test(/\.xsl$/)
+            .use('raw-loader')
+            .loader('raw-loader');
 
         // add an automatic callback to execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
         // this only applies to the production build; dev build calls this function from `main-serve.ts`


### PR DESCRIPTION
This is an initial implementation of the metadata fixture. As of right now, the fixture supports both `XML` and `HTML` files.

The panel will open when the fixture receives a `metadata/open` event and a payload. 

NOTE: I had to make some changes to the build files in order to use XSL files. I'm not 100% sure how the build process works, but everything still seems to work properly. If I've made any changes that you think could cause problems in the future, let me know and I'll fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/114)
<!-- Reviewable:end -->
