### PR TITLE
Fix grid date filtering

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/table/CustomDateFilter.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/CustomDateFilter.vue
@@ -16,9 +16,8 @@ import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
 export default class CustomNumberFilter extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)
-        this.minVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' min');
-        this.maxVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' max');
-
+        this.minVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' min') || '';
+        this.maxVal = this.params.stateManager.getColumnFilter(this.params.column.colDef.field + ' max') || '';
         // Apply the default values to the column filter.
         this.minValChanged();
         this.maxValChanged();
@@ -27,7 +26,6 @@ export default class CustomNumberFilter extends Vue {
     minValChanged() {
         this.params.parentFilterInstance((instance: any) => {
             this.setFilterModel(instance);
-
             // Save the new filter value in the state manager. Allows for quick recovery if the grid is
             // closed and re-opened.
             this.params.stateManager.setColumnFilter(this.params.column.colDef.field + ' min', this.minVal);
@@ -37,7 +35,6 @@ export default class CustomNumberFilter extends Vue {
     maxValChanged() {
         this.params.parentFilterInstance((instance: any) => {
             this.setFilterModel(instance);
-
             // Save the new filter value in the state manager. Allows for quick recovery if the grid is
             // closed and re-opened.
             this.params.stateManager.setColumnFilter(this.params.column.colDef.field + ' max', this.maxVal);
@@ -48,12 +45,13 @@ export default class CustomNumberFilter extends Vue {
         // This is the furthest date supported by JavaScript.
         let maxPossibleDate: Date | String = new Date(8640000000000000);
         maxPossibleDate = `${maxPossibleDate.getFullYear()}-${maxPossibleDate.getMonth() + 1}-${maxPossibleDate.getDate()}`;
-
         // This is the earliest date supported by JavaScript.
         let minPossibleDate: Date | String = new Date(0);
         minPossibleDate = `${minPossibleDate.getFullYear()}-${minPossibleDate.getMonth() + 1}-${minPossibleDate.getDate()}`;
-
-        if (this.maxVal !== '' && this.minVal !== '') {
+        if (this.maxVal === '' && this.minVal === '') {
+            // If neither value is set, clear the date filter.
+            instance.setModel(null);
+        } else if (this.maxVal !== '' && this.minVal !== '') {
             // If both values are set, display all items that occur between the two dates.
             instance.setModel({
                 filterType: 'date',
@@ -77,9 +75,6 @@ export default class CustomNumberFilter extends Vue {
                 dateFrom: this.minVal,
                 dateTo: maxPossibleDate
             });
-        } else {
-            // If neither value is set, clear the date filter.
-            instance.setModel(null);
         }
         this.params.api.onFilterChanged();
     }


### PR DESCRIPTION
See #455.
Grid now properly filters by date the first time one of the bounds is typed in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/459)
<!-- Reviewable:end -->
