### PR TITLE
legend improvements

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-placeholder.vue
@@ -64,6 +64,11 @@ export default class LegendPlaceholderV extends Vue {
             });
         }
     }
+
+    mounted() {
+        // in case layer is added while placeholder component is dead
+        this.layerAdded(this.layers, []);
+    }
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -121,12 +121,13 @@ export class LegendEntry extends LegendItem {
         this._layer = legendEntry.layers.find((layer: BaseLayer) => layer.id === this._id);
         this._layerIndex = legendEntry.entryIndex;
 
-        // check if a layer has been bound to this entry. If not, set the type to "placeholder".
-        if (this._layer === undefined) {
+        this._isLoaded = this._layer !== undefined ? this._layer.isValidState() : true;
+
+        // check if a layer has been bound to this entry and is done loading. If not, set the type to "placeholder".
+        if (this._layer === undefined || !this._isLoaded) {
             this._type = LegendTypes.Placeholder;
         }
 
-        this._isLoaded = this._layer !== undefined ? this._layer.isValidState() : true;
         // initialize more layer properties after layer loads
         this._waitLayerLoad();
     }


### PR DESCRIPTION
This should fix []() #295, #281 #215 and #227 (on my machine at least).

The placeholder getting stuck despite the layer loading happened if a layer loaded while there was no vue component (legend's panel not visible).
The startup errors were caused by the legend using the esri layer api before the layer fully loaded.

http://ramp4-app.azureedge.net/demo/users/an-w/legend/host/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/349)
<!-- Reviewable:end -->
