### PR TITLE
Truncate long titles in the grid header

### DIFF
--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -9,7 +9,7 @@
                 v-if="$iApi.screenSize === 'xs'"
                 @click="panel.close()"
             ></back>
-            <h2 class="flex-grow text-lg py-16 pl-8">
+            <h2 class="flex-grow text-lg py-16 pl-8 truncate min-w-0">
                 <slot name="header"></slot>
             </h2>
 

--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -15,7 +15,7 @@
                 preserveAspectRatio="xMidYMid meet"
                 viewBox="0 0 24 24"
                 focusable="false"
-                class="fill-current w-24 h-24"
+                class="fill-current w-24 h-24 flex-shrink-0"
                 v-if="quicksearch.length < 3"
             >
                 <g id="search_cache224">


### PR DESCRIPTION
Related issue: #462

Note that this is a temporary fix for the long layer titles.
There is currently a discussion on the design for the grid panel: #471 

**Before:**
![image](https://user-images.githubusercontent.com/34178949/119693280-20951380-be1a-11eb-8ffe-cbcf228504f6.png)

**After fix:**
![image](https://user-images.githubusercontent.com/34178949/119695428-27248a80-be1c-11eb-9446-95dd80e61788.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/487)
<!-- Reviewable:end -->
