### PR TITLE
Client Side Filter Events

### DIFF
--- a/common/docs/app/defaults.md
+++ b/common/docs/app/defaults.md
@@ -57,6 +57,34 @@ The `metadata` provides an interface to view extra information about a layer. TO
 
 The `settings` allow you to make live modifications to a layer on the map. TODO create and hyperlink to `settings.md`
 
+## Default Events
+
+All events are specific to a RAMP instance. An event on one instance says nothing about a different instance.
+
+### Core Events
+
+These events will always be present, regardless of what fixtures are active. Event names here include the `GlobalEvents` enum value first. Italics in the payload indicate a property of a general payload object.
+
+TODO if we have API docs that expose the payload interfaces, link to those definitions. Otherwise we'll need to put the interface specs here
+
+| Event Name | Payload | Event Announces|
+| ---------- | ---------- | ---------- |
+| COMPONENT<br>'ramp/component' | *id*: component id| A vue component registered |
+| FILTER_CHANGE<br>'filter/change' | FilterEventParam object| A filter has changed |
+| MAP_CLICK<br>'map/click' | MapClick object | The map was clicked |
+| MAP_CREATED<br>'map/created' | Map API object| The map was created |
+| MAP_DOUBLECLICK<br>'map/doubleclick' | MapClick object | The map was double clicked |
+| MAP_EXTENTCHANGE<br>'map/extentchanged' | RAMP Extent object| The map extent changed|
+| MAP_IDENTIFY<br>'map/identify' | *results*: Array of IdentifyResult<br>*click*: MapClick object| A map identify was requested |
+| MAP_MOUSEMOVE<br>'map/mousemove' | MapMove object | The mouse moved over the map |
+
+
+### Core Fixture Events
+
+These events will be present if the associated core fixtures are running
+
+TODO add stuff as we make events that core fixtures raise
+
 ## Default Events Handlers
 
 Along with the default fixtures, there are default event handlers that are applied to make them react to each other and to the RAMP core. See the examples section below and the LINKTO Events API page for details on how to work with event handlers.

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -9,7 +9,10 @@ export enum GlobalEvents {
      * Fires when a Vue component is registered with `rInstance.component(...)`.
      * Payload: `(id: string)`
      */
-    COMPONENT = 'r4/component', // TODO for compatibility with future versions of ramp, maybe use ramp/ instead of r4/ ?
+    COMPONENT = 'ramp/component',
+
+    // TODO document payload
+    FILTER_CHANGE = 'filter/change',
 
     /**
      * Fires when the map is created

--- a/packages/ramp-geoapi/src/gapiTypes.ts
+++ b/packages/ramp-geoapi/src/gapiTypes.ts
@@ -7,6 +7,7 @@
 
 import esri = __esri; // magic command to get ESRI JS API type definitions.
 import BaseGeometry from './api/geometry/BaseGeometry'; // this is a bit wonky. could expose on RampAPI, but dont want clients using the baseclass
+import Extent from './api/geometry/Extent';
 import Point from './api/geometry/Point';
 import SpatialReference from './api/geometry/SpatialReference';
 import { Attributes } from './api/apiDefs';
@@ -65,7 +66,7 @@ export class EsriBundle {
     Polygon: esri.PolygonConstructor;
     Polyline: esri.PolylineConstructor;
     SpatialReference: esri.SpatialReferenceConstructor;
-    
+
     // SYMBOLS & RENDERERS
     ClassBreaksRenderer: esri.ClassBreaksRendererConstructor;
     PictureMarkerSymbol: esri.PictureMarkerSymbolConstructor;
@@ -268,8 +269,19 @@ export interface IdentifyResultSet {
 }
 
 export interface FilterEventParam {
-    filter: string;
-    uid: string;
+    filterKey: string;
+    uid?: string;
+    extent?: Extent;
+    extraData?: any;
+}
+
+// these represent filter keys that the core reserves. the above interface does not use it for typing as
+// 3rd parties can define their own keys.
+export enum CoreFilterKey {
+    SYMBOL = 'symbol',
+    GRID = 'grid',
+    EXTENT = 'extent',
+    API = 'api'
 }
 
 // ----------------------- CLIENT CONFIG INTERFACES -----------------------------------

--- a/packages/ramp-geoapi/src/layer/BaseLayer.ts
+++ b/packages/ramp-geoapi/src/layer/BaseLayer.ts
@@ -25,6 +25,9 @@ export default class BaseLayer extends BaseBase {
     _innerLayer: esri.Layer;
     _innerView: esri.LayerView;
 
+    // used to manage debouncing when applying filter updates against a layer. Private! but needs to be seen by FCs.
+    _lastFilterUpdate: string = '';
+
     // events
     visibilityChanged: TypedEvent<boolean>;
     opacityChanged: TypedEvent<number>;


### PR DESCRIPTION
Donethankses https://github.com/ramp4-pcar4/ramp4-pcar4/issues/240

Puts filter events on the Instance API, wires up core stuff to it (Layers, Map).
Adds apply-to-map debounce to deal with issue recently found in RAMP2.

Difficult to test via the demo. I did some console logging and some "set filter SQL after timeout" tests to validate events were raising and map layers were changing as expected.

No rush, this can marinate until next Wednesday

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/269)
<!-- Reviewable:end -->
