### PR TITLE
add test page

### DIFF
--- a/packages/ramp-core/host/index-e2e.html
+++ b/packages/ramp-core/host/index-e2e.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+    <!-- Fun Note: the `host` instance of index.html is what gets used when building the project via `rush build` -->
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+        <link rel="icon" href="./favicon.ico" />
+        <title>Test Page</title>
+
+        <link rel="stylesheet" href="./../dist/RAMP.css" />
+
+        <!-- the host page must load Vue since RAMP doesn't bundle it -->
+        <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+
+        <!-- loading main RAMP file; this needs to be loaded after Vue -->
+        <script src="./../dist/RAMP.umd.js"></script>
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <span id="ramp-version"></span>
+
+        <script>
+            // get RAMP "starter" script from url param
+            const params = new URLSearchParams(document.location.search);
+            let script = document.createElement("script");
+            let starterParam = params.get("script");
+            if (starterParam) {
+                // html-webpack-plugin doesn't like template strings
+                script.src = "./../dist/starter-scripts/" + starterParam + ".js";
+            } else {
+                script.src = "./../dist/ramp-starter.js";
+            }
+            // log an error msg if script doesn't exist / is broken
+            script.onerror = () => {
+                console.log("invalid script");
+            }
+            document.body.appendChild(script);
+        </script>
+    </body>
+</html>

--- a/packages/ramp-core/public/index-e2e.html
+++ b/packages/ramp-core/public/index-e2e.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+    <!-- Fun Note: the `public` instance of index.html is what gets used when running locally via `rush serve` -->
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+        <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
+        <title>Test Page</title>
+
+        <!-- Vue is loaded in dev builds as well because of an issue with Cypress and external fixtures -->
+        <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+
+        <!-- RAMP will be injected here -->
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <span id="ramp-version"></span>
+
+        <script>
+            // get RAMP "starter" script from url param
+            const params = new URLSearchParams(document.location.search);
+            let script = document.createElement("script");
+            let starterParam = params.get("script");
+            if (starterParam) {
+                // html-webpack-plugin doesn't like template strings
+                script.src = "./starter-scripts/" + starterParam + ".js";
+            } else {
+                script.src = "./ramp-starter.js";
+            }
+            document.body.appendChild(script);
+            // log an error msg if script doesn't exist / is broken
+            window.onerror = (msg, src) => {
+                if (src === script.src) {
+                    console.log("invalid script")
+                }
+            }
+        </script>
+    </body>
+</html>

--- a/packages/ramp-core/public/starter-scripts/basemap-only.js
+++ b/packages/ramp-core/public/starter-scripts/basemap-only.js
@@ -1,0 +1,43 @@
+window.rInstance = null;
+
+document.title = "Basemap"
+
+function initRAMP() {
+    let config = {
+        en: {
+            map: {
+                extent: {
+                    xmax: -5007771.626060756,
+                    xmin: -16632697.354854,
+                    ymax: 10015875.184845109,
+                    ymin: 5022907.964742964,
+                    spatialReference: {
+                        wkid: 102100,
+                        latestWkid: 3857
+                    }
+                },
+                lods: RAMP.geoapi.maps.defaultLODs(RAMP.geoapi.maps.defaultTileSchemas()[1]), // idx 1 = mercator
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esriTile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            }
+        }
+    }
+
+    let options = {
+        loadDefaultFixtures: false,
+        loadDefaultEvents: false
+    };
+
+    rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
+}

