### PR TITLE
Scroll page on single touch, pan on double touch

### DIFF
--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -169,6 +169,7 @@ export class FixtureAPI extends APIScope {
                 'northarrow',
                 'overviewmap',
                 'scrollguard',
+                'panguard',
                 'settings',
                 'wizard'
             ];

--- a/packages/ramp-core/src/fixtures/panguard/index.ts
+++ b/packages/ramp-core/src/fixtures/panguard/index.ts
@@ -1,0 +1,24 @@
+import messages from './lang/lang.csv';
+import PanguardV from './panguard.vue';
+import { FixtureInstance } from '@/api';
+
+class PanguardFixture extends FixtureInstance {
+    added(): void {
+        console.log(`[fixture] ${this.id} added`);
+        // Manually add lang entries to i18n
+        Object.entries(messages).forEach(value =>
+            this.$vApp.$i18n.mergeLocaleMessage(...value)
+        );
+
+        const panguard = this.extend(PanguardV);
+        this.$vApp.$root.$el
+            .getElementsByClassName('inner-shell')[0]
+            .prepend(panguard.$el);
+    }
+
+    removed(): void {
+        console.log(`[fixture] ${this.id} removed`);
+    }
+}
+
+export default PanguardFixture;

--- a/packages/ramp-core/src/fixtures/panguard/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/panguard/lang/lang.csv
@@ -1,0 +1,2 @@
+key,enValue,enValid,frValue,frValid
+panguard.instructions,Use two fingers to scroll the map,1,Utiliser deux doigts pour faire défiler la carte,1

--- a/packages/ramp-core/src/fixtures/panguard/panguard.vue
+++ b/packages/ramp-core/src/fixtures/panguard/panguard.vue
@@ -1,0 +1,98 @@
+<template>
+    <div class="pan-guard" ref="panGuard">
+        <p class="label">{{ $t('panguard.instructions') }}</p>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+
+@Component
+export default class MapPanguard extends Vue {
+    timeoutID: number | undefined = undefined;
+
+    mounted(): void {
+        // keep track of how many concurrent pointers are on the screen and their initial positions. This is a javascript map, not a map-map
+        const pointers = new Map();
+
+        // prevent possible issues with esri event registration if this fixture runs before the map has built itself
+        this.$iApi.geo.map.viewPromise.getPromise().then(() => {
+            // TODO: when projection change is implemented check that the below events track any changes to
+            // the esriView or update MapAPI to be raising pointer events on the EventAPI, and this will listen to for those events
+            this.$iApi.geo.map.esriView!.on('pointer-down', e => {
+                if (e.pointerType !== 'touch') return;
+                pointers.set(e.pointerId, { x: e.x, y: e.y });
+            });
+
+            this.$iApi.geo.map.esriView!.on(
+                ['pointer-up', 'pointer-leave'],
+                e => {
+                    if (e.pointerType !== 'touch') return;
+                    pointers.delete(e.pointerId);
+                }
+            );
+
+            this.$iApi.geo.map.esriView!.on('pointer-move', e => {
+                const { pointerId, pointerType, x, y } = e;
+                const pointer = pointers.get(pointerId);
+
+                if (!pointer || pointerType !== 'touch' || pointers.size !== 1)
+                    return;
+
+                // ignore very small movements to avoid scrolling when someone is tapping the screen
+                const distance = Math.sqrt(
+                    Math.pow(x - pointer.x, 2) + Math.pow(y - pointer.y, 2)
+                );
+                if (distance < 20) return;
+
+                // show the text on screen and remove after 2 seconds of no movement
+                this.$el.classList.add('active');
+                clearTimeout(this.timeoutID);
+                this.timeoutID = window.setTimeout(() => {
+                    this.$el.classList.remove('active');
+                }, 2000);
+
+                // manually scroll the page since scrolling doesn't work when moving over the map
+                window.scrollBy(pointer.x - x, pointer.y - y);
+            });
+        });
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.pan-guard {
+    transition: opacity ease-in-out;
+    background-color: rgba(0, 0, 0, 0.45);
+    text-align: center;
+
+    position: absolute;
+    padding: 0px;
+    margin: 0px;
+    border-width: 0px;
+    width: 100%;
+    height: 100%;
+    left: 0px;
+    top: 0px;
+
+    transition-duration: 0.8s;
+
+    opacity: 0;
+    z-index: 100;
+    pointer-events: none !important;
+
+    &.active {
+        opacity: 1;
+        transition-duration: 0.3s;
+    }
+
+    .label {
+        font-size: 1em * 1.5;
+        color: white;
+        position: relative;
+        margin: 0;
+        top: 50% !important;
+        transform: translateY(-50%);
+    }
+}
+</style>

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -88,7 +88,10 @@ export class MapAPI extends CommonMapAPI {
             spatialReference: this.$iApi.geo.utils.geom._convSrToEsri(
                 this._rampSR
             ), // internal, so we will sneak an internal call
-            extent: config.extent
+            extent: config.extent,
+            navigation: {
+                browserTouchPanEnabled: false
+            }
         };
 
         // TODO extract more from config and set appropriate view properties (e.g. intial extent, initial projection, LODs)


### PR DESCRIPTION
Prompts users to `use two fingers to pan` on single touch and instead scrolls the page on mobile browsers. 

Tested on mobile chromium (desktop) and on latest ios safari. 

[Demo](http://ramp4-app.azureedge.net/demo/users/milespetrov/452-finger-pan/host/index.html)
Closes #452

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/498)
<!-- Reviewable:end -->
