### PR TITLE
Panel minimizing and temp appbar buttons

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { APIScope, InstanceAPI, LayerInstance } from './internal';
 import { DetailsAPI } from '@/fixtures/details/api/details';
-import { SettingsAPI} from '@/fixtures/settings/api/settings';
+import { SettingsAPI } from '@/fixtures/settings/api/settings';
 import { HelpAPI } from '@/fixtures/help/api/help';
 import { GridAPI } from '@/fixtures/grid/api/grid';
 import { WizardAPI } from '@/fixtures/wizard/api/wizard';
@@ -49,7 +49,19 @@ export enum GlobalEvents {
     HELP_TOGGLE = 'help/toggle',
     GRID_TOGGLE = 'grid/toggle',
     WIZARD_OPEN = 'wizard/open',
-    LEGEND_DEFAULT = 'legend/generate'
+    LEGEND_DEFAULT = 'legend/generate',
+
+    /**
+     * Fires when a panel opens
+     * Payload: the panel that opened (PanelInstance)
+     */
+    PANEL_OPENED = 'panel/opened',
+
+    /**
+     * Fires when a panel is closed
+     * Payload: the panel that closed (PanelInstance)
+     */
+    PANEL_CLOSED = 'panel/closed'
 }
 
 // TODO export this enum?
