### PR TITLE
Small Geoapi bug fixes

### DIFF
--- a/packages/ramp-core/src/fixtures/details/details-item.vue
+++ b/packages/ramp-core/src/fixtures/details/details-item.vue
@@ -67,8 +67,8 @@ export default class DetailsItemV extends Vue {
 
     get itemName() {
         // TODO get name field from layer once https://github.com/ramp4-pcar4/ramp4-pcar4/issues/272 is implemented.
-        if (this.identifyItem.data.Name != undefined) return this.identifyItem.data.Name;
-        else if (this.identifyItem.data.StationName != undefined) return this.identifyItem.data.StationName;
+        if (this.identifyItem.data.Name !== undefined) return this.identifyItem.data.Name;
+        else if (this.identifyItem.data.StationName !== undefined) return this.identifyItem.data.StationName;
         return 'Details';
     }
 
@@ -78,8 +78,7 @@ export default class DetailsItemV extends Vue {
         const layer: BaseLayer | undefined = this.getLayerByUid(uid);
         if (layer === undefined) return '';
         // TODO get objectid field from layer once https://github.com/ramp4-pcar4/ramp4-pcar4/issues/273 is implemented.
-        // TODO use second uid parameter in getIcon after https://github.com/ramp4-pcar4/ramp4-pcar4/issues/257 is implemented.
-        return layer.getIcon(this.identifyItem.data.OBJECTID).then(value => this.icon = value);
+        return layer.getIcon(this.identifyItem.data.OBJECTID, uid).then(value => this.icon = value);
     }
 
     get detailsTemplate() {

--- a/packages/ramp-core/src/fixtures/details/details-layers.vue
+++ b/packages/ramp-core/src/fixtures/details/details-layers.vue
@@ -61,7 +61,7 @@ export default class DetailsLayersV extends Vue {
                     return layer;
                 }
             })
-            .filter(node => node != undefined)[0];
+            .filter(node => node !== undefined)[0];
 
         if (!item) return;
 

--- a/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
@@ -24,7 +24,7 @@ export default class ESRIDefaultV extends Vue {
     get itemData() {
         const helper: any = {};
         Object.assign(helper, this.identifyData.data);
-        if (helper.Symbol != undefined) delete helper.Symbol;
+        if (helper.Symbol !== undefined) delete helper.Symbol;
         return helper;
     }
 }

--- a/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
@@ -56,7 +56,7 @@ export default class LegendPlaceholderV extends Vue {
     layerAdded(newValue: BaseLayer[], oldValue: BaseLayer[]) {
         this.layer = newValue.find((layer: BaseLayer) => layer.id === this.legendItem.id);
 
-        if (this.layer != undefined) {
+        if (this.layer !== undefined) {
             this.layer.isLayerLoaded().then(r => {
                 this.legendItem._layer = this.layer;
                 this.legendItem._type = LegendTypes.Entry;

--- a/packages/ramp-geoapi/src/layer/BaseLayer.ts
+++ b/packages/ramp-geoapi/src/layer/BaseLayer.ts
@@ -332,7 +332,7 @@ export default class BaseLayer extends BaseBase {
         if (uid === this.uid) {
             return -1;
         } else {
-            const fcIdx: number = this.fcs.findIndex(fc => fc.uid === uid);
+            const fcIdx: number = this.fcs.findIndex(fc => fc?.uid === uid);
             if (fcIdx === -1) {
                 // no match
                 throw new Error(`Attempt to access non-existing unique id [layerid ${this._innerLayer.id}, uid ${uid}]`);

--- a/packages/ramp-geoapi/src/layer/FeatureLayer.ts
+++ b/packages/ramp-geoapi/src/layer/FeatureLayer.ts
@@ -89,6 +89,7 @@ export class FeatureLayer extends AttribLayer {
         this.fcs[featIdx] = featFC;
         featFC.serviceUrl = layerUrl;
         this.layerTree.children.push(new TreeNode(featIdx, featFC.uid, this.name)); // TODO verify name is populated at this point
+        featFC.name = this.name; // feature layer is flat, so the FC and layer share their name
 
         // TODO see if we need to re-synch the parent name
         // this.layerTree.name = this.name;

--- a/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
+++ b/packages/ramp-geoapi/src/layer/GeoJsonLayer.ts
@@ -161,6 +161,7 @@ export class GeoJsonLayer extends AttribLayer {
         // feature has only one layer
         const featIdx: number = 0; // GeoJSON is always 0
         const gjFC = new GeoJsonFC(this.infoBundle(), this, featIdx);
+        gjFC.name = this.name; // geojson layer is flat, so the FC and layer share their name. we do this here and not in extractMetaData because .name is private
         this.fcs[featIdx] = gjFC;
         this.layerTree.children.push(new TreeNode(featIdx, gjFC.uid, this.name));
 


### PR DESCRIPTION
Fixes a bug in code that searches feature class arrays (hat tip to Maggie for discovering, Andrew for debugging, and me for writing bad code).

Fixes a bug where feature class objects did not have their layer name set, so requesting a name with an fc uid would give you nothing.

Powered up some `!=` to be much more impressive `!==` for a glorious future of not-equal justice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/275)
<!-- Reviewable:end -->
