### PR TITLE
Move Map-Caption Scale Bar Event Listener to Default Event Handlers 

### DIFF
--- a/packages/ramp-core/docs/app/defaults.md
+++ b/packages/ramp-core/docs/app/defaults.md
@@ -133,6 +133,7 @@ TODO keep updating the list, make new subsections as appropriate. Maybe move to 
 
 -   `updates_map_caption_attribution_basemap` updates the attribution in the map-caption by retrieving it from the current basemap config when the basemap changes
 -   `updates_map_caption_attribution_config` updates the attribution in the map-caption by retrieving it from the current basemap config when the config changes
+-   `updates_map_caption_scale` updates the scale bar in the map-caption when the map scale changes
 
 ## Examples
 

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -8,6 +8,7 @@ import { WizardAPI } from '@/fixtures/wizard/api/wizard';
 import { LegendAPI } from '@/fixtures/legend/api/legend';
 import { MapClick, RampBasemapConfig } from '@/geo/api';
 import { RampConfig } from '@/types';
+import { debounce } from 'debounce';
 
 export enum GlobalEvents {
     /**
@@ -80,7 +81,8 @@ enum DefEH {
     OPEN_WIZARD = 'opens_wizard_panel',
     GENERATE_LEGEND = 'generates_default_legend_entry',
     MAP_BASEMAPCHANGE_ATTRIBUTION = 'updates_map_caption_attribution_basemap',
-    CONFIG_CHANGE_ATTRIBUTION = 'updates_map_caption_attribution_config'
+    CONFIG_CHANGE_ATTRIBUTION = 'updates_map_caption_attribution_config',
+    MAP_SCALECHANGE_SCALEBAR = 'updates_map_caption_scale'
 }
 
 // private for EventBus internals, so don't export
@@ -331,7 +333,8 @@ export class EventAPI extends APIScope {
                 DefEH.OPEN_WIZARD,
                 DefEH.GENERATE_LEGEND,
                 DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION,
-                DefEH.CONFIG_CHANGE_ATTRIBUTION
+                DefEH.CONFIG_CHANGE_ATTRIBUTION,
+                DefEH.MAP_SCALECHANGE_SCALEBAR
             ];
         }
 
@@ -539,6 +542,13 @@ export class EventAPI extends APIScope {
                 this.$iApi.event.on(
                     GlobalEvents.CONFIG_CHANGE,
                     zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_SCALECHANGE_SCALEBAR:
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_SCALECHANGE,
+                    debounce(() => this.$iApi.geo.map.updateScale(), 300),
                     handlerName
                 );
                 break;

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -373,12 +373,6 @@ export interface Attribution {
     };
 }
 
-// MapCaption interface for all elements in the map-caption bar
-// If more elements are added to the map-caption, they can be added here
-export interface MapCaption {
-    attribution: Attribution;
-}
-
 // ----------------------- CLIENT CONFIG INTERFACES -----------------------------------
 
 // TODO migrate these to /geo/api/geo-common ? if we need config interfaces before creating an instance,

--- a/packages/ramp-core/src/store/modules/mapcaption/mapcaption-state.ts
+++ b/packages/ramp-core/src/store/modules/mapcaption/mapcaption-state.ts
@@ -1,10 +1,11 @@
 import { Attribution } from '@/geo/api';
 
 export class MapCaptionState {
-    // TODO: Make attribution into a defined type and update all instances (including config)
     attribution: Attribution;
+    scale: { label: string; width: string; isImperialScale: boolean };
 
-    constructor(attrib: Attribution) {
+    constructor(attrib: Attribution, scale: any) {
         this.attribution = attrib;
+        this.scale = scale;
     }
 }

--- a/packages/ramp-core/src/store/modules/mapcaption/mapcaption-store.ts
+++ b/packages/ramp-core/src/store/modules/mapcaption/mapcaption-store.ts
@@ -12,31 +12,48 @@ const getters = {};
 const actions = {
     setAttribution: (context: MapCaptionContext, attribution: Attribution) => {
         context.commit('SET_ATTRIBUTION', attribution);
+    },
+    setScale: (context: MapCaptionContext, scale: any) => {
+        context.commit('SET_SCALE', scale);
     }
 };
 
 const mutations = {
     SET_ATTRIBUTION: (state: MapCaptionState, value: Attribution) => {
         state.attribution = value;
+    },
+    SET_SCALE: (state: MapCaptionState, value: any) => {
+        state.scale = value;
     }
 };
 
 export enum MapCaptionStore {
     /**
-     * (State) attribution: any // TODO: Create concrete definition type for attribution
+     * (State) attribution: Attribution
      */
     attribution = 'mapcaption/attribution',
     /**
      * (Action) setAttribution: (attribution: any)
      */
-    setAttribution = 'mapcaption/setAttribution!'
+    setAttribution = 'mapcaption/setAttribution!',
+    /**
+     * (State) scale: any
+     */
+    scale = 'mapcaption/scale',
+    /**
+     * (Action) setScale: (scale: any)
+     */
+    setScale = 'mapcaption/setScale!'
 }
 
 export function mapcaption() {
-    const state = new MapCaptionState({
-        text: { disabled: true },
-        logo: { disabled: true }
-    });
+    const state = new MapCaptionState(
+        {
+            text: { disabled: true },
+            logo: { disabled: true }
+        },
+        { label: '0km', width: '0px', isImperialScale: false }
+    );
 
     return {
         namespaced: true,


### PR DESCRIPTION
Related issue: #489 

The `scale` attributes have been moved to the `MapCaptionStore` and its event listener has been moved to the default handler. 

Additionally, there was a bug where the scale bar will be larger than the caption bar itself if the user zooms in fully. 
This is fixed in this PR where the scale bar will start using meters (or feet) as the precision units if the scale bar distance is less than 1km. 

Example:
![image](https://user-images.githubusercontent.com/34178949/120229938-422c3b80-c21c-11eb-9a94-0814ded374a6.png)
![image](https://user-images.githubusercontent.com/34178949/120229981-5bcd8300-c21c-11eb-88ec-0763148c4fcf.png)

---
Note that the `latLongCursor` event lister was **not** moved to a default handler as it requires consensus on how to approach this (discussion: #494). 
This specific task will be moved into a new issue (#495).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/493)
<!-- Reviewable:end -->
