### PR TITLE
fix: remove double call to startup function

### DIFF
--- a/packages/ramp-core/host/index.html
+++ b/packages/ramp-core/host/index.html
@@ -30,12 +30,6 @@
 
         <span id="ramp-version"></span>
 
-        <script>
-            function initRAMP() {
-                console.log('RAMP has loaded.');
-            }
-        </script>
-
         <script src="./../dist/ramp-starter.js"></script>
     </body>
 </html>

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -36,12 +36,6 @@
         <span id="ramp-version"></span>
         <!-- built files will be auto injected -->
 
-        <script>
-            function initRAMP() {
-                console.log('RAMP has loaded.');
-            }
-        </script>
-
         <script src="./ramp-starter.js"></script>
     </body>
 </html>

--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -1,5 +1,7 @@
 window.rInstance = null;
 function initRAMP() {
+    console.log('RAMP has loaded.');
+
     document.getElementById('ramp-version').innerText =
         'v.' +
         RAMP.version.major +

--- a/packages/ramp-core/src/main.ts
+++ b/packages/ramp-core/src/main.ts
@@ -12,7 +12,7 @@ export function startup() {
 
     // expose Vue to the global scope so fixtures that use Vue have access to it
     // this is only needed in `serve` mode; in `build`, Vue is explicitly loaded by the host page
-    //TODO: there are issues with how Vue is loading when using Cypress
+    // TODO: there are issues with how Vue is loading when using Cypress
     window.Vue = Vue;
 
     // execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
@@ -22,5 +22,3 @@ export function startup() {
         }
     });
 }
-
-startup();

--- a/packages/ramp-core/vue.config.js
+++ b/packages/ramp-core/vue.config.js
@@ -45,28 +45,30 @@ module.exports = {
             .use('raw-loader')
             .loader('raw-loader');
 
-        // add an automatic callback to execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
-        // this only applies to the production build; dev build calls this function from `main-serve.ts`
-        config.plugin('wrapper-plugin').use(WrapperPlugin, [
-            {
-                test: /RAMP.umd.js/, // only wrap output of bundle files with '.js' extension,
-                footer: "RAMP.gapiPromise.then(function() { if (typeof initRAMP === 'function') { initRAMP(); }});",
-                afterOptimization: true
-            }
-        ]);
-
         // copy over external fixture samples
         config
             .plugin('webpack-copy-plugin')
             .use(CopyPlugin, [[{ from: 'node_modules/ramp-sample-fixtures/dist/', to: 'sample-fixtures' }]]);
 
-        // modify the default injection point from 'body' to 'head', so it's easier to orchestrate the loading order; only when `serve`ing
+        // DEV-specific configuration
         config.when(process.env.NODE_ENV === 'development', config => {
+            // modify the default injection point from 'body' to 'head', so it's easier to orchestrate the loading order; only when `serve`ing
             config.plugin('html').tap(args => [{ ...args[0], inject: 'head' }]);
         });
 
-        // copy `ramp-starter.js` to `dist` folder when building prod build
+        // PROD-specific configuration
         config.when(process.env.NODE_ENV === 'production', config => {
+            // add an automatic callback to execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
+            // this only applies to the production build; dev build calls this function from `main-serve.ts`
+            config.plugin('wrapper-plugin').use(WrapperPlugin, [
+                {
+                    test: /RAMP.umd.js/, // only wrap output of bundle files with '.js' extension,
+                    footer: "RAMP.gapiPromise.then(function() { if (typeof initRAMP === 'function') { initRAMP(); }});",
+                    afterOptimization: true
+                }
+            ]);
+
+            // copy `ramp-starter.js` to `dist` folder when building prod build
             config.plugin('webpack-copy-plugin').tap(args => [[...args[0], { from: 'public/ramp-starter.js', to: '' }]]);
         });
 


### PR DESCRIPTION
The `startup` function was called twice: in `main.ts` directly and `main-serve.ts` after importing `main.ts`. Removed the direct call in `main.ts`.

Also, only call wrapper plugin adding a call to initRamp when building for production just in case.

Closes #123 
Related #128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/176)
<!-- Reviewable:end -->
