### PR TITLE
Tooltip hover fix

### DIFF
--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -19,6 +19,17 @@ export default class TooltipV extends Vue {
         //give the tooltip a random id and then set aria attributes as needed on parent
         this.$el.setAttribute('id', this.generateID());
         this.$el.previousElementSibling!.setAttribute('aria-labelledby', this.$el.id);
+
+        // Handle hovering through events so that we can stop propogation
+        (this.$el.previousElementSibling! as HTMLElement).addEventListener('mouseover', function(event: MouseEvent) {
+            event.stopPropagation();
+            this.classList.add('show-tooltip');
+        });
+        (this.$el.previousElementSibling! as HTMLElement).addEventListener('mouseout', function(event: MouseEvent) {
+            if (this.classList.contains('show-tooltip')) {
+                this.classList.remove('show-tooltip');
+            }
+        });
     }
 
     generateID(): string {
@@ -72,7 +83,7 @@ export default class TooltipV extends Vue {
         transform: translateY(-50%);
     }
 
-    :hover > &,
+    .show-tooltip + &,
     :focus + &,
     :focus .focused + & {
         @apply visible opacity-100 text-base;

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -9,7 +9,8 @@ enum KEYS {
     ArrowRightIE = 'Right',
     Escape = 'Escape',
     EscapeIE = 'Esc',
-    Enter = 'Enter'
+    Enter = 'Enter',
+    Space = ' '
 }
 
 const LIST_ATTR = 'focus-list';
@@ -278,6 +279,7 @@ class FocusListManager {
                 break;
 
             case KEYS.Enter:
+            case KEYS.Space:
                 // if the the list is the target then it has focus, meaning the user is traversing this list
                 // and not a list farther down the tree (or a tabbable button, etc.)
                 // however if the list is the highlighted item we let the default behaviour through (as it has regular focus)

--- a/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
@@ -1,27 +1,30 @@
 <template>
     <div class="legend-item">
-        <div
-            class="default-focus-style p-5 flex items-center hover:bg-gray-200 cursor-pointer h-44"
-            @click="$iApi.fixture.get('grid').openGrid(legendItem.layer.uid)"
-            v-focus-item
-        >
-            <!-- symbology stack toggle-->
-            <div class="relative w-32 h-32">
-                <button @click.stop="toggleSymbology" tabindex="-1">
-                    <symbology-stack class="w-32 h-32" :visible="displaySymbology" :layer="legendItem.layer" />
-                </button>
-                <tooltip position="top-left">
-                    {{ displaySymbology ? $t('legend.symbology.hide') : $t('legend.symbology.expand') }}
-                </tooltip>
-            </div>
+        <div class="relative">
+            <div
+                class="default-focus-style p-5 flex items-center hover:bg-gray-200 cursor-pointer h-44"
+                @click="$iApi.fixture.get('grid').openGrid(legendItem.layer.uid)"
+                v-focus-item
+            >
+                <!-- symbology stack toggle-->
+                <div class="relative w-32 h-32">
+                    <button @click.stop="toggleSymbology" tabindex="-1">
+                        <symbology-stack class="w-32 h-32" :visible="displaySymbology" :layer="legendItem.layer" />
+                    </button>
+                    <tooltip position="top-left">
+                        {{ displaySymbology ? $t('legend.symbology.hide') : $t('legend.symbology.expand') }}
+                    </tooltip>
+                </div>
 
-            <!-- name -->
-            <div class="flex-1 truncate ml-15">
-                <span>{{ legendItem.name }}</span>
-            </div>
+                <!-- name -->
+                <div class="flex-1 truncate ml-15">
+                    <span>{{ legendItem.name }}</span>
+                </div>
 
-            <!-- visibility -->
-            <checkbox :value="visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem" />
+                <!-- visibility -->
+                <checkbox :value="visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem" />
+            </div>
+            <tooltip position="top-left">{{ $t('legend.entry.data') }}</tooltip>
         </div>
 
         <!-- Symbology Stack Section -->

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -12,3 +12,4 @@ legend.visibility.show,Show layer,1,Afficher la couche,0
 legend.visibility.hide,Hide layer,1,Masquer la couche,0
 legend.symbology.expand,Expand legend,1,Développer la légende,0
 legend.symbology.hide,Hide legend,1,Hide legend,0
+legend.entry.data,Show more data,1,Show more data,0

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -11,5 +11,5 @@ legend.group.collapse,Collapse Group,1,Réduire la groupe,0
 legend.visibility.show,Show layer,1,Afficher la couche,0
 legend.visibility.hide,Hide layer,1,Masquer la couche,0
 legend.symbology.expand,Expand legend,1,Développer la légende,0
-legend.symbology.hide,Hide legend,1,Hide legend,0
-legend.entry.data,Show more data,1,Show more data,0
+legend.symbology.hide,Hide legend,1,Cacher la légende,0
+legend.entry.data,Show more data,1,Démontrer plus de données,0


### PR DESCRIPTION
#306 

Added some event handlers for hovering; CSS hover cannot have propagation stopped like events can. Additionally there is no way to alter a parent elements CSS based on an interaction on a child... this means that I could make the lowest tooltip show (the legend item) without showing the symbology tooltip etc. but I could not make the opposite happen with just CSS.

Bonus accessibility enhancement, spacebar now actually triggers focus items, used to be only enter.

DEMO: http://ramp4-app.azureedge.net/demo/users/spencerwahl/more-ui/host/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/307)
<!-- Reviewable:end -->
