### PR TITLE
Details Fixture Improvements

### DIFF
--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -1,5 +1,5 @@
 window.rInstance = null;
-document.title = "WMS Layer"
+document.title = "WMS Layers"
 
 function initRAMP() {
     let config = {
@@ -32,6 +32,20 @@ function initRAMP() {
             },
             layers: [
                 {
+                    id: "ahocevar",
+                    layerType: "ogcWms",
+                    url: "https://ahocevar.com/geoserver/wms",
+                    state: {
+                        visibility: true
+                    },
+                    layerEntries: [
+                        {
+                            id: "ne:ne"
+                        }
+                    ],
+                    featureInfoMimeType: "text/plain"
+                },
+                {
                     id: 'RailwayNetwork',
                     layerType: 'ogcWms',
                     url: 'http://maps.geogratis.gc.ca/wms/railway_en',
@@ -49,7 +63,7 @@ function initRAMP() {
                         { id: "railway.marker_post" },
                         { id: "railway.crossing" }
                     ],
-                    customRenderer: {}
+                    featureInfoMimeType: "text/html"
                 },
                 {
                   id: "GeoMet",
@@ -59,20 +73,12 @@ function initRAMP() {
                       visibility: true,
                       opacity: 0.5
                   },
-                  disabledControls: [
-                    "styles"
-                  ],
                   layerEntries: [
                     {
-                      id: "GDPS.ETA_UU",
-                      allStyles: [
-                        "WINDARROW",
-                        "WINDARROWKMH"
-                      ],
-                      currentStyle: "WINDARROWKMH"
+                      id: "GDPS.ETA_NT"
                     }
                   ],
-                  customRenderer: {}
+                  featureInfoMimeType: "text/plain"
                 }
             ],
             fixtures: {
@@ -85,8 +91,12 @@ function initRAMP() {
                                 name: 'Railways'
                             },
                             {
+                                layerId: 'ahocevar',
+                                name: 'ahocevar'
+                            },
+                            {
                                 layerId: 'GeoMet',
-                                name: 'Winds'
+                                name: 'Cloud Coverage'
                             }
                         ]
                     }
@@ -97,7 +107,14 @@ function initRAMP() {
                     ]
                 },
                 mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
-                details: { items: [] }
+                details: { 
+                    items: [
+                        {
+                            id: 'GeoMet',
+                            template: 'GeoMet-Template'
+                        }
+                    ] 
+                }
             }
         }
     }
@@ -106,6 +123,104 @@ function initRAMP() {
         loadDefaultFixtures: false,
         loadDefaultEvents: true
     };
+
+    Vue.component('GeoMet-Template', {
+        props: ['identifyData'],
+        render: function(h) {
+            if (!this.identifyData) return;
+            let parseText = text => {
+                let obj = {};
+                let rx = /(\w+) = '(?:"([^"]*)"|([^']*))/g;
+                while((m = rx.exec(text)) !== null) {
+                    if (m[2]) {
+                        obj[m[1]] = m[2];
+                    } else {
+                        obj[m[1]] = m[3];
+                    }
+                }
+                return obj;
+            }
+
+            let data = parseText(this.identifyData.data);
+
+            return h(
+                'div', 
+                {
+                    style: 'align-items: center; justify-content: center; font-size: .875rem; font-family: "Arial", sans-serif;'
+                },
+                [
+                    h(
+                        'span',
+                        {
+                            style:
+                                'display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;'
+                        },
+                        'GDPS.ETA_NT - Cloud Coverage (%)'
+                    ),
+                    h(
+                        'div',
+                        {
+                            style: 'display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;'
+                        },
+                        [
+                            h(
+                                'span',
+                                {
+                                    style: 'color: #a0aec0; font-weight: bold;'
+                                },
+                                'Coverage'
+                            ),
+                            h('span', data.value_0)
+                        ]
+                    ),
+                    h(
+                        'div',
+                        {
+                            style: 'display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;'
+                        },
+                        [
+                            h(
+                                'div',
+                                {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                },
+                                'x'
+                            ),
+                            h(
+                                'div',
+                                {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                },
+                                'y'
+                            )
+                        ]
+                    ),
+                    h(
+                        'div',
+                        {
+                            style: 'display: flex; flex-direction: row;'
+                        },
+                        [
+                            h(
+                                'div',
+                                {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                },
+                                data.x
+                            ),
+                            h(
+                                'div',
+                                {
+                                    style: 'flex: 1 1 0%; width: 100%;'
+                                },
+                                data.y
+                            )
+                        ]
+                    )
+                ]
+            );
+        }
+    });
 
     rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
     rInstance.fixture.addDefaultFixtures(['mapnav', 'legend', 'appbar', 'grid', 'details']);

