### PR TITLE
implement grid details button

### DIFF
--- a/common/docs/app/defaults.md
+++ b/common/docs/app/defaults.md
@@ -68,6 +68,11 @@ TODO keep updating the list, make new subsections as appropriate. Maybe move to 
 - `ramp_map_click_runs_identify` causes the identify process to start when the map is clicked
 - `ramp_identify_opens_details` causes the details fixture to open, displaying the result of an identify request.
 
+### Fixture Handlers
+
+- `ramp_settings_opens_panel` causes the settings fixture to open for a layer
+- `opens_feature_details` causes the details fixture to open for a single feature
+
 ## Examples
 
 ### Default Setup

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -23,6 +23,8 @@ export enum GlobalEvents {
     MAP_EXTENTCHANGE = 'map/extentchanged', // payload is rampapi Extent
     MAP_IDENTIFY = 'map/identify',
     MAP_MOUSEMOVE = 'map/mousemove',
+    SETTINGS_OPEN = 'settings/open',
+    DETAILS_OPEN = 'details/open'
 }
 
 // TODO export this enum?
@@ -35,7 +37,8 @@ export enum GlobalEvents {
 enum DefEH {
     IDENTIFY_DETAILS = 'ramp_identify_opens_details',
     MAP_IDENTIFY = 'ramp_map_click_runs_identify',
-    OPEN_SETTINGS = 'ramp_settings_opens_panel'
+    OPEN_SETTINGS = 'ramp_settings_opens_panel',
+    OPEN_DETAILS = 'opens_feature_details'
 }
 
 // private for EventBus internals, so don't export
@@ -267,7 +270,7 @@ export class EventAPI extends APIScope {
             // TODO the enum-values-to-array logic we use in the event names list
             //      fails a bit here. we could make it work if we force every default
             //      handler name to being with a specific prefix. Alternately use object, not enum.
-            eventHandlerNames = [DefEH.MAP_IDENTIFY, DefEH.IDENTIFY_DETAILS, DefEH.OPEN_SETTINGS];
+            eventHandlerNames = [DefEH.MAP_IDENTIFY, DefEH.IDENTIFY_DETAILS, DefEH.OPEN_SETTINGS, DefEH.OPEN_DETAILS];
         }
 
         // add all the requested default event handlers.
@@ -286,7 +289,6 @@ export class EventAPI extends APIScope {
         let zeHandler: Function;
 
         switch (handlerName) {
-
             case DefEH.MAP_IDENTIFY:
                 // when map clicks, run the identify action
                 zeHandler = (clickParam: MapClick) => {
@@ -296,7 +298,6 @@ export class EventAPI extends APIScope {
                 };
                 this.on(GlobalEvents.MAP_CLICK, zeHandler, handlerName);
                 break;
-
             case DefEH.IDENTIFY_DETAILS:
                 // when identify runs, open details fixture and show the results
                 zeHandler = (identifyParam: any) => {
@@ -307,19 +308,25 @@ export class EventAPI extends APIScope {
                 };
                 this.on(GlobalEvents.MAP_IDENTIFY, zeHandler, handlerName);
                 break;
-
             case DefEH.OPEN_SETTINGS:
                 zeHandler = (payload: any) => {
                     const settingsFixture: SettingsAPI = this.$iApi.fixture.get('settings');
-                    if(settingsFixture) {
+                    if (settingsFixture) {
                         settingsFixture.open(payload);
                     }
                 };
-
                 // Create a new event: opens the settings panel and hooks it up to the requested layer.
-                this.$iApi.event.on('settings/open', zeHandler, handlerName);
+                this.$iApi.event.on(GlobalEvents.SETTINGS_OPEN, zeHandler, handlerName);
                 break;
-
+            case DefEH.OPEN_DETAILS:
+                zeHandler = (payload: any) => {
+                    const detailsFixture: DetailsAPI = this.$iApi.fixture.get('details');
+                    if (detailsFixture) {
+                        detailsFixture.openFeature(payload.identifyItem, payload.uid);
+                    }
+                };
+                this.$iApi.event.on(GlobalEvents.DETAILS_OPEN, zeHandler, handlerName);
+                break;
             default:
                 console.error(`Unrecognized default event handler name encountered: ${handlerName}`);
                 return `ERROR_NOT_REGISTERED__${handlerName}`;

--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -31,16 +31,18 @@ export class DetailsAPI extends FixtureInstance {
      * Provided with the data for a single feature, open the details panel directly to the feature screen.
      *
      * @param {IdentifyItem} payload
+     * @param {string} uid
      * @memberof DetailsAPI
      */
-    openFeature(payload: IdentifyItem) {
+    openFeature(identifyItem: IdentifyItem, uid: string) {
         // Save the provided identify result in the store.
-        this.$vApp.$store.set('details/setPayload!', payload);
-
+        this.$vApp.$store.set('details/setPayload!', identifyItem);
         // Open the details panel.
-        if (!this.$iApi.panel.get('details-panel').isOpen) {
-            this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-item', props: { isFeature: true } });
+        const panel = this.$iApi.panel.get('details-panel');
+        if (panel.isOpen) {
+            this.$iApi.panel.close(panel);
         }
+        this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-item', props: { isFeature: true, uid: uid } });
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/details/details-item.vue
+++ b/packages/ramp-core/src/fixtures/details/details-item.vue
@@ -40,10 +40,12 @@ export default class DetailsItemV extends Vue {
 
     // true if the current payload is a single IdentifyItem
     @Prop() isFeature!: boolean;
+    @Prop() uid!: string;
 
     // retrieve the identify payload from the store
     @Get(DetailsStore.payload) payload!: IdentifyResult[];
     @Get('layer/layers') layers!: BaseLayer[];
+    @Get('layer/getLayerByUid') getLayerByUid!: (id: string) => BaseLayer | undefined;
 
     identifyTypes: any = IdentifyResultFormat;
 
@@ -56,25 +58,12 @@ export default class DetailsItemV extends Vue {
 
     get detailsTemplate() {
         const layerInfo = this.payload[this.layerIndex];
-
-        // Check to see if there is a custom template defined for the selected layer.
-        let item: BaseLayer | undefined = this.layers
-            .map(layer => {
-                let layerNode = layer.getLayerTree();
-
-                if (!layerNode) return;
-
-                // Determine if the selected UID is a child of this layer.
-                if (layerNode.findChildByUid(layerInfo.uid) !== undefined) {
-                    return layer;
-                }
-            })
-            .filter(node => node != undefined)[0];
+        const layer: BaseLayer | undefined = this.getLayerByUid(layerInfo?.uid || this.uid);
 
         // If there is a custom template binding for this layer in the store, then
         // return its name.
-        if (item && this.templateBindings[item.id] && this.templateBindings[item.id].componentId) {
-            return this.templateBindings[item.id].componentId;
+        if (layer && this.templateBindings[layer.id] && this.templateBindings[layer.id].componentId) {
+            return this.templateBindings[layer.id].componentId;
         }
 
         // If nothing is found, use a default template.

--- a/packages/ramp-core/src/fixtures/grid/table/table.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/table.vue
@@ -58,6 +58,8 @@
 <script lang="ts">
 import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
+import { GlobalEvents } from '../../../api/internal';
+import deepmerge from 'deepmerge';
 
 import { LayerStore, layer } from '@/store/modules/layer';
 import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
@@ -359,6 +361,12 @@ export default class TableComponent extends Vue {
                         justifyContent: 'center',
                         alignItems: 'center'
                     };
+                },
+                onCellClicked: (cell: any) => {
+                    const fakeIdentifyItem = deepmerge({}, {data: cell.data});
+                    delete fakeIdentifyItem['data']['rvInteractive'];
+                    delete fakeIdentifyItem['data']['rvSymbol']; 
+                    this.$iApi.event.emit(GlobalEvents.DETAILS_OPEN, {identifyItem: fakeIdentifyItem, uid: this.layerUid});
                 }
             };
             colDef.push(detailsDef);


### PR DESCRIPTION
Can now open feature details from grid rows #140

For the `fakeIdentifyItem`, not sure about `IdentifyResultFormat`since it's not used anywhere right now. Also, we can probably use the cell data's `rv-symbol` for #137 but I've kept it deleted for now to keep the "grid details" and "identify details" the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/263)
<!-- Reviewable:end -->
