### PR TITLE
build: update tailwindcss dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: trusty
 language: node_js
 node_js:
     - 10.16.3
+before_script:
+    - export NODE_OPTIONS=--max_old_space_size=4096
 script:
     - set -e
 

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -5,12 +5,11 @@ dependencies:
   '@babel/plugin-proposal-object-rest-spread': 7.11.0_@babel+core@7.11.0
   '@babel/preset-env': 7.11.0_@babel+core@7.11.0
   '@babel/preset-typescript': 7.10.4_@babel+core@7.11.0
-  '@fullhuman/postcss-purgecss': 1.3.0
   '@rush-temp/ramp-core': 'file:projects/ramp-core.tgz_777e958c1436af419002454c0780d0b4'
   '@rush-temp/ramp-geoapi': 'file:projects/ramp-geoapi.tgz'
   '@rush-temp/ramp-locale-loader': 'file:projects/ramp-locale-loader.tgz'
   '@rush-temp/ramp-sample-fixtures': 'file:projects/ramp-sample-fixtures.tgz'
-  '@tailwindcss/custom-forms': 0.2.1_tailwindcss@1.1.4
+  '@tailwindcss/custom-forms': 0.2.1_tailwindcss@1.6.2
   '@types/animejs': 3.1.1
   '@types/arcgis-js-api': 4.16.0
   '@types/clone-deep': 4.0.1
@@ -56,7 +55,7 @@ dependencies:
   screenfull: 5.0.2
   source-map-loader: 0.2.3
   svg.js: 2.7.1
-  tailwindcss: 1.1.4
+  tailwindcss: 1.6.2
   terraformer: 1.0.9
   terraformer-arcgis-parser: 1.1.0
   ts-jest: 23.10.5_jest@23.6.0
@@ -1129,13 +1128,13 @@ packages:
     dev: false
     resolution:
       integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
-  /@fullhuman/postcss-purgecss/1.3.0:
+  /@fullhuman/postcss-purgecss/2.3.0:
     dependencies:
       postcss: 7.0.32
-      purgecss: 1.4.2
+      purgecss: 2.3.0
     dev: false
     resolution:
-      integrity: sha512-zvfS3dPKD2FAtMcXapMJXGbDgEp9E++mLR6lTgSruv6y37uvV5xJ1crVktuC1gvnmMwsa7Zh1m05FeEiz4VnIQ==
+      integrity: sha512-qnKm5dIOyPGJ70kPZ5jiz0I9foVOic0j+cOzNDoo8KoCf6HjicIZ99UfO2OmE7vCYSKAAepEwJtNzpiiZAh9xw==
   /@hapi/address/2.1.4:
     deprecated: This version has been deprecated and is no longer supported or maintained
     dev: false
@@ -1367,11 +1366,11 @@ packages:
     dev: false
     resolution:
       integrity: sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==
-  /@tailwindcss/custom-forms/0.2.1_tailwindcss@1.1.4:
+  /@tailwindcss/custom-forms/0.2.1_tailwindcss@1.6.2:
     dependencies:
       lodash: 4.17.19
       mini-svg-data-uri: 1.2.3
-      tailwindcss: 1.1.4
+      tailwindcss: 1.6.2
       traverse: 0.6.6
     dev: false
     peerDependencies:
@@ -2141,6 +2140,14 @@ packages:
       acorn: ^6.0.0 || ^7.0.0
     resolution:
       integrity: sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
+  /acorn-node/1.8.2:
+    dependencies:
+      acorn: 7.4.0
+      acorn-walk: 7.2.0
+      xtend: 4.0.2
+    dev: false
+    resolution:
+      integrity: sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
   /acorn-walk/6.2.0:
     dev: false
     engines:
@@ -3011,7 +3018,7 @@ packages:
     dev: false
     resolution:
       integrity: sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
-  /browserify-sign/4.2.0:
+  /browserify-sign/4.2.1:
     dependencies:
       bn.js: 5.1.2
       browserify-rsa: 4.0.1
@@ -3024,7 +3031,7 @@ packages:
       safe-buffer: 5.2.1
     dev: false
     resolution:
-      integrity: sha512-hEZC1KEeYuoHRqhGhTy6gWrpJA3ZDjFWv0DE61643ZnOXAKJb3u7yWcrU0mMc9SwAqK1n7myPGndkp0dFG7NFA==
+      integrity: sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==
   /browserify-zlib/0.2.0:
     dependencies:
       pako: 1.0.11
