### PR TITLE
More legend setup - wrapper definitions + bindings 

### DIFF
--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -144,22 +144,22 @@
                                             exclusiveVisibility: [
                                                 {
                                                     layerId: "CleanAir",
-                                                    name: "Clean Air"
+                                                    name: "Clean Air in Set"
                                                 },
                                                 {
                                                     name: "Group in Set",
                                                     children: [
                                                         {
                                                             layerId: "CleanAir",
-                                                            name: "Clean Air"
+                                                            name: "Clean Air in Nested Group"
                                                         },
                                                         {
                                                             layerId: "WaterQuantity",
-                                                            name: "Water Quantity"
+                                                            name: "Water Quantity in Nested Group"
                                                         }
                                                     ]
                                                 }
-                                            ]       
+                                            ]
                                         }
                                     ]
                                 }

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -140,8 +140,26 @@
                                             name: "Water Quantity"
                                         },
                                         {
-                                            layerId: "CleanAir",
-                                            name: "Clean Air"
+                                            name: "Visibility Set",
+                                            exclusiveVisibility: [
+                                                {
+                                                    layerId: "CleanAir",
+                                                    name: "Clean Air"
+                                                },
+                                                {
+                                                    name: "Group in Set",
+                                                    children: [
+                                                        {
+                                                            layerId: "CleanAir",
+                                                            name: "Clean Air"
+                                                        },
+                                                        {
+                                                            layerId: "WaterQuantity",
+                                                            name: "Water Quantity"
+                                                        }
+                                                    ]
+                                                }
+                                            ]       
                                         }
                                     ]
                                 }

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -1,9 +1,23 @@
-import LegendAppbarButtonV from './appbar-button.vue';
-import { FixtureInstance } from '@/api';
+import { LegendAPI } from './api/legend';
+import { legend } from './store/index';
 
