### PR TITLE
Restore EsriRequest web call error handling

### DIFF
--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -378,6 +378,14 @@ class MapImageLayer extends AttribLayer {
                     this.name = serviceResult.data.mapName || '';
                     // @ts-ignore
                     this.layerTree.name = this.name;
+                } else {
+                    this.name = '[server error]';
+                    // @ts-ignore
+                    this.layerTree.name = '[server error]';
+                    // @ts-ignore
+                    console.error(
+                        `Get map name service failed: ${this.esriLayer.url}`
+                    );
                 }
             });
             loadPromises.push(setTitle);


### PR DESCRIPTION
Related issue: #396

Added `await-to-js` error handling for `EsriRequest` web calls in the following places:
- Attribute FC metadata loader (Error)
- Attribute FC feature count (Warning)
- MapImageLayer legend inspector (Error - set name to '[server error]')
- Attribute API attribute batch downloader (Error)
- Attribute API single-feature downloader (Error)
- Symbology API map server legend grabber (Error - returns empty data)

Other locations that use `EsriRequest` are either not `async` or already reject the web call promise on error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/475)
<!-- Reviewable:end -->
