### PR TITLE
Add Functionality for Map Nav Home Button

### DIFF
--- a/packages/ramp-core/public/starter-scripts/mapnav.js
+++ b/packages/ramp-core/public/starter-scripts/mapnav.js
@@ -30,7 +30,7 @@ let config = {
             initialBasemapId: 'esriImagery'
         },
         fixtures: {
-            mapnav: { items: ['fullscreen'] },
+            mapnav: { items: ['fullscreen', 'help', 'home'] },
         }
     }
 }

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/home-nav.vue
@@ -1,5 +1,5 @@
 <template>
-    <mapnav-button>
+    <mapnav-button :onClickFunction="goToHome">
         <template #icon>
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="fill-current w-32 h-20">
                 <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -11,10 +11,17 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component } from 'vue-property-decorator';
+import { Extent } from '@/geo/api';
+import { Vue } from 'vue-property-decorator';
 
-@Component
-export default class HomeNavV extends Vue {}
+export default class HomeNavV extends Vue {
+    goToHome(): void {
+        // Get extent from config and convert it to extent object
+        const homeExtent = Extent.fromConfig("home_extent", this.$iApi.getConfig().map.extent);
+        // apply extent
+        this.$iApi.geo.map.zoomMapTo(homeExtent);
+    }
+}
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
+++ b/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
@@ -6,28 +6,60 @@ describe('Mapnav', () => {
     });
 
     it('has zoom buttons', () => {
-        cy.get('.mapnav .zoom-in');
+        cy.get('.mapnav .mapnav-section .w-full').eq(0);
+        cy.get('.mapnav .mapnav-section .w-full').eq(1);
     });
 
     it('has other buttons', () => {
-        cy.get('.mapnav .mapnav-section');
+        cy.get('.mapnav .mapnav-section .w-full').eq(2);
+        cy.get('.mapnav .mapnav-section .w-full').eq(3);
     });
 
     it('zoom-in button works', () => {
         cy.window().then(window => {
-            cy.get('.mapnav .zoom-in').click();
-            /* cy.wrap(window.rInstance.map.esriView)
+            cy.get('.mapnav .mapnav-section .w-full')
+                .eq(0)
+                .click();
+            cy.wait(1000);
+            cy.wrap(window.rInstance.geo.map.esriView)
                 .its('zoom')
-                .should('change'); */
+                .should('eq', 1);
         });
     });
 
     it('zoom-out button works', () => {
         cy.window().then(window => {
-            cy.get('.mapnav .zoom-out').click();
-            cy.wrap(window.rInstance.map.esriView)
+            cy.get('.mapnav .mapnav-section .w-full')
+                .eq(1)
+                .click();
+            cy.wait(1000);
+            cy.wrap(window.rInstance.geo.map.esriView)
                 .its('zoom')
                 .should('eq', 0);
+        });
+    });
+
+    it('home button works', () => {
+        cy.window().then(window => {
+            cy.get('.mapnav .mapnav-section .w-full')
+                .eq(3)
+                .click();
+            cy.wait(1000);
+            cy.wrap(window.rInstance.geo.map.getExtent())
+                .its('xmin')
+                .should('eq', -16632697.354854);
+
+            cy.wrap(window.rInstance.geo.map.getExtent())
+                .its('xmax')
+                .should('eq', -5007771.626060756);
+
+            cy.wrap(window.rInstance.geo.map.getExtent())
+                .its('ymin')
+                .should('eq', 5022907.964742964);
+
+            cy.wrap(window.rInstance.geo.map.getExtent())
+                .its('ymax')
+                .should('eq', 10015875.184845109);
         });
     });
 });

--- a/packages/ramp-core/src/geo/api/graphic/geometry/extent.ts
+++ b/packages/ramp-core/src/geo/api/graphic/geometry/extent.ts
@@ -1,6 +1,6 @@
 // TODO add proper documentation
 
-import { BaseGeometry, GeometryType, Point, Polygon, SrDef, IdDef } from '@/geo/api';
+import { BaseGeometry, GeometryType, Point, Polygon, SpatialReference, SrDef, IdDef, RampExtentConfig } from '@/geo/api';
 
 export class Extent extends BaseGeometry {
 
@@ -85,6 +85,13 @@ export class Extent extends BaseGeometry {
         ymax: string | number,
         sr?: SrDef): Extent {
         return new Extent(id, [xmin, ymin], [xmax, ymax], sr);
+    }
+
+    static fromConfig(id: IdDef, configExtent: RampExtentConfig): Extent {
+        return new Extent(id,
+            [configExtent.xmin, configExtent.ymin],
+            [configExtent.xmax, configExtent.ymax],
+            SpatialReference.fromConfig(configExtent.spatialReference));
     }
 
     isEqual(e: Extent | undefined): boolean {


### PR DESCRIPTION
Related issue: #380 

Clicking on the home button will zoom back to the default extent provided in the config.
Additionally implemented a static function `Extent.fromConfig` in `extent.ts` that creates an extent from a given `RampExtentConfig`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/460)
<!-- Reviewable:end -->
