### PR TITLE
fix grid fullscreen

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/table/table.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/table.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-full h-full bg-white">
+    <div class="flex flex-col w-full h-full bg-white">
         <div class="flex items-center">
             <span class="truncate w-full text-sm mb-0">
                 {{
@@ -44,8 +44,7 @@
 
         <!-- main grid component -->
         <ag-grid-vue
-            class="ag-theme-material"
-            style="height: calc(100% - 30px);"
+            class="ag-theme-material flex-grow"
             :gridOptions="gridOptions"
             :columnDefs="columnDefs"
             :rowData="rowData"


### PR DESCRIPTION
Grid becomes full-sized when in fullscreen mode. Uses flexbox to auto-adjust grid height.

fixes #228

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/236)
<!-- Reviewable:end -->
