### PR TITLE
legend controls

### DIFF
--- a/common/docs/app/defaults.md
+++ b/common/docs/app/defaults.md
@@ -102,9 +102,10 @@ TODO add stuff as we make events that core fixtures raise
 
 | Event Name | Payload | Event Announces |
 | ---------- | ---------- | ---------- |
-| SETTINGS_OPEN<br>'settings/open' | BaseLayer object | A layer's settings was requested |
+| SETTINGS_TOGGLE<br>'settings/toggle' | layer uid | Settings panel toggle was requested for a layer |
 | DETAILS_OPEN<br>'details/open' | *identifyItem*: IdentifyItem object<br>*uid*: layer uid | A feature's details was requested |
 | HELP_TOGGLE<br>'help/toggle' | boolean (optional) | Help panel toggle was requested with optional force open/close |
+| GRID_TOGGLE<br>'grid/toggle' | *uid*: layer uid<br>*open*: boolean (optional) | Grid panel toggle was requested with optional force open/close |
 
 
 ## Default Events Handlers
@@ -123,9 +124,10 @@ TODO keep updating the list, make new subsections as appropriate. Maybe move to 
 
 ### Fixture Handlers
 
-- `ramp_settings_opens_panel` causes the settings fixture to open for a layer
+- `ramp_settings_toggles_panel` causes the settings fixture to toggle the settings panel
 - `opens_feature_details` causes the details fixture to open for a single feature
 - `toggles_help_panel` causes the help fixture to toggle the help panel
+- `toggles_grid_panel` causes the grid fixture to toggle the grid panel
 
 ## Examples
 

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -54,7 +54,7 @@ enum DefEH {
     TOGGLE_SETTINGS = 'ramp_settings_toggles_panel',
     OPEN_DETAILS = 'opens_feature_details',
     TOGGLE_HELP = 'toggles_help_panel',
-    TOGGLE_GRID = 'opens_grid_panel'
+    TOGGLE_GRID = 'toggles_grid_panel'
 }
 
 // private for EventBus internals, so don't export
