### PR TITLE
Add Getter Method for View Zoom Level in MapAPI

### DIFF
--- a/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
+++ b/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
@@ -21,9 +21,7 @@ describe('Mapnav', () => {
                 .eq(0)
                 .click();
             cy.wait(1000);
-            cy.wrap(window.rInstance.geo.map.esriView)
-                .its('zoom')
-                .should('eq', 1);
+            expect(window.rInstance.geo.map.getZoomLevel()).to.eq(1);
         });
     });
 
@@ -33,9 +31,7 @@ describe('Mapnav', () => {
                 .eq(1)
                 .click();
             cy.wait(1000);
-            cy.wrap(window.rInstance.geo.map.esriView)
-                .its('zoom')
-                .should('eq', 0);
+            expect(window.rInstance.geo.map.getZoomLevel()).to.eq(0);
         });
     });
 

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -293,6 +293,20 @@ export class MapAPI extends CommonMapAPI {
     }
 
     /**
+     * Provides the zoom level of the map
+     *
+     * @returns {number} the map zoom level
+     */
+    getZoomLevel(): number {
+        if (this.esriView) {
+            return this.esriView.zoom;
+        } else {
+            this.noMapErr();
+            return 1; // avoid returning zero, could cause divide-by-zero error in caller.
+        }
+    }
+
+    /**
      * Provides the scale of the map (the scale denominator as integer)
      *
      * @returns {number} the map scale


### PR DESCRIPTION
Related issue: #467

Add getter method that returns the zoom level of `esriView` in the `MapAPI`. 

Updated zoom level test cases in `fixtures/mapnav/tests/e2e/test.js` to use this getter method instead of reading the value directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/477)
<!-- Reviewable:end -->
