### PR TITLE
Fix date filter to single out dates when startDate = endDate

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/table/table.vue
+++ b/packages/ramp-core/src/fixtures/grid/table/table.vue
@@ -305,13 +305,29 @@ export default class TableComponent extends Vue {
             entryDate: any
         ) {
             let entry = new Date(entryDate);
-            if (entry > filterDate) {
+
+            // We need to specifically compare the UTC year, month, and date because
+            // directly comparing the dates returns the wrong value due to timezone differences
+            // Thus both dates need to be converted to UTC before comparing
+
+            // Check year
+            if (entry.getUTCFullYear() > filterDate.getUTCFullYear()) {
                 return 1;
-            } else if (entry < filterDate) {
+            } else if (entry.getUTCFullYear() < filterDate.getUTCFullYear()) {
                 return -1;
-            } else {
-                return 0;
             }
+
+            // At this point year is the same
+            // Check month
+            if (entry.getUTCMonth() > filterDate.getUTCMonth()) {
+                return 1;
+            } else if (entry.getUTCMonth() < filterDate.getUTCMonth()) {
+                return -1;
+            }
+
+            // At this point month is the same
+            // Now return the sign based on the date difference
+            return entry.getUTCDate() - filterDate.getUTCDate();
         };
         colDef.filterParams.inRangeInclusive = true;
         colDef.floatingFilterComponentParams = {

--- a/packages/ramp-core/src/fixtures/grid/tests/e2e/grid-test.js
+++ b/packages/ramp-core/src/fixtures/grid/tests/e2e/grid-test.js
@@ -576,7 +576,6 @@ describe('Grid', () => {
 
         // TODO: Add tests for wildcard formats once it is implemented
 
-        // TODO: Fix bug: #455
         it('filters date start date only', () => {
             toggleGrid('Shellfish');
             // filter "RISC_DATE" field start date
@@ -599,7 +598,6 @@ describe('Grid', () => {
             toggleGrid('Shellfish');
         });
 
-        // TODO: Fix bug: #455
         it('filters date end date only', () => {
             toggleGrid('Shellfish');
             // filter "RISC_DATE" field end date
@@ -627,13 +625,15 @@ describe('Grid', () => {
             // filter "RISC_DATE" field start and end date
             cy.get('[aria-rowindex="2"] [aria-colindex="7"] .rv-input')
                 .eq(0)
-                .type('2003-05-07');
+                .type('2003-05-07')
+                .blur();
             cy.get('[aria-rowindex="2"] [aria-colindex="7"] .rv-input')
                 .eq(1)
                 .type('2004-09-25')
                 .blur();
 
             // need to wait for date filter
+            cy.wait(5000);
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
@@ -659,12 +659,14 @@ describe('Grid', () => {
                 .blur();
 
             // need to wait for date filter
+            cy.wait(5000);
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
             ).each($cell => {
                 // compare lexicographically since dates are yyyy-MM-dd
                 const dateStr = $cell.text().trim();
+                cy.log(dateStr);
                 expect(dateStr >= '2003-05-07').to.be.true;
                 expect(dateStr <= '2004-09-25').to.be.true;
             });
@@ -673,32 +675,33 @@ describe('Grid', () => {
             toggleGrid('Shellfish');
         });
 
-        // TODO: Fix bug: #454
         it('filters date single date value', () => {
             toggleGrid('Shellfish');
             // filter "RISC_DATE" field
             cy.get('[aria-rowindex="2"] [aria-colindex="7"] .rv-input')
                 .eq(0)
-                .type('2014-04-30');
+                .type('2000-12-05')
+                .blur();
             cy.get('[aria-rowindex="2"] [aria-colindex="7"] .rv-input')
                 .eq(1)
-                .type('2014-04-30')
+                .type('2000-12-05')
                 .blur();
 
             // need to wait for date filter
+            cy.wait(5000);
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
             ).each($cell => {
                 // compare lexicographically since dates are yyyy-MM-dd
                 const dateStr = $cell.text().trim();
-                expect(dateStr == '2014-04-30').to.be.true;
+                expect(dateStr == '2000-12-05').to.be.true;
             });
 
-            // There are 4 records with this date
+            // There are 3 records with this date
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
-            ).should('have.length', 4);
+            ).should('have.length', 3);
 
             clearFilters();
             toggleGrid('Shellfish');


### PR DESCRIPTION
Related issue: #454

- Modified the date comparator to strictly use UTC time and only compare the year, month, and date fields
- All test cases in `grid-test.js` now pass successfully

Demo:
- Visit [local build](http://ramp4-app.azureedge.net/demo/users/sharvenp/454/host/index.html)
- Add the [Shellfish Harvest](https://maps-cartes.ec.gc.ca/arcgis/rest/services/Shellfish_Classification_Mollusques/MapServer/6) layer
- Set startDate = endDate to single out specific dates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/499)
<!-- Reviewable:end -->
