### PR TITLE
fix RAMP not loading in cypress

### DIFF
--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "serve": "vue-cli-service serve src/main-serve.ts",
+        "serve": "vue-cli-service serve",
         "build": "vue-cli-service build --target lib --formats umd --name RAMP src/main-build.ts 2>&1",
         "test:unit": "vue-cli-service test:unit",
         "test:e2e": "vue-cli-service test:e2e",

--- a/packages/ramp-core/src/main-serve.ts
+++ b/packages/ramp-core/src/main-serve.ts
@@ -1,3 +1,0 @@
-import { startup } from './main';
-
-startup();

--- a/packages/ramp-core/src/main.ts
+++ b/packages/ramp-core/src/main.ts
@@ -1,24 +1,22 @@
-// We have 3 `main` files as Cypress requires a `main.ts`, `main-serve` is used for serves and `main-build` is used for builds.
+// `main.ts` is used for serves and tests, and `main-build.ts` is used for builds
 
-// this file is used when running `rush serve`
+// this file is used when running `rush serve` and `rush test:e2e`
 // when compiled using the `serve` command, the code is treated as an app, not a library,
 // so we need to expose RAMP API on the window manually
 import api from '@/api';
 import Vue from 'vue';
 
-export function startup() {
-    // assign RAMP api to global variable
-    window.RAMP = api;
+// assign RAMP api to global variable
+window.RAMP = api;
 
-    // expose Vue to the global scope so fixtures that use Vue have access to it
-    // this is only needed in `serve` mode; in `build`, Vue is explicitly loaded by the host page
-    // TODO: there are issues with how Vue is loading when using Cypress
-    window.Vue = Vue;
+// expose Vue to the global scope so fixtures that use Vue have access to it
+// this is only needed in `serve` mode; in `build`, Vue is explicitly loaded by the host page
+// TODO: there are issues with how Vue is loading when using Cypress
+window.Vue = Vue;
 
-    // execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
-    api.gapiPromise.then(() => {
-        if (typeof window.initRAMP === 'function') {
-            window.initRAMP();
-        }
-    });
-}
+// execute `initRAMP` global function if it's defined as soon at the RAMP library is added to the global scope
+api.gapiPromise.then(() => {
+    if (typeof window.initRAMP === 'function') {
+        window.initRAMP();
+    }
+});


### PR DESCRIPTION
Partial fix of #258 to get e2e tests working at all before we make a dedicated test page.

Currently, `vue-cli-service serve` uses `src/main-serve.ts` as its entry file but `vue-cli-service test:e2e` uses `src/main.ts`, which doesn't actually load RAMP. Calling`initRAMP()` directly in `src/main.ts` and using that as the entry file for both `serve` and `test:e2e` will load RAMP properly in cypress and avoid the double call to `initRAMP()` from #176 during regular `serve`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/260)
<!-- Reviewable:end -->
