### PR TITLE
improve legend checkbox/radio buttons; change legend vue component names

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -1,13 +1,13 @@
 <template>
     <!-- Display a checkbox. -->
     <div v-if="!isRadio" class="relative">
-        <input type="checkbox" :checked="value" class="rounded-none form-checkbox mx-5 h-15 w-15 text-black border-gray-500 hover:border-black cursor-pointer">
+        <input type="checkbox" :checked="value" @click="legendItem.toggleVisibility()" class="rounded-none form-checkbox mx-5 h-15 w-15 text-black border-gray-500 hover:border-black cursor-pointer">
         <tooltip position="left"> {{$t(value? 'legend.hide' : 'legend.show')}} </tooltip>
     </div>
 
     <!-- If isRadio is set to true, a radio button will be displayed instead. -->
     <div v-else class="relative">
-        <input type="radio" :checked="value" class="form-radio mx-5 h-15 w-15 text-black border-gray-500 hover:border-black cursor-pointer">
+        <input type="radio" :checked="value" :name="legendItem.parent.name" @click="legendItem.toggleVisibility()" class="form-radio mx-5 h-15 w-15 text-black border-gray-500 hover:border-black cursor-pointer">
         <tooltip position="left"> {{$t(value? 'legend.hide' : 'legend.show')}} </tooltip>
     </div>
 </template>
@@ -16,10 +16,13 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
+import { LegendEntry } from '../store/legend-defs';
+
 @Component