--- a/packages/ramp-core/public/starter-scripts/mapnav.js
+++ b/packages/ramp-core/public/starter-scripts/mapnav.js
@@ -1,0 +1,46 @@
+window.rInstance = null;
+document.title = "Mapnav"
+
+function initRAMP() {
+    let config = {
+        en: {
+            map: {
+                extent: {
+                    xmax: -5007771.626060756,
+                    xmin: -16632697.354854,
+                    ymax: 10015875.184845109,
+                    ymin: 5022907.964742964,
+                    spatialReference: {
+                        wkid: 102100,
+                        latestWkid: 3857
+                    }
+                },
+                lods: RAMP.geoapi.maps.defaultLODs(RAMP.geoapi.maps.defaultTileSchemas()[1]), // idx 1 = mercator
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esriTile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            },
+            fixtures: {
+                mapnav: { items: ['fullscreen'] },
+            }
+        }
+    }
+
+    let options = {
+        loadDefaultFixtures: false,
+        loadDefaultEvents: false
+    };
+
+    rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
+    rInstance.fixture.addDefaultFixtures(['mapnav']);
+}

--- a/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
+++ b/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
@@ -1,6 +1,6 @@
 describe('Mapnav', () => {
     beforeEach(() => {
-        cy.visit('/');
+        cy.visit('/index-e2e.html?script=mapnav');
         cy.get('.ramp-app');
         cy.get('.mapnav');
     });

--- a/packages/ramp-core/vue.config.js
+++ b/packages/ramp-core/vue.config.js
@@ -6,6 +6,18 @@ const childProcess = require('child_process');
 const pkg = require('./package.json');
 
 module.exports = {
+    pages: {
+        index: {
+          entry: 'src/main.ts',
+          template: 'public/index.html',
+          filename: 'index.html'
+        },
+        test: {
+          entry: 'src/main.ts',
+          template: 'public/index-e2e.html',
+          filename: 'index-e2e.html'
+        }
+    },
     configureWebpack: {
         output: {
             libraryExport: 'default'
@@ -53,7 +65,8 @@ module.exports = {
         // DEV-specific configuration
         config.when(process.env.NODE_ENV === 'development', config => {
             // modify the default injection point from 'body' to 'head', so it's easier to orchestrate the loading order; only when `serve`ing
-            config.plugin('html').tap(args => [{ ...args[0], inject: 'head' }]);
+            config.plugin('html-index').tap(args => [{ ...args[0], inject: 'head' }]);
+            config.plugin('html-test').tap(args => [{ ...args[0], inject: 'head' }]);
         });
 
         // PROD-specific configuration
@@ -70,6 +83,7 @@ module.exports = {
 
             // copy `ramp-starter.js` to `dist` folder when building prod build
             config.plugin('webpack-copy-plugin').tap(args => [[...args[0], { from: 'public/ramp-starter.js', to: '' }]]);
+            config.plugin('webpack-copy-plugin').tap(args => [[...args[0], { from: 'public/starter-scripts/', to: './starter-scripts/' }]]);
         });
 
         // get version numbers


### PR DESCRIPTION
demo: http://ramp4-app.azureedge.net/demo/users/an-w/test/host/index-e2e.html

Basic e2e test page #258
Looking for feedback; if this isn't the way to go I can scrap it 

So the "base" test page is `index-e2e.html` that only has a `#app` div to mount RAMP to. It reads the URL param `script` for which "starter" script (like `ramp-starter.js`) to load. Each script will implement `initRAMP()` with a specified config and be free to do whatever with fixtures/events/page template. By default it loads the current `ramp-starter.js`.

Few examples for demo:
`/index-e2e.html?script=basemap-only` will load a RAMP page with no layers/fixtures  
`/index-e2e.html?script=mapnav` will load a RAMP page with only the mapnav

e2e cypress scripts can just navigate to their respective config script for example:
`cy.visit('/index-e2e.html?script=mapnav');`

Not sure what's the best way for things to work in `serve` as well as the prod/demo build since the `pages` in the vue config only applies to `serve`. Keeping both `index-e2e.html` files relatively barebones and copying the script files with webpack seems a bit more maintainable but I'm not too confident with how everything works. Lmk if there's a better way to handle this.

Also not too sure about the naming and structure of things.

thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/282)
<!-- Reviewable:end -->
