### PR TITLE
"no config" legend generation for layers (incomplete)

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -78,4 +78,29 @@ export class LegendAPI extends FixtureInstance {
         this.$vApp.$store.set(LegendStore.children, legendEntries);
         // TODO: validate legend items?
     }
+
+    /**
+     * Legend generation for layers.
+     * 
+     * @param {BaseLayer} [layer]
+     * @returns
+     * @memberOf LegendFixture
+     */
+    generateDefaultLegend(layer: BaseLayer | undefined, parent: LegendGroup | undefined) {
+        // return if input is invalid
+        if (!layer) {
+            return;
+        }
+        
+        // create LegendEntry from layer
+        let config = {
+            layerId: layer.id,
+            name: layer.getName(layer.uid) ? layer.getName(layer.uid) : '',
+            layers: this.$vApp.$store.get(LayerStore.layers)}
+        let entry = new LegendEntry(config, parent);
+
+        // add entry to store
+        this.$vApp.$store.set(LegendStore.addEntry, entry);
+    }
+
 }

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -20,7 +20,11 @@ const getters = {
     }
 };
 
-const mutations = {};
+const mutations = {
+    ADD_ITEM: (state: LegendState, value: LegendEntry) => {
+        state.children = [...state.children, value];
+    }
+};
 
 const actions = {
     /** Expand all legend groups */
@@ -46,6 +50,10 @@ const actions = {
         context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
             toggle(entry, { visibility: false });
         });
+    },
+    /** Add legend entry to store */
+    addEntry: (context: LegendContext, item: LegendEntry) => {
+        context.commit('ADD_ITEM', item);
     }
 };
 
@@ -145,7 +153,11 @@ export enum LegendStore {
     /**
      * (Action) hideAll - turn off visibility for all legend entries
      */
-    hideAll = 'legend/hideAll'
+    hideAll = 'legend/hideAll',
+    /**
+     * (Action) addEntry - add entry to legend store
+     */
+    addEntry = 'legend/addEntry!'
 }
 
 export function legend() {


### PR DESCRIPTION
Adds a layer to the legend with a BaseLayer input. Currently the layers added stays as the placeholder structure on the legend panel.

Sample inputs I've used for testing: [script](https://hackmd.io/CcgruXbPQmG9mIjB_U97mQ?view).

Demo: [link](http://ramp4-app.azureedge.net/demo/users/avocadoes/legendgen/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/385)
<!-- Reviewable:end -->