-export default class CheckboxComponent extends Vue {
+export default class CheckboxV extends Vue {
     @Prop() value!: boolean;
     @Prop() isRadio!: boolean;
+    @Prop() legendItem!: LegendEntry;
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-component.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-component.vue
@@ -9,22 +9,22 @@ import { Get, Sync, Call } from 'vuex-pathify';
 import { LegendStore } from '../store';
 import { LegendItem } from '../store/legend-defs';
 
-import LayerEntry from './legend-entry.vue';
-import LegendGroup from './legend-group.vue';
-import LegendVisibilitySet from './legend-visibility-set.vue';
-import LegendPlaceholder from './legend-placeholder.vue';
+import LayerEntryV from './legend-entry.vue';
+import LegendGroupV from './legend-group.vue';
+import LegendVisibilitySetV from './legend-visibility-set.vue';
+import LegendPlaceholderV from './legend-placeholder.vue';
 
 @Component
-export default class LegendComponent extends Vue {
+export default class LegendComponentV extends Vue {
     @Prop() legendItem!: LegendItem;
     @Prop() props!: any;
 
     // Binds each type to its respective Vue component.
     templates = {
-        VisibilitySet: LegendVisibilitySet,
-        LegendGroup: LegendGroup,
-        LegendEntry: LayerEntry,
-        Placeholder: LegendPlaceholder
+        VisibilitySet: LegendVisibilitySetV,
+        LegendGroup: LegendGroupV,
+        LegendEntry: LayerEntryV,
+        Placeholder: LegendPlaceholderV
     };
 }
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
@@ -13,8 +13,8 @@
             </div>
 
             <!-- visibility -->
-            <div @click="legendItem.toggleVisibility()">
-                <checkbox :value="legendItem.visibility" :isRadio="props && props.isVisibilitySet" />
+            <div>
+                <checkbox :value="visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem"/>
             </div>
         </div>
 
@@ -29,7 +29,7 @@
                 <div class="flex-1 truncate">{{ item.label }}</div>
 
                 <!-- TODO: add visibility button functionality. It should toggle each symbol individually. -->
-                <checkbox :value="legendItem.visibility" />
+                <checkbox :value="visibility" :legendItem="legendItem"/>
             </div>
         </div>
     </div>
@@ -40,22 +40,29 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { LegendStore } from '../store';
-import { LegendItem } from '../store/legend-defs';
+import { LegendEntry } from '../store/legend-defs';
 
-import CheckboxComponent from './checkbox.vue';
+import CheckboxV from './checkbox.vue';
 import SymbologyStack from './symbology-stack.vue';
 
 @Component({
     components: {
-        checkbox: CheckboxComponent,
+        checkbox: CheckboxV,
         'symbology-stack': SymbologyStack
     }
 })
-export default class LegendEntry extends Vue {
+export default class LegendEntryV extends Vue {
     @Prop() legendItem!: LegendEntry;
     @Prop() props!: any;
 
     displaySymbology: boolean = false;
+    visibility: boolean | undefined = this.legendItem.visibility;
+
+    mounted(): void {
+        this.legendItem.layer?.visibilityChanged.listen((visibility: boolean) => {
+            this.visibility = this.legendItem.visibility;
+        })
+    }
 
     /**
      * Display symbology stack for the layer.

--- a/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
@@ -13,8 +13,8 @@
             <span class="flex-1">{{ legendItem.name }}</span>
 
             <!-- visibility -->
-            <div @click="legendItem.toggleVisibility(); legendItem.toggleExpanded();">
-                <checkbox :value="legendItem.visibility" :isRadio="props && props.isVisibilitySet" />
+            <div @click="legendItem.toggleExpanded();">
+                <checkbox :value="legendItem.visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem"/>
             </div>
         </div>
 
@@ -30,16 +30,16 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { LegendStore } from '../store';
-import { LegendItem } from '../store/legend-defs';
-import CheckboxComponent from './checkbox.vue';
+import { LegendGroup } from '../store/legend-defs';
+import CheckboxV from './checkbox.vue';
 
 @Component({
     components: {
         LegendComponent: () => import('./legend-component.vue'),
-        checkbox: CheckboxComponent
+        checkbox: CheckboxV
     }
 })
-export default class LegendGroup extends Vue {
+export default class LegendGroupV extends Vue {
     @Prop() legendItem!: LegendGroup;
     @Prop() props!: any;
 }

--- a/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
@@ -36,16 +36,16 @@ import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 import { LegendStore } from '../store';
 import { LegendEntry, LegendTypes } from '../store/legend-defs';
 
-import CheckboxComponent from './checkbox.vue';
+import CheckboxV from './checkbox.vue';
 import SymbologyStack from './symbology-stack.vue';
 
 @Component({
     components: {
-        checkbox: CheckboxComponent,
+        checkbox: CheckboxV,
         'symbology-stack': SymbologyStack
     }
 })
-export default class LegendPlaceholder extends Vue {
+export default class LegendPlaceholderV extends Vue {
     @Prop() legendItem!: LegendEntry;
     @Prop() props!: any;
     @Get(LayerStore.layers) layers!: BaseLayer[];

--- a/packages/ramp-core/src/fixtures/legend/components/legend-visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-visibility-set.vue
@@ -13,8 +13,8 @@
             <span class="flex-1">{{ legendItem.name }}</span>
 
             <!-- visibility -->
-            <div @click="legendItem.toggleVisibility(); legendItem.toggleExpanded();">
-                <checkbox :value="legendItem.visibility" :isRadio="props && props.isVisibilitySet" />
+            <div @click="legendItem.toggleExpanded();">
+                <checkbox :value="legendItem.visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem" />
             </div>
         </div>
 
@@ -35,16 +35,16 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { LegendStore } from '../store';
-import { LegendItem } from '../store/legend-defs';
-import CheckboxComponent from './checkbox.vue';
+import { LegendGroup } from '../store/legend-defs';
+import CheckboxV from './checkbox.vue';
 
 @Component({
     components: {
         LegendComponent: () => import('./legend-component.vue'),
-        checkbox: CheckboxComponent
+        checkbox: CheckboxV
     }
 })
-export default class LegendGroup extends Vue {
+export default class LegendVisibilitySetV extends Vue {
     @Prop() legendItem!: LegendGroup;
     @Prop() props!: any;
 }

--- a/packages/ramp-core/src/fixtures/legend/legend-header.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend-header.vue
@@ -23,7 +23,7 @@ import { Get, Sync, Call } from 'vuex-pathify';
 import { LegendStore } from './store';
 
 @Component
-export default class LegendHeader extends Vue {
+export default class LegendHeaderV extends Vue {
     // toggle all possible legend groups
     toggleGroups(): void {
         // TODO: call expandGroups() or collapseGroups() action in store

--- a/packages/ramp-core/src/fixtures/legend/legend.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend.vue
@@ -23,13 +23,13 @@ import { PanelInstance } from '@/api';
 
 import { LegendStore } from './store';
 import { LegendItem } from './store/legend-defs';
-import LegendHeader from './legend-header.vue';
-import LegendComponent from './components/legend-component.vue';
+import LegendHeaderV from './legend-header.vue';
+import LegendComponentV from './components/legend-component.vue';
 
 @Component({
     components: {
-        LegendHeader,
-        LegendComponent
+        'legend-header': LegendHeaderV,
+        'legend-component': LegendComponentV
     }
 })
 export default class LegendV extends Vue {


### PR DESCRIPTION
Few legend checkbox/radio improvements
 - Fixed radio buttons not radio-ing #256
 - Attached legend entry visibility to layer's `visibilityChanged` event to fix sync issues between checkbox value and actual layer visibility #233
 - Moved click event to checkbox/radio instead of container div to stop weird behaviour when clicking inside the div but outside the checkbox

Also changed the names of legend vue components to prevent confusion with class names in `legend-defs.ts`

demo link: http://ramp4-app.azureedge.net/demo/users/an-w/legend/host/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/261)
<!-- Reviewable:end -->
