### PR TITLE
Legend groups/sets functionality 

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -63,6 +63,25 @@ function initRAMP() {
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
                 {
+                    id: 'WaterQuality',
+                    layerType: 'esriMapImage',
+                    url: 'http://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    layerEntries: [
+                        {
+                            index: 5,
+                            state: {
+                                opacity: 1,
+                                visibility: true
+                            }
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
                     id: 'CleanAir',
                     layerType: 'esriFeature',
                     url: 'http://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/9',
@@ -98,10 +117,6 @@ function initRAMP() {
                     root: {
                         children: [
                             {
-                                layerId: 'WaterQuantity',
-                                name: 'Water Quantity'
-                            },
-                            {
                                 name: 'Visibility Set',
                                 exclusiveVisibility: [
                                     {
@@ -112,12 +127,12 @@ function initRAMP() {
                                         name: 'Group in Set',
                                         children: [
                                             {
-                                                layerId: 'CleanAir',
-                                                name: 'Clean Air in Nested Group'
-                                            },
-                                            {
                                                 layerId: 'WaterQuantity',
                                                 name: 'Water Quantity in Nested Group'
+                                            },
+                                            {
+                                                layerId: 'WaterQuality',
+                                                name: 'Water Quality in Nested Group'
                                             }
                                         ]
                                     }

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -40,27 +40,30 @@ export class LegendAPI extends FixtureInstance {
             // pop legend entry in stack and check if it has a corresponding layer
             const lastEntry = stack.pop();
             lastEntry.layers = layers;
-            // this.$vApp.$store.set(LegendStore.addLegendItem, { config: lastEntry, layers: layers });
 
             // (assuming visibility sets and groups will specify in config `exclusiveVisibility` or `children` properties, respectively)
             if (lastEntry.children !== undefined || lastEntry.exclusiveVisibility !== undefined) {
                 // create a wrapper legend object for group or visibility set
-                const legendGroup = new LegendGroup(lastEntry);
+                const legendGroup = new LegendGroup(lastEntry, lastEntry.parent);
                 legendEntries.push(legendGroup);
+
+                if (lastEntry?.children !== undefined && lastEntry.children.length > 0) {
+                    // push all children in current legend node back onto stack (for legend groups)
+                    lastEntry?.children.forEach((groupChild: any) => {
+                        groupChild.parent = legendGroup;
+                        stack.push(groupChild);
+                    });
+                } else {
+                    // push all children in current legend node back onto stack (for visibility sets)
+                    lastEntry?.exclusiveVisibility.forEach((setChild: any) => {
+                        setChild.parent = legendGroup;
+                        stack.push(setChild);
+                    });
+                }
             } else if (lastEntry.layerId !== undefined && layers !== undefined) {
                 // create a wrapper legend object for single legend entry
-                const legendEntry = new LegendEntry(lastEntry);
+                const legendEntry = new LegendEntry(lastEntry, lastEntry.parent);
                 legendEntries.push(legendEntry);
-            }
-
-            // TODO: link parent objects as required for visibility sets
-            // push all children in current legend node back onto stack (for legend groups)
-            if (lastEntry?.children !== undefined && lastEntry.children.length > 0) {
-                lastEntry?.children.forEach((groupChild: any) => stack.push(groupChild));
-            }
-            // push all children in current legend node back onto stack (for visibility sets)
-            if (lastEntry?.exclusiveVisibility !== undefined && lastEntry.exclusiveVisibility.length > 0) {
-                lastEntry?.exclusiveVisibility.forEach((setChild: any) => stack.push(setChild));
             }
         }
 

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -47,19 +47,20 @@ export class LegendAPI extends FixtureInstance {
                 const legendGroup = new LegendGroup(lastEntry, lastEntry.parent);
                 legendEntries.push(legendGroup);
 
-                if (lastEntry?.children !== undefined && lastEntry.children.length > 0) {
-                    // push all children in current legend node back onto stack (for legend groups)
-                    lastEntry?.children.forEach((groupChild: any) => {
-                        groupChild.parent = legendGroup;
-                        stack.push(groupChild);
-                    });
-                } else {
-                    // push all children in current legend node back onto stack (for visibility sets)
-                    lastEntry?.exclusiveVisibility.forEach((setChild: any) => {
-                        setChild.parent = legendGroup;
-                        stack.push(setChild);
-                    });
-                }
+                // NOTE: the below code is if storing nested legend items is necessary, alternative method is to just store top-level legend items and perform traversals, there are pros and cons for each method
+                // if (lastEntry?.children !== undefined && lastEntry.children.length > 0) {
+                //     // push all children in current legend node back onto stack (for legend groups)
+                //     lastEntry?.children.forEach((groupChild: any) => {
+                //         groupChild.parent = legendGroup;
+                //         stack.push(groupChild);
+                //     });
+                // } else {
+                //     // push all children in current legend node back onto stack (for visibility sets)
+                //     lastEntry?.exclusiveVisibility.forEach((setChild: any) => {
+                //         setChild.parent = legendGroup;
+                //         stack.push(setChild);
+                //     });
+                // }
             } else if (lastEntry.layerId !== undefined && layers !== undefined) {
                 // create a wrapper legend object for single legend entry
                 const legendEntry = new LegendEntry(lastEntry, lastEntry.parent);

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -333,6 +333,10 @@ export class LegendGroup extends LegendItem {
             this._lastVisible = toggledChild;
             this._visibility = false;
         }
+        // case for updating nested groups
+        if (this.parent instanceof LegendGroup) {
+            this.parent.checkVisibility(this);
+        }
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -12,14 +12,11 @@ const getters = {
     getChildById: (state: LegendState, id: string): LegendItem | undefined => {
         return state.children.find((entry: LegendItem) => entry instanceof LegendEntry && entry.uid === id);
     },
-    getAllToggled: (state: LegendState, expanded: boolean): boolean => {
-        return state.children.every((entry: LegendItem) => !(entry instanceof LegendGroup) || entry.expanded === expanded);
+    getAllExpanded: (state: LegendState, expanded: boolean): boolean => {
+        return state.children.every((entry: LegendItem) => !(entry instanceof LegendGroup) || checkExpanded(entry, expanded));
     },
     getAllVisibility: function(state: LegendState, visible: boolean): boolean {
-        return state.children.every(
-            (entry: LegendEntry | LegendGroup) =>
-                entry.visibility === visible || (entry.parent instanceof LegendGroup && entry.parent.visibility === visible)
-        );
+        return state.children.every((entry: LegendEntry | LegendGroup) => checkVisibility(entry, visible));
     }
 };
 
@@ -28,35 +25,26 @@ const mutations = {};
 const actions = {
     /** Expand all legend groups */
     expandGroups: function(context: LegendContext): void {
-        context.state.children.forEach((entry: LegendItem) => {
-            if (entry instanceof LegendGroup && !entry.expanded) {
-                entry.toggleExpanded(true);
-            }
+        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
+            toggle(entry, { expand: true });
         });
     },
     /** Collapse all legend groups */
     collapseGroups: function(context: LegendContext): void {
-        context.state.children.forEach((entry: LegendItem) => {
-            if (entry instanceof LegendGroup && entry.expanded) {
-                entry.toggleExpanded(false);
-            }
+        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
+            toggle(entry, { expand: false });
         });
     },
     /** Turn visibility on for all legend entries */
     showAll: function(context: LegendContext): void {
         context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
-            // entry must be toggled on or must be part of a visbiility set and there is another entry in the set toggled on
-            if (!entry.visibility || (entry.parent instanceof LegendGroup && entry.parent.visibility)) {
-                entry.toggleVisibility(true);
-            }
+            toggle(entry, { visibility: true });
         });
     },
     /** Turn visibility off for all legend entries */
     hideAll: function(context: LegendContext): void {
         context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
-            if (entry.visibility) {
-                entry.toggleVisibility(false);
-            }
+            toggle(entry, { visibility: false });
         });
     }
 };
@@ -68,20 +56,23 @@ const actions = {
  * @param {LegendElement}   child Current legend item that is being checked
  * @param {boolean}         visible Specifies whether visibility or expand/collapse functionality is to be changed
  */
-// function checkVisibility(child: LegendElement, visible: boolean): boolean {
-//     // traverse tree to check if all legend items have visibility toggled on/off
-//     if (child.children && child.children.length > 0) {
-//         child.children.forEach(ch => {
-//             if (!checkVisibility(ch, visible)) {
-//                 return false;
-//             }
-//         });
-//     }
-//     if (child.type === 'legendEntry' && child.visibility === visible) {
-//         return false;
-//     }
-//     return true;
-// }
+function checkVisibility(child: LegendEntry | LegendGroup, visible: boolean): boolean {
+    // traverse tree to check if all legend items have visibility toggled on/off
+    if (child.children && child.children.length > 0) {
+        child.children.forEach(ch => {
+            if (!checkVisibility(ch, visible)) {
+                return false;
+            }
+        });
+    }
+    // visibility set edge case: entry must be toggled on or must be part of a visbiility set and there is another entry in the set toggled on
+    if (!child.visibility && !(child.parent instanceof LegendGroup && child.parent.visibility)) {
+        return false;
+    } else if (child.visibility !== visible) {
+        return false;
+    }
+    return true;
+}
 
 /**
  * Helper function that checks if all entries are expanded/collapsed.
@@ -90,20 +81,20 @@ const actions = {
  * @param {LegendElement} child Current legend item that is being checked
  * @param {Object}        expanded Specifies whether visibility or expand/collapse functionality is to be changed
  */
-// function checkExpanded(child: LegendElement, expanded: boolean): boolean {
-//     // traverse tree to check if all legend groups are expanded/collapsed
-//     if (child.children && child.children.length > 0) {
-//         child.children.forEach(ch => {
-//             if (!checkExpanded(ch, expanded)) {
-//                 return false;
-//             }
-//         });
-//     }
-//     if (child.type === 'legendGroup' && child.expanded === expanded) {
-//         return false;
-//     }
-//     return true;
-// }
+function checkExpanded(child: LegendItem, expanded: boolean): boolean {
+    // traverse tree to check if all legend groups are expanded/collapsed
+    if (child.children && child.children.length > 0) {
+        child.children.forEach(ch => {
+            if (!checkExpanded(ch, expanded)) {
+                return false;
+            }
+        });
+    }
+    if (child instanceof LegendGroup && child.expanded === expanded) {
+        return false;
+    }
+    return true;
+}
 
 /**
  * Helper function that toggles visibility for all entries or expands/collapses all groups.
@@ -112,26 +103,24 @@ const actions = {
  * @param {LegendElement}   child Current legend item that is being checked
  * @param {Object}          options Specifies whether visibility or expand/collapse functionality is to be changed
  */
-// function toggle(child: LegendElement, options: any) {
-//     const visibility = options.visibility;
-//     const expand = options.expand;
-//     // traverse the tree and make recursive calls
-//     if (child.children && child.children.length > 0) {
-//         child.children.forEach(ch => {
-//             // level order traversal
-//             toggle(ch, options);
-//         });
-//     }
-//     // for current legend child toggle properties if possible, check for appropriate legend element type
-//     if (visibility && child.type === 'legendEntry') {
-//         // TODO: call functions to toggle visibility on/off for legend entry once implemented
-//         // e.g. visibility ? child.toggleVisibility(true) : child.toggleVisibility(false);
-//     }
-//     if (expand && child.type === 'legendGroup') {
-//         // TODO: call functions to expand/collapse group for legend group once implemented
-//         // e.g. expand ? child.expand(true) : child.expand(false);
-//     }
-// }
+function toggle(child: LegendEntry | LegendGroup, options: any) {
+    const visibility = options.visibility;
+    const expand = options.expand;
+    // traverse the tree and make recursive calls
+    if (child.children && child.children.length > 0) {
+        child.children.forEach(ch => {
+            // level order traversal
+            toggle(ch, options);
+        });
+    }
+    // for current legend child toggle properties if possible, check for appropriate legend element type
+    if (visibility !== undefined) {
+        visibility ? child.toggleVisibility(true) : child.toggleVisibility(false);
+    }
+    if (expand !== undefined && child instanceof LegendGroup) {
+        expand ? child.toggleExpanded(true) : child.toggleExpanded(false);
+    }
+}
 
 export enum LegendStore {
     /**

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -106,6 +106,16 @@ function checkExpanded(child: LegendItem, expanded: boolean): boolean {
 function toggle(child: LegendEntry | LegendGroup, options: any) {
     const visibility = options.visibility;
     const expand = options.expand;
+    // for current legend child toggle properties if possible, check for appropriate legend element type
+    if (visibility !== undefined) {
+        // visibility set edge case
+        if (!(child.parent instanceof LegendGroup && child.parent.visibility === visibility)) {
+            child.toggleVisibility(visibility);
+        }
+    }
+    if (expand !== undefined && child instanceof LegendGroup) {
+        child.toggleExpanded(expand);
+    }
     // traverse the tree and make recursive calls
     if (child.children && child.children.length > 0) {
         child.children.forEach(ch => {
@@ -113,20 +123,29 @@ function toggle(child: LegendEntry | LegendGroup, options: any) {
             toggle(ch, options);
         });
     }
-    // for current legend child toggle properties if possible, check for appropriate legend element type
-    if (visibility !== undefined) {
-        visibility ? child.toggleVisibility(true) : child.toggleVisibility(false);
-    }
-    if (expand !== undefined && child instanceof LegendGroup) {
-        expand ? child.toggleExpanded(true) : child.toggleExpanded(false);
-    }
 }
 
 export enum LegendStore {
     /**
      * (State) children: Array<LegendItem>
      */
-    children = 'legend/children'
+    children = 'legend/children',
+    /**
+     * (Action) expandGroups - expand all possible legend groups
+     */
+    expandGroups = 'legend/expandGroups',
+    /**
+     * (Action) collapseGroups - collapse all legend groups
+     */
+    collapseGroups = 'legend/collapseGroups',
+    /**
+     * (Action) showAll - turn on visibility for all possible legend entries
+     */
+    showAll = 'legend/showAll',
+    /**
+     * (Action) hideAll - turn off visibility for all legend entries
+     */
+    hideAll = 'legend/hideAll'
 }
 
 export function legend() {

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -45,7 +45,8 @@ const actions = {
     /** Turn visibility on for all legend entries */
     showAll: function(context: LegendContext): void {
         context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
-            if (!entry.visibility) {
+            // entry must be toggled on or must be part of a visbiility set and there is another entry in the set toggled on
+            if (!entry.visibility || (entry.parent instanceof LegendGroup && entry.parent.visibility)) {
                 entry.toggleVisibility(true);
             }
         });
@@ -59,6 +60,78 @@ const actions = {
         });
     }
 };
+
+/**
+ * Helper function that checks if all entries are visible/not visible.
+ *
+ * @function checkVisibility
+ * @param {LegendElement}   child Current legend item that is being checked
+ * @param {boolean}         visible Specifies whether visibility or expand/collapse functionality is to be changed
+ */
+// function checkVisibility(child: LegendElement, visible: boolean): boolean {
+//     // traverse tree to check if all legend items have visibility toggled on/off
+//     if (child.children && child.children.length > 0) {
+//         child.children.forEach(ch => {
+//             if (!checkVisibility(ch, visible)) {
+//                 return false;
+//             }
+//         });
+//     }
+//     if (child.type === 'legendEntry' && child.visibility === visible) {
+//         return false;
+//     }
+//     return true;
+// }
+
+/**
+ * Helper function that checks if all entries are expanded/collapsed.
+ *
+ * @function checkExpanded
+ * @param {LegendElement} child Current legend item that is being checked
+ * @param {Object}        expanded Specifies whether visibility or expand/collapse functionality is to be changed
+ */
+// function checkExpanded(child: LegendElement, expanded: boolean): boolean {
+//     // traverse tree to check if all legend groups are expanded/collapsed
+//     if (child.children && child.children.length > 0) {
+//         child.children.forEach(ch => {
+//             if (!checkExpanded(ch, expanded)) {
+//                 return false;
+//             }
+//         });
+//     }
+//     if (child.type === 'legendGroup' && child.expanded === expanded) {
+//         return false;
+//     }
+//     return true;
+// }
+
+/**
+ * Helper function that toggles visibility for all entries or expands/collapses all groups.
+ *
+ * @function toggle
+ * @param {LegendElement}   child Current legend item that is being checked
+ * @param {Object}          options Specifies whether visibility or expand/collapse functionality is to be changed
+ */
+// function toggle(child: LegendElement, options: any) {
+//     const visibility = options.visibility;
+//     const expand = options.expand;
+//     // traverse the tree and make recursive calls
+//     if (child.children && child.children.length > 0) {
+//         child.children.forEach(ch => {
+//             // level order traversal
+//             toggle(ch, options);
+//         });
+//     }
+//     // for current legend child toggle properties if possible, check for appropriate legend element type
+//     if (visibility && child.type === 'legendEntry') {
+//         // TODO: call functions to toggle visibility on/off for legend entry once implemented
+//         // e.g. visibility ? child.toggleVisibility(true) : child.toggleVisibility(false);
+//     }
+//     if (expand && child.type === 'legendGroup') {
+//         // TODO: call functions to expand/collapse group for legend group once implemented
+//         // e.g. expand ? child.expand(true) : child.expand(false);
+//     }
+// }
 
 export enum LegendStore {
     /**


### PR DESCRIPTION
Implement proper visibility toggle functionality and rules for legend groups/sets. Updated legend children to only store top-level elements and rewrote corresponding header functions. Did some testing using basic sample legend UI and layer visibility on map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/211)
<!-- Reviewable:end -->