--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -1,0 +1,112 @@
+window.rInstance = null;
+document.title = "WMS Layer"
+
+function initRAMP() {
+    let config = {
+        en: {
+            map: {
+                extent: {
+                    xmax: -5007771.626060756,
+                    xmin: -16632697.354854,
+                    ymax: 10015875.184845109,
+                    ymin: 5022907.964742964,
+                    spatialReference: {
+                        wkid: 102100,
+                        latestWkid: 3857
+                    }
+                },
+                lods: RAMP.geoapi.maps.defaultLODs(RAMP.geoapi.maps.defaultTileSchemas()[1]), // idx 1 = mercator
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esriTile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            },
+            layers: [
+                {
+                    id: 'RailwayNetwork',
+                    layerType: 'ogcWms',
+                    url: 'http://maps.geogratis.gc.ca/wms/railway_en',
+                    state: {
+                        visibility: true
+                    },
+                    layerEntries: [
+                        { id: "railway" },
+                        { id: "railway.structure.line" },
+                        { id: "railway.structure.point" },
+                        { id: "railway.track" },
+                        { id: "railway.ferry" },
+                        { id: "railway.subdivision" },
+                        { id: "railway.station" },
+                        { id: "railway.marker_post" },
+                        { id: "railway.crossing" }
+                    ],
+                    customRenderer: {}
+                },
+                {
+                  id: "GeoMet",
+                  layerType: "ogcWms",
+                  url: "http://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities",
+                  state: {
+                      visibility: true,
+                      opacity: 0.5
+                  },
+                  disabledControls: [
+                    "styles"
+                  ],
+                  layerEntries: [
+                    {
+                      id: "GDPS.ETA_UU",
+                      allStyles: [
+                        "WINDARROW",
+                        "WINDARROWKMH"
+                      ],
+                      currentStyle: "WINDARROWKMH"
+                    }
+                  ],
+                  customRenderer: {}
+                }
+            ],
+            fixtures: {
+                legend: {
+                    reorderable: true,
+                    root: {
+                        children: [
+                            {
+                                layerId: 'RailwayNetwork',
+                                name: 'Railways'
+                            },
+                            {
+                                layerId: 'GeoMet',
+                                name: 'Winds'
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend'
+                    ]
+                },
+                mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
+                details: { items: [] }
+            }
+        }
+    }
+
+    let options = {
+        loadDefaultFixtures: false,
+        loadDefaultEvents: true
+    };
+
+    rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
+    rInstance.fixture.addDefaultFixtures(['mapnav', 'legend', 'appbar', 'grid', 'details']);
+}

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -38,4 +38,8 @@ export default class App extends Vue {
     @include focus-list.default-focused-styling;
     height: 700px;
 }
+.symbologyIcon {
+    @apply bg-white inline-flex justify-center items-center overflow-hidden;
+    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
+}
 </style>

--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -49,7 +49,7 @@ export class DetailsAPI extends FixtureInstance {
         if (panel.isOpen) {
             this.$iApi.panel.close(panel);
         }
-        this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-item', props: { isFeature: true, layerIndex: 0, itemIndex: 0 } });
+        this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-item', props: { isFeature: true, resultIndex: 0, itemIndex: 0 } });
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -35,14 +35,21 @@ export class DetailsAPI extends FixtureInstance {
      * @memberof DetailsAPI
      */
     openFeature(identifyItem: IdentifyItem, uid: string) {
+        // make IdentifyResult[] for consitency
+        const identifyResult: IdentifyResult = {
+            items: [identifyItem],
+            uid: uid,
+            isLoading: false
+        };
+
         // Save the provided identify result in the store.
-        this.$vApp.$store.set('details/setPayload!', identifyItem);
+        this.$vApp.$store.set('details/setPayload!', [identifyResult]);
         // Open the details panel.
         const panel = this.$iApi.panel.get('details-panel');
         if (panel.isOpen) {
             this.$iApi.panel.close(panel);
         }
-        this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-item', props: { isFeature: true, uid: uid } });
+        this.$iApi.panel.open({ id: 'details-panel', screen: 'details-screen-item', props: { isFeature: true, layerIndex: 0, itemIndex: 0 } });
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/details/details-item.vue
+++ b/packages/ramp-core/src/fixtures/details/details-item.vue
@@ -10,8 +10,8 @@
         </template>
         <template #content>
             <div class="flex py-8" v-if="layerType !== 'ogcWms'">
-                <span v-html="icon" class="symbologyIcon"> </span>
-                <span class="flex-grow my-auto text-lg"> {{ itemName }} </span>
+                <span class="flex-none m-auto symbologyIcon" v-html="icon"></span>
+                <span class="flex-grow my-auto text-lg px-8"> {{ itemName }} </span>
                 <button @click="zoomToFeature()" class="text-gray-600 m-8">
                     <svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20">
                         <path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/>

--- a/packages/ramp-core/src/fixtures/details/details-item.vue
+++ b/packages/ramp-core/src/fixtures/details/details-item.vue
@@ -4,7 +4,7 @@
             {{ $t('details.title') }}
         </template>
         <template #controls>
-            <back @click="panel.show({ screen: 'details-screen-result', props: { layerIndex: layerIndex } })" v-if="!isFeature && layerType !== 'ogcWms'"></back>
+            <back @click="panel.show({ screen: 'details-screen-result', props: { resultIndex: resultIndex } })" v-if="!isFeature && layerType !== 'ogcWms'"></back>
             <back @click="panel.show({ screen: 'details-screen-layers' })" v-if="layerType === 'ogcWms'"></back>
             <close @click="panel.close()"></close>
         </template>
@@ -49,7 +49,7 @@ export default class DetailsItemV extends Vue {
     @Prop() panel!: PanelInstance;
 
     // the index of the details item we want to display
-    @Prop() layerIndex!: number;
+    @Prop() resultIndex!: number;
     @Prop() itemIndex!: number;
     @Prop() layerType!: string;
 
@@ -73,11 +73,11 @@ export default class DetailsItemV extends Vue {
      * Returns the information for a single identify result, given the layer and item offsets.
      */
     get identifyItem() {
-        return this.payload[this.layerIndex].items[this.itemIndex];
+        return this.payload[this.resultIndex].items[this.itemIndex];
     }
 
     get itemName() {
-        const layerInfo = this.payload[this.layerIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo.uid;
         const layer: BaseLayer | undefined = this.getLayerByUid(uid);
         const nameField = layer?.getNameField(uid);
@@ -85,7 +85,7 @@ export default class DetailsItemV extends Vue {
     }
 
     fetchIcon() {
-        const layerInfo = this.payload[this.layerIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo.uid;
         const layer: BaseLayer | undefined = this.getLayerByUid(uid);
         if (layer === undefined) {
@@ -99,7 +99,7 @@ export default class DetailsItemV extends Vue {
     }
 
     get detailsTemplate() {
-        const layerInfo = this.payload[this.layerIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const layer: BaseLayer | undefined = this.getLayerByUid(layerInfo.uid);
 
         // If there is a custom template binding for this layer in the store, then
@@ -117,7 +117,7 @@ export default class DetailsItemV extends Vue {
     }
 
     zoomToFeature() {
-        const layerInfo = this.payload[this.layerIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo.uid;
         const layer: BaseLayer | undefined = this.getLayerByUid(uid);
         if (layer === undefined) {

--- a/packages/ramp-core/src/fixtures/details/details-layers.vue
+++ b/packages/ramp-core/src/fixtures/details/details-layers.vue
@@ -46,9 +46,9 @@ export default class DetailsLayersV extends Vue {
     openResult(index: number) {
         if (this.getLayerByUid(this.payload[index].uid)!.layerType === 'ogcWms') {
             // skip results screen for wms layers
-            this.panel.show({ screen: 'details-screen-item', props: { layerIndex: index, layerType: 'ogcWms' , itemIndex: 0} });
+            this.panel.show({ screen: 'details-screen-item', props: { resultIndex: index, layerType: 'ogcWms' , itemIndex: 0} });
         } else {
-            this.panel.show({ screen: 'details-screen-result', props: { layerIndex: index } });
+            this.panel.show({ screen: 'details-screen-result', props: { resultIndex: index } });
         }
     }
 

--- a/packages/ramp-core/src/fixtures/details/details-layers.vue
+++ b/packages/ramp-core/src/fixtures/details/details-layers.vue
@@ -38,12 +38,18 @@ export default class DetailsLayersV extends Vue {
     @Prop() panel!: PanelInstance;
     @Get(DetailsStore.payload) payload!: IdentifyResult[];
     @Get('layer/layers') layers!: BaseLayer[];
+    @Get('layer/getLayerByUid') getLayerByUid!: (uid: string) => BaseLayer | undefined;
 
     /**
      * Switches the panel screen to display the data for a given result.
      */
     openResult(index: number) {
-        this.panel.show({ screen: 'details-screen-result', props: { layerIndex: index } });
+        if (this.getLayerByUid(this.payload[index].uid)!.layerType === 'ogcWms') {
+            // skip results screen for wms layers
+            this.panel.show({ screen: 'details-screen-item', props: { layerIndex: index, layerType: 'ogcWms' , itemIndex: 0} });
+        } else {
+            this.panel.show({ screen: 'details-screen-result', props: { layerIndex: index } });
+        }
     }
 
     layerInfo(idx: number) {

--- a/packages/ramp-core/src/fixtures/details/details-result.vue
+++ b/packages/ramp-core/src/fixtures/details/details-result.vue
@@ -16,8 +16,8 @@
                     @click="openResult(idx)"
                     v-focus-item
                 >
-                    <span v-html=icon[idx] class="flex-initial"> {{ itemIcon(item.data, idx) }} </span>
-                    <span class="flex-initial p-5"> {{ item.data[nameField] || 'Identify Result ' + (idx + 1) }} </span>
+                    <span v-html="icon[idx]" class="flex-none symbologyIcon"> {{ itemIcon(item.data, idx) }} </span>
+                    <span class="flex-initial py-5 px-10 truncate"> {{ item.data[nameField] || 'Identify Result ' + (idx + 1) }} </span>
                 </div>
             </div>
             <div v-else>{{ $t('details.results.empty') }}</div>

--- a/packages/ramp-core/src/fixtures/details/details-result.vue
+++ b/packages/ramp-core/src/fixtures/details/details-result.vue
@@ -37,7 +37,7 @@ import BaseLayer from 'ramp-geoapi/dist/layer/BaseLayer';
 @Component({})
 export default class DetailsResultV extends Vue {
     @Prop() panel!: PanelInstance;
-    @Prop() layerIndex!: number;
+    @Prop() resultIndex!: number;
 
     @Get(DetailsStore.payload) payload!: IdentifyResult[];
     @Get('layer/getLayerByUid') getLayerByUid!: (uid: string) => BaseLayer | undefined;
@@ -48,7 +48,7 @@ export default class DetailsResultV extends Vue {
      * Switches the panel screen to display the data for a given result. Provides the currently selected layer index and the currently selected feature index as props.
      */
     openResult(itemIndex: number) {
-        this.panel.show({ screen: 'details-screen-item', props: { layerIndex: this.layerIndex, itemIndex: itemIndex } });
+        this.panel.show({ screen: 'details-screen-item', props: { resultIndex: this.resultIndex, itemIndex: itemIndex } });
     }
 
     /**
@@ -69,17 +69,17 @@ export default class DetailsResultV extends Vue {
     }
 
     /**
-     * Returns the identify information for the layer specified by layerIndex.
+     * Returns the identify information for the layer specified by resultIndex.
      */
     get identifyResult() {
-        return this.payload[this.layerIndex];
+        return this.payload[this.resultIndex];
     }
 
     /**
-     * Returns the name field for the layer specified by layerIndex.
+     * Returns the name field for the layer specified by resultIndex.
      */
     get nameField() {
-        const layerInfo = this.payload[this.layerIndex];
+        const layerInfo = this.payload[this.resultIndex];
         const uid = layerInfo?.uid;
         const layer: BaseLayer | undefined = this.getLayerByUid(uid);
         return layer?.getNameField(uid);

--- a/packages/ramp-core/src/fixtures/details/store/details-state.ts
+++ b/packages/ramp-core/src/fixtures/details/store/details-state.ts
@@ -42,9 +42,9 @@ export class DetailsState {
     /**
      * An object containing a features attributes.
      *
-     * @type IdentifyResult[] | IdentifyItem
+     * @type IdentifyResult[]
      * @memberof DetailsState
      */
 
-    payload: IdentifyResult[] | IdentifyItem = [];
+    payload: IdentifyResult[] = [];
 }

--- a/packages/ramp-core/src/fixtures/details/templates/html-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/html-default.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="whitespace-pre-wrap break-words h-full overflow-auto" v-if="identifyData" v-html="identifyData.data"></div>
+    <div v-else>{{ $t('details.results.empty') }}</div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+import { PanelInstance } from '@/api';
+import { IdentifyItem } from 'ramp-geoapi';
+
+@Component({})
+export default class HTMLDefaultV extends Vue {
+    @Prop() identifyData!: IdentifyItem;
+}
+</script>
+
+<style lang="scss"></style>

--- a/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
@@ -68,11 +68,6 @@ export default class SymbologyStack extends Vue {
 </script>
 
 <style lang="scss" scoped>
-.symbologyIcon {
-    @apply bg-white inline-flex justify-center items-center overflow-hidden;
-    box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.2), 0px 1px 1px 0px rgba(0, 0, 0, 0.14), 0px 2px 1px -1px rgba(0, 0, 0, 0.12);
-}
-
 .symbol-2 {
     transition-property: margin-left margin-top;
     transition-duration: 0.2s;

--- a/packages/ramp-core/src/store/modules/layer/layer-blueprint.class.ts
+++ b/packages/ramp-core/src/store/modules/layer/layer-blueprint.class.ts
@@ -383,9 +383,9 @@ class WMSServiceSource extends mixins(BlueprintBase, ServerSideData) {
     }
 
     // TODO uncomment
-    // get layerRecordFactory(): LayerRecordFactory {
-    //     return undefined;  // TODO: gapiService.gapi.layer.createWmsRecord;
-    // }
+    get layerRecordFactory(): LayerRecordFactory {
+        return config => api.geoapi.layers.createWmsLayer(config);
+    }
 
     get type() {
         return GEO.Service.Types.WMS;

--- a/packages/ramp-geoapi/src/layer/WmsLayer.ts
+++ b/packages/ramp-geoapi/src/layer/WmsLayer.ts
@@ -186,25 +186,25 @@ export class WmsLayer extends BaseLayer {
                 this.sublayerNames,
                 <Point>options.geometry,
                 this.mimeType)
-            .then(data => {
+            .then(response => {
 
                 // check if a result is returned by the service. If not, do not add to the array of data
                 // TODO verify we want empty .items array
                 // TODO is is possible to have more than one item as a result? check how this works
-                if (data) {
-                    if (typeof data !== 'string') {
+                if (response) {
+                    if (typeof response.data !== 'string') {
                         // likely json or an image
                         // TODO improve the dection (maybe use the this.mimeType?)
                         innerResult.items.push({
                             format: IdentifyResultFormat.JSON,
-                            data: data
+                            data: response.data
                         });
-                    } else if (data.indexOf('Search returned no results') === -1 && data !== '') {
+                    } else if (response.data.indexOf('Search returned no results') === -1 && response.data !== '') {
                         // TODO if service is french, will the "no results" message be different?
                         // TODO consider utilizing the infoMap variable above to detect HTML format.
                         innerResult.items.push({
                             format: IdentifyResultFormat.TEXT,
-                            data: data
+                            data: response.data
                         });
                     }
                 }


### PR DESCRIPTION
Details should work with WMS layers now for html and text identify results. #264

Also made `symbologyIcon` a global style rule to bring back the symbol borders that disappeared a while ago.

[Demo config](http://ramp4-app.azureedge.net/demo/users/an-w/details/host/index-e2e.html?script=wms-layer) with text, html, and templated WMS layer details.
[Regular demo](http://ramp4-app.azureedge.net/demo/users/an-w/details/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/355)
<!-- Reviewable:end -->