-class LegendFixture extends FixtureInstance {
+import messages from './lang/lang.csv';
+
+class LegendFixture extends LegendAPI {
     added() {
-        this.$iApi.component('legend-appbar-button', LegendAppbarButtonV);
+        // TODO: register legend panel, appbar buttons, etc. once Vue components complete
+        this.$vApp.$store.registerModule('legend', legend());
+
+        // parse legend section of config and store information in legend store
+        this._parseConfig(this.config);
+        this.$vApp.$watch(
+            () => this.config,
+            value => this._parseConfig(value)
+        );
+    }
+
+    removed() {
+        this.$vApp.$store.unregisterModule('legend');
     }
 }
 

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -1,11 +1,13 @@
 import { LegendAPI } from './api/legend';
 import { legend } from './store/index';
+import LegendAppbarButtonV from './appbar-button.vue';
 
 import messages from './lang/lang.csv';
 
 class LegendFixture extends LegendAPI {
     added() {
-        // TODO: register legend panel, appbar buttons, etc. once Vue components complete
+        // TODO: register legend panel
+        this.$iApi.component('legend-appbar-button', LegendAppbarButtonV);
         this.$vApp.$store.registerModule('legend', legend());
 
         // parse legend section of config and store information in legend store

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -1,0 +1,1 @@
+key,enValue,enValid,frValue,frValid

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -2,7 +2,7 @@ import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 import TreeNode from 'ramp-geoapi/dist/layer/TreeNode';
 
 /**
- * Function definitions for legend item wrapper objects
+ * Function definitions for legend item wrapper objects.
  */
 export class LegendItem {
     _id: string;
@@ -11,12 +11,7 @@ export class LegendItem {
     _controls: Array<string>;
     _parent: LegendItem | undefined = undefined; // (mainly would be useful to deal with visibility sets)
 
-    _uid: string;
-    _layerTree: TreeNode | undefined;
-
     _hidden: boolean;
-    _opacity: number;
-    _visibility: boolean;
     _itemConfig: any;
 
     /**
@@ -24,101 +19,49 @@ export class LegendItem {
      */
     constructor(legendItem: any) {
         this._id = legendItem.layerId;
-        this._uid = legendItem.uid;
         this._name = legendItem.name !== undefined ? legendItem.name : '';
         this._type = legendItem.type !== undefined ? legendItem.type : LegendTypes.Entry;
         this._controls =
             legendItem.controls !== undefined
                 ? legendItem.controls
                 : [
-                      Controls.Opacity,
                       Controls.Visibility,
-                      Controls.Boundingbox,
-                      Controls.Query,
-                      Controls.Metadata,
                       Controls.BoundaryZoom,
+                      Controls.Metadata,
                       Controls.Refresh,
                       Controls.Reload,
                       Controls.Remove,
+                      Controls.Datatable,
                       Controls.Settings
                   ];
-        this._opacity = legendItem.opacity !== undefined ? legendItem.opacity : 1;
-        this._visibility = legendItem.visibility !== undefined ? legendItem.visibility : true;
         this._hidden = legendItem.hidden !== undefined ? legendItem.hidden : false;
-        this._layerTree = legendItem.layerTree;
         this._itemConfig = legendItem;
     }
 
-    /** Returns the item's id */
+    /** Returns the item's id. */
     get id(): string {
         return this._id;
     }
 
-    /** Returns the item's name */
+    /** Returns the item's name. */
     get name(): string {
         return this._name;
     }
 
-    /** Returns the item's type */
+    /** Returns the item's type. */
     get type(): string {
         return this._type;
     }
 
-    /** Returns if item is hidden */
+    /** Returns if item is hidden. */
     get hidden(): boolean {
         return this._hidden;
     }
 
-    /** Returns item's parent */
+    /** Returns item's parent - not yet initialized. */
     get parent(): LegendItem | undefined {
         return this._parent;
     }
-
-    /**
-     * Returns the opacity of the LegendItem.
-     * @return {number | undefined} - ranges from 0 (hidden) to 1 (fully visible). undefined if "opacity" is not
-     * part of `LegendItem's` `_Controls`.
-     */
-    get opacity(): number | undefined {
-        return this._opacity;
-    }
-
-    /**
-     * Sets the opacity value for the LegendItem
-     * @param opacity - ranges from 0 (hidden) to 1 (fully visible); `undefined` has no effect.
-     */
-    set opacity(opacity: number | undefined) {
-        if (typeof opacity !== 'undefined' && this._controls.includes(Controls.Opacity)) {
-            if (this._opacity !== opacity) {
-                this._opacity = opacity;
-                // some event/listener should trigger after opacity value changes
-            }
-        }
-    }
-
-    /**
-     * Gets visibility of the LegendItem
-     * @return {boolean | undefined} - true if the item is currently visible, false if invisible, undefined if "visibility" is not part of controls
-     */
-    get visibility(): boolean | undefined {
-        return this._visibility;
-    }
-
-    /**
-     * Sets visibility of the LegendItem
-     * @param visibility - true if visible, false if invisible. Undefined has no effect.
-     */
-    toggleVisibility(visibility: boolean | undefined = undefined): void {
-        // TODO: need to rework some logic to check if legend entry is apart of a visibility set
-        if (visibility !== undefined && this._controls.includes(Controls.Visibility)) {
-            this._visibility = visibility;
-            // some event/listener should trigger after visibility value toggles
-        } else {
-            this._visibility = !this._visibility;
-        }
-    }
-
-    // TODO: add BaseLayer event listeners to update properties on change
 
     /**
      * Removes element from legend and removes layer if it's the last reference to it.
@@ -139,7 +82,7 @@ export class LegendItem {
     }
 
     /**
-     * Check if a control is available for the legend item
+     * Check if a control is available for the legend item.
      * @param control name of the control
      * @return {boolean} - true if the control is included in legend item's available controls
      */
@@ -149,42 +92,92 @@ export class LegendItem {
 }
 
 /**
- * `LegendEntry` can either be a single legend entry or an info section (no link to layer)
+ * `LegendEntry` can either be a single legend entry or an info section (no link to layer).
  */
 export class LegendEntry extends LegendItem {
     _symbologyExpanded: boolean;
-    // _symbologyStack: any;
+    _uid: string | undefined;
+    _layer: BaseLayer | undefined;
+    _layerTree: TreeNode | undefined;
+    _isLoaded: boolean;
+    _symbologyStack: any;
 
     /**
      * Creates a new single legend entry.
      * @param legendEntry legend entry config snippet
      */
-    constructor(legendEntry: any) {
+    constructor(legendEntry: any, parent: LegendItem | undefined = undefined) {
         super(legendEntry);
         this._type = legendEntry.type !== undefined ? legendEntry.type : LegendTypes.Entry;
         this._symbologyExpanded = legendEntry.symbologyExpanded !== undefined ? legendEntry.symbologyExpanded : false;
+        this._parent = parent;
+
+        // find matching BaseLayer in layer store to the layerId in config
+        this._layer = legendEntry.layers.find((layer: BaseLayer) => layer.id === this._id);
+        this._isLoaded = this._layer !== undefined ? this._layer.isValidState() : true;
+        // initialize more layer properties after layer loads
+        this._waitLayerLoad();
     }
 
-    /** Returns uid associated with BaseLayer */
-    get uid(): string {
+    /**
+     * Waits for layer to load before fetching layer properties - uid, tree structure, and more as needed.
+     */
+    _waitLayerLoad(): void {
+        // wait for layer to finish loading
+        this._layer?.isLayerLoaded().then(() => {
+            // obtain uid and layer tree structure
+            this._uid = this._layer?.uid;
+            this._layerTree = this._layer?.getLayerTree();
+        });
+    }
+
+    /** Returns visibility of layer. */
+    get visibility(): boolean | undefined {
+        return this._layer?.getVisibility();
+    }
+
+    /** Returns uid associated with BaseLayer. */
+    get uid(): string | undefined {
         return this._uid;
+    }
+
+    /** Returns BaseLayer associated with legend entry. */
+    get layer(): BaseLayer | undefined {
+        return this._layer;
+    }
+
+    /** Returns layer tree associated with legend entry. */
+    get layerTree(): TreeNode | undefined {
+        return this._layerTree;
+    }
+
+    /** Returns if layer is done loading. */
+    get isLoaded(): boolean {
+        return this._layer !== undefined ? this._layer.isValidState() : true;
+    }
+
+    /**
+     * Sets visibility of the Legend Entry - needs to verify parent visibility is updated.
+     * @param visibility - true if visible, false if invisible, undefined means toggle visibility
+     */
+    toggleVisibility(visibility: boolean | undefined = undefined): void {
+        // TODO: need to rework some logic to check if legend entry is apart of a visibility set
+        if (visibility !== undefined && this._controls.includes(Controls.Visibility)) {
+            this._layer?.setVisibility(visibility);
+        }
     }
 
     /**
      * Expand/collapses symbology stack.
      */
-    // toggleSymbologyStack(): void {
-    //     if (this.type === LegendTypes.Entry) {
-    //         // TODO: implementation
-    //     }
-    // }
+    // TODO: expand symbology stack implementation
 
     /**
      * Toggles metadata panel to open/close for the LegendItem.
      */
     toggleMetadata(): void {
         if (this._controlAvailable(Controls.Metadata)) {
-            // TODO: toggle metadata panel through API/store call - undecided if this method should reside here
+            // TODO: toggle metadata panel through API/store call
         }
     }
 
@@ -193,7 +186,7 @@ export class LegendEntry extends LegendItem {
      */
     toggleSettings(): void {
         if (this._controlAvailable(Controls.Settings)) {
-            // TODO: toggle settings panel through API/store call - undecided if this method should reside here
+            // TODO: toggle settings panel through API/store call
         }
     }
 
@@ -201,8 +194,8 @@ export class LegendEntry extends LegendItem {
      * Toggles data table panel to open/close for the LegendItem.
      */
     toggleDataTable(): any {
-        if (this._controlAvailable(Controls.Data)) {
-            // TODO: toggle datatable through API using uid - undecided if this method should reside here
+        if (this._controlAvailable(Controls.Datatable)) {
+            // TODO: toggle datatable through API using uid
         }
     }
 }
@@ -213,15 +206,17 @@ export class LegendEntry extends LegendItem {
 export class LegendGroup extends LegendItem {
     _children: Array<LegendEntry | LegendGroup> = [];
     _expanded: boolean;
+    _visibility: boolean;
     _lastVisible: LegendEntry | LegendGroup | undefined;
 
     /**
      * Creates a new LegendGroup and stores all children.
      * @param legendGroup legend group config snippet
      */
-    constructor(legendGroup: any) {
+    constructor(legendGroup: any, parent: LegendItem | undefined = undefined) {
         super(legendGroup);
         this._expanded = legendGroup.expanded !== undefined ? legendGroup.expanded : true;
+        this._visibility = legendGroup.visibility !== undefined ? legendGroup.visibility : true;
         this._type = legendGroup.exclusiveVisibility !== undefined ? LegendTypes.Set : LegendTypes.Group;
 
         // initialize group children properties
@@ -231,54 +226,46 @@ export class LegendGroup extends LegendItem {
     /**
      * Set group properties such as id, visibility and opacity. Called whenever group is created or reloaded.
      * @param legendGroup config snippet for legend group
-     * @ignore
      */
     _initGroupProperties(legendGroup: any): void {
         // initialize objects for all non-hidden group/set children entries
         const children = this._type === LegendTypes.Set ? legendGroup.exclusiveVisibility : legendGroup.children;
-        // console.log("checking children: ", children);
         children
             .filter((entry: any) => !entry.hidden)
             .forEach((entry: any) => {
                 // create new LegendGroup/LegendEntry and push to child array
-                if (entry._type === LegendTypes.Group || entry._type === LegendTypes.Set) {
-                    this._children.push(new LegendGroup(entry));
+                entry.layers = legendGroup.layers;
+                if (entry.exclusiveVisibility !== undefined || entry.children !== undefined) {
+                    this._children.push(new LegendGroup(entry, this));
                 } else {
-                    // obtain all layers and fetch uid
-                    const layers = legendGroup.layers;
-                    const curLayer = layers.find((layer: BaseLayer) => layer.id === this._id);
-                    // wait for layer to finish loading
-                    curLayer?.isLayerLoaded().then(() => {
-                        // obtain uid and layer tree structure
-                        entry.uid = curLayer?.uid;
-                        entry.layerTree = curLayer?.getLayerTree();
-
-                        // create and save new single legend entry
-                        this._children.push(new LegendEntry(entry));
-                    });
+                    this._children.push(new LegendEntry(entry, this));
                 }
             });
-
-        this._children.forEach(child => {
-            // TODO: need to setup events to watch for visibility and opacity (+ other key layer properties) changes here?
-        });
     }
 
-    /** Returns children of the group. Children can be either legend groups (nested) or single legend entries. */
+    /** Returns children of the group, which can be either legend groups (nested) or single legend entries. */
     get children(): Array<LegendGroup | LegendEntry> {
         return this._children;
     }
 
     /**
-     * Gets expanded value of the LegendGroup
-     * @return {boolean | undefined} - true if the group is expanded, false if the group is collapsed
+     * Gets visibility of the Legend Group.
+     * @return {boolean | undefined} - true if the item is currently visible, false if invisible, undefined if "visibility" is not part of controls
+     */
+    get visibility(): boolean | undefined {
+        return this._visibility;
+    }
+
+    /**
+     * Gets expanded value of the LegendGroup.
+     * @return {boolean | undefined} - true if the group isexpanded, false if the group is collapsed
      */
     get expanded(): boolean | undefined {
         return this._expanded;
     }
 
     /**
-     * Toggles group to reveal/hide children
+     * Toggles/collapses legend group.
      * @param expanded true if group should be expanded, false if group should be collapsed, or undefined if group should just be toggled
      */
     toggleExpanded(expanded: boolean | undefined = undefined): void {
@@ -286,10 +273,11 @@ export class LegendGroup extends LegendItem {
     }
 
     /**
-     * Toggles group to reveal/hide children
+     * Toggles group visibility to show/hide children.
      * @param visible true if group should have visibility toggled on, false if group visibility should be toggled off, or undefined if group visibility should be toggled
      */
     toggleVisibility(visible: boolean | undefined = undefined): void {
+        // TODO: verify parent visibility b/c there can be complex nested groups or even sets
         const oldVal = this._visibility;
         visible !== undefined ? (this._visibility = visible) : (this._visibility = !this._visibility);
         // check if visibility value changes
@@ -306,7 +294,7 @@ export class LegendGroup extends LegendItem {
             // otherwise ensure that there is only one child entry visible in a set
             if (this._visibility) {
                 // if there is already a child with visibility toggled on, do nothing
-                if (!this._children.some((entry: LegendItem) => entry.visibility === this._visibility)) {
+                if (!this._children.some((entry: LegendItem) => entry instanceof LegendEntry && entry.visibility === this._visibility)) {
                     // otherwise toggle the last visible child on or by default the first child entry in the set
                     this._lastVisible !== undefined
                         ? this._lastVisible.toggleVisibility(this._visibility)
@@ -314,19 +302,14 @@ export class LegendGroup extends LegendItem {
                 }
             } else {
                 // turn off visibility for all child entries and save/update the last legend entry
-                this._children.forEach((entry: LegendEntry | LegendGroup) => {
-                    if (entry.visibility) {
+                this._children.forEach((entry: LegendItem) => {
+                    if (entry instanceof LegendEntry && entry.visibility) {
                         entry.toggleVisibility(this._visibility);
                         this._lastVisible = entry;
                     }
                 });
             }
         }
-    }
-
-    /** Get a child LegendEntry or LegendGroup by uid */
-    getById(id: string): any {
-        return this._layerTree?.findChildByUid(id);
     }
 }
 
@@ -341,14 +324,13 @@ enum Controls {
     Opacity = 'opacity',
     Visibility = 'visibility',
     Boundingbox = 'boundingBox',
-    Query = 'query',
-    Snapshot = 'snapshot',
-    Metadata = 'metadata',
     BoundaryZoom = 'boundaryZoom',
+    Query = 'query',
+    Metadata = 'metadata',
     Refresh = 'refresh',
     Reload = 'reload',
     Remove = 'remove',
     Settings = 'settings',
-    Data = 'data',
+    Datatable = 'datatable',
     Symbology = 'symbology'
 }

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -1,0 +1,338 @@
+import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
+import TreeNode from 'ramp-geoapi/dist/layer/TreeNode';
+
+/**
+ * Function definitions for legend item wrapper objects
+ */
+export class LegendItem {
+    _id: string;
+    _name: string;
+    _type: 'LegendEntry' | 'LegendGroup' | 'VisibilitySet' | 'InfoSection';
+    _controls: Array<string>;
+    _parent: LegendItem | undefined = undefined; // (mainly would be useful to deal with visibility sets)
+
+    _uid: string;
+    _layer: BaseLayer | undefined;
+    _layerTree: TreeNode | undefined;
+
+    _hidden: boolean;
+    _opacity: number;
+    _visibility: boolean;
+    _itemConfig: any;
+
+    /**
+     * Create a new legend item with defaulting for all properties given config snippet, id is required.
+     */
+    constructor(legendItem: any) {
+        this._id = legendItem.layerId;
+        this._uid = legendItem.uid;
+        this._name = legendItem.name !== undefined ? legendItem.name : '';
+        this._type = legendItem.type !== undefined ? legendItem.type : 'LegendEntry';
+        this._controls =
+            legendItem.controls !== undefined
+                ? legendItem.controls
+                : [
+                      Controls.Opacity,
+                      Controls.Visibility,
+                      Controls.Boundingbox,
+                      Controls.Query,
+                      Controls.Metadata,
+                      Controls.BoundaryZoom,
+                      Controls.Refresh,
+                      Controls.Reload,
+                      Controls.Remove,
+                      Controls.Settings
+                  ];
+        this._opacity = legendItem.opacity !== undefined ? legendItem.opacity : 1;
+        this._visibility = legendItem.visibility !== undefined ? legendItem.visibility : true;
+        this._hidden = legendItem.hidden !== undefined ? legendItem.hidden : false;
+        this._layer = legendItem.layer;
+        this._layerTree = legendItem.layerTree;
+        this._itemConfig = legendItem;
+    }
+
+    /** Returns the item's id */
+    get id(): string {
+        return this._id;
+    }
+
+    /** Returns the item's name */
+    get name(): string {
+        return this._name;
+    }
+
+    /** Returns the item's type */
+    get type(): string {
+        return this._type;
+    }
+
+    /** Returns if item is hidden */
+    get hidden(): boolean {
+        return this._hidden;
+    }
+
+    /**
+     * Gets visibility of the LegendItem
+     * @return {boolean | undefined} - true if the item is currently visible, false if invisible, undefined if "visibility" is not part of controls
+     */
+    get visibility(): boolean | undefined {
+        return this._visibility;
+    }
+
+    /**
+     * Returns the opacity of the LegendItem.
+     * @return {number | undefined} - ranges from 0 (hidden) to 1 (fully visible). undefined if "opacity" is not
+     * part of `LegendItem's` `_Controls`.
+     */
+    get opacity(): number | undefined {
+        return this._opacity;
+    }
+
+    /**
+     * Sets the opacity value for the LegendItem
+     * @param opacity - ranges from 0 (hidden) to 1 (fully visible); `undefined` has no effect.
+     */
+    set opacity(opacity: number | undefined) {
+        if (typeof opacity !== 'undefined' && this._controls.includes(Controls.Opacity)) {
+            if (this._opacity !== opacity) {
+                this._opacity = opacity;
+                // some event/listener should trigger after opacity value changes
+            }
+        }
+    }
+
+    /**
+     * Removes element from legend and removes layer if it's the last reference to it.
+     */
+    remove(): void {
+        if (this._controls.includes(Controls.Remove) || this.type === LegendTypes.Info) {
+            // TODO: implementation
+        }
+    }
+
+    /**
+     * Reloads element in legend.
+     */
+    reload(): void {
+        if (this._controls.includes(Controls.Reload)) {
+            // TODO: implementation
+        }
+    }
+
+    /**
+     * Check if a control is available for the legend item
+     * @param control name of the control
+     * @return {boolean} - true if the control is included in legend item's available controls
+     */
+    _controlAvailable(control: Controls): boolean {
+        return this._controls.includes(control);
+    }
+}
+
+/**
+ * `LegendEntry` can either be a single legend entry or an info section (no link to layer)
+ */
+export class LegendEntry extends LegendItem {
+    _symbologyExpanded: boolean;
+    // _symbologyStack: any;
+
+    /**
+     * Creates a new single legend entry.
+     * @param legendEntry legend entry config snippet
+     */
+    constructor(legendEntry: any) {
+        super(legendEntry);
+        this._type = legendEntry.type !== undefined ? legendEntry.type : 'LegendEntry';
+        this._symbologyExpanded = legendEntry.symbologyExpanded !== undefined ? legendEntry.symbologyExpanded : false;
+    }
+
+    /** Returns uid associated with BaseLayer */
+    get uid(): string {
+        return this._uid;
+    }
+
+    /** Returns BaseLayer associated to legend entry */
+    get layer(): BaseLayer | undefined {
+        return this._layer;
+    }
+
+    /**
+     * Sets visibility of the LegendItem
+     * @param visibility - true if visible, false if invisible. Undefined has no effect.
+     */
+    toggleVisibility(visibility: boolean | undefined = undefined): void {
+        // TODO: need to rework some logic to check if legend entry is apart of a visibility set
+        if (visibility !== undefined && this._controls.includes(Controls.Visibility)) {
+            this._visibility = visibility;
+            // some event/listener should trigger after visibility value toggles
+        } else {
+            this._visibility = !this._visibility;
+        }
+    }
+
+    /**
+     * Expand/collapses symbology stack.
+     */
+    // toggleSymbologyStack(): void {
+    //     if (this.type === LegendTypes.Entry) {
+    //         // TODO: implementation
+    //     }
+    // }
+
+    /**
+     * Toggles metadata panel to open/close for the LegendItem.
+     */
+    toggleMetadata(): void {
+        if (this._controlAvailable(Controls.Metadata)) {
+            // TODO: toggle metadata panel through API/store call
+        }
+    }
+
+    /**
+     * Toggles settings panel to open/close type for the LegendItem.
+     */
+    toggleSettings(): void {
+        if (this._controlAvailable(Controls.Settings)) {
+            // TODO: toggle settings panel through API/store call
+        }
+    }
+
+    /**
+     * Toggles data table panel to open/close for the LegendItem.
+     */
+    toggleDataTable(): any {
+        if (this._controlAvailable(Controls.Data)) {
+            // TODO: toggle datatable through API using uid
+        }
+    }
+}
+
+/**
+ * Create a legend group (which can also be visibility sets) which can contain children - providing nesting capability for Legends.
+ */
+export class LegendGroup extends LegendItem {
+    _children: Array<LegendEntry | LegendGroup> = [];
+    _expanded: boolean;
+    // _isSet: boolean;
+    _lastVisible: LegendEntry | LegendGroup | undefined;
+
+    /**
+     * Creates a new LegendGroup and stores all children.
+     * @param legendGroup legend group config snippet
+     */
+    constructor(legendGroup: any) {
+        super(legendGroup);
+        this._expanded = legendGroup.expanded !== undefined ? legendGroup.expanded : true;
+        this._type = legendGroup.exclusiveVisibility !== undefined ? 'VisibilitySet' : 'LegendGroup';
+        // this._isSet = this._type === 'VisibilitySet' ? true : false;
+
+        // initialize group children properties
+        this._initGroupProperties(legendGroup);
+    }
+
+    /**
+     * Set group properties such as id, visibility and opacity. Called whenever group is created or reloaded.
+     * @param legendGroup config snippet for legend group
+     * @ignore
+     */
+    _initGroupProperties(legendGroup: any): void {
+        // initialize objects for all non-hidden group children entries
+        legendGroup.children
+            .filter((entry: any) => !entry.hidden)
+            .forEach((entry: any) => {
+                // create new LegendGroup/LegendEntry/VisibilitySet and push to child array
+                if (entry.exclusiveVisibility !== undefined)
+                    if (entry._type === LegendTypes.Group || entry._type === LegendTypes.Set) {
+                        this._children.push(new LegendGroup(entry));
+                    } else {
+                        this._children.push(new LegendEntry(entry));
+                    }
+            });
+
+        this._children.forEach(child => {
+            // TODO: setup events to watch for visibility and opacity (+ other key layer properties) changes here?
+        });
+    }
+
+    /** Returns the children for the group (if any). Children can be either LegendGroups (if nested groups) or LegendEntrys. */
+    get children(): Array<LegendGroup | LegendEntry> {
+        return this._children;
+    }
+
+    /**
+     * Gets expanded value of the LegendGroup
+     * @return {boolean | undefined} - true if the group is expanded, false if the group is collapsed
+     */
+    get expanded(): boolean | undefined {
+        return this._expanded;
+    }
+
+    /**
+     * Toggles group to reveal/hide children
+     * @param expanded true if group should be expanded, false if group should be collapsed, or undefined if group should just be toggled
+     */
+    toggleExpanded(expanded: boolean | undefined = undefined): void {
+        expanded !== undefined ? (this._expanded = expanded) : (this._expanded = !this._expanded);
+    }
+
+    /**
+     * Toggles group to reveal/hide children
+     * @param visible true if group should have visibility toggled on, false if group visibility should be toggled off, or undefined if group visibility should be toggled
+     */
+    toggleVisibility(visible: boolean | undefined = undefined): void {
+        const oldVal = this._visibility;
+        visible !== undefined ? (this._visibility = visible) : (this._visibility = !this._visibility);
+        if (this._type === LegendTypes.Group) {
+            this._children.forEach((entry: any) => {
+                entry.toggleVisibility(visible);
+            });
+        } else {
+            // otherwise ensure that there is only one child entry visible in a set
+            if (this._visibility) {
+                // if there is already a child with visibility toggled on, do nothing
+                if (!this._children.some((entry: LegendItem) => entry.visibility === this._visibility)) {
+                    // otherwise toggle the last visible child on or by default the first child entry in the set
+                    this._lastVisible !== undefined
+                        ? this._lastVisible.toggleVisibility(this._visibility)
+                        : this._children[0].toggleVisibility(this._visibility);
+                }
+            } else {
+                // turn off visibility for all child entries and save/update the last legend entry
+                this._children.forEach((entry: LegendEntry | LegendGroup) => {
+                    if (entry.visibility) {
+                        entry.toggleVisibility(this._visibility);
+                        this._lastVisible = entry;
+                    }
+                })
+            }
+        }
+    }
+
+    /** Get a child LegendEntry or LegendGroup by uid */
+    getById(id: string): any {
+        return this._layerTree?.findChildByUid(id);
+    }
+}
+
+enum LegendTypes {
+    Group = 'LegendGroup',
+    Set = 'VisibilitySet',
+    Entry = 'LegendEntry',
+    Info = 'InfoSection'
+}
+
+enum Controls {
+    Opacity = 'opacity',
+    Visibility = 'visibility',
+    Boundingbox = 'boundingBox',
+    Query = 'query',
+    Snapshot = 'snapshot',
+    Metadata = 'metadata',
+    BoundaryZoom = 'boundaryZoom',
+    Refresh = 'refresh',
+    Reload = 'reload',
+    Remove = 'remove',
+    Settings = 'settings',
+    Data = 'data',
+    Symbology = 'symbology'
+}

--- a/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
@@ -1,8 +1,8 @@
-import { LegendItem } from './legend-defs';
+import { LegendEntry, LegendGroup } from './legend-defs';
 
 export class LegendState {
     legendConfig: LegendConfig | undefined = undefined;
-    children: Array<LegendItem> = [];
+    children: Array<LegendEntry | LegendGroup> = [];
 }
 
 export interface LegendConfig {

--- a/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
@@ -1,42 +1,12 @@
-import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
+import { LegendItem } from './legend-defs';
 
 export class LegendState {
     legendConfig: LegendConfig | undefined = undefined;
-    children: Array<LegendElement> = [];
+    children: Array<LegendItem> = [];
 }
 
 export interface LegendConfig {
     isOpen: boolean;
     reorderable: boolean;
-    root: { name: string; children: Array<LegendElement> };
-}
-
-// TODO: following should be ported over from separate legend item object definitions file
-export interface LegendElement {
-    id: string;
-    name: string;
-    type: 'LegendEntry' | 'LegendGroup' | 'VisibilitySet' | 'InfoSection';
-    controls: Array<string>;
-    visibility: boolean;
-    opacity: number;
-    // symbologyExpanded: boolean;
-    children: Array<LegendElement> | [];
-    expanded: boolean | undefined;
-    layer: BaseLayer;
-    parent: LegendElement | undefined;
-}
-
-interface LegendEntry extends LegendElement {
-    children: [];
-    layer: BaseLayer;
-}
-
-interface LegendGroup extends LegendElement {
-    children: Array<LegendEntry | LegendGroup | VisibilitySet>;
-    expanded: boolean;
-}
-
-interface VisibilitySet extends LegendElement {
-    children: Array<LegendElement | LegendGroup>;
-    expanded: boolean;
+    root: { name: string; children: Array<any> };
 }

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -1,23 +1,26 @@
 import { ActionContext, Action } from 'vuex';
 import { make } from 'vuex-pathify';
 
-import { LegendState, LegendConfig, LegendElement } from './legend-state';
+import { LegendState, LegendConfig } from './legend-state';
+import { LegendItem, LegendEntry, LegendGroup } from './legend-defs';
 import { ConfigStore } from '@/store/modules/config';
+import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 import { RootState } from '@/store';
 
 // use for actions
 type LegendContext = ActionContext<LegendState, RootState>;
 
 const getters = {
-    getChildById: (state: LegendState, id: string): LegendElement | undefined => {
-        return state.children.find((entry: LegendElement) => entry.type === 'LegendEntry' && entry.layer.uid === id);
+    getChildById: (state: LegendState, id: string): LegendItem | undefined => {
+        return state.children.find((entry: LegendItem) => entry instanceof LegendEntry && entry.uid === id);
     },
     getAllToggled: (state: LegendState, expanded: boolean): boolean => {
-        return state.children.every(entry => entry.type !== 'LegendGroup' || entry.expanded === expanded);
+        return state.children.every((entry: LegendItem) => !(entry instanceof LegendGroup) || entry.expanded === expanded);
     },
     getAllVisibility: function(state: LegendState, visible: boolean): boolean {
         return state.children.every(
-            entry => entry.visibility === visible || (entry.parent !== undefined && entry.parent.visibility === visible)
+            (entry: LegendItem) =>
+                entry.visibility === visible || (entry.parent instanceof LegendGroup && entry.parent.visibility === visible)
         );
     }
 };
@@ -25,35 +28,67 @@ const getters = {
 const mutations = {};
 
 const actions = {
-    expandGroups: function(this: any, context: LegendContext): void {
-        context.state.children.forEach(entry => {
-            if (entry.type === 'LegendGroup' && !entry.expanded) {
-                // TODO: call function to expand legend group once implemented
+    /** Creates and saves a single legend item */
+    addLegendItem: function(this: any, context: LegendContext, legendItem: any): void {
+        const layers = legendItem.layers;
+        const itemConfig = legendItem.config;
+
+        // (assuming visibility sets and groups will specify in config `exclusiveVisibility` or `children` properties, respectively)
+        if (itemConfig.children !== undefined || itemConfig.exclusiveVisibility !== undefined) {
+            itemConfig.layers = layers;
+            // create a wrapper legend object for group or visibility set
+            const legendObj = new LegendGroup(itemConfig);
+            context.state.children.push(legendObj);
+        } else if (itemConfig.layerId !== undefined && layers !== undefined) {
+            // find matching BaseLayer in layer store to the layerId in config
+            const curLayer = layers.find((layer: BaseLayer) => layer.id === itemConfig.layerId);
+
+            // wait for layer to finish loading
+            curLayer?.isLayerLoaded().then(() => {
+                // obtain uid and layer tree structure
+                itemConfig.uid = curLayer?.uid;
+                itemConfig.layerTree = curLayer?.getLayerTree();
+
+                // create a wrapper legend object for single legend entry
+                const legendObj = new LegendEntry(itemConfig);
+                // save newly created legend object
+                context.state.children.push(legendObj);
+            });
+        }
+    },
+    /** Expand all legend groups */
+    expandGroups: function(context: LegendContext): void {
+        context.state.children.forEach((entry: LegendItem) => {
+            if (entry instanceof LegendGroup && !entry.expanded) {
+                entry.toggleExpanded(true);
             }
         });
     },
-    collapseGroups: function(this: any, context: LegendContext): void {
-        context.state.children.forEach(entry => {
-            if (entry.type === 'LegendGroup' && entry.expanded) {
-                // TODO: call function to collapse legend group once implemented
+    /** Collapse all legend groups */
+    collapseGroups: function(context: LegendContext): void {
+        context.state.children.forEach((entry: LegendItem) => {
+            if (entry instanceof LegendGroup && entry.expanded) {
+                entry.toggleExpanded(false);
             }
         });
     },
-    showAll: function(this: any, context: LegendContext): void {
-        context.state.children.forEach(entry => {
+    /** Turn visibility on for all legend entries */
+    showAll: function(context: LegendContext): void {
+        context.state.children.forEach((entry: LegendItem) => {
             if (!entry.visibility) {
-                // TODO: call function to toggle visibility on for legend entry once implemented
-                // implementations will differ significantly for groups, sets and single entries
+                entry.toggleVisibility(true);
             }
         });
     },
-    hideAll: function(this: any, context: LegendContext): void {
-        context.state.children.forEach(entry => {
+    /** Turn visibility off for all legend entries */
+    hideAll: function(context: LegendContext): void {
+        context.state.children.forEach((entry: LegendItem) => {
             if (entry.visibility) {
-                // TODO: call function to toggle visibility off for legend entry once implemented
+                entry.toggleVisibility(false);
             }
         });
     },
+    /** Update legend section of saved main config */
     updateLegendConfig: function(this: any, context: LegendContext, config: LegendConfig): void {
         this.$vApp.$store.set(ConfigStore.updateConfig, config);
         const newLegendConfig = this.$vApp.$store.get(ConfigStore.getFixtureConfig, 'legend');
@@ -61,84 +96,15 @@ const actions = {
     }
 };
 
-// commented out functions below were initially used if legend entries were stored in config tree structure
-/**
- * Helper function that checks if all entries are visible/not visible.
- *
- * @function checkVisibility
- * @param {LegendElement}   child Current legend item that is being checked
- * @param {boolean}         visible Specifies whether visibility or expand/collapse functionality is to be changed
- */
-// function checkVisibility(child: LegendElement, visible: boolean): boolean {
-//     // traverse tree to check if all legend items have visibility toggled on/off
-//     if (child.children && child.children.length > 0) {
-//         child.children.forEach(ch => {
-//             if (!checkVisibility(ch, visible)) {
-//                 return false;
-//             }
-//         });
-//     }
-//     if (child.type === 'legendEntry' && child.visibility === visible) {
-//         return false;
-//     }
-//     return true;
-// }
-
-/**
- * Helper function that checks if all entries are expanded/collapsed.
- *
- * @function checkExpanded
- * @param {LegendElement} child Current legend item that is being checked
- * @param {Object}        expanded Specifies whether visibility or expand/collapse functionality is to be changed
- */
-// function checkExpanded(child: LegendElement, expanded: boolean): boolean {
-//     // traverse tree to check if all legend groups are expanded/collapsed
-//     if (child.children && child.children.length > 0) {
-//         child.children.forEach(ch => {
-//             if (!checkExpanded(ch, expanded)) {
-//                 return false;
-//             }
-//         });
-//     }
-//     if (child.type === 'legendGroup' && child.expanded === expanded) {
-//         return false;
-//     }
-//     return true;
-// }
-
-/**
- * Helper function that toggles visibility for all entries or expands/collapses all groups.
- *
- * @function toggle
- * @param {LegendElement}   child Current legend item that is being checked
- * @param {Object}          options Specifies whether visibility or expand/collapse functionality is to be changed
- */
-// function toggle(child: LegendElement, options: any) {
-//     const visibility = options.visibility;
-//     const expand = options.expand;
-//     // traverse the tree and make recursive calls
-//     if (child.children && child.children.length > 0) {
-//         child.children.forEach(ch => {
-//             // level order traversal
-//             toggle(ch, options);
-//         });
-//     }
-//     // for current legend child toggle properties if possible, check for appropriate legend element type
-//     if (visibility && child.type === 'legendEntry') {
-//         // TODO: call functions to toggle visibility on/off for legend entry once implemented
-//         // e.g. visibility ? child.toggleVisibility(true) : child.toggleVisibility(false);
-//     }
-//     if (expand && child.type === 'legendGroup') {
-//         // TODO: call functions to expand/collapse group for legend group once implemented
-//         // e.g. expand ? child.expand(true) : child.expand(false);
-//     }
-// }
-
 export enum LegendStore {
     /**
-     * (State) children: Array<LegendElement>
+     * (State) children: Array<LegendItem>
      */
-    children = 'legend/children'
+    children = 'legend/children',
+    /**
+     * (Action) addLegendItem: (itemConfig: any)
+     */
+    addLegendItem = 'legend/addLegendItem!'
 }
 
 export function legend() {

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -1,10 +1,8 @@
 import { ActionContext, Action } from 'vuex';
 import { make } from 'vuex-pathify';
 
-import { LegendState, LegendConfig } from './legend-state';
+import { LegendState } from './legend-state';
 import { LegendItem, LegendEntry, LegendGroup } from './legend-defs';
-import { ConfigStore } from '@/store/modules/config';
-import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 import { RootState } from '@/store';
 
 // use for actions
@@ -19,7 +17,7 @@ const getters = {
     },
     getAllVisibility: function(state: LegendState, visible: boolean): boolean {
         return state.children.every(
-            (entry: LegendItem) =>
+            (entry: LegendEntry | LegendGroup) =>
                 entry.visibility === visible || (entry.parent instanceof LegendGroup && entry.parent.visibility === visible)
         );
     }
@@ -28,34 +26,6 @@ const getters = {
 const mutations = {};
 
 const actions = {
-    /** Creates and saves a single legend item */
-    addLegendItem: function(this: any, context: LegendContext, legendItem: any): void {
-        const layers = legendItem.layers;
-        const itemConfig = legendItem.config;
-
-        // (assuming visibility sets and groups will specify in config `exclusiveVisibility` or `children` properties, respectively)
-        if (itemConfig.children !== undefined || itemConfig.exclusiveVisibility !== undefined) {
-            itemConfig.layers = layers;
-            // create a wrapper legend object for group or visibility set
-            const legendObj = new LegendGroup(itemConfig);
-            context.state.children.push(legendObj);
-        } else if (itemConfig.layerId !== undefined && layers !== undefined) {
-            // find matching BaseLayer in layer store to the layerId in config
-            const curLayer = layers.find((layer: BaseLayer) => layer.id === itemConfig.layerId);
-
-            // wait for layer to finish loading
-            curLayer?.isLayerLoaded().then(() => {
-                // obtain uid and layer tree structure
-                itemConfig.uid = curLayer?.uid;
-                itemConfig.layerTree = curLayer?.getLayerTree();
-
-                // create a wrapper legend object for single legend entry
-                const legendObj = new LegendEntry(itemConfig);
-                // save newly created legend object
-                context.state.children.push(legendObj);
-            });
-        }
-    },
     /** Expand all legend groups */
     expandGroups: function(context: LegendContext): void {
         context.state.children.forEach((entry: LegendItem) => {
@@ -74,7 +44,7 @@ const actions = {
     },
     /** Turn visibility on for all legend entries */
     showAll: function(context: LegendContext): void {
-        context.state.children.forEach((entry: LegendItem) => {
+        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
             if (!entry.visibility) {
                 entry.toggleVisibility(true);
             }
@@ -82,17 +52,11 @@ const actions = {
     },
     /** Turn visibility off for all legend entries */
     hideAll: function(context: LegendContext): void {
-        context.state.children.forEach((entry: LegendItem) => {
+        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
             if (entry.visibility) {
                 entry.toggleVisibility(false);
             }
         });
-    },
-    /** Update legend section of saved main config */
-    updateLegendConfig: function(this: any, context: LegendContext, config: LegendConfig): void {
-        this.$vApp.$store.set(ConfigStore.updateConfig, config);
-        const newLegendConfig = this.$vApp.$store.get(ConfigStore.getFixtureConfig, 'legend');
-        context.commit('SET_LEGEND_CONFIG', newLegendConfig);
     }
 };
 
@@ -100,11 +64,7 @@ export enum LegendStore {
     /**
      * (State) children: Array<LegendItem>
      */
-    children = 'legend/children',
-    /**
-     * (Action) addLegendItem: (itemConfig: any)
-     */
-    addLegendItem = 'legend/addLegendItem!'
+    children = 'legend/children'
 }
 
 export function legend() {


### PR DESCRIPTION
Wrote the legend item class definitions and created these objects inside `parseConfig` when extracting info from config file. In the init method for each single entry object (that correspond to a defined layer), additional layer properties (e.g. `uid`, `layerTree`) will be extracted after layer successfully loads. Most of the other object properties are based off the doc.

Did some brief testing on a config with a single entry + visibility set with a nested group to cover all basic legend items. Will still need to make some modifications and test these objects in greater depth but wanted to PR first as the main Vue legend component will require this to be complete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/121)
<!-- Reviewable:end -->