@@ -3034,7 +3041,7 @@ packages:
   /browserslist/4.13.0:
     dependencies:
       caniuse-lite: 1.0.30001110
-      electron-to-chromium: 1.3.518
+      electron-to-chromium: 1.3.519
       escalade: 3.0.2
       node-releases: 1.1.60
     dev: false
@@ -3659,6 +3666,12 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+  /commander/5.1.0:
+    dev: false
+    engines:
+      node: '>= 6'
+    resolution:
+      integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
   /common-tags/1.8.0:
     dev: false
     engines:
@@ -3857,13 +3870,13 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
-  /create-ecdh/4.0.3:
+  /create-ecdh/4.0.4:
     dependencies:
       bn.js: 4.11.9
       elliptic: 6.5.3
     dev: false
     resolution:
-      integrity: sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
+      integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==
   /create-hash/1.2.0:
     dependencies:
       cipher-base: 1.0.4
@@ -3918,8 +3931,8 @@ packages:
   /crypto-browserify/3.12.0:
     dependencies:
       browserify-cipher: 1.0.1
-      browserify-sign: 4.2.0
-      create-ecdh: 4.0.3
+      browserify-sign: 4.2.1
+      create-ecdh: 4.0.4
       create-hash: 1.2.0
       create-hmac: 1.1.7
       diffie-hellman: 5.0.3
@@ -4368,6 +4381,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+  /defined/1.0.0:
+    dev: false
+    resolution:
+      integrity: sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=
   /del/4.1.1:
     dependencies:
       '@types/glob': 7.1.3
@@ -4429,6 +4446,17 @@ packages:
     dev: false
     resolution:
       integrity: sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+  /detective/5.2.0:
+    dependencies:
+      acorn-node: 1.8.2
+      defined: 1.0.0
+      minimist: 1.2.5
+    dev: false
+    engines:
+      node: '>=0.8.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==
   /diff-sequences/24.9.0:
     dev: false
     engines:
@@ -4621,10 +4649,10 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==
-  /electron-to-chromium/1.3.518:
+  /electron-to-chromium/1.3.519:
     dev: false
     resolution:
-      integrity: sha512-IspiwXYDKZMxo+qc3Vof4WtwbG9BMDbJfati8PYj7uS4DJmJ67pwjCKZxlTBSAuCZSMcbRnj2Xz2H14uiKT7bQ==
+      integrity: sha512-2r/p/9YOjIpX10KxcH1HcAGz1oadSD9Cwwotoek8wNJx/SRpklea14qdAMzCTTZlIezvsJ8sNsBQN05bJ/ZjhA==
   /elegant-spinner/1.0.1:
     dev: false
     engines:
@@ -6730,13 +6758,13 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
-  /is-docker/2.1.0:
+  /is-docker/2.1.1:
     dev: false
     engines:
       node: '>=8'
     hasBin: true
     resolution:
-      integrity: sha512-mB2WygGsSeoXtLKpSYzP6sa0Z9DyU9ZyKlnvuZWxCociaI0qsF8u12sR72DFTX236g1u6oWSWYFuUk09nGQEjg==
+      integrity: sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
   /is-dotfile/1.0.3:
     dev: false
     engines:
@@ -7010,7 +7038,7 @@ packages:
       integrity: sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
   /is-wsl/2.2.0:
     dependencies:
-      is-docker: 2.1.0
+      is-docker: 2.1.1
     dev: false
     engines:
       node: '>=8'
@@ -10399,19 +10427,16 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-  /purgecss/1.4.2:
+  /purgecss/2.3.0:
     dependencies:
+      commander: 5.1.0
       glob: 7.1.6
       postcss: 7.0.32
       postcss-selector-parser: 6.0.2
-      yargs: 14.2.3
     dev: false
-    engines:
-      node: '>=4.4.0'
-      npm: '>=5.2.0'
     hasBin: true
     resolution:
-      integrity: sha512-hkOreFTgiyMHMmC2BxzdIw5DuC6kxAbP/gGOGd3MEsF3+5m69rIvUEPaxrnoUtfODTFKe9hcXjGwC6jcjoyhOw==
+      integrity: sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==
   /q/1.5.1:
     dev: false
     engines:
@@ -11892,11 +11917,15 @@ packages:
       node: '>=6.0.0'
     resolution:
       integrity: sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
-  /tailwindcss/1.1.4:
+  /tailwindcss/1.6.2:
     dependencies:
