### PR TITLE
fix WFS loading, map layer adding

### DIFF
--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -36,11 +36,8 @@ export default class EsriMap extends Vue {
         //      the root cause and fix that.
         if (!this.map) { return; }
 
-        newValue.forEach(layer => {
-            // TODO add a proper check for this after
-            // if (!oldValue.includes(layer)) {
+        newValue.filter(l => !oldValue.includes(l)).forEach(layer => {
             this.map.addLayer(layer);
-            // }
 
             // a bit dangerous but ideally https://github.com/ramp4-pcar4/ramp4-pcar4/issues/126 and https://github.com/ramp4-pcar4/ramp4-pcar4/issues/173
             // will make this more seamless and not need to worry about having multiple listeners.

--- a/packages/ramp-core/src/store/modules/config/config-store.ts
+++ b/packages/ramp-core/src/store/modules/config/config-store.ts
@@ -32,9 +32,8 @@ const getters = {
 const actions = {
     newConfig: function(this: any, context: ConfigContext, config: RampConfig): void {
         const newConfig = merge(context.state.config, config);
-        this.set(LayerStore.addLayers, newConfig.layers);
-
         context.commit('SET_CONFIG', newConfig);
+        this.set(LayerStore.addLayers, newConfig.layers);
     },
     registerConfig: function(this: any, context: ConfigContext, configInfo: any): void {
         const langs = configInfo.langs;

--- a/packages/ramp-core/src/store/modules/layer/layer-blueprint.class.ts
+++ b/packages/ramp-core/src/store/modules/layer/layer-blueprint.class.ts
@@ -737,7 +737,7 @@ class UrlWrapper {
      * @memberof UrlWrapper
      */
     updateQuery(queryMapUpdate: QueryMap): string {
-        const requestQueryMap: QueryMap = deepmerge({}, this.queryMap, queryMapUpdate);
+        const requestQueryMap: QueryMap = <QueryMap>deepmerge.all([{}, this.queryMap, queryMapUpdate]);
         const requestUrl = `${this.base}${Object.entries(requestQueryMap)
             .filter(([_, value]) => value !== undefined)
             .map(([key, value], index) => `${index === 0 ? '?' : ''}${key}=${value}`)

--- a/packages/ramp-core/src/store/modules/layer/layer-store.ts
+++ b/packages/ramp-core/src/store/modules/layer/layer-store.ts
@@ -43,7 +43,8 @@ const actions = {
 
 const mutations = {
     ADD_LAYER: (state: LayerState, value: BaseLayer) => {
-        state.layers.push(value);
+        // copy to new array so watchers will have a reference to the old value
+        state.layers = [...state.layers, value]
     }
 };
 


### PR DESCRIPTION
Fixed WFS loading the same data multiple times. The request URL wasn't being updated with the new query. #239

Fixed map layer watcher adding layers multiple times. Changed the layers mutator to copy the array so  `oldValue` and `newValue` would reference different arrays which we can compare.  #268

Also the layer watcher was being triggered before map exists. Setting the config before the layers seems to fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/271)
<!-- Reviewable:end -->
