### PR TITLE
build: set up custom purge css config

### DIFF
--- a/packages/ramp-core/postcss.config.js
+++ b/packages/ramp-core/postcss.config.js
@@ -1,8 +1,36 @@
+const purgecss = require('@fullhuman/postcss-purgecss')({
+    // Specify the paths to all of the template files in your project
+    content: [
+        './src/**/*.html',
+        './src/**/*.vue',
+        './node_modules/ag-grid-community/dist/styles/ag-grid.css',
+        './node_modules/ag-grid-community/dist/styles/ag-theme-material.css'
+    ],
+
+    whitelist: ['xs', 'sm', 'md', 'lg'],
+
+    // This is the function used to extract class names from your templates
+    defaultExtractor: content => {
+        // Capture as liberally as possible, including things like `h-(screen-1.5)`
+        const broadMatches = content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [];
+
+        // Capture classes within other delimiters like .block(class="w-1/2") in Pug
+        const innerMatches = content.match(/[^<>"'`\s.(){}[\]#=%]*[^<>"'`\s.(){}[\]#=%:]/g) || [];
+
+        return broadMatches.concat(innerMatches);
+    }
+});
+
 module.exports = {
     plugins: [
         require('tailwindcss'),
         require('autoprefixer'),
         // needed to scope tailwind styles
-        require('postcss-nested')
+        require('postcss-nested'),
+
+        // css purge must happen after `postcss-nested`
+        // when using tailwind's built-in purge, it happens immediately after and before `postcss-nested`
+        // and all the nested classes like `.ramp-app.sm .sm:{selector}` will get dropped
+        ...(process.env.NODE_ENV === 'production' ? [purgecss] : [])
     ]
 };

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -1,5 +1,3 @@
-const postcss = require('postcss');
-
 // generate spacing rules, these create width, height, padding, margin, etc. rules
 // will end up with w-0 = 0px, w-1 = 1px, and so on
 spacingConfig = {};
@@ -8,21 +6,7 @@ for (i = 0; i < 1000; i++) {
 }
 
 module.exports = {
-    purge: {
-        // Paths to all of the template files in your project
-        content: [
-            './src/**/*.html',
-            './src/**/*.vue',
-            './node_modules/ag-grid-community/dist/styles/ag-grid.css',
-            './node_modules/ag-grid-community/dist/styles/ag-theme-material.css'
-        ],
-
-        // These options are passed through directly to PurgeCSS
-        options: {
-            // whitelist ramp shell size classes so they are not purged
-            whitelist: ['xs', 'sm', 'md', 'lg']
-        }
-    },
+    purge: false,
     theme: {
         // remove all breakpoints because ramp components will depend on the shell size, not the size of the window/page
         screens: {


### PR DESCRIPTION
After four hours of debugging, it turned out that purge css must run after the `postcss-nested` plugin. Otherwise all our custom class container wrappers like `.ramp-app.sm .sm\:w-64` will be dropped. 

That's why the Tailwind's built-in purge command fails--it runs at the same time as Tailwind itself, before `postcss-nested` is called.

Working prod build: http://ramp4-app.azureedge.net/demo/users/AleksueiR/177-broken-prod-css/host/index.html

Closes #177

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/179)
<!-- Reviewable:end -->
