### PR TITLE
Reduce data size of wfs sample

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -94,7 +94,7 @@ function initRAMP() {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogcWfs',
-                    url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=6000',
+                    url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
                     state: {
                         visibility: true
                     },


### PR DESCRIPTION
This is a prod service that isn't ours, so being respectful and reducing the data draw from 1000 records to < 100. 

There is also a bug I'll be logging shortly that was doing the load twice, so it was 2000 records per page load.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/238)
<!-- Reviewable:end -->
