### PR TITLE
Align attribute format for file and server layers

### DIFF
--- a/packages/ramp-geoapi/package.json
+++ b/packages/ramp-geoapi/package.json
@@ -16,6 +16,7 @@
     "author": "Good ol James & Jahid, with scaffold from our fine buddy Juri Strumpflohner",
     "license": "ISC",
     "dependencies": {
+        "deepmerge": "~4.2.2",
         "proj4": "2.6.0",
         "svg.js": "2.7.1",
         "terraformer": "1.0.9",

--- a/packages/ramp-geoapi/src/layer/AttribFC.ts
+++ b/packages/ramp-geoapi/src/layer/AttribFC.ts
@@ -12,6 +12,7 @@ import QuickCache from './QuickCache';
 import Filter from './Filter';
 import Extent from '../api/geometry/Extent';
 import { DataFormat } from '../api/apiDefs';
+import deepmerge from 'deepmerge';
 
 export default class AttribFC extends BaseFC {
 
@@ -287,18 +288,20 @@ export default class AttribFC extends BaseFC {
 
                         // assuming there is at least one attribute - empty attribute budnle promises should be rejected, so it never even gets this far
                         // filter out fields where there is no corresponding attribute data
-                        attSet.features[0].attributes.hasOwnProperty(field.name))
+                        attSet.features[0].hasOwnProperty(field.name))
                     .map(field => ({
                         data: field.name, // TODO calling this data is really unintuitive. consider global rename to fieldName, name, attribName, etc.
                         title: field.alias || field.name
                     }));
 
                 // derive the icon for the row
-                // TODO figure out if we want to change the system attributes.
+                // TODO figure out if we want to change the system attributes. making a copy for now with deepmerge.
+                // if we add rv properties to the feature in the attribute set, we may see those fields showing up in details panes, API outputs, etc.
+                // that said, copying means we double the size of attributes in memory.
                 const rows = attSet.features.map(feature => {
-                    const att = feature.attributes;
+                    const att = deepmerge({}, feature);
                     att.rvInteractive = '';
-                    att.rvSymbol = this.renderer.getGraphicIcon(feature.attributes);
+                    att.rvSymbol = this.renderer.getGraphicIcon(feature);
                     return att;
                 });
 
@@ -385,7 +388,7 @@ export default class AttribFC extends BaseFC {
                 // all attributes have been loaded (or is a file and are local). use that store.
                 // since attributes come from a promise, reset the wait promise to the attribute promise
                 const atSet = await this.attLoader.getAttribs();
-                resultFeat.attributes = atSet.features[atSet.oidIndex[objectId]].attributes;
+                resultFeat.attributes = atSet.features[atSet.oidIndex[objectId]];
 
             } else {
                 // we will need to download data from the service

--- a/packages/ramp-geoapi/src/layer/QuickCache.ts
+++ b/packages/ramp-geoapi/src/layer/QuickCache.ts
@@ -1,5 +1,8 @@
 // TODO add proper comments
 
+import { Attributes } from "../api/apiDefs";
+import BaseGeometry from '../api/geometry/BaseGeometry';
+
 // manages the quick-lookup of attributes.
 // i.e. when it makes sense to just download one instead of the entire set
 
@@ -15,7 +18,11 @@ export default class QuickCache {
 
     // TODO if we come up with nice types for attribs or geoms, apply them
 
-    private attribs: {[key: number]: any};
+    private attribs: {[key: number]: Attributes};
+
+    // the "any" type here is funny. for points, its BaseGeometry, for line/poly based, it's an object indexed by scale,
+    // which then containts an object indexed by key (likely oid) and returns BaseGeometry.
+    // will keep as any since it's private and the interfaces are casting to BaseGeometry. otherwise would need type shenannigans.
     private geoms: {[key: number]: any};
 
     readonly isPoint: boolean;
@@ -34,7 +41,7 @@ export default class QuickCache {
         return this.geoms[scale];
     }
 
-    private getGeomStore(scale: number = undefined): {[key: number]: any} {
+    private getGeomStore(scale: number = undefined): {[key: number]: BaseGeometry} {
         // polygon and line layers have to also cache their geometry by scale level, as the
         // geometry can be simplified at smaller scales
 
@@ -48,22 +55,22 @@ export default class QuickCache {
         // throw new Error('LOD must be provided for geometry quickcache on line or polygon layer');
     }
 
-    getAttribs(key: number): any {
+    getAttribs(key: number): Attributes {
         return this.attribs[key];
     }
 
-    setAttribs(key: number, atts: any): void {
+    setAttribs(key: number, atts: Attributes): void {
         this.attribs[key] = atts;
     }
 
-    getGeom(key: number, scale: number = undefined): any {
+    getGeom(key: number, scale: number = undefined): BaseGeometry {
 
         // polygon and line layers have to also cache their geometry by scale level, as the
         // geometry can be simplified at smaller scales
         return this.getGeomStore(scale)[key];
     }
 
-    setGeom(key: number, geom: any, scale: number = undefined): void {
+    setGeom(key: number, geom: BaseGeometry, scale: number = undefined): void {
         const store = this.getGeomStore(scale);
         store[key] = geom;
     }


### PR DESCRIPTION
Donethankses https://github.com/ramp4-pcar4/ramp4-pcar4/issues/226

Fixes a mismatch between file and server attribute results. Server attribute objects had a sub-property `attributes` bundling the goodies, file objects had the values sitting on the root object. Since the `Attributes` type is open ended to support any name, it didn't complain.

Changed the server to put the attributes at the root as well. The type is `Attributes` so doesn't make sense to have a subproperty `attributes` in it.

Cleaned up any references to the subproperty, added some better types to the feature cache module, added an object copy to the table output as I think it probably needs it (am keeping the TODO to revisit later).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/235)
<!-- Reviewable:end -->
