### PR TITLE
Truncate Long legend Group Names

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
@@ -15,7 +15,9 @@
                 </div>
 
                 <!-- name -->
-                <span class="flex-1">{{ legendItem.name }}</span>
+                <div class="flex-1 truncate ml-15">
+                    <span>{{ legendItem.name }}</span>
+                </div>
 
                 <!-- visibility -->
                 <checkbox :value="legendItem.visibility" :isRadio="props && props.isVisibilitySet" :legendItem="legendItem" />


### PR DESCRIPTION
Related issue: #389 

Result after fix:
![image](https://user-images.githubusercontent.com/34178949/118665642-75081580-b7c0-11eb-9c57-424735c3dd2d.png)
