### PR TITLE
custom keyboard navigation

### DIFF
--- a/packages/ramp-core/public/starter-scripts/basemap-only.js
+++ b/packages/ramp-core/public/starter-scripts/basemap-only.js
@@ -36,7 +36,7 @@ function initRAMP() {
 
     let options = {
         loadDefaultFixtures: false,
-        loadDefaultEvents: false
+        loadDefaultEvents: true
     };
 
     rInstance = new RAMP.Instance(document.getElementById('app'), config, options);

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -27,6 +27,9 @@ export enum GlobalEvents {
     MAP_EXTENTCHANGE = 'map/extentchanged', // payload is rampapi Extent
     MAP_IDENTIFY = 'map/identify',
     MAP_MOUSEMOVE = 'map/mousemove',
+    MAP_KEYDOWN = 'map/keydown',
+    MAP_KEYUP = 'map/keyup',
+    MAP_BLUR = 'map/blur',
     SETTINGS_OPEN = 'settings/open',
     DETAILS_OPEN = 'details/open',
     HELP_TOGGLE = 'help/toggle'
@@ -42,6 +45,9 @@ export enum GlobalEvents {
 enum DefEH {
     IDENTIFY_DETAILS = 'ramp_identify_opens_details',
     MAP_IDENTIFY = 'ramp_map_click_runs_identify',
+    MAP_KEYDOWN = 'ramp_map_keydown',
+    MAP_KEYUP = 'ramp_map_keyup',
+    MAP_BLUR = 'ramp_map_blur',
     OPEN_SETTINGS = 'ramp_settings_opens_panel',
     OPEN_DETAILS = 'opens_feature_details',
     TOGGLE_HELP = 'toggles_help_panel'
@@ -276,7 +282,7 @@ export class EventAPI extends APIScope {
             // TODO the enum-values-to-array logic we use in the event names list
             //      fails a bit here. we could make it work if we force every default
             //      handler name to being with a specific prefix. Alternately use object, not enum.
-            eventHandlerNames = [DefEH.MAP_IDENTIFY, DefEH.IDENTIFY_DETAILS, DefEH.OPEN_SETTINGS, DefEH.OPEN_DETAILS, DefEH.TOGGLE_HELP];
+            eventHandlerNames = [DefEH.MAP_IDENTIFY, DefEH.MAP_KEYDOWN, DefEH.MAP_KEYUP, DefEH.MAP_BLUR, DefEH.IDENTIFY_DETAILS, DefEH.OPEN_SETTINGS, DefEH.OPEN_DETAILS, DefEH.TOGGLE_HELP];
         }
 
         // add all the requested default event handlers.
@@ -341,6 +347,24 @@ export class EventAPI extends APIScope {
                     }
                 };
                 this.$iApi.event.on(GlobalEvents.HELP_TOGGLE, zeHandler, handlerName);
+                break;
+            case DefEH.MAP_KEYDOWN:
+                zeHandler = (payload: KeyboardEvent) => {
+                    this.$iApi.mapActions.mapKeyDown(payload);
+                };
+                this.$iApi.event.on(GlobalEvents.MAP_KEYDOWN, zeHandler, handlerName);
+                break;
+            case DefEH.MAP_KEYUP:
+                zeHandler = (payload: KeyboardEvent) => {
+                    this.$iApi.mapActions.mapKeyUp(payload);
+                };
+                this.$iApi.event.on(GlobalEvents.MAP_KEYUP, zeHandler, handlerName);
+                break;
+            case DefEH.MAP_BLUR:
+                zeHandler = (payload: FocusEvent) => {
+                    this.$iApi.mapActions.stopPan();
+                };
+                this.$iApi.event.on(GlobalEvents.MAP_BLUR, zeHandler, handlerName);
                 break;
             default:
                 console.error(`Unrecognized default event handler name encountered: ${handlerName}`);

--- a/packages/ramp-core/src/api/map.ts
+++ b/packages/ramp-core/src/api/map.ts
@@ -1,5 +1,5 @@
 import { APIScope, GlobalEvents } from './internal';
-import { IdentifyResult, IdentifyResultSet, IdentifyParameters, MapClick } from 'ramp-geoapi';
+import { IdentifyResult, IdentifyResultSet, IdentifyParameters, MapClick, ApiBundle } from 'ramp-geoapi';
 import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 import { LayerStore } from '@/store/modules/layer';
 
@@ -30,14 +30,14 @@ export class MapAPI extends APIScope {
      * @param {*} payload
      * @memberof DetailsFixture
      */
-    identify(payload: MapClick) {
+    identify(payload: MapClick | ApiBundle.Point) {
         let layers: BaseLayer[] | undefined = this.$vApp.$store.get(LayerStore.layers);
 
         // Don't perform an identify request if the layers array hasn't been established yet.
         if (layers === undefined) return;
 
         let p: IdentifyParameters = {
-            geometry: payload.mapPoint
+            geometry: payload instanceof ApiBundle.Point ? payload : payload.mapPoint
         };
 
         // Perform an identify request on each layer. Does not perform the request on layers that do not have an identify function (layers that do not support identify).
@@ -50,8 +50,142 @@ export class MapAPI extends APIScope {
         // Merge all results received by the identify into one array.
         const identifyResults: IdentifyResult[] = ([] as IdentifyResult[]).concat(...identifyInstances.map(({ results }) => results));
 
+        let mapClick: MapClick;
+        if (payload instanceof ApiBundle.Point) {
+            // construct MapClick if only point is given
+            const screenPoint = this.$iApi.map.mapPointToScreenPoint(payload);
+            mapClick = {
+                mapPoint: payload,
+                screenX: screenPoint.screenX,
+                screenY: screenPoint.screenY,
+                button: 0,
+                clickTime: Date.now()
+            };
+        } else {
+            mapClick = payload;
+        }
+
         // TODO make the event payload an interface? should there be a public area with all event payload interfaces?
-        this.$iApi.event.emit(GlobalEvents.MAP_IDENTIFY, { results: identifyResults, click: payload });
+        this.$iApi.event.emit(GlobalEvents.MAP_IDENTIFY, { results: identifyResults, click: mapClick });
+    }
+
+    // list of keys that are currently pressed
+    private _activeKeys: string[] = [];
+
+    // ID of pan interval
+    private _panInterval: any;
+
+    /**
+     * Processes keydown event on map and initiates panning/zooming
+     *
+     * @param {KeyboardEvent} payload
+     * @memberof MapAPI
+     */
+    mapKeyDown(payload: KeyboardEvent) {
+        let zoomKeys = ['=', '-'];
+        let panKeys = ['Shift', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowUp'];
+
+        if (panKeys.includes(payload.key) && !this._activeKeys.includes(payload.key)) {
+            this._activeKeys.push(payload.key);
+            this.pan();
+        } else if (zoomKeys.includes(payload.key)) {
+            this.zoom(payload);
+        } else if (payload.key === 'Enter') {
+            this.identify(this.$iApi.map.getExtent().center());
+        }
+    }
+
+    /**
+     * Processes keyup event on map and deactivates key
+     *
+     * @param {KeyboardEvent} payload
+     * @memberof MapAPI
+     */
+    mapKeyUp(payload: KeyboardEvent) {
+        if (this._activeKeys.includes(payload.key)) {
+            this._activeKeys.splice(this._activeKeys.indexOf(payload.key), 1);
+            this.pan();
+        }
+    }
+
+    /**
+     * Stops panning and deactivates all keys
+     *
+     * @memberof MapAPI
+     */
+    stopPan() {
+        this._activeKeys = [];
+        clearInterval(this._panInterval);
+    }
+
+    /**
+     * Pauses pan interval to process zoom from keyboard
+     *
+     * @param {KeyboardEvent} payload
+     * @memberof MapAPI
+     * @private
+     */
+    private async zoom(payload: KeyboardEvent) {
+        clearInterval(this._panInterval);
+        if (payload.key === '=') {
+            await this.$iApi.map.zoomIn();
+        } else if (payload.key === '-') {
+            await this.$iApi.map.zoomOut();
+        }
+        this.pan();
+    }
+
+    /**
+     * Starts/restarts panning with active keys
+     *
+     * @memberof MapAPI
+     * @private
+     */
+    private pan() {
+        clearInterval(this._panInterval);
+        if (this._activeKeys.length === 0) {
+            return;
+        }
+
+        const center = this.$iApi.map.getExtent().center();
+
+        // calculate pan velocity based on constant pixel value that won't change based on zoom
+        const screenCenter = this.$iApi.map.mapPointToScreenPoint(center);
+        const p = this.$iApi.map.screenPointToMapPoint(screenCenter.screenX + 5, screenCenter.screenY + 5);
+        const xDiff = Math.abs(p.x - center.x);
+        const yDiff = Math.abs(p.y - center.y);
+
+        let dx = 0;
+        let dy = 0;
+        let multiplier = 1;
+
+        for (let i = 0; i < this._activeKeys.length; ++i) {
+            switch (this._activeKeys[i]) {
+                case 'ArrowLeft':
+                    dx -= xDiff;
+                    break;
+                case 'ArrowRight':
+                    dx += xDiff;
+                    break;
+                case 'ArrowUp':
+                    dy += yDiff;
+                    break;
+                case 'ArrowDown':
+                    dy -= yDiff;
+                    break;
+                case 'Shift':
+                    multiplier = 2;
+                    break;
+            };
+        }
+
+        const scale = this.$iApi.map.getScale();
+
+        this._panInterval = setInterval(() => {
+            center.x += multiplier * dx;
+            center.y += multiplier * dy;
+            this.$iApi.map.zoomMapTo(center, scale, false);
+        }, 25)
     }
 }
 

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -79,6 +79,15 @@ export default class EsriMap extends Vue {
             // TODO debounce here? the map event fires pretty much every change in pixel value.
             this.$iApi.event.emit(GlobalEvents.MAP_MOUSEMOVE, payload);
         });
+        this.$iApi.map.mapKeyDown.listen((payload: KeyboardEvent) => {
+            this.$iApi.event.emit(GlobalEvents.MAP_KEYDOWN, payload);
+        });
+        this.$iApi.map.mapKeyUp.listen((payload: KeyboardEvent) => {
+            this.$iApi.event.emit(GlobalEvents.MAP_KEYUP, payload);
+        });
+        this.$iApi.map.mapBlur.listen((payload: FocusEvent) => {
+            this.$iApi.event.emit(GlobalEvents.MAP_BLUR, payload);
+        });
 
 
         this.onLayerArrayChange(this.layers, []);


### PR DESCRIPTION
#124
Same as RAMP2. Arrow keys to move, `shift` to move faster, `-` and `=` to zoom, `enter` to identify. Tabbing/clicking away from the map will stop panning, and zooming while panning should work (issues I found with RAMP2).

Not sure if this belongs in the `mapActions` or somewhere else (maybe it can be its own fixture with crosshairs? #125).

Had to hack `mapActions.identify()` a bit to work without a click, but it seems the map `Point` is the only thing that's ever used so I'm not sure why we need a click at all in `mapActions.identify()` and  the `IDENTIFY_DETAILS` handler?

[demo](http://ramp4-app.azureedge.net/demo/users/an-w/navigation/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/322)
<!-- Reviewable:end -->
