### PR TITLE
Tooltips, appbar button helper component

### DIFF
--- a/common/docs/app/appbar.md
+++ b/common/docs/app/appbar.md
@@ -68,3 +68,20 @@ And, you guessed it, you can register your own `my-fancy-divider` component and 
     ]
 }
 ```
+
+## Making an appbar button
+
+Most things on the appbar will want a button that has an icon, a tooltip, and does something when clicked. For this you can use the `appbar-button` helper component:
+
+```html
+<template>
+    <appbar-button :onClickFunction="yourFunctionHere">
+        <template #icon>
+            <!-- whatever you want the button to show goes here, it will usually be an svg -->
+        </template>
+        <template #tooltip>
+            <!-- what you want the tooltip to say (don't forget translations!) -->
+        </template>
+    </appbar-button>
+</template>
+```

--- a/common/docs/app/tooltips.md
+++ b/common/docs/app/tooltips.md
@@ -1,0 +1,16 @@
+# Tooltips
+
+The `tooltip` component will show the desired text in a bubble, on hover or on navigation with the keyboard. It is also used as `aria-labelledby` to help with accessibility.
+
+## Use
+
+The component only needs the text you want to show, and optionally a position. By default the position is `top`.
+
+The tooltip should be the next sibling of the button/control/etc.
+
+```html
+<div class="relative">
+    <button>X</button>
+    <tooltip position="bottom">Close</tooltip>
+</div>
+```

--- a/common/docs/app/tooltips.md
+++ b/common/docs/app/tooltips.md
@@ -4,7 +4,7 @@ The `tooltip` component will show the desired text in a bubble, on hover or on n
 
 ## Use
 
-The component only needs the text you want to show, and optionally a position. By default the position is `top`.
+The component only needs the text you want to show, and optionally a position. Position can be `top`, `bottom`, `left` or `right`. By default the position is `top`.
 
 The tooltip should be the next sibling of the button/control/etc.
 

--- a/packages/ramp-core/postcss.config.js
+++ b/packages/ramp-core/postcss.config.js
@@ -8,6 +8,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
     ],
 
     whitelist: ['xs', 'sm', 'md', 'lg'],
+    whitelistPatternsChildren: [/:focus/, /:hover/],
 
     // This is the function used to extract class names from your templates
     defaultExtractor: content => {

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -15,6 +15,9 @@ import { FocusList, FocusItem } from '@/directives/focus-list';
 Vue.directive('focus-list', FocusList);
 Vue.directive('focus-item', FocusItem);
 
+import TooltipV from '@/components/util/tooltip.vue';
+Vue.component('tooltip', TooltipV);
+
 @Component({
     components: {
         Shell

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <button class="text-gray-500 hover:text-black p-8" @click="open = !open">
+        <button class="relative text-gray-500 hover:text-black p-8" @click="open = !open">
             <slot name="header"></slot>
         </button>
         <button

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -8,7 +8,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="bottom">Back</tooltip>
+        <tooltip direction="bottom">{{ $t('panels.controls.back') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -8,7 +8,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="bottom">{{ $t('panels.controls.back') }}</tooltip>
+        <tooltip position="bottom">{{ $t('panels.controls.back') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -1,12 +1,15 @@
 <template>
-    <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
-        <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-16 h-16" viewBox="0 0 16 16">
-            <path
-                d="M20.485784919653916,7.578491965389372h-14.170000000000005l3.5800000000000054,-3.589999999999997l-1.409999999999993,-1.4099999999999984l-6.000000000000008,6.0000000000000275l6.000000000000008,6l1.409999999999993,-1.4100000000000001l-3.58,-3.59h14.170000000000007Z"
-                transform="matrix(0.865803 0 0 0.865803 -1.99071 0.638058)"
-            />
-        </svg>
-    </button>
+    <div class="relative" tabindex="-1">
+        <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
+            <svg xmlns="http://www.w3.org/2000/svg" class="fill-current w-16 h-16" viewBox="0 0 16 16">
+                <path
+                    d="M20.485784919653916,7.578491965389372h-14.170000000000005l3.5800000000000054,-3.589999999999997l-1.409999999999993,-1.4099999999999984l-6.000000000000008,6.0000000000000275l6.000000000000008,6l1.409999999999993,-1.4100000000000001l-3.58,-3.59h14.170000000000007Z"
+                    transform="matrix(0.865803 0 0 0.865803 -1.99071 0.638058)"
+                />
+            </svg>
+        </button>
+        <tooltip direction="bottom">Back</tooltip>
+    </div>
 </template>
 
 <script lang="ts">

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -1,18 +1,27 @@
 <template>
-    <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
-        <svg class="fill-current w-16 h-16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512">
-            <path
-                d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-            />
-        </svg>
-    </button>
+    <div class="relative" tabindex="-1">
+        <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
+            <svg class="fill-current w-16 h-16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512">
+                <path
+                    d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                />
+            </svg>
+        </button>
+        <tooltip direction="bottom">Close</tooltip>
+    </div>
 </template>
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
-@Component
+import TooltipV from '@/components/util/tooltip.vue';
+
+@Component({
+    components: {
+        tooltip: TooltipV
+    }
+})
 export default class CloseV extends Vue {
     @Prop() active!: boolean;
 }

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -7,7 +7,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="bottom">Close</tooltip>
+        <tooltip direction="bottom">{{ $t('panels.controls.close') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -7,7 +7,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="bottom">{{ $t('panels.controls.close') }}</tooltip>
+        <tooltip position="bottom">{{ $t('panels.controls.close') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
@@ -6,6 +6,7 @@
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                 />
             </svg>
+            <tooltip>More</tooltip>
         </template>
         <slot></slot>
     </dropdown-menu>

--- a/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
@@ -6,7 +6,7 @@
                     d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
                 />
             </svg>
-            <tooltip>More</tooltip>
+            <tooltip>{{ $t('panels.controls.optionsMenu') }}</tooltip>
         </template>
         <slot></slot>
     </dropdown-menu>

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -12,7 +12,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="bottom">{{ this.active ? 'Unpin' : 'Pin' }}</tooltip>
+        <tooltip direction="bottom">{{ $t(this.active ? 'panels.controls.unpin' : 'panels.controls.pin') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -12,7 +12,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="bottom">{{ $t(this.active ? 'panels.controls.unpin' : 'panels.controls.pin') }}</tooltip>
+        <tooltip position="bottom">{{ $t(this.active ? 'panels.controls.unpin' : 'panels.controls.pin') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -1,20 +1,23 @@
 <template>
-    <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
-        <svg
-            class="fill-current w-16 h-16"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 384 512"
-            :transform="`rotate(${active ? 30 : 0})`"
-        >
-            <path
-                d="M298.028 214.267L285.793 96H328c13.255 0 24-10.745 24-24V24c0-13.255-10.745-24-24-24H56C42.745 0 32 10.745 32 24v48c0 13.255 10.745 24 24 24h42.207L85.972 214.267C37.465 236.82 0 277.261 0 328c0 13.255 10.745 24 24 24h136v104.007c0 1.242.289 2.467.845 3.578l24 48c2.941 5.882 11.364 5.893 14.311 0l24-48a8.008 8.008 0 0 0 .845-3.578V352h136c13.255 0 24-10.745 24-24-.001-51.183-37.983-91.42-85.973-113.733z"
-            />
-        </svg>
-    </button>
+    <div class="relative" tabindex="-1">
+        <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
+            <svg
+                class="fill-current w-16 h-16"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 384 512"
+                :transform="`rotate(${active ? 30 : 0})`"
+            >
+                <path
+                    d="M298.028 214.267L285.793 96H328c13.255 0 24-10.745 24-24V24c0-13.255-10.745-24-24-24H56C42.745 0 32 10.745 32 24v48c0 13.255 10.745 24 24 24h42.207L85.972 214.267C37.465 236.82 0 277.261 0 328c0 13.255 10.745 24 24 24h136v104.007c0 1.242.289 2.467.845 3.578l24 48c2.941 5.882 11.364 5.893 14.311 0l24-48a8.008 8.008 0 0 0 .845-3.578V352h136c13.255 0 24-10.745 24-24-.001-51.183-37.983-91.42-85.973-113.733z"
+                />
+            </svg>
+        </button>
+        <tooltip direction="bottom">{{ this.active ? 'Unpin' : 'Pin' }}</tooltip>
+    </div>
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 @Component

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -25,7 +25,7 @@ import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 Vue.component('panel-screen', PanelScreenV);
 Vue.component('pin', PinV);
 Vue.component('close', CloseV);
-Vue.component('back', BackV)
+Vue.component('back', BackV);
 Vue.component('panel-options-menu', PanelOptionsMenuV);
 Vue.component('dropdown-menu', DropdownMenuV);
 

--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -1,0 +1,108 @@
+<template>
+    <span
+        role="tooltip"
+        :class="'rv-ui-tooltip-' + direction"
+        class="rv-ui-tooltip absolute opacity-0 invisible bg-black text-white text-center py-3 px-5 rounded z-50"
+        ><slot></slot
+    ></span>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class TooltipV extends Vue {
+    @Prop({ default: 'top' }) direction!: string;
+    @Prop() tooltipfor!: HTMLElement | null;
+
+    mounted() {
+        //give the tooltip a random id and then set aria attributes as needed on parent
+        this.$el.setAttribute('id', this.generateID());
+        this.$el.previousElementSibling!.setAttribute('aria-labelledby', this.$el.id);
+    }
+
+    generateID(): string {
+        let newID;
+        do {
+            newID =
+                'tooltip-' +
+                Math.random()
+                    .toString(36)
+                    .substring(2, 9);
+        } while (document.getElementById(newID) !== null);
+
+        return newID;
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.rv-ui-tooltip {
+    transition: opacity 0.3s;
+    width: max-content;
+
+    &::after {
+        content: '';
+        position: absolute;
+        border-width: 5px;
+    }
+
+    :hover > &,
+    :focus + &,
+    :focus .focused + & {
+        @apply visible opacity-100;
+    }
+}
+
+.rv-ui-tooltip-top {
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+
+    &::after {
+        top: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-color: black transparent transparent transparent;
+    }
+}
+
+.rv-ui-tooltip-bottom {
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+
+    &::after {
+        bottom: 100%;
+        left: 50%;
+        margin-left: -5px;
+        border-color: transparent transparent black transparent;
+    }
+}
+
+.rv-ui-tooltip-left {
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+
+    &::after {
+        right: -9px;
+        bottom: 50%;
+        margin-bottom: -4px;
+        border-color: transparent transparent transparent black;
+    }
+}
+
+.rv-ui-tooltip-right {
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+
+    &::after {
+        left: -9px;
+        bottom: 50%;
+        margin-bottom: -4px;
+        border-color: transparent black transparent transparent;
+    }
+}
+</style>

--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -1,7 +1,7 @@
 <template>
     <span
         role="tooltip"
-        :class="'rv-ui-tooltip-' + direction"
+        :class="'rv-ui-tooltip-' + position"
         class="rv-ui-tooltip absolute opacity-0 invisible bg-black text-white text-center py-3 px-5 rounded z-50"
         ><slot></slot
     ></span>
@@ -12,7 +12,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 
 @Component
 export default class TooltipV extends Vue {
-    @Prop({ default: 'top' }) direction!: string;
+    @Prop({ default: 'top' }) position!: string;
     @Prop() tooltipfor!: HTMLElement | null;
 
     mounted() {

--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -43,8 +43,8 @@ export default class TooltipV extends Vue {
 
     &::after {
         content: '';
-        position: absolute;
         border-width: 5px;
+        @apply absolute;
     }
 
     :hover > &,
@@ -55,52 +55,44 @@ export default class TooltipV extends Vue {
 }
 
 .rv-ui-tooltip-top {
-    bottom: 100%;
-    left: 50%;
+    @apply left-1/2 bottom-full;
     transform: translateX(-50%);
 
     &::after {
-        top: 100%;
-        left: 50%;
+        @apply left-1/2 top-full;
         margin-left: -5px;
         border-color: black transparent transparent transparent;
     }
 }
 
 .rv-ui-tooltip-bottom {
-    top: 100%;
-    left: 50%;
+    @apply left-1/2 top-full;
     transform: translateX(-50%);
 
     &::after {
-        bottom: 100%;
-        left: 50%;
+        @apply left-1/2 bottom-full;
         margin-left: -5px;
         border-color: transparent transparent black transparent;
     }
 }
 
 .rv-ui-tooltip-left {
-    right: 100%;
-    top: 50%;
+    @apply right-full top-1/2;
     transform: translateY(-50%);
 
     &::after {
-        right: -9px;
-        bottom: 50%;
+        @apply -right-9 bottom-1/2;
         margin-bottom: -4px;
         border-color: transparent transparent transparent black;
     }
 }
 
 .rv-ui-tooltip-right {
-    left: 100%;
-    top: 50%;
+    @apply left-full top-1/2;
     transform: translateY(-50%);
 
     &::after {
-        left: -9px;
-        bottom: 50%;
+        @apply -left-9 bottom-1/2;
         margin-bottom: -4px;
         border-color: transparent black transparent transparent;
     }

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -1,12 +1,14 @@
 <template>
-    <div class="absolute top-0 left-0 flex flex-col items-stretch w-40 h-full pointer-events-auto appbar bg-black-75 sm:w-64" v-focus-list>
+    <div
+        class="absolute top-0 left-0 z-50 flex flex-col items-stretch w-40 h-full pointer-events-auto appbar bg-black-75 sm:w-64"
+        v-focus-list
+    >
         <component
             v-for="(item, index) in items"
             :is="item.componentId"
             :key="`${item}-${index}`"
-            class="my-4 text-gray-400 first:mt-8 hover:text-white focus:outline-none"
-            :class="{ 'py-12': item.id !== 'divider' }"
-            :focus-item="item.id !== 'divider'"
+            class="my-4 text-gray-400 first:mt-8 hover:text-white"
+            :class="{ 'h-48': item.id !== 'divider' }"
             :options="item.options"
         ></component>
     </div>
@@ -17,8 +19,10 @@ import { Vue, Watch, Component } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 import { AppbarItemInstance } from './store';
 import DividerV from './divider.vue';
+import AppbarButtonV from './button.vue';
 
 Vue.component('divider', DividerV);
+Vue.component('appbar-button', AppbarButtonV);
 
 @Component
 export default class AppbarV extends Vue {
@@ -26,16 +30,8 @@ export default class AppbarV extends Vue {
 }
 </script>
 
-<style lang="scss" scoped>
-.focused {
-    @apply bg-blue-900 text-white;
-}
-
+<style lang="scss">
 .appbar {
     backdrop-filter: blur(5px);
-
-    > button {
-        outline: none;
-    }
 }
 </style>

--- a/packages/ramp-core/src/fixtures/appbar/button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/button.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="relative" tabindex="-1">
+        <button class="py-6 w-full h-full focus:outline-none" @click="onClickFunction()" v-focus-item>
+            <slot name="icon"></slot>
+        </button>
+        <tooltip direction="right">
+            <slot name="tooltip"></slot>
+        </tooltip>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+
+@Component
+export default class AppbarButtonV extends Vue {
+    @Prop() onClickFunction!: any;
+}
+</script>
+
+<style lang="scss" scoped>
+button {
+    outline: none;
+
+    &.focused {
+        @apply bg-blue-900 text-white;
+    }
+}
+</style>

--- a/packages/ramp-core/src/fixtures/appbar/button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/button.vue
@@ -3,7 +3,7 @@
         <button class="py-6 w-full h-full focus:outline-none" @click="onClickFunction()" v-focus-item>
             <slot name="icon"></slot>
         </button>
-        <tooltip direction="right">
+        <tooltip position="right">
             <slot name="tooltip"></slot>
         </tooltip>
     </div>

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -12,7 +12,7 @@ class AppbarFixture extends AppbarAPI {
         // TODO: registering a fixture store module seems like a common action almost every fixture needs; check if this can be automated somehow
         this.$vApp.$store.registerModule('appbar', appbar());
 
-        const appbarInstance = this.extend(AppbarV, { store: this.$vApp.$store });
+        const appbarInstance = this.extend(AppbarV, { store: this.$vApp.$store, i18n: this.$vApp.$i18n });
 
         // TODO: the `innerShell` reference will probably get used more than once; consider creating a dedicated ref on `$iApi`;
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];

--- a/packages/ramp-core/src/fixtures/basemap/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/appbar-button.vue
@@ -1,21 +1,27 @@
 <template>
-    <button class="py-6" @click="$iApi.panel.toggle('basemap-panel')">
-        <!-- Basemap icon -->
-        <svg class="fill-current w-24 h-24 ml-8 md:ml-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path
-                d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z"
-            />
-            <path d="M0 0h24v24H0z" fill="none" />
-        </svg>
-    </button>
+    <appbar-button :onClickFunction="onClick">
+        <template #icon>
+            <!-- Basemap icon -->
+            <svg class="fill-current w-24 h-24 ml-8 md:ml-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path
+                    d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+            </svg>
+        </template>
+        <template #tooltip>Basemap</template>
+    </appbar-button>
 </template>
+
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 
-import BasemapComponent from './basemap.vue';
-
 @Component
-export default class BasemapAppbarButtonV extends Vue {}
+export default class BasemapAppbarButtonV extends Vue {
+    onClick() {
+        this.$iApi.panel.toggle('basemap-panel');
+    }
+}
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/basemap/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/appbar-button.vue
@@ -9,7 +9,7 @@
                 <path d="M0 0h24v24H0z" fill="none" />
             </svg>
         </template>
-        <template #tooltip>Basemap</template>
+        <template #tooltip>{{ $t('basemap.title') }}</template>
     </appbar-button>
 </template>
 

--- a/packages/ramp-core/src/fixtures/basemap/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/nav-button.vue
@@ -8,7 +8,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="left">Basemap</tooltip>
+        <tooltip direction="left">{{ $t('basemap.title') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/basemap/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/nav-button.vue
@@ -1,12 +1,15 @@
 <template>
-    <button @click="togglePanel()">
-        <svg class="fill-current w-32 h-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path
-                d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z"
-            />
-        </svg>
-    </button>
+    <div class="relative" tabindex="-1">
+        <button @click="togglePanel()" class="w-full h-full default-focus-style" v-focus-item>
+            <svg class="fill-current w-32 h-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path
+                    d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z"
+                />
+            </svg>
+        </button>
+        <tooltip direction="left">Basemap</tooltip>
+    </div>
 </template>
 
 <script lang="ts">

--- a/packages/ramp-core/src/fixtures/basemap/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/basemap/nav-button.vue
@@ -8,7 +8,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="left">{{ $t('basemap.title') }}</tooltip>
+        <tooltip position="left">{{ $t('basemap.title') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
@@ -1,11 +1,10 @@
 <template>
-    <button
-        class="py-6"
-        @click="$iApi.panel.toggle({ id: 'p2', screen: 'p-2-screen-2' })"
-        :style="{ fontWeight: 'bold', color: options.colour }"
-    >
-        G
-    </button>
+    <appbar-button :onClickFunction="onClick">
+        <template #icon>
+            <span :style="{ fontWeight: 'bold', color: options.colour }">G</span>
+        </template>
+        <template #tooltip>Gazebo</template>
+    </appbar-button>
 </template>
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
@@ -13,6 +12,10 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 @Component
 export default class GazeboAppbarButton extends Vue {
     @Prop({ default: { colour: 'auto' } }) options!: { colour: string };
+
+    onClick() {
+        this.$iApi.panel.toggle({ id: 'p2', screen: 'p-2-screen-2' });
+    }
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
@@ -1,13 +1,16 @@
 <template>
-    <button class="py-6" @click="$iApi.panel.toggle('geosearch-panel')">
-        <!-- Geosearch icon -->
-        <svg class="fill-current w-24 h-24 ml-8 md:ml-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path
-                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-            />
-            <path d="M0 0h24v24H0z" fill="none" />
-        </svg>
-    </button>
+    <appbar-button :onClickFunction="onClick">
+        <template #icon>
+            <!-- Geosearch icon -->
+            <svg class="fill-current w-24 h-24 ml-8 md:ml-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                />
+                <path d="M0 0h24v24H0z" fill="none" />
+            </svg>
+        </template>
+        <template #tooltip>Geosearch</template>
+    </appbar-button>
 </template>
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
@@ -15,7 +18,11 @@ import { Vue, Component } from 'vue-property-decorator';
 import GeosearchComponent from './geosearch-component.vue';
 
 @Component
-export default class GeosearchAppbarButtonV extends Vue {}
+export default class GeosearchAppbarButtonV extends Vue {
+    onClick() {
+        this.$iApi.panel.toggle('geosearch-panel');
+    }
+}
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
@@ -9,7 +9,7 @@
                 <path d="M0 0h24v24H0z" fill="none" />
             </svg>
         </template>
-        <template #tooltip>Geosearch</template>
+        <template #tooltip>{{ $t('geosearch.title') }}</template>
     </appbar-button>
 </template>
 <script lang="ts">

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-bar.vue
@@ -3,7 +3,7 @@
         <input
             type="search"
             class="flex-grow border-b text-base px-12 py-8 outline-none focus:shadow-outline border-gray-600 mx-8 h-8"
-            :placeholder="$t('searchText')"
+            :placeholder="$t('geosearch.searchText')"
             :value="searchVal"
             @input="onSearchTermChange($event.target.value)"
         />

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-bottom-filters.vue
@@ -7,7 +7,7 @@
                     class="form-checkbox border-2 mx-8 border-gray-600"
                     :checked="resultsVisible"
                     @change="updateMapExtent($event.target.checked)"
-                />{{ $t('visible') }}</label
+                />{{ $t('geosearch.visible') }}</label
             >
         </div>
     </div>

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-component.vue
@@ -13,7 +13,7 @@
             <loading-bar class="mb-2" v-if="loadingResults"></loading-bar>
             <div class="px-5 mt-10 truncate">
                 <span class="relative h-48" v-if="searchVal && searchResults.length === 0 && !loadingResults"
-                    >{{ $t('noResults') }}<span class="font-bold text-blue-600">{{ searchVal }}</span></span
+                    >{{ $t('geosearch.noResults') }}<span class="font-bold text-blue-600">{{ searchVal }}</span></span
                 >
             </div>
             <ul

--- a/packages/ramp-core/src/fixtures/geosearch/geosearch-top-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/geosearch-top-filters.vue
@@ -6,7 +6,7 @@
                 :value="queryParams.province"
                 v-on:change="setProvince($event.target.value)"
             >
-                <option value="" disabled hidden>{{ $t('filters.province') }}</option>
+                <option value="" disabled hidden>{{ $t('geosearch.filters.province') }}</option>
                 <option v-for="province in provinces" v-bind:key="province.code">
                     {{ province.name }}
                 </option>
@@ -18,7 +18,7 @@
                 :value="queryParams.type"
                 v-on:change="setType($event.target.value)"
             >
-                <option value="" disabled hidden>{{ $t('filters.type') }}</option>
+                <option value="" disabled hidden>{{ $t('geosearch.filters.type') }}</option>
                 <option v-for="type in types" v-bind:key="type.code">
                     {{ type.name }}
                 </option>
@@ -37,7 +37,7 @@
                 </svg>
                 <span
                     class="text-center text-white rounded absolute bg-gray-200 invisible group-hover:visible w-28 top-400 left-200 -ml-64 z-4"
-                    >{{ $t('filters.clear') }}</span
+                    >{{ $t('geosearch.filters.clear') }}</span
                 >
             </div>
         </button>

--- a/packages/ramp-core/src/fixtures/geosearch/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/geosearch/lang/lang.csv
@@ -1,7 +1,8 @@
 key,enValue,enValid,frValue,frValid
-noResults,No results to show for ,1,Aucun résultat pour montrer pour ,0
-searchText,Geolocation Search,1,[fr] Geolocation Search,0
-visible,Visible on map,1,Visible sur la carte,0
-filters.province,Province,1,Province,0
-filters.type,Type,1,Type,0
-filters.clear,Clear filters,1,Effacer les filtres,0
+geosearch.title,Geolocation Search,1,Recherche géolocalisée,1
+geosearch.noResults,No results to show for ,1,Aucun résultat pour montrer pour ,0
+geosearch.searchText,Geolocation Search,1,Recherche géolocalisée,1
+geosearch.visible,Visible on map,1,Visible sur la carte,1
+geosearch.filters.province,Province,1,Province,1
+geosearch.filters.type,Type,1,Type,1
+geosearch.filters.clear,Clear filters,1,Effacer les filtres,1

--- a/packages/ramp-core/src/fixtures/help/index.ts
+++ b/packages/ramp-core/src/fixtures/help/index.ts
@@ -1,8 +1,13 @@
 import { HelpAPI } from './api/help';
 import HelpNavV from './nav-button.vue';
 
+import messages from './lang/lang.csv';
+
 class HelpFixture extends HelpAPI {
     added() {
+        // since this has no panel we need to merge in translations ourselves
+        Object.entries(messages).forEach(value => this.$vApp.$i18n.mergeLocaleMessage(...value));
+
         this.$iApi.component('help-nav-button', HelpNavV);
     }
 }

--- a/packages/ramp-core/src/fixtures/help/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/help/lang/lang.csv
@@ -1,0 +1,2 @@
+key,enValue,enValid,frValue,frValid
+help.title,Help,1,Aide,1

--- a/packages/ramp-core/src/fixtures/help/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/help/nav-button.vue
@@ -8,7 +8,7 @@
                 />
             </svg>
         </button>
-        <tooltip position="left">Help</tooltip>
+        <tooltip position="left">{{ $t('help.title') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/help/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/help/nav-button.vue
@@ -8,7 +8,7 @@
                 />
             </svg>
         </button>
-        <tooltip direction="left">Help</tooltip>
+        <tooltip position="left">Help</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/help/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/help/nav-button.vue
@@ -1,12 +1,15 @@
 <template>
-    <button>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path
-                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
-            />
-        </svg>
-    </button>
+    <div class="relative" tabindex="-1">
+        <button class="w-full h-full default-focus-style" v-focus-item>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"
+                />
+            </svg>
+        </button>
+        <tooltip direction="left">Help</tooltip>
+    </div>
 </template>
 
 <script lang="ts">

--- a/packages/ramp-core/src/fixtures/legend/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/legend/appbar-button.vue
@@ -1,11 +1,14 @@
 <template>
-    <button @click="onClick()">
-        <!-- https://material.io/resources/icons/?icon=layers&style=baseline -->
-        <svg class="fill-current w-24 h-24 ml-8 sm:ml-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z" />
-        </svg>
-    </button>
+    <appbar-button :onClickFunction="onClick">
+        <template #icon>
+            <!-- https://material.io/resources/icons/?icon=layers&style=baseline -->
+            <svg class="fill-current w-24 h-24 ml-8 sm:ml-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z" />
+            </svg>
+        </template>
+        <template #tooltip>Legend</template>
+    </appbar-button>
 </template>
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';

--- a/packages/ramp-core/src/fixtures/legend/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/legend/appbar-button.vue
@@ -7,7 +7,7 @@
                 <path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z" />
             </svg>
         </template>
-        <template #tooltip>Legend</template>
+        <template #tooltip>{{ $t('legend.title') }}</template>
     </appbar-button>
 </template>
 <script lang="ts">
@@ -16,7 +16,7 @@ import { Vue, Component } from 'vue-property-decorator';
 @Component
 export default class LegendAppbarButtonV extends Vue {
     onClick() {
-        console.log('legend appbar button clicked');
+        this.$iApi.panel.toggle('legend-panel');
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -7,16 +7,22 @@ import messages from './lang/lang.csv';
 
 class LegendFixture extends LegendAPI {
     added() {
-        this.$iApi.panel.register({
-            'legend-panel': {
-                screens: {
-                    'legend-screen': LegendV
-                },
-                style: {
-                    width: '350px'
+        console.log(`[fixture] ${this.id} added`);
+        this.$iApi.panel.register(
+            {
+                'legend-panel': {
+                    screens: {
+                        'legend-screen': LegendV
+                    },
+                    style: {
+                        width: '350px'
+                    }
                 }
+            },
+            {
+                i18n: { messages }
             }
-        });
+        );
 
         this.$iApi.panel.open('legend-panel');
 

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -1,1 +1,2 @@
 key,enValue,enValid,frValue,frValid
+legend.title,Legend,1,Légende,1

--- a/packages/ramp-core/src/fixtures/legend/legend.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend.vue
@@ -1,8 +1,7 @@
 <template>
     <panel-screen>
         <template #header>
-            <!-- TODO: add translation -->
-            Legend
+            {{ $t('legend.title') }}
         </template>
 
         <template #controls>

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
@@ -10,7 +10,7 @@
                 <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
             </svg>
         </button>
-        <tooltip direction="left">Fullscreen</tooltip>
+        <tooltip direction="left">{{ $t('mapnav.fullscreen') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
@@ -10,7 +10,7 @@
                 <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
             </svg>
         </button>
-        <tooltip direction="left">{{ $t('mapnav.fullscreen') }}</tooltip>
+        <tooltip position="left">{{ $t('mapnav.fullscreen') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
@@ -1,14 +1,17 @@
 <template>
-    <button @click="$iApi.toggleFullscreen()">
-        <svg v-if="$iApi.isFullscreen" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z" />
-        </svg>
-        <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
-            <path d="M0 0h24v24H0z" fill="none" />
-            <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
-        </svg>
-    </button>
+    <div class="relative" tabindex="-1">
+        <button @click="$iApi.toggleFullscreen()" class="w-full h-full default-focus-style" v-focus-item>
+            <svg v-if="$iApi.isFullscreen" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z" />
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
+            </svg>
+        </button>
+        <tooltip direction="left">Fullscreen</tooltip>
+    </div>
 </template>
 
 <script lang="ts">

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
@@ -6,7 +6,7 @@
                 <path d="M0 0h24v24H0z" fill="none" />
             </svg>
         </button>
-        <tooltip direction="left">Home</tooltip>
+        <tooltip direction="left">{{ $t('mapnav.home') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
@@ -6,7 +6,7 @@
                 <path d="M0 0h24v24H0z" fill="none" />
             </svg>
         </button>
-        <tooltip direction="left">{{ $t('mapnav.home') }}</tooltip>
+        <tooltip position="left">{{ $t('mapnav.home') }}</tooltip>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
@@ -1,10 +1,13 @@
 <template>
-    <button>
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
-            <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
-            <path d="M0 0h24v24H0z" fill="none" />
-        </svg>
-    </button>
+    <div class="relative" tabindex="-1">
+        <button class="w-full h-full default-focus-style" v-focus-item>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
+                <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+                <path d="M0 0h24v24H0z" fill="none" />
+            </svg>
+        </button>
+        <tooltip direction="left">Home</tooltip>
+    </div>
 </template>
 
 <script lang="ts">

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -7,7 +7,7 @@
                     <path d="M0 0h24v24H0z" fill="none" />
                 </svg>
             </button>
-            <tooltip direction="left">Zoom In</tooltip>
+            <tooltip direction="left">{{ $t('mapnav.zoomIn') }}</tooltip>
         </div>
         <divider-nav></divider-nav>
         <div class="relative w-32 h-32" tabindex="-1">
@@ -17,7 +17,7 @@
                     <path d="M0 0h24v24H0z" fill="none" />
                 </svg>
             </button>
-            <tooltip direction="left">Zoom Out</tooltip>
+            <tooltip direction="left">{{ $t('mapnav.zoomOut') }}</tooltip>
         </div>
     </div>
 </template>

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -7,7 +7,7 @@
                     <path d="M0 0h24v24H0z" fill="none" />
                 </svg>
             </button>
-            <tooltip direction="left">{{ $t('mapnav.zoomIn') }}</tooltip>
+            <tooltip position="left">{{ $t('mapnav.zoomIn') }}</tooltip>
         </div>
         <divider-nav></divider-nav>
         <div class="relative w-32 h-32" tabindex="-1">
@@ -17,7 +17,7 @@
                     <path d="M0 0h24v24H0z" fill="none" />
                 </svg>
             </button>
-            <tooltip direction="left">{{ $t('mapnav.zoomOut') }}</tooltip>
+            <tooltip position="left">{{ $t('mapnav.zoomOut') }}</tooltip>
         </div>
     </div>
 </template>

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -1,18 +1,24 @@
 <template>
     <div>
-        <button @click="zoomIn()" class="zoom-in default-focus-style w-32 h-32 text-gray-600 hover:text-black" v-focus-item>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
-                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-                <path d="M0 0h24v24H0z" fill="none" />
-            </svg>
-        </button>
+        <div class="relative w-32 h-32" tabindex="-1">
+            <button @click="zoomIn()" class="zoom-in default-focus-style w-full h-full text-gray-600 hover:text-black" v-focus-item>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
+                    <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+                    <path d="M0 0h24v24H0z" fill="none" />
+                </svg>
+            </button>
+            <tooltip direction="left">Zoom In</tooltip>
+        </div>
         <divider-nav></divider-nav>
-        <button @click="zoomOut()" class="zoom-out default-focus-style w-32 h-32 text-gray-600 hover:text-black" v-focus-item>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
-                <path d="M19 13H5v-2h14v2z" />
-                <path d="M0 0h24v24H0z" fill="none" />
-            </svg>
-        </button>
+        <div class="relative w-32 h-32" tabindex="-1">
+            <button @click="zoomOut()" class="zoom-out default-focus-style w-full h-full text-gray-600 hover:text-black" v-focus-item>
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
+                    <path d="M19 13H5v-2h14v2z" />
+                    <path d="M0 0h24v24H0z" fill="none" />
+                </svg>
+            </button>
+            <tooltip direction="left">Zoom Out</tooltip>
+        </div>
     </div>
 </template>
 

--- a/packages/ramp-core/src/fixtures/mapnav/index.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/index.ts
@@ -2,6 +2,7 @@ import MapnavV from './mapnav.vue';
 import { MapnavAPI } from './api/mapnav';
 import { mapnav } from './store';
 import { GlobalEvents } from '@/api';
+import messages from './lang/lang.csv';
 
 class MapnavFixture extends MapnavAPI {
     async added() {
@@ -10,7 +11,11 @@ class MapnavFixture extends MapnavAPI {
         // TODO: registering a fixture store module seems like a common action almost every fixture needs; check if this can be automated somehow
         this.$vApp.$store.registerModule('mapnav', mapnav());
 
-        const mapnavInstance = this.extend(MapnavV, { store: this.$vApp.$store });
+        // since this has no panel we need to merge in translations ourselves
+        // TODO?: see if giving fixtures a nicer way to merge translations w/o panel makes sense
+        Object.entries(messages).forEach(value => this.$vApp.$i18n.mergeLocaleMessage(...value));
+
+        const mapnavInstance = this.extend(MapnavV, { store: this.$vApp.$store, i18n: this.$vApp.$i18n });
 
         // TODO: the `innerShell` reference will probably get used more than once; consider creating a dedicated ref on `$iApi`;
         const innerShell = this.$vApp.$el.getElementsByClassName('inner-shell')[0];

--- a/packages/ramp-core/src/fixtures/mapnav/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/mapnav/lang/lang.csv
@@ -1,0 +1,5 @@
+key,enValue,enValid,frValue,frValid
+mapnav.zoomIn,Zoom In,1,Zoom avant,1
+mapnav.zoomOut,Zoom Out,1,Zoom arrière,1
+mapnav.home,Home,1,[fr] Home,0
+mapnav.fullscreen,Full Screen,1,Plein Écran,1

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -7,9 +7,8 @@
                 <template v-for="(button, index) in visible">
                     <component
                         :is="button.id + '-nav-button'"
-                        class="default-focus-style w-32 h-32 text-gray-600 hover:text-black"
+                        class="w-32 h-32 text-gray-600 hover:text-black"
                         :key="button.id + 'button'"
-                        v-focus-item
                     ></component>
                     <divider-nav class="mapnav-divider" v-if="index !== visible.length - 1" :key="button.id + 'spacer'"></divider-nav>
                 </template>
@@ -46,5 +45,9 @@ export default class MapNavV extends Vue {
 <style lang="scss" scoped>
 .mapnav-section {
     @apply flex-col flex shadow-tm pointer-events-auto;
+
+    .focused {
+        @apply text-black;
+    }
 }
 </style>

--- a/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/snowman/appbar-button.vue
@@ -1,7 +1,10 @@
 <template>
-    <button class="py-6" @click="togglePanel()">
-        <span class="block h-24">⛄</span>
-    </button>
+    <appbar-button :onClickFunction="togglePanel">
+        <template #icon>
+            <span class="block h-24">⛄</span>
+        </template>
+        <template #tooltip>⛄</template>
+    </appbar-button>
 </template>
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -9,3 +9,7 @@ map.coordinates.east,E,1,E,1
 map.coordinates.west,W,1,O,1
 map.coordinates.north,N,1,N,1
 map.coordinates.south,S,1,S,1
+panels.controls.close,Close,1,Fermer,1
+panels.controls.pin,Pin,1,Épingler,0
+panels.controls.unpin,Unpin,1,Détacher,0
+panels.controls.back,Back,1,Retourner,0

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -13,3 +13,4 @@ panels.controls.close,Close,1,Fermer,1
 panels.controls.pin,Pin,1,Épingler,0
 panels.controls.unpin,Unpin,1,Détacher,0
 panels.controls.back,Back,1,Retourner,0
+panels.controls.optionsMenu,More,1,Plus,0

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -13,8 +13,16 @@ module.exports = {
             // sm: '640px'
         },
         spacing: spacingConfig,
-        inset: spacingConfig,
         extend: {
+            inset: {
+                '-9': '-9px',
+                '1': '1px',
+                '32': '32px',
+                '64': '64px',
+                '200': '200px',
+                '1/2': '50%',
+                full: '100%'
+            },
             colors: {
                 'black-75': 'rgba(0, 0, 0, 0.75)',
                 'white-75': 'rgba(255, 255, 255, 0.75)',


### PR DESCRIPTION
Tooltips, some appbar/navbar restructuring, translations, docs

Tooltips can be positioned on the top/bottom/left/right of the component. They are also used for aria labels for accessibility. Use is in docs, examples all over the place in the code now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/241)
<!-- Reviewable:end -->
