### PR TITLE
improve fixtures for map image layers

### DIFF
--- a/packages/ramp-core/public/starter-scripts/map-image-layer.js
+++ b/packages/ramp-core/public/starter-scripts/map-image-layer.js
@@ -1,0 +1,102 @@
+window.rInstance = null;
+document.title = "Map Image Layer"
+
+function initRAMP() {
+    let config = {
+        en: {
+            map: {
+                extent: {
+                    xmax: -5007771.626060756,
+                    xmin: -16632697.354854,
+                    ymax: 10015875.184845109,
+                    ymin: 5022907.964742964,
+                    spatialReference: {
+                        wkid: 102100,
+                        latestWkid: 3857
+                    }
+                },
+                lods: RAMP.geoapi.maps.defaultLODs(RAMP.geoapi.maps.defaultTileSchemas()[1]), // idx 1 = mercator
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esriTile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            },
+            layers: [
+                {
+                    id: 'AirEmissions',
+                    layerType: 'esriMapImage',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    layerEntries: [
+                        {
+                            index: 9,
+                            state: {
+                                opacity: 1,
+                                visibility: true
+                            }
+                        },
+                        {
+                            index: 18,
+                            state: {
+                                opacity: 1,
+                                visibility: true
+                            }
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                }
+            ],
+            fixtures: {
+                legend: {
+                    reorderable: true,
+                    root: {
+                        children: [
+                            {
+                                name: 'Air emissions',
+                                children: [
+                                    {
+                                        layerId: 'AirEmissions',
+                                        name: 'Carbon monoxide emissions by facility',
+                                        entryIndex: 9
+                                    },
+                                    {
+                                        layerId: 'AirEmissions',
+                                        name: 'Sulphur oxide emissions by facility',
+                                        entryIndex: 18
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend'
+                    ]
+                },
+                mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
+                details: { items: [] }
+            }
+        }
+    }
+
+    let options = {
+        loadDefaultFixtures: false,
+        loadDefaultEvents: true
+    };
+
+    rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
+    rInstance.fixture.addDefaultFixtures(['mapnav', 'legend', 'appbar', 'grid', 'details']);
+}

--- a/packages/ramp-core/src/fixtures/details/details-item.vue
+++ b/packages/ramp-core/src/fixtures/details/details-item.vue
@@ -55,7 +55,7 @@ export default class DetailsItemV extends Vue {
 
     // retrieve the identify payload from the store
     @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    @Get('layer/getLayerByUid') getLayerByUid!: (id: string) => BaseLayer | undefined;
+    @Get('layer/getLayerByUid') getLayerByUid!: (uid: string) => BaseLayer | undefined;
 
     identifyTypes: any = IdentifyResultFormat;
     icon: string = '';
@@ -74,8 +74,9 @@ export default class DetailsItemV extends Vue {
 
     get itemName() {
         const layerInfo = this.payload[this.layerIndex];
-        const layer: BaseLayer | undefined = this.getLayerByUid(layerInfo?.uid || this.uid);
-        const nameField = layer?.getNameField();
+        const uid = layerInfo?.uid || this.uid;
+        const layer: BaseLayer | undefined = this.getLayerByUid(uid);
+        const nameField = layer?.getNameField(uid);
         return nameField ? this.identifyItem.data[nameField] : 'Details';
     }
 
@@ -87,7 +88,7 @@ export default class DetailsItemV extends Vue {
             console.warn(`could not find layer for uid ${uid} during icon lookup`);
             return '';
         }
-        const oidField = layer.getOidField();
+        const oidField = layer.getOidField(uid);
         return layer.getIcon(this.identifyItem.data[oidField], uid).then(value => this.icon = value);
     }
 
@@ -113,9 +114,9 @@ export default class DetailsItemV extends Vue {
             console.warn(`Could not find layer for uid ${uid} during zoom geometry lookup`);
             return;
         }
-        const oid = this.identifyItem.data[layer.getOidField()];
+        const oid = this.identifyItem.data[layer.getOidField(uid)];
         const opts = { getGeom: true };
-        layer.getGraphic(oid, opts).then(g => {
+        layer.getGraphic(oid, opts, uid).then(g => {
             if (g.geometry === undefined) {
                 console.error(`Could not find graphic for objectid ${oid}`);
             } else {

--- a/packages/ramp-core/src/fixtures/details/details-result.vue
+++ b/packages/ramp-core/src/fixtures/details/details-result.vue
@@ -40,7 +40,7 @@ export default class DetailsResultV extends Vue {
     @Prop() layerIndex!: number;
 
     @Get(DetailsStore.payload) payload!: IdentifyResult[];
-    @Get('layer/getLayerByUid') getLayerByUid!: (id: string) => BaseLayer | undefined;
+    @Get('layer/getLayerByUid') getLayerByUid!: (uid: string) => BaseLayer | undefined;
 
     icon: string[] = [];
 
@@ -64,7 +64,7 @@ export default class DetailsResultV extends Vue {
             console.warn(`could not find layer for uid ${uid} during icon lookup`);
             return;
         }
-        const oidField = layer.getOidField();
+        const oidField = layer.getOidField(uid);
         layer.getIcon(data[oidField], uid).then(value => {if (this.icon[idx] !== value) this.$set(this.icon, idx, value)});
     }
 

--- a/packages/ramp-core/src/fixtures/grid/api/grid.ts
+++ b/packages/ramp-core/src/fixtures/grid/api/grid.ts
@@ -6,17 +6,17 @@ export class GridAPI extends FixtureInstance {
     /**
      * Open the grid for the layer with the given uid.
      *
-     * @param {string} id
+     * @param {string} uid
      * @memberof GridAPI
      */
-    openGrid(id: string): void {
+    openGrid(uid: string): void {
         // get GridConfig for specified uid
-        let gridSettings: GridConfig | undefined = this.$vApp.$store.get(`grid/grids@${id}`);
+        let gridSettings: GridConfig | undefined = this.$vApp.$store.get(`grid/grids@${uid}`);
 
         // if no GridConfig exists for the given uid, create it.
         if (gridSettings === undefined) {
             gridSettings = {
-                uid: id,
+                uid: uid,
                 state: new TableStateManager({
                     table: {
                         showFilter: true,
@@ -29,7 +29,7 @@ export class GridAPI extends FixtureInstance {
         }
 
         // open the grid
-        this.$vApp.$store.set('grid/open', id ? id : null);
+        this.$vApp.$store.set('grid/currentUid', uid ? uid : null);
 
         this.$iApi.panel.open('grid-panel');
     }

--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -1,6 +1,6 @@
 <template>
     <panel-screen>
-        <template #header>{{$t('grid.title')}}: {{head}} </template>
+        <template #header>{{ $t('grid.title') }}: {{ head }} </template>
         <template #controls>
             <input
                 @keyup="updateQuickSearch()"
@@ -44,7 +44,7 @@
             <close @click="panel.close()"></close>
         </template>
         <template #content>
-            <TableComponent class="rv-grid" ref="rvGrid" :layerUid="open"></TableComponent>
+            <TableComponent class="rv-grid" ref="rvGrid" :layerUid="currentUid"></TableComponent>
         </template>
     </panel-screen>
 </template>
@@ -57,7 +57,7 @@ import { PanelInstance } from '@/api';
 import TableComponent from '@/fixtures/grid/table/table.vue';
 
 import { LayerStore, layer } from '@/store/modules/layer';
-import FeatureLayer from 'ramp-geoapi/dist/layer/FeatureLayer';
+import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 
 @Component({
     components: {
@@ -68,8 +68,8 @@ export default class Screen1 extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() header!: String;
 
-    @Get(LayerStore.layers) layers!: FeatureLayer[];
-    @Get('grid/open') open: any;
+    @Get(LayerStore.layers) layers!: BaseLayer[];
+    @Get('grid/currentUid') currentUid: any;
 
     quicksearch: String = '';
     grid: any = undefined;

--- a/packages/ramp-core/src/fixtures/grid/store/grid-state.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/grid-state.ts
@@ -24,7 +24,7 @@ export class GridState {
      * @type {(string | null)}
      * @memberof GridState
      */
-    open: String | null = null;
+    currentUid: String | null = null;
 }
 
 export interface GridConfig {

--- a/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
@@ -43,6 +43,6 @@ export function grid() {
         state,
         getters: { ...getters },
         actions: { ...actions },
-        mutations: { ...mutations, ...make.mutations(['grids', 'open']) }
+        mutations: { ...mutations, ...make.mutations(['grids', 'currentUid']) }
     };
 }

--- a/packages/ramp-core/src/fixtures/grid/table/table.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/table.vue
@@ -98,7 +98,7 @@ const TEXT_TYPE: string = 'string';
 })
 export default class TableComponent extends Vue {
     @Prop() layerUid!: string;
-    @Get('layer/getLayerByUid') getLayerByUid!: (id: string) => BaseLayer | undefined;
+    @Get('layer/getLayerByUid') getLayerByUid!: (uid: string) => BaseLayer | undefined;
     @Sync('grid/grids') grids!: { [uid: string]: GridConfig };
 
     columnApi: any = null;
@@ -145,7 +145,7 @@ export default class TableComponent extends Vue {
         }
 
         fancyLayer.isLayerLoaded().then(() => {
-            const tableAttributePromise = fancyLayer.getTabularAttributes();
+            const tableAttributePromise = fancyLayer.getTabularAttributes(this.layerUid);
 
             tableAttributePromise.then((tableAttributes: any) => {
                 // Iterate through table columns and set up column definitions and column filter stuff.
@@ -396,7 +396,7 @@ export default class TableComponent extends Vue {
                     if (layer === undefined) return;
                     const oid = cell.data[this.oidField];
                     const opts = { getGeom: true };
-                    layer.getGraphic(oid, opts).then(g => {
+                    layer.getGraphic(oid, opts, this.layerUid).then(g => {
                         if (g.geometry === undefined) {
                             console.error(`Could not find graphic for objectid ${oid}`);
                         } else {
@@ -421,7 +421,7 @@ export default class TableComponent extends Vue {
                     if (layer === undefined) return;
                     const iconContainer = document.createElement('span');
                     const oid = cell.data[this.oidField];
-                    layer.getIcon(oid).then(i => {
+                    layer.getIcon(oid, this.layerUid).then(i => {
                         iconContainer.innerHTML = i;
                     });
                     return iconContainer;

--- a/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
@@ -3,13 +3,13 @@
         <div class="relative">
             <div
                 class="default-focus-style p-5 flex items-center hover:bg-gray-200 cursor-pointer h-44"
-                @click="$iApi.fixture.get('grid').openGrid(legendItem.layer.uid)"
+                @click="$iApi.fixture.get('grid').openGrid(legendItem.uid)"
                 v-focus-item
             >
                 <!-- symbology stack toggle-->
                 <div class="relative w-32 h-32">
                     <button @click.stop="toggleSymbology" tabindex="-1">
-                        <symbology-stack class="w-32 h-32" :visible="displaySymbology" :layer="legendItem.layer" />
+                        <symbology-stack class="w-32 h-32" :visible="displaySymbology" :layer="legendItem.layer" :uid="legendItem.uid" />
                     </button>
                     <tooltip position="top-left">
                         {{ displaySymbology ? $t('legend.symbology.hide') : $t('legend.symbology.expand') }}
@@ -30,7 +30,7 @@
         <!-- Symbology Stack Section -->
         <div v-if="displaySymbology" v-focus-item class="default-focus-style">
             <!-- display each symbol -->
-            <div class="p-5 flex items-center" v-for="(item, idx) in legendItem.layer.getLegend()" :key="idx">
+            <div class="p-5 flex items-center" v-for="(item, idx) in legendItem.layer.getLegend(legendItem.uid)" :key="idx">
                 <div class="symbologyIcon">
                     <span v-html="item.svgcode"></span>
                 </div>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
@@ -60,6 +60,7 @@ export default class LegendPlaceholderV extends Vue {
             this.layer.isLayerLoaded().then(r => {
                 this.legendItem._layer = this.layer;
                 this.legendItem._type = LegendTypes.Entry;
+                this.legendItem._uid = this.layer!.getLayerTree().findChildByIdx(this.legendItem._layerIndex!)?.uid || this.layer!.uid;
             });
         }
     }

--- a/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
@@ -41,6 +41,7 @@ import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 export default class SymbologyStack extends Vue {
     @Prop() visible!: boolean;
     @Prop() layer!: BaseLayer;
+    @Prop() uid!: string;
 
     stack: any = [];
 
@@ -59,8 +60,8 @@ export default class SymbologyStack extends Vue {
      * Retrieves the symbology stack. Waits on all symbols in the stack to finish loading before displaying.
      */
     getSymbologyStack(): any {
-        Promise.all(this.layer.getLegend().map((l: any) => l.drawPromise)).then((r: any) => {
-            this.stack = this.layer.getLegend();
+        Promise.all(this.layer.getLegend(this.uid).map((l: any) => l.drawPromise)).then((r: any) => {
+            this.stack = this.layer.getLegend(this.uid);
         });
     }
 }

--- a/packages/ramp-geoapi/src/layer/MapImageLayer.ts
+++ b/packages/ramp-geoapi/src/layer/MapImageLayer.ts
@@ -264,6 +264,10 @@ export class MapImageLayer extends AttribLayer {
 
                 const treeLeaf = new TreeNode(sid, this.fcs[sid].uid, this.fcs[sid].name, true);
                 parentTreeNode.children.push(treeLeaf);
+
+                subLayer.watch('visible', () => {
+                    this.visibilityChanged.fireEvent(this.getVisibility());
+                })
             }
         };
 


### PR DESCRIPTION
#257

The `legend`, `grid`, and `details` fixtures should be working properly now with map image layers. With respect to [James' UID Checkup](https://hackmd.io/J9HPqZyOSPqU4kmksebBJg?view), a lot of this might change but I guess we can see things working if we go the "keep what we have" route.

Don't think we have a way to deal with the `visibilityChanged` event for map image layers since it's only bound to the root layer's visibility. Just to get legend checkboxes working, I made each sublayer fire the root's `visibilityChanged` event but listeners  would need to get the visibility of map image layer children themselves.


[basic demo config with map image layer](http://ramp4-app.azureedge.net/demo/users/an-w/zzz/host/index-e2e.html?script=map-image-layer)
[regular setup still works too](http://ramp4-app.azureedge.net/demo/users/an-w/zzz/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/347)
<!-- Reviewable:end -->