+      '@fullhuman/postcss-purgecss': 2.3.0
       autoprefixer: 9.8.6
+      browserslist: 4.13.0
       bytes: 3.1.0
-      chalk: 2.4.2
+      chalk: 4.1.0
+      color: 3.1.2
+      detective: 5.2.0
       fs-extra: 8.1.0
       lodash: 4.17.19
       node-emoji: 1.10.0
@@ -11908,12 +11937,13 @@ packages:
       postcss-selector-parser: 6.0.2
       pretty-hrtime: 1.0.3
       reduce-css-calc: 2.1.7
+      resolve: 1.17.0
     dev: false
     engines:
       node: '>=8.9.0'
     hasBin: true
     resolution:
-      integrity: sha512-p4AxVa4CKpX7IbNxImwNMGG9MHuLgratOaOE/iGriNd4AsRQRM2xMisoQ3KQHqShunrWuObga7rI7xbNsVoWGA==
+      integrity: sha512-Cpa0kElG8Sg5sJSvTYi2frmIQZq0w37RLNNrYyy/W6HIWKspqSdTfb9tIN6X1gm4KV5a+TE/n7EKmn5Q9C7EUQ==
   /tapable/1.1.3:
     dev: false
     engines:
@@ -13425,13 +13455,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  /yargs-parser/15.0.1:
-    dependencies:
-      camelcase: 5.3.1
-      decamelize: 1.2.0
-    dev: false
-    resolution:
-      integrity: sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
   /yargs-parser/18.1.3:
     dependencies:
       camelcase: 5.3.1
@@ -13512,22 +13535,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
-  /yargs/14.2.3:
-    dependencies:
-      cliui: 5.0.0
-      decamelize: 1.2.0
-      find-up: 3.0.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      require-main-filename: 2.0.0
-      set-blocking: 2.0.0
-      string-width: 3.1.0
-      which-module: 2.0.0
-      y18n: 4.0.0
-      yargs-parser: 15.0.1
-    dev: false
-    resolution:
-      integrity: sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
   /yargs/15.4.1:
     dependencies:
       cliui: 6.0.0
@@ -13573,8 +13580,7 @@ packages:
       integrity: sha512-jcKpkthap6x63MB4TxwCyuIGkV0oYP/YRyuQU5UO0Yz/E/ZAu+653/uov+phdmO54n6BcvFRyyt0RRrWdN2mpw==
   'file:projects/ramp-core.tgz_777e958c1436af419002454c0780d0b4':
     dependencies:
-      '@fullhuman/postcss-purgecss': 1.3.0
-      '@tailwindcss/custom-forms': 0.2.1_tailwindcss@1.1.4
+      '@tailwindcss/custom-forms': 0.2.1_tailwindcss@1.6.2
       '@types/animejs': 3.1.1
       '@types/clone-deep': 4.0.1
       '@types/debounce': 1.2.0
@@ -13609,7 +13615,7 @@ packages:
       sass: 1.26.10
       sass-loader: 8.0.2_sass@1.26.10+webpack@4.41.3
       screenfull: 5.0.2
-      tailwindcss: 1.1.4
+      tailwindcss: 1.6.2
       tslib: 1.10.0
       typescript: 3.8.3
       vue: 2.6.11
@@ -13629,7 +13635,7 @@ packages:
       webpack: '*'
       webpack-cli: '*'
     resolution:
-      integrity: sha512-U1gP1eRgbvrYts2KWS9TzT9NCrchB0rN4r/AnimSoQD5POqLZkwG+wnSru72zygoZSqpLpGJsGgiAXbhwtt7gA==
+      integrity: sha512-0nEnUJk0t5U3t5IarQWCydHpvQzifeaUHp836sZGOR4q0Oh6yqLoKr2M5daLFhFZQWo4YQY35ZaoeMCLk/KsTQ==
       tarball: 'file:projects/ramp-core.tgz'
     version: 0.0.0
   'file:projects/ramp-geoapi.tgz':
@@ -13709,7 +13715,6 @@ specifiers:
   '@babel/plugin-proposal-object-rest-spread': ^7.4.0
   '@babel/preset-env': ^7.4.1
   '@babel/preset-typescript': ^7.3.3
-  '@fullhuman/postcss-purgecss': ~1.3.0
   '@rush-temp/ramp-core': 'file:./projects/ramp-core.tgz'
   '@rush-temp/ramp-geoapi': 'file:./projects/ramp-geoapi.tgz'
   '@rush-temp/ramp-locale-loader': 'file:./projects/ramp-locale-loader.tgz'
