### PR TITLE
fix mobile pan/zoom

### DIFF
--- a/packages/ramp-geoapi/src/map/RampMap.ts
+++ b/packages/ramp-geoapi/src/map/RampMap.ts
@@ -108,6 +108,12 @@ export class RampMap extends MapBase {
             //      should we debounce here? or on the client?
             this.mapMouseMoved.fireEvent(this.gapi.utils.geom.esriMapMouseToRamp(esriMouseMove));
         });
+
+        this._innerView.container.addEventListener('touchmove', e => {
+            // need this for panning and zooming to work on mobile devices / touchscreens
+            // touchmove stops the drag event (what the MapView reacts to) from firing properly
+            e.preventDefault();
+        });
     }
 
     /**


### PR DESCRIPTION
#320
So the `touchmove` event was stopping `drag` from working properly on touchscreens. Seems like panning and zooming works on Android/iOS now (i think).

[demo link](http://ramp4-app.azureedge.net/demo/users/an-w/zzz/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/321)
<!-- Reviewable:end -->
