### PR TITLE
(fixed) partial animation toggle

### DIFF
--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -30,7 +30,7 @@
         <noscript>
             <strong>We're sorry but ramp-core doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
         </noscript>
-        <button onclick="animateToggle()">Animations: {{//get on/off status}}</button>
+        <button id="animate-status" onclick="animateToggle()">Animate: on</button>
         <button onclick="switchLang()">Switch language</button><span id="instance-language"></span>
 
         <div id="app"></div>

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -30,6 +30,7 @@
         <noscript>
             <strong>We're sorry but ramp-core doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
         </noscript>
+        <button onclick="animateToggle()">Animations: {{//get on/off status}}</button>
         <button onclick="switchLang()">Switch language</button><span id="instance-language"></span>
 
         <div id="app"></div>

--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -437,3 +437,7 @@ function switchLang() {
     }
     document.getElementById('instance-language').innerText = rInstance.language;
 }
+
+function animateToggle() {
+    // get and toggle animate status
+}

--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -439,5 +439,10 @@ function switchLang() {
 }
 
 function animateToggle() {
-    // get and toggle animate status
+    if (rInstance.$vApp.$el.classList.contains("animation-enabled")) {
+        rInstance.$vApp.$el.classList.remove("animation-enabled");
+    } else {
+        rInstance.$vApp.$el.classList.add("animation-enabled");
+    }
+    document.getElementById('animate-status').innerText = "Animate: " + rInstance.animate;
 }

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -169,14 +169,6 @@ export class InstanceAPI {
         return this.$vApp.$i18n.locale;
     }
 
-    get animate(): string{
-        return " " // fix: return animate status
-    }
-
-    setAnimate(status:string): void {
-        // toggle animate status
-    }
-
     /**
      * The current animation status.
      * 

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -169,12 +169,18 @@ export class InstanceAPI {
         return this.$vApp.$i18n.locale;
     }
 
-    get animate(): string{
-        return " " // fix: return animate status
-    }
-
-    setAnimate(status:string): void {
-        // toggle animate status
+    /**
+     * The current animation status.
+     * 
+     * @readonly
+     * @type string
+     * @memberof InstanceAPI
+     */
+    get animate(): string {
+        if (this.$vApp.$el.classList.contains("animation-enabled")) {
+            return "on"
+        }
+        return "off"
     }
 
     /**

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -169,6 +169,14 @@ export class InstanceAPI {
         return this.$vApp.$i18n.locale;
     }
 
+    get animate(): string{
+        return " " // fix: return animate status
+    }
+
+    setAnimate(status:string): void {
+        // toggle animate status
+    }
+
     /**
      * Toggles fullscreen for the app.
      *

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -40,9 +40,6 @@ export default class App extends Vue {
     @include focus-list.default-focused-styling;
     height: 700px;
 }
-.ramp-app.animation-enabled .rv-ui-tooltip {
-    transition-duration: 0.2s;
-}
 </style>
 
 <style lang="scss" scoped>

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -1,14 +1,12 @@
 <template>
-    <div class="ramp-app" :lang="$i18n.locale">
+    <div class="ramp-app animation-enabled" :lang="$i18n.locale">
         <shell></shell>
     </div>
 </template>
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
-
 import Shell from '@/components/shell.vue';
-
 import ro from '@/scripts/resize-observer.js';
 
 import { FocusList, FocusItem } from '@/directives/focus-list';
@@ -39,10 +37,5 @@ export default class App extends Vue {
 .ramp-app {
     @include focus-list.default-focused-styling;
     height: 700px;
-}
-</style>
-
-<style lang="scss" scoped>
-.ramp-app {
 }
 </style>

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -28,7 +28,6 @@ export default class App extends Vue {
         // let ResizeObserver observe the app div
         // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
         ro.observe(this.$el);
-        console.log(this.$el);
     }
 }
 </script>

--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -14,6 +14,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 export default class TooltipV extends Vue {
     @Prop({ default: 'top' }) position!: string;
     @Prop() tooltipfor!: HTMLElement | null;
+    animate: boolean = false; //@Get animate status
 
     mounted() {
         //give the tooltip a random id and then set aria attributes as needed on parent
@@ -30,6 +31,13 @@ export default class TooltipV extends Vue {
                 this.classList.remove('show-tooltip');
             }
         });
+        
+        // if !animate, set transition duration to 0
+        if (this.animate) {
+            this.$el.setAttribute('animate', 'true')
+        } else {
+            this.$el.setAttribute('animate', 'false')
+        }
     }
 
     generateID(): string {
@@ -49,11 +57,16 @@ export default class TooltipV extends Vue {
 
 <style lang="scss" scoped>
 .rv-ui-tooltip {
-    transition: opacity 0.2s;
-    transition: font-size 0.2s;
+    transition-property: opacity font-size;
     width: max-content;
     font-size: x-small;
 
+    &[animate='true'] {
+        transition-duration: 0.2s;
+    }
+    &[animate='false'] {
+        transition-duration: 0s;
+    }
     &[position='top'] {
         @apply left-1/2 bottom-full;
         transform: translateX(-50%);

--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -52,7 +52,6 @@ export default class TooltipV extends Vue {
     transition-property: opacity font-size;
     width: max-content;
     font-size: x-small;
-    
     &[position='top'] {
         @apply left-1/2 bottom-full;
         transform: translateX(-50%);
@@ -81,7 +80,6 @@ export default class TooltipV extends Vue {
         @apply left-full top-1/2;
         transform: translateY(-50%);
     }
-
     .show-tooltip + &,
     :focus + &,
     :focus .focused + & {

--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -86,4 +86,7 @@ export default class TooltipV extends Vue {
         @apply visible opacity-100 text-base;
     }
 }
+.ramp-app.animation-enabled .rv-ui-tooltip {
+    transition-duration: 0.2s;
+}
 </style>

--- a/packages/ramp-core/src/components/util/tooltip.vue
+++ b/packages/ramp-core/src/components/util/tooltip.vue
@@ -14,7 +14,6 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 export default class TooltipV extends Vue {
     @Prop({ default: 'top' }) position!: string;
     @Prop() tooltipfor!: HTMLElement | null;
-    animate: boolean = false; //@Get animate status
 
     mounted() {
         //give the tooltip a random id and then set aria attributes as needed on parent
@@ -31,12 +30,20 @@ export default class TooltipV extends Vue {
                 this.classList.remove('show-tooltip');
             }
         });
-        
-        // if !animate, set transition duration to 0
-        if (this.animate) {
-            this.$el.setAttribute('animate', 'true')
+
+        if (this.$iApi.$vApp.$el.classList.contains("animation-enabled")) {
+            this.$el.setAttribute('animate', 'true');
         } else {
-            this.$el.setAttribute('animate', 'false')
+            this.$el.setAttribute('animate', 'false');
+        }
+        (this.$el.previousElementSibling! as HTMLElement).addEventListener('mouseover', this.checkAnimation);
+    }
+
+    checkAnimation(event: MouseEvent) {
+        if (this.$el.getAttribute('animate') == 'false' && this.$iApi.$vApp.$el.classList.contains("animation-enabled")) {
+            this.$el.setAttribute('animate', 'true');
+        } else if (this.$el.getAttribute('animate') == 'true' && !this.$iApi.$vApp.$el.classList.contains("animation-enabled")) {
+            this.$el.setAttribute('animate', 'false');
         }
     }
 


### PR DESCRIPTION
For issue [#304](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/304).

I'm not sure of the right place/way to store a global animation status for an instance. The animation toggle for tooltips currently works only if you manually change the variable 'animate' on 'tooltip.vue'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/318)
<!-- Reviewable:end -->