@@ -353,10 +353,10 @@ export class EventAPI extends APIScope {
                 this.$iApi.event.on(GlobalEvents.HELP_TOGGLE, zeHandler, handlerName);
                 break;
             case DefEH.TOGGLE_GRID:
-                zeHandler = (payload: string) => {
+                zeHandler = (uid: string, open?: boolean) => {
                     const gridFixture: GridAPI = this.$iApi.fixture.get('grid');
                     if (gridFixture) {
-                        gridFixture.toggleGrid(payload);
+                        gridFixture.toggleGrid(uid, open);
                     }
                 };
                 this.$iApi.event.on(GlobalEvents.GRID_TOGGLE, zeHandler, handlerName);

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -32,7 +32,7 @@ export enum GlobalEvents {
     MAP_KEYDOWN = 'map/keydown',
     MAP_KEYUP = 'map/keyup',
     MAP_BLUR = 'map/blur',
-    SETTINGS_TOGGLE = 'settings/open',
+    SETTINGS_TOGGLE = 'settings/toggle',
     DETAILS_OPEN = 'details/open',
     HELP_TOGGLE = 'help/toggle',
     GRID_TOGGLE = 'grid/toggle'
@@ -51,7 +51,7 @@ enum DefEH {
     MAP_KEYDOWN = 'ramp_map_keydown',
     MAP_KEYUP = 'ramp_map_keyup',
     MAP_BLUR = 'ramp_map_blur',
-    TOGGLE_SETTINGS = 'ramp_SETTINGS_TOGGLEs_panel',
+    TOGGLE_SETTINGS = 'ramp_settings_toggles_panel',
     OPEN_DETAILS = 'opens_feature_details',
     TOGGLE_HELP = 'toggles_help_panel',
     TOGGLE_GRID = 'opens_grid_panel'

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -3,6 +3,7 @@ import { APIScope, InstanceAPI } from './internal';
 import { DetailsAPI } from '@/fixtures/details/api/details';
 import { SettingsAPI} from '@/fixtures/settings/api/settings'
 import { HelpAPI } from '@/fixtures/help/api/help'
+import { GridAPI } from '@/fixtures/grid/api/grid'
 import { IdentifyResult, IdentifyResultSet, MapClick } from 'ramp-geoapi';
 
 export enum GlobalEvents {
@@ -31,9 +32,10 @@ export enum GlobalEvents {
     MAP_KEYDOWN = 'map/keydown',
     MAP_KEYUP = 'map/keyup',
     MAP_BLUR = 'map/blur',
-    SETTINGS_OPEN = 'settings/open',
+    SETTINGS_TOGGLE = 'settings/open',
     DETAILS_OPEN = 'details/open',
-    HELP_TOGGLE = 'help/toggle'
+    HELP_TOGGLE = 'help/toggle',
+    GRID_TOGGLE = 'grid/toggle'
 }
 
 // TODO export this enum?
@@ -49,9 +51,10 @@ enum DefEH {
     MAP_KEYDOWN = 'ramp_map_keydown',
     MAP_KEYUP = 'ramp_map_keyup',
     MAP_BLUR = 'ramp_map_blur',
-    OPEN_SETTINGS = 'ramp_settings_opens_panel',
+    TOGGLE_SETTINGS = 'ramp_SETTINGS_TOGGLEs_panel',
     OPEN_DETAILS = 'opens_feature_details',
-    TOGGLE_HELP = 'toggles_help_panel'
+    TOGGLE_HELP = 'toggles_help_panel',
+    TOGGLE_GRID = 'opens_grid_panel'
 }
 
 // private for EventBus internals, so don't export
@@ -283,7 +286,7 @@ export class EventAPI extends APIScope {
             // TODO the enum-values-to-array logic we use in the event names list
             //      fails a bit here. we could make it work if we force every default
             //      handler name to being with a specific prefix. Alternately use object, not enum.
-            eventHandlerNames = [DefEH.MAP_IDENTIFY, DefEH.MAP_KEYDOWN, DefEH.MAP_KEYUP, DefEH.MAP_BLUR, DefEH.IDENTIFY_DETAILS, DefEH.OPEN_SETTINGS, DefEH.OPEN_DETAILS, DefEH.TOGGLE_HELP];
+            eventHandlerNames = [DefEH.MAP_IDENTIFY, DefEH.MAP_KEYDOWN, DefEH.MAP_KEYUP, DefEH.MAP_BLUR, DefEH.IDENTIFY_DETAILS, DefEH.TOGGLE_SETTINGS, DefEH.OPEN_DETAILS, DefEH.TOGGLE_HELP, DefEH.TOGGLE_GRID];
         }
 
         // add all the requested default event handlers.
@@ -321,15 +324,15 @@ export class EventAPI extends APIScope {
                 };
                 this.on(GlobalEvents.MAP_IDENTIFY, zeHandler, handlerName);
                 break;
-            case DefEH.OPEN_SETTINGS:
+            case DefEH.TOGGLE_SETTINGS:
                 zeHandler = (payload: any) => {
                     const settingsFixture: SettingsAPI = this.$iApi.fixture.get('settings');
                     if (settingsFixture) {
-                        settingsFixture.open(payload);
+                        settingsFixture.toggleSettings(payload);
                     }
                 };
                 // Create a new event: opens the settings panel and hooks it up to the requested layer.
-                this.$iApi.event.on(GlobalEvents.SETTINGS_OPEN, zeHandler, handlerName);
+                this.$iApi.event.on(GlobalEvents.SETTINGS_TOGGLE, zeHandler, handlerName);
                 break;
             case DefEH.OPEN_DETAILS:
                 zeHandler = (payload: any) => {
@@ -348,6 +351,15 @@ export class EventAPI extends APIScope {
                     }
                 };
                 this.$iApi.event.on(GlobalEvents.HELP_TOGGLE, zeHandler, handlerName);
+                break;
+            case DefEH.TOGGLE_GRID:
+                zeHandler = (payload: string) => {
+                    const gridFixture: GridAPI = this.$iApi.fixture.get('grid');
+                    if (gridFixture) {
+                        gridFixture.toggleGrid(payload);
+                    }
+                };
+                this.$iApi.event.on(GlobalEvents.GRID_TOGGLE, zeHandler, handlerName);
                 break;
             case DefEH.MAP_KEYDOWN:
                 zeHandler = (payload: KeyboardEvent) => {

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -3,12 +3,6 @@
         <button class="relative text-gray-500 hover:text-black p-8" @click="open = !open">
             <slot name="header"></slot>
         </button>
-        <button
-            v-if="open"
-            @click="open = false"
-            tabindex="-1"
-            class="fixed inset-0 h-full w-full bg-black opacity-0 cursor-default"
-        ></button>
         <div
             v-if="open"
             @blur="open = false"
@@ -27,10 +21,14 @@ import { Get, Sync, Call } from 'vuex-pathify';
 @Component
 export default class MenuV extends Vue {
     @Prop({ default: 'bottom-right' }) position!: string;
-    data() {
-        return {
-            open: false
-        };
+    open: boolean = false;
+
+    mounted() {
+        window.addEventListener('click', event => {
+            if (event.target instanceof HTMLElement && !this.$el.contains(event.target)) {
+                this.open = false;
+            }
+        }, { capture: true });
     }
 }
 </script>
@@ -41,7 +39,7 @@ export default class MenuV extends Vue {
     padding: 0.5rem 1rem 0.5rem 1rem;
     color: #2d3748;
 }
-.rv-dropdown > *:hover {
+.rv-dropdown > *:hover:not(.disabled) {
     background-color: #eee;
 }
 .rv-dropdown {

--- a/packages/ramp-core/src/fixtures/grid/api/grid.ts
+++ b/packages/ramp-core/src/fixtures/grid/api/grid.ts
@@ -9,7 +9,7 @@ export class GridAPI extends FixtureInstance {
      * @param {string} uid
      * @memberof GridAPI
      */
-    openGrid(uid: string): void {
+    toggleGrid(uid: string): void {
         // get GridConfig for specified uid
         let gridSettings: GridConfig | undefined = this.$vApp.$store.get(`grid/grids@${uid}`);
 
@@ -28,9 +28,17 @@ export class GridAPI extends FixtureInstance {
             this.$vApp.$store.set('grid/addGrid!', gridSettings);
         }
 
-        // open the grid
+        const prevUid = this.$vApp.$store.get('grid/currentUid', uid ? uid : null);
         this.$vApp.$store.set('grid/currentUid', uid ? uid : null);
 
-        this.$iApi.panel.open('grid-panel');
+        const panel = this.$iApi.panel.get('grid-panel');
+        if (!panel.isOpen) {
+            this.$iApi.panel.open('grid-panel');
+        } else if (prevUid !== uid) {
+            // don't toggle off if different layer, use key prop to force rerender
+            panel.show({ screen: 'grid-screen', props: { key: uid } });
+        } else {
+            panel.close();
+        }
     }
 }

--- a/packages/ramp-core/src/fixtures/grid/api/grid.ts
+++ b/packages/ramp-core/src/fixtures/grid/api/grid.ts
@@ -7,9 +7,10 @@ export class GridAPI extends FixtureInstance {
      * Open the grid for the layer with the given uid.
      *
      * @param {string} uid
+     * @param {boolean} [open] force panel open or closed
      * @memberof GridAPI
      */
-    toggleGrid(uid: string): void {
+    toggleGrid(uid: string, open?: boolean): void {
         // get GridConfig for specified uid
         let gridSettings: GridConfig | undefined = this.$vApp.$store.get(`grid/grids@${uid}`);
 
@@ -32,10 +33,17 @@ export class GridAPI extends FixtureInstance {
         this.$vApp.$store.set('grid/currentUid', uid ? uid : null);
 
         const panel = this.$iApi.panel.get('grid-panel');
+
+        if (open === false) {
+            // force close
+            panel.close();
+            return;
+        }
+
         if (!panel.isOpen) {
             this.$iApi.panel.open('grid-panel');
-        } else if (prevUid !== uid) {
-            // don't toggle off if different layer, use key prop to force rerender
+        } else if (prevUid !== uid || open === true) {
+            // don't toggle off if different layer or force open, use key prop to force rerender
             panel.show({ screen: 'grid-screen', props: { key: uid } });
         } else {
             panel.close();

--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -6,9 +6,13 @@
             :checked="value"
             @click.stop="legendItem.toggleVisibility()"
             @keyup.enter.stop="legendItem.toggleVisibility()"
-            :class="isRadio ? 'form-radio' : 'form-checkbox rounded-none'"
-            class="mx-5 h-15 w-15 text-black border-gray-500 hover:border-black cursor-pointer"
+            :class="[
+                isRadio ? 'form-radio' : 'form-checkbox rounded-none',
+                disabled ? 'text-gray-400 ' : 'text-black cursor-pointer'
+            ]"
+            class="mx-5 h-15 w-15 border-gray-500 hover:border-black"
             tabindex="-1"
+            :disabled="disabled"
         />
         <tooltip position="top-right"> {{ $t(value ? 'legend.visibility.hide' : 'legend.visibility.show') }} </tooltip>
     </div>
@@ -25,6 +29,7 @@ export default class CheckboxV extends Vue {
     @Prop() value!: boolean;
     @Prop() isRadio!: boolean;
     @Prop() legendItem!: LegendEntry;
+    @Prop() disabled!: boolean;
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
@@ -3,13 +3,13 @@
         <div class="relative">
             <div
                 class="default-focus-style p-5 flex items-center hover:bg-gray-200 cursor-pointer h-44"
-                @click="$iApi.fixture.get('grid').openGrid(legendItem.uid)"
+                @click="toggleGrid"
                 v-focus-item
             >
                 <!-- symbology stack toggle-->
                 <div class="relative w-32 h-32">
-                    <button @click.stop="toggleSymbology" tabindex="-1">
-                        <symbology-stack class="w-32 h-32" :visible="displaySymbology" :layer="legendItem.layer" :uid="legendItem.uid" />
+                    <button @click.stop="toggleSymbology" tabindex="-1" :class="{ 'cursor-default': !legendItem._controlAvailable('symbology') }" :disabled="!legendItem._controlAvailable('symbology')">
+                        <symbology-stack :class="{ 'pointer-events-none': !legendItem._controlAvailable('symbology') }" class="w-32 h-32" :visible="displaySymbology" :layer="legendItem.layer" :uid="legendItem.uid" />
                     </button>
                     <tooltip position="top-left">
                         {{ displaySymbology ? $t('legend.symbology.hide') : $t('legend.symbology.expand') }}
@@ -21,8 +21,46 @@
                     <span>{{ legendItem.name }}</span>
                 </div>
 
+                <!-- options -->
+                <div @click.stop class="options hidden cursor-auto">
+                    <dropdown-menu position="right" >
+                        <template #header  >
+                            <div class="flex">
+                                <svg class="fill-current w-18 h-18 mx-8" viewBox="0 0 23 21">
+                                    <path d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+                                </svg>
+                            </div>
+                            <tooltip class="mx-5" position="left"> {{ $t('legend.entry.options') }} </tooltip>
+                        </template>
+                        <a href="#" class="flex leading-snug items-start w-auto" :class="{ disabled: !legendItem._controlAvailable(`metadata`) }" @click="toggleMetadata">
+                            <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                                    <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>
+                            </svg>
+                             {{ $t('legend.entry.controls.metadata') }}
+                        </a>
+                        <a href="#" class="flex leading-snug items-center w-auto" :class="{ disabled: !legendItem._controlAvailable(`settings`) }" @click="toggleSettings">
+                            <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                                <g id="tune"><path d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "/></g>
+                            </svg>
+                             {{ $t('legend.entry.controls.settings') }}
+                        </a>
+                        <a href="#" class="flex leading-snug items-center w-auto" :class="{ disabled: !legendItem._controlAvailable(`datatable`) }" @click="toggleGrid">
+                            <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                                <path d="M 4.00002,3L 20,3C 21.1046,3 22,3.89543 22,5L 22,20C 22,21.1046 21.1046,22 20,22L 4.00001,22C 2.89544,22 2.00001,21.1046 2.00001,20L 2.00002,5C 2.00002,3.89543 2.89545,3 4.00002,3 Z M 4.00002,7L 4.00001,10L 8,10L 8,7.00001L 4.00002,7 Z M 10,7.00001L 9.99999,10L 14,10L 14,7.00001L 10,7.00001 Z M 20,10L 20,7L 16,7.00001L 16,10L 20,10 Z M 4.00002,12L 4.00002,15L 8,15L 8,12L 4.00002,12 Z M 4.00001,20L 8,20L 8,17L 4.00002,17L 4.00001,20 Z M 9.99999,12L 9.99999,15L 14,15L 14,12L 9.99999,12 Z M 9.99999,20L 14,20L 14,17L 9.99999,17L 9.99999,20 Z M 20,20L 20,17L 16,17L 16,20L 20,20 Z M 20,12L 16,12L 16,15L 20,15L 20,12 Z "/>
+                            </svg>
+                             {{ $t('legend.entry.controls.datatable') }}
+                        </a>
+                        <a href="#" class="flex leading-snug items-center w-auto" :class="{ disabled: !legendItem._controlAvailable(`symbology`) }" @click="toggleSymbology">
+                            <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                                <path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"/>
+                            </svg>
+                             {{ $t('legend.entry.controls.symbology') }}
+                        </a>
+                    </dropdown-menu>
+                </div>
+
                 <!-- visibility -->
-                <checkbox :value="visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem" />
+                <checkbox :value="visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem" :disabled="!legendItem._controlAvailable('visibility')" />
             </div>
             <tooltip position="top-left">{{ $t('legend.entry.data') }}</tooltip>
         </div>
@@ -49,10 +87,11 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { LegendStore } from '../store';
-import { LegendEntry } from '../store/legend-defs';
+import { LegendEntry, Controls } from '../store/legend-defs';
 
 import CheckboxV from './checkbox.vue';
 import SymbologyStack from './symbology-stack.vue';
+import { GlobalEvents } from '../../../api/internal';
 
 @Component({
     components: {
@@ -77,9 +116,48 @@ export default class LegendEntryV extends Vue {
      * Display symbology stack for the layer.
      */
     toggleSymbology(): void {
-        this.displaySymbology = !this.displaySymbology;
+        if (this.legendItem._controlAvailable(Controls.Symbology)) {
+            this.displaySymbology = !this.displaySymbology;
+        }
+    }
+
+    /**
+     * Toggles data table panel to open/close for the LegendItem.
+     */
+    toggleGrid() {
+        if (this.legendItem._controlAvailable(Controls.Datatable)) {
+            this.$iApi.event.emit(GlobalEvents.GRID_TOGGLE, this.legendItem.uid);
+        }
+    }
+
+    /**
+     * Toggles settings panel to open/close type for the LegendItem.
+     */
+    toggleSettings() {
+        if (this.legendItem._controlAvailable(Controls.Settings)) {
+            this.$iApi.event.emit(GlobalEvents.SETTINGS_TOGGLE, this.legendItem.uid);
+        }
+    }
+
+    /**
+     * Toggles metadata panel to open/close for the LegendItem.
+     */
+    toggleMetadata() {
+        if (this.legendItem._controlAvailable(Controls.Metadata)) {
+            // TODO: toggle metadata panel through API/store call
+        }
     }
 }
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.legend-item:hover, .legend-item .focused, .legend-item:focus-within  {
+    .options {
+        display: block;
+    }
+}
+.disabled {
+    @apply text-gray-400;
+    pointer-events: none;
+}
+</style>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
@@ -21,7 +21,7 @@
                     <span>{{ legendItem.name }}</span>
                 </div>
 
-                <!-- options -->
+                <!-- options dropdown menu -->
                 <div @click.stop class="options hidden cursor-auto">
                     <dropdown-menu position="right" >
                         <template #header  >
@@ -32,24 +32,28 @@
                             </div>
                             <tooltip class="mx-5" position="left"> {{ $t('legend.entry.options') }} </tooltip>
                         </template>
+                        <!-- metadata -->
                         <a href="#" class="flex leading-snug items-start w-auto" :class="{ disabled: !legendItem._controlAvailable(`metadata`) }" @click="toggleMetadata">
                             <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                                     <path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/>
                             </svg>
                              {{ $t('legend.entry.controls.metadata') }}
                         </a>
+                        <!-- settings -->
                         <a href="#" class="flex leading-snug items-center w-auto" :class="{ disabled: !legendItem._controlAvailable(`settings`) }" @click="toggleSettings">
                             <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                                 <g id="tune"><path d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "/></g>
                             </svg>
                              {{ $t('legend.entry.controls.settings') }}
                         </a>
+                        <!-- datatable -->
                         <a href="#" class="flex leading-snug items-center w-auto" :class="{ disabled: !legendItem._controlAvailable(`datatable`) }" @click="toggleGrid">
                             <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                                 <path d="M 4.00002,3L 20,3C 21.1046,3 22,3.89543 22,5L 22,20C 22,21.1046 21.1046,22 20,22L 4.00001,22C 2.89544,22 2.00001,21.1046 2.00001,20L 2.00002,5C 2.00002,3.89543 2.89545,3 4.00002,3 Z M 4.00002,7L 4.00001,10L 8,10L 8,7.00001L 4.00002,7 Z M 10,7.00001L 9.99999,10L 14,10L 14,7.00001L 10,7.00001 Z M 20,10L 20,7L 16,7.00001L 16,10L 20,10 Z M 4.00002,12L 4.00002,15L 8,15L 8,12L 4.00002,12 Z M 4.00001,20L 8,20L 8,17L 4.00002,17L 4.00001,20 Z M 9.99999,12L 9.99999,15L 14,15L 14,12L 9.99999,12 Z M 9.99999,20L 14,20L 14,17L 9.99999,17L 9.99999,20 Z M 20,20L 20,17L 16,17L 16,20L 20,20 Z M 20,12L 16,12L 16,15L 20,15L 20,12 Z "/>
                             </svg>
                              {{ $t('legend.entry.controls.datatable') }}
                         </a>
+                        <!-- symbology stack -->
                         <a href="#" class="flex leading-snug items-center w-auto" :class="{ disabled: !legendItem._controlAvailable(`symbology`) }" @click="toggleSymbology">
                             <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                                 <path d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"/>
@@ -145,19 +149,25 @@ export default class LegendEntryV extends Vue {
     toggleMetadata() {
         if (this.legendItem._controlAvailable(Controls.Metadata)) {
             // TODO: toggle metadata panel through API/store call
+            // this.$iApi.event.emit('metadata/open', {
+            //     type: 'html',
+            //     layer: 'Sample Layer Name',
+            //     url:
+            //         'https://ryan-coulson.com/RAMPMetadataDemo.html'
+            // });
         }
     }
 }
 </script>
 
 <style lang="scss" scoped>
-.legend-item:hover, .legend-item .focused, .legend-item:focus-within  {
+.legend-item:hover, .legend-item:focus-within  {
     .options {
         display: block;
     }
 }
 .disabled {
     @apply text-gray-400;
-    pointer-events: none;
+    cursor: default;
 }
 </style>

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -13,3 +13,8 @@ legend.visibility.hide,Hide layer,1,Masquer la couche,0
 legend.symbology.expand,Expand legend,1,Développer la légende,0
 legend.symbology.hide,Hide legend,1,Cacher la légende,0
 legend.entry.data,Show more data,1,Démontrer plus de données,0
+legend.entry.options,More options,1,Plus d'options,1
+legend.entry.controls.metadata,Metadata,1,Métadonnées,1
+legend.entry.controls.settings,Settings,1,Paramètres,1
+legend.entry.controls.datatable,Datatable,1,Tableau de données,1
+legend.entry.controls.symbology,Legend,1,Légende,1

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -33,7 +33,8 @@ export class LegendItem {
                       Controls.Reload,
                       Controls.Remove,
                       Controls.Datatable,
-                      Controls.Settings
+                      Controls.Settings,
+                      Controls.Symbology
                   ];
         this._hidden = legendItem.hidden !== undefined ? legendItem.hidden : false;
         this._itemConfig = legendItem;
@@ -196,43 +197,6 @@ export class LegendEntry extends LegendItem {
                     });
                 }
             }
-        }
-    }
-
-    /**
-     * Expand/collapses symbology stack.
-     * TODO: check if `LegendEntry` is an `InfoSection`
-     */
-    toggleSymbologyStack(): void {
-        if (this._controls.includes(Controls.Symbology)) {
-            this._symbologyStack.expanded = !this._symbologyStack.expanded;
-        }
-    }
-
-    /**
-     * Toggles metadata panel to open/close for the LegendItem.
-     */
-    toggleMetadata(): void {
-        if (this._controlAvailable(Controls.Metadata)) {
-            // TODO: toggle metadata panel through API/store call
-        }
-    }
-
-    /**
-     * Toggles settings panel to open/close type for the LegendItem.
-     */
-    toggleSettings(): void {
-        if (this._controlAvailable(Controls.Settings)) {
-            // TODO: toggle settings panel through API/store call
-        }
-    }
-
-    /**
-     * Toggles data table panel to open/close for the LegendItem.
-     */
-    toggleDataTable(): any {
-        if (this._controlAvailable(Controls.Datatable)) {
-            // TODO: toggle datatable through API using uid
         }
     }
 }
@@ -416,7 +380,7 @@ export enum LegendTypes {
     Placeholder = 'Placeholder'
 }
 
-enum Controls {
+export enum Controls {
     Opacity = 'opacity',
     Visibility = 'visibility',
     Boundingbox = 'boundingBox',

--- a/packages/ramp-core/src/fixtures/settings/SettingsV.vue
+++ b/packages/ramp-core/src/fixtures/settings/SettingsV.vue
@@ -95,30 +95,31 @@ import SettingsComponent from './SettingsComponentV.vue';
 export default class SettingsV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() layer!: BaseLayer;
+    @Prop() uid!: string;
 
     // Models.
-    visibilityModel: boolean = this.layer.getVisibility();
-    opacityModel: number = this.layer.getOpacity() * 100;
+    visibilityModel: boolean = this.layer.getVisibility(this.uid);
+    opacityModel: number = this.layer.getOpacity(this.uid) * 100;
     snapshotToggle: boolean = false;
 
     mounted() {
         // Listen for a layer load event. Some of these values may change when the layer fully loads.
         this.layer.stateChanged.listen(payload => {
-            this.visibilityModel = this.layer.getVisibility();
-            this.opacityModel = this.layer.getOpacity() * 100;
+            this.visibilityModel = this.layer.getVisibility(this.uid);
+            this.opacityModel = this.layer.getOpacity(this.uid) * 100;
         });
     }
 
     // Update the layer visibility.
     updateVisibility(val: any) {
         this.visibilityModel = val.value;
-        this.layer.setVisibility(this.visibilityModel);
+        this.layer.setVisibility(this.visibilityModel, this.uid);
     }
 
     // Update the layer opacity.
     updateOpacity(val: number) {
         this.opacityModel = val;
-        this.layer.setOpacity(this.opacityModel / 100);
+        this.layer.setOpacity(this.opacityModel / 100, this.uid);
     }
 
     // Toggle snapshot mode for the layer.

--- a/packages/ramp-core/src/fixtures/settings/api/settings.ts
+++ b/packages/ramp-core/src/fixtures/settings/api/settings.ts
@@ -6,7 +6,18 @@ export class SettingsAPI extends FixtureInstance {
      * Opens the settings panel. Passes the provided BaseLayer object to the panel.
      * @param layer
      */
-    open(layer: BaseLayer): void {
-        this.$iApi.panel.open({ id: 'settings-panel', props: { layer: layer } });
+    toggleSettings(uid: string): void {
+        const layer = this.$iApi.$vApp.$store.get('layer/getLayerByUid', uid);
+        const panel = this.$iApi.panel.get('settings-panel');
+        if (!panel.isOpen) {
+            this.$iApi.panel.open({ id: 'settings-panel', props: { layer: layer , uid: uid} });
+        } else {
+            const currentUid = (panel.route.props! as any).uid;
+            if (currentUid !== uid) {
+                panel.show({screen: 'settings-screen-content', props: { layer: layer , uid: uid }});
+            } else {
+                panel.close();
+            }
+        }
     }
 }


### PR DESCRIPTION
Changed grid and settings opening to toggles. This also means only one grid can be opened at once (#248). We might want to support multiple grids when we have better panels but that would require changes to the grid fixture/store since it was very broken before. I'm not sure if we would want to have multiple settings panels open, but that would be more trivial.

Added the control options dropdown ui to the legend (#220) which will toggle the respective fixtures (skipped metadata for now).  If/when we have layer reloading and "zoom to extent", those could be added too. Also wired up the visibility checkbox and symbology stack to the legend entry's controls. By default, all controls should all be enabled but they can be specified in the legend entry config. I understand RAMP2 also had layer-level config for enabled/disabled controls if we want to add that. 

[demo](http://ramp4-app.azureedge.net/demo/users/an-w/zzz/host/index.html#)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/359)
<!-- Reviewable:end -->