@@ -81,7 +93,7 @@ class EventHandler {
     handlerName: string;
     handlerFunc: Function;
 
-    constructor (eName: string, hName: string, handler: Function) {
+    constructor(eName: string, hName: string, handler: Function) {
         this.eventName = eName;
         this.handlerName = hName;
         this.handlerFunc = handler;
@@ -89,7 +101,6 @@ class EventHandler {
 }
 
 export class EventAPI extends APIScope {
-
     /**
      * A vue instance that provides an event bus for all events.
      *
@@ -118,8 +129,7 @@ export class EventAPI extends APIScope {
         // add the public enum items here, as they will always exist.
         // getting enum values is a mess. this code does it but assumes
         // all event names in global events use the slash format
-        this._nameRegister = Object.values(GlobalEvents)
-            .filter(e => (typeof e === 'string') && (e.indexOf('/') > -1));
+        this._nameRegister = Object.values(GlobalEvents).filter(e => typeof e === 'string' && e.indexOf('/') > -1);
     }
 
     /**
@@ -160,7 +170,7 @@ export class EventAPI extends APIScope {
             if (this._nameRegister.indexOf(n) === -1) {
                 this._nameRegister.push(n);
             }
-        })
+        });
     }
 
     /**
@@ -252,7 +262,6 @@ export class EventAPI extends APIScope {
      * @memberof EventAPI
      */
     once(event: string, callback: Function, handlerName: string = ''): string {
-
         // need to do this here and upfront, so we have the name for the unregistration.
         // otherwise we would let the .on() call do its naming thing
         if (!handlerName) {
@@ -302,7 +311,19 @@ export class EventAPI extends APIScope {
             // TODO the enum-values-to-array logic we use in the event names list
             //      fails a bit here. we could make it work if we force every default
             //      handler name to being with a specific prefix. Alternately use object, not enum.
-            eventHandlerNames = [DefEH.MAP_IDENTIFY, DefEH.MAP_KEYDOWN, DefEH.MAP_KEYUP, DefEH.MAP_BLUR, DefEH.IDENTIFY_DETAILS, DefEH.TOGGLE_SETTINGS, DefEH.OPEN_DETAILS, DefEH.TOGGLE_HELP, DefEH.TOGGLE_GRID, DefEH.OPEN_WIZARD, DefEH.GENERATE_LEGEND];
+            eventHandlerNames = [
+                DefEH.MAP_IDENTIFY,
+                DefEH.MAP_KEYDOWN,
+                DefEH.MAP_KEYUP,
+                DefEH.MAP_BLUR,
+                DefEH.IDENTIFY_DETAILS,
+                DefEH.TOGGLE_SETTINGS,
+                DefEH.OPEN_DETAILS,
+                DefEH.TOGGLE_HELP,
+                DefEH.TOGGLE_GRID,
+                DefEH.OPEN_WIZARD,
+                DefEH.GENERATE_LEGEND
+            ];
         }
 
         // add all the requested default event handlers.
@@ -322,7 +343,6 @@ export class EventAPI extends APIScope {
 
         switch (handlerName) {
             case DefEH.MAP_IDENTIFY:
-
                 // when map clicks, run the identify action
                 zeHandler = (clickParam: MapClick) => {
                     if (clickParam.button === 0) {
@@ -336,7 +356,7 @@ export class EventAPI extends APIScope {
                 zeHandler = (identifyParam: any) => {
                     const detailFix: DetailsAPI = this.$iApi.fixture.get('details');
                     if (detailFix) {
-                        detailFix.openDetails(identifyParam.results)
+                        detailFix.openDetails(identifyParam.results);
                     }
                 };
                 this.on(GlobalEvents.MAP_IDENTIFY, zeHandler, handlerName);
@@ -420,7 +440,5 @@ export class EventAPI extends APIScope {
         }
 
         return handlerName;
-
     }
-
 }

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -236,19 +236,6 @@ export class PanelInstance extends APIScope {
     }
 
     /**
-     * Re-open this panel. This is the reverse of minimizing a panel.
-     * This is a proxy to `RAMP.panel.reopen(...)`.
-     *
-     * @returns {this}
-     * @memberof PanelInstance
-     */
-    reopen(): this {
-        this.$iApi.panel.reopen(this);
-
-        return this;
-    }
-
-    /**
      * Toggle panel.
      * This is a proxy to `RAMP.panel.toggle(...)`.
      *

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -223,6 +223,32 @@ export class PanelInstance extends APIScope {
     }
 
     /**
+     * Minimize this panel.
+     * This is a proxy to `RAMP.panel.minimize(...)`.
+     *
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    minimize(): this {
+        this.$iApi.panel.minimize(this);
+
+        return this;
+    }
+
+    /**
+     * Re-open this panel. This is the reverse of minimizing a panel.
+     * This is a proxy to `RAMP.panel.reopen(...)`.
+     *
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    reopen(): this {
+        this.$iApi.panel.reopen(this);
+
+        return this;
+    }
+
+    /**
      * Toggle panel.
      * This is a proxy to `RAMP.panel.toggle(...)`.
      *
@@ -242,6 +268,34 @@ export class PanelInstance extends APIScope {
             }
         } else {
             this.$iApi.panel.toggle(
+                { id: this.id, screen: value.screen, props: value.props },
+                typeof value.toggle !== 'undefined' ? value.toggle : !this.isOpen
+            );
+        }
+
+        return this;
+    }
+
+    /**
+     * Toggle panel's minimize state.
+     * This is a proxy to `RAMP.panel.toggleMinimize(...)`.
+     *
+     * @param {(boolean | { screen: string; props?: object; toggle?: boolean })} [value]
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    toggleMinimize(value?: boolean | { screen: string; props?: object; toggle?: boolean }): this {
+        // toggle panel if no value provided, force toggle panel if value specified, or toggle panel on specified screen if provided
+        // ensure that a toggle value must be provided to panel API toggle if called
+        if (typeof value === 'undefined') {
+            this.$iApi.panel.toggleMinimize(this, !this.isOpen);
+        } else if (typeof value === 'boolean') {
+            // only call forced toggle if it is possible to do so
+            if (value !== this.isOpen) {
+                this.$iApi.panel.toggleMinimize(this, value);
+            }
+        } else {
+            this.$iApi.panel.toggleMinimize(
                 { id: this.id, screen: value.screen, props: value.props },
                 typeof value.toggle !== 'undefined' ? value.toggle : !this.isOpen
             );
@@ -290,6 +344,7 @@ export class PanelInstance extends APIScope {
      */
     show(value: string | PanelConfigRoute): this {
         const route = typeof value === 'string' ? { screen: value } : value;
+        this.route = route;
 
         this.$iApi.panel.show(this, route);
 

--- a/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="relative" tabindex="-1">
+        <button class="text-gray-500 hover:text-black p-8" :class="{ 'text-gray-700': active }" @click="$emit('click')">
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000">
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path d="M6 19h12v2H6z" />
+            </svg>
+        </button>
+        <tooltip position="bottom">{{ $t('panels.controls.minimize') }}</tooltip>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+import TooltipV from '@/components/util/tooltip.vue';
+
+@Component({
+    components: {
+        tooltip: TooltipV
+    }
+})
+export default class MinimizeV extends Vue {
+    @Prop() active!: boolean;
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -21,6 +21,7 @@ import CloseV from './controls/close.vue';
 import BackV from './controls/back.vue';
 import PanelOptionsMenuV from './controls/panel-options-menu.vue';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
+import MinimizeV from './controls/minimize.vue';
 
 Vue.component('panel-screen', PanelScreenV);
 Vue.component('pin', PinV);
@@ -28,6 +29,7 @@ Vue.component('close', CloseV);
 Vue.component('back', BackV);
 Vue.component('panel-options-menu', PanelOptionsMenuV);
 Vue.component('dropdown-menu', DropdownMenuV);
+Vue.component('minimize', MinimizeV);
 
 import { PanelInstance } from '@/api';
 

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -11,6 +11,14 @@
             :class="{ 'h-48': item.id !== 'divider' }"
             :options="item.options"
         ></component>
+        <divider></divider>
+        <temp-appbar-button
+            v-for="(item, index) in temporaryItems"
+            :key="index + Math.random()"
+            class="my-4 text-gray-400 first:mt-8 hover:text-white h-48"
+            :options="item.options"
+        >
+        </temp-appbar-button>
     </div>
 </template>
 
@@ -20,13 +28,19 @@ import { Get, Sync, Call } from 'vuex-pathify';
 import { AppbarItemInstance } from './store';
 import DividerV from './divider.vue';
 import AppbarButtonV from './button.vue';
+import TempAppbarButtonV from './temp-button.vue';
 
 Vue.component('divider', DividerV);
 Vue.component('appbar-button', AppbarButtonV);
 
-@Component
+@Component({
+    components: {
+        'temp-appbar-button': TempAppbarButtonV
+    }
+})
 export default class AppbarV extends Vue {
     @Get('appbar/visible') items!: AppbarItemInstance[];
+    @Get('appbar/temporary') temporaryItems!: AppbarItemInstance[];
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -1,7 +1,7 @@
 import AppbarV from './appbar.vue';
 import { AppbarAPI } from './api/appbar';
-import { appbar } from './store';
-import { GlobalEvents } from '@/api';
+import { appbar, AppbarItemInstance } from './store';
+import { GlobalEvents, PanelInstance } from '@/api';
 
 // "It's a trap!" -- Admiral Appbar
 
@@ -24,8 +24,17 @@ class AppbarFixture extends AppbarAPI {
             value => this._parseConfig(value)
         );
 
+        this.$vApp.$on(GlobalEvents.PANEL_OPENED, (panel: PanelInstance) => {
+            console.log(panel);
+            this.$vApp.$store.dispatch('appbar/addTempButton', new AppbarItemInstance({ id: panel.id, options: { panel: panel } }));
+        });
+
+        this.$vApp.$on(GlobalEvents.PANEL_CLOSED, (panel: PanelInstance) => {
+            this.$vApp.$store.dispatch('appbar/removeTempButton', panel.id);
+        });
+
         // since components used in appbar can be registered after this point, listen to the global component registration event and re-validate items
-        // TODO revisit. this seems to be self-contained to the appbar fixture, so ideally can stay as is and not worry about events api.
+        // TODO revist. this seems to be self-contained to the appbar fixture, so ideally can stay as is and not worry about events api.
         this.$iApi.event.on(GlobalEvents.COMPONENT, this._validateItems.bind(this));
     }
 

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -24,12 +24,12 @@ class AppbarFixture extends AppbarAPI {
             value => this._parseConfig(value)
         );
 
-        this.$vApp.$on(GlobalEvents.PANEL_OPENED, (panel: PanelInstance) => {
+        this.$iApi.event.on(GlobalEvents.PANEL_OPENED, (panel: PanelInstance) => {
             console.log(panel);
             this.$vApp.$store.dispatch('appbar/addTempButton', new AppbarItemInstance({ id: panel.id, options: { panel: panel } }));
         });
 
-        this.$vApp.$on(GlobalEvents.PANEL_CLOSED, (panel: PanelInstance) => {
+        this.$iApi.event.on(GlobalEvents.PANEL_CLOSED, (panel: PanelInstance) => {
             this.$vApp.$store.dispatch('appbar/removeTempButton', panel.id);
         });
 

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-state.ts
@@ -1,6 +1,6 @@
 export class AppbarState {
     /**
-     * A set of all open (visible and hidden) panels.
+     * A set of all fixed appbar buttons.
      *
      * @type {AppbarItem[]}
      * @memberof AppbarState
@@ -8,12 +8,17 @@ export class AppbarState {
     items: AppbarItemSet = {};
 
     /**
-     * An ordered list of appbar item ids.
+     * An ordered list of fixed appbar item ids.
      *
      * @type {string[]}
      * @memberof AppbarState
      */
     order: string[] = [];
+
+    /**
+     * An ordered list of appbar items to show in the bottom temporary panel section
+     */
+    temporary: AppbarItemInstance[] = [];
 }
 
 export type AppbarItemSet = { [name: string]: AppbarItemInstance };

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
@@ -6,11 +6,16 @@ import { RootState } from '@/store/state';
 
 type AppbarContext = ActionContext<AppbarState, RootState>;
 
-export enum AppbarAction {}
+export enum AppbarAction {
+    ADD_TEMP_BUTTON = 'addTempButton',
+    REMOVE_TEMP_BUTTON = 'removeTempButton'
+}
 
 export enum AppbarMutation {
     ADD_ITEM = 'ADD_ITEM',
-    REMOVE_ITEM = 'REMOVE_ITEM'
+    REMOVE_ITEM = 'REMOVE_ITEM',
+    ADD_TEMP_BUTTON = 'ADD_TEMP_BUTTON',
+    REMOVE_TEMP_BUTTON = 'REMOVE_TEMP_BUTTON'
 }
 
 const getters = {
@@ -25,9 +30,28 @@ const getters = {
     }
 };
 
-const actions = {};
+const actions = {
+    [AppbarAction.ADD_TEMP_BUTTON](context: AppbarContext, value: AppbarItemInstance) {
+        if (!context.state.temporary.find(button => button.id === value.id)) {
+            context.commit(AppbarMutation.ADD_TEMP_BUTTON, value);
+        }
+    },
+    [AppbarAction.REMOVE_TEMP_BUTTON](context: AppbarContext, value: string) {
+        const button = context.state.temporary.find(button => button.id === value);
+        if (button) {
+            context.commit(AppbarMutation.REMOVE_TEMP_BUTTON, button);
+        }
+    }
+};
 
-const mutations = {};
+const mutations = {
+    [AppbarMutation.ADD_TEMP_BUTTON](state: AppbarState, value: AppbarItemInstance) {
+        state.temporary.push(value);
+    },
+    [AppbarMutation.REMOVE_TEMP_BUTTON](state: AppbarState, value: AppbarItemInstance) {
+        state.temporary.splice(state.temporary.indexOf(value), 1);
+    }
+};
 
 export function appbar() {
     const state = new AppbarState();
@@ -37,6 +61,6 @@ export function appbar() {
         state,
         getters: { ...getters },
         actions: { ...actions },
-        mutations: { ...mutations, ...make.mutations(['items', 'order']) }
+        mutations: { ...mutations, ...make.mutations(['items', 'order', 'temporary']) }
     };
 }

--- a/packages/ramp-core/src/fixtures/appbar/temp-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/temp-button.vue
@@ -1,0 +1,29 @@
+<template>
+    <appbar-button :onClickFunction="onClick">
+        <template #icon> {{ tooltip.substring(0, 1) }} </template>
+        <template #tooltip> {{ tooltip }} </template>
+    </appbar-button>
+</template>
+
+<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import AppbarButtonV from './button.vue';
+import { PanelInstance } from '../../api';
+
+@Component({
+    components: {
+        'appbar-button': AppbarButtonV
+    }
+})
+export default class TempAppbarButtonV extends Vue {
+    @Prop() options!: { panel: PanelInstance };
+
+    get tooltip() {
+        return this.options.panel.id || '';
+    }
+
+    onClick() {
+        this.options.panel.toggleMinimize();
+    }
+}
+</script>

--- a/packages/ramp-core/src/fixtures/details/details-item.vue
+++ b/packages/ramp-core/src/fixtures/details/details-item.vue
@@ -4,6 +4,7 @@
             {{ $t('details.title') }}
         </template>
         <template #controls>
+            <minimize @click="panel.minimize()"></minimize>
             <back @click="panel.show({ screen: 'details-screen-result', props: { resultIndex: resultIndex } })" v-if="!isFeature && layerType !== 'ogcWms'"></back>
             <back @click="panel.show({ screen: 'details-screen-layers' })" v-if="layerType === 'ogcWms'"></back>
             <close @click="panel.close()"></close>

--- a/packages/ramp-core/src/fixtures/details/details-layers.vue
+++ b/packages/ramp-core/src/fixtures/details/details-layers.vue
@@ -4,6 +4,7 @@
             {{ $t('details.title') }}
         </template>
         <template #controls>
+            <minimize @click="panel.minimize()"></minimize>
             <close @click="panel.close()"></close>
         </template>
         <template #content>

--- a/packages/ramp-core/src/fixtures/details/details-result.vue
+++ b/packages/ramp-core/src/fixtures/details/details-result.vue
@@ -4,6 +4,7 @@
             {{ $t('details.title') }}
         </template>
         <template #controls>
+            <minimize @click="panel.minimize()"></minimize>
             <back @click="panel.show('details-screen-layers')"></back>
             <close @click="panel.close()"></close>
         </template>

--- a/packages/ramp-core/src/store/modules/panel/panel-store.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-store.ts
@@ -14,8 +14,8 @@ export enum PanelAction {
     openPanel = 'openPanel',
     closePanel = 'removePanel',
     setWidth = 'setWidth',
-    updateVisible = 'updateVisible',
-    setStackWidth = 'setStackWidth'
+    setStackWidth = 'setStackWidth',
+    updateVisible = 'updateVisible'
 }
 
 export enum PanelMutation {


### PR DESCRIPTION
Includes work on #159 and #346 

Minimizing works, temp appbar buttons are in a very basic state... every panel gets one, they minimize and reopen panels. I plan on fixing the temp appbar buttons before this is merged, their current state just makes testing all of the new panel stuff much easier. 

I plan on fixing up the appbar buttons before this is merged and possibly giving my `TODO:` one last try.

Also, I wrote part of this months ago and part recently, so if anything feels out of place definitely mention it, I may have coded the same thing twice somewhere.

demo: http://ramp4-app.azureedge.net/demo/users/spencerwahl/appbar-and-panels/host/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/468)
<!-- Reviewable:end -->
