### PR TITLE
Hide add layer when wizard isn't loaded

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/legend-header.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend-header.vue
@@ -4,6 +4,7 @@
         <button
             @click="openWizard"
             class="relative mr-auto text-gray-500 hover:text-black p-8"
+            v-show="wizardExists"
         >
             <div class="flex">
                 <svg class="fill-current w-18 h-18 mx-8" viewBox="0 0 23 21">
@@ -14,6 +15,7 @@
                 {{ $t('legend.header.addlayer') }}
             </tooltip>
         </button>
+        <span class="flex-1"></span>
         <!-- groups toggle -->
         <dropdown-menu position="right">
             <template #header>
@@ -97,6 +99,14 @@ export default class LegendHeaderV extends Vue {
 
     openWizard() {
         this.$iApi.event.emit(GlobalEvents.WIZARD_OPEN);
+    }
+
+    get wizardExists(): boolean {
+        try {
+            return !!this.$iApi.fixture.get('wizard');
+        } catch (e) {
+            return false;
+        }
     }
 }
 </script>


### PR DESCRIPTION
#442: Hides the legend add layer button if the wizard isn't loaded. (again 🐒)

When the wizard is loaded:
![show-add-layer](https://user-images.githubusercontent.com/33560973/119543216-6ab8bf00-bd5e-11eb-8346-1e5f8263bf0b.png)

When the wizard isn't loaded:
![hide-add-layer](https://user-images.githubusercontent.com/33560973/119543231-6f7d7300-bd5e-11eb-8c6f-5e0b1aa8610b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/483)
<!-- Reviewable:end -->
