### PR TITLE
Expose takeScreenshot() on MapAPI

### DIFF
--- a/packages/ramp-core/src/fixtures/export-v1-map/index.ts
+++ b/packages/ramp-core/src/fixtures/export-v1-map/index.ts
@@ -5,11 +5,7 @@ import { ExportV1SubFixture } from '@/fixtures/export-v1';
 
 class ExportV1MapFixture extends FixtureInstance implements ExportV1SubFixture {
     async make(options: any): Promise<fabric.Image> {
-        if (!this.$iApi.geo.map.esriView) {
-            throw new Error('Export attempted without a map view available');
-        }
-        // TODO: expose the esri takeScreenshot on the MapAPI
-        const screenshot = await this.$iApi.geo.map.esriView.takeScreenshot({
+        const screenshot = await this.$iApi.geo.map.takeScreenshot({
             quality: 1,
             format: 'png'
         });

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -234,6 +234,11 @@ export interface ScreenPoint {
     screenY: number;
 }
 
+export interface Screenshot {
+    dataUrl: string;
+    data: ImageData;
+}
+
 // a collection of attributes
 // TODO consider changin .features to .attributes or .attribs.
 //      features would be back-compatible, but it's confusing as we now have a Graphic class, which would be more

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -22,6 +22,7 @@ import {
     Point,
     RampMapConfig,
     ScreenPoint,
+    Screenshot,
     ScaleSet,
     SpatialReference
 } from '@/geo/api';
@@ -353,6 +354,32 @@ export class MapAPI extends CommonMapAPI {
             ) || modLods[modLods.length - 1];
 
         return this.zoomToLevel(scaleLod.level);
+    }
+
+    /**
+     * Create a screenshot of the current view.
+     *
+     * Possible ESRI takeScreenshot() options:
+     * https://developers.arcgis.com/javascript/latest/api-reference/esri-views-MapView.html#takeScreenshot
+     * Will default to quality = 1 and format = 'png'.
+     *
+     * @param {__esri.MapViewTakeScreenshotOptions} options ESRI takeScreenshot() options
+     * @returns {Promise<Screenshot>} a promise that resolves with a Screenshot
+     */
+    async takeScreenshot(
+        options: __esri.MapViewTakeScreenshotOptions
+    ): Promise<Screenshot> {
+        if (this.esriView) {
+            if (!options.quality) {
+                options.quality = 1;
+            }
+            if (!options.format) {
+                options.format = 'png';
+            }
+            return this.esriView.takeScreenshot(options);
+        } else {
+            throw new Error('Export attempted without a map view available');
+        }
     }
 
     /**


### PR DESCRIPTION
For #390: Add a method to the `MapAPI` to wrap/abstract the `takeScreenshot` function, and update the Export fixture to use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/485)
<!-- Reviewable:end -->
