### PR TITLE
increased y-margin of close button tooltip

### DIFF
--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -2,7 +2,7 @@
     <span
         role="tooltip"
         :class="'rv-ui-tooltip-' + position"
-        class="rv-ui-tooltip absolute opacity-0 invisible bg-black text-white text-center py-3 px-5 rounded z-50"
+        class="rv-ui-tooltip pointer-events-none absolute opacity-0 invisible bg-black text-white text-center py-3 px-5 rounded z-50"
         ><slot></slot
     ></span>
 </template>


### PR DESCRIPTION
Possibly fixes [279](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/279).

On my setup, the button becomes inactive (grey) in the "black highlight" area only when the mouse gets close to the tooltip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/280)
<!-- Reviewable:end -->