@@ -13760,7 +13765,7 @@ specifiers:
   screenfull: ~5.0.2
   source-map-loader: 0.2.3
   svg.js: 2.7.1
-  tailwindcss: ~1.1.4
+  tailwindcss: ^1.1.4
   terraformer: 1.0.9
   terraformer-arcgis-parser: 1.1.0
   ts-jest: ^23.10.3

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -34,7 +34,6 @@
         "vuex-pathify": "~1.4.1"
     },
     "devDependencies": {
-        "@fullhuman/postcss-purgecss": "~1.3.0",
         "@tailwindcss/custom-forms": "^0.2.1",
         "@types/animejs": "~3.1.0",
         "@types/clone-deep": "~4.0.1",
@@ -60,7 +59,7 @@
         "prettier": "^1.19.1",
         "sass": "^1.23.7",
         "sass-loader": "^8.0.0",
-        "tailwindcss": "~1.1.4",
+        "tailwindcss": "^1.1.4",
         "tslib": "~1.10.0",
         "typescript": "~3.8.3",
         "vue-template-compiler": "^2.6.10",

--- a/packages/ramp-core/postcss.config.js
+++ b/packages/ramp-core/postcss.config.js
@@ -1,21 +1,8 @@
-// purgecss stuff is from https://tailwindcss.com/docs/controlling-file-size
-const purgecss = require('@fullhuman/postcss-purgecss')({
-    // Paths to all of the template files in your project
-    content: ['./src/**/*.html', './src/**/*.vue', './node_modules/ag-grid-community/dist/styles/ag-grid.css', './node_modules/ag-grid-community/dist/styles/ag-theme-material.css'],
-
-    whitelist: ['xs', 'sm', 'md', 'lg'], // whitelist ramp shell size classes so they are not purged
-
-    // Include any special characters you're using in this regular expression
-    defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
-});
-
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
         // needed to scope tailwind styles
-        require('postcss-nested'),
-        // needed to cut down on css file size, tailwind is very large without any trimming
-        ...(process.env.NODE_ENV === 'production' ? [purgecss] : [])
+        require('postcss-nested')
     ]
 };

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -1,10 +1,10 @@
 <template>
-    <div class="appbar absolute top-0 left-0 flex flex-col items-stretch bg-black-75 h-full w-40 sm:w-64 pointer-events-auto" v-focus-list>
+    <div class="absolute top-0 left-0 flex flex-col items-stretch w-40 h-full pointer-events-auto appbar bg-black-75 sm:w-64" v-focus-list>
         <component
             v-for="(item, index) in items"
             :is="item.componentId"
             :key="`${item}-${index}`"
-            class="h-24 my-4 first:mt-8 text-gray-400 hover:text-white focus:outline-none"
+            class="my-4 text-gray-400 first:mt-8 hover:text-white focus:outline-none"
             :class="{ 'py-12': item.id !== 'divider' }"
             :focus-item="item.id !== 'divider'"
             :options="item.options"

--- a/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
@@ -1,6 +1,6 @@
 <template>
     <button class="py-6" @click="togglePanel()">
-        ⛄
+        <span class="block h-24">⛄</span>
     </button>
 </template>
 <script lang="ts">

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -8,6 +8,21 @@ for (i = 0; i < 1000; i++) {
 }
 
 module.exports = {
+    purge: {
+        // Paths to all of the template files in your project
+        content: [
+            './src/**/*.html',
+            './src/**/*.vue',
+            './node_modules/ag-grid-community/dist/styles/ag-grid.css',
+            './node_modules/ag-grid-community/dist/styles/ag-theme-material.css'
+        ],
+
+        // These options are passed through directly to PurgeCSS
+        options: {
+            // whitelist ramp shell size classes so they are not purged
+            whitelist: ['xs', 'sm', 'md', 'lg']
+        }
+    },
     theme: {
         // remove all breakpoints because ramp components will depend on the shell size, not the size of the window/page
         screens: {


### PR DESCRIPTION
Bumps TailwindCSS version beyond 1.1.4.

TailwindCSS made purge the built-in option, so it's not necessary to call it separately in the PostCSS config anymore (which was what probably messed with styles before). https://tailwindcss.com/docs/controlling-file-size/#removing-unused-css

Also removes an unnecessary class from the appbar components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/119)
<!-- Reviewable:end -->
