### PR TITLE
fix file layer feature query

### DIFF
--- a/packages/ramp-geoapi/src/util/QueryService.ts
+++ b/packages/ramp-geoapi/src/util/QueryService.ts
@@ -69,7 +69,10 @@ export default class QueryService extends BaseBase {
         // NOTE: for this to work, the outfields need to be set on the geojson layer when it is created.
         //       anything not in the outfields will not be available for the .where filter and will give
         //       an empty result.
-        const featSet = await options.layer._innerView.queryFeatures(query);
+        // NOTE: using ._innerView appears to be somewhat flawed. The query tends to only respect items that
+        //       are in the visible view of the map. The layer query appears to be working now with local data
+        //       (was not in earlier versions of ESRI API)
+        const featSet = await options.layer._innerLayer.queryFeatures(query);
 
         // convert to our type. seems a bit wasteful, but we already want to convert to ramp geoms so do it
         return featSet.features.map((f, i) => {


### PR DESCRIPTION
Donethankses https://github.com/ramp4-pcar4/ramp4-pcar4/issues/247

Using layer view for local layer queries was bombing if desired targets were not visible in the view. Using the actual layer query now appears to work (did not months ago).

Can test by opening the WFS Layer grid from the legend, do zoomies on one point (which is fine since all points are visible), then do zoomies on a different point. Map will zoooom and no longer error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/259)
<!-- Reviewable:end -->
