### PR TITLE
Improve getName()

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -57,12 +57,14 @@ rInstance = new RAMP.Instance(document.getElementById('app'), {
         layers: [
             {
                 id: 'WaterQuantity',
+                name: 'Water quantity parent',
                 layerType: 'esriMapImage',
                 url:
                     'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
                 layerEntries: [
                     {
                         index: 1,
+                        name: 'Water quantity child',
                         state: {
                             opacity: 1,
                             visibility: true
@@ -115,19 +117,7 @@ rInstance = new RAMP.Instance(document.getElementById('app'), {
                     visibility: true
                 },
                 customRenderer: {}
-            },
-            {
-                id: 'Happy',
-                layerType: 'esriFeature',
-                fileType: 'geojson',
-                url:
-                    'https://fgpv-app.azureedge.net/demo/assets/sample_data/happy.json',
-                state: {
-                    visibility: true
-                },
-                customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
             }
-
             /*
             {
                 id: 'TestTile',

--- a/packages/ramp-core/src/fixtures/details/details-layers.vue
+++ b/packages/ramp-core/src/fixtures/details/details-layers.vue
@@ -22,7 +22,7 @@
                 @click="openResult(idx)"
             >
                 <div class="truncate">
-                    {{ layerInfo(idx) }}
+                    {{ layerInfo(idx) || $t('details.layers.loading') }}
                 </div>
                 <div class="flex-auto"></div>
                 <div class="px-5">{{ item.items.length }}</div>
@@ -87,7 +87,7 @@ export default class DetailsLayersV extends Vue {
 
         if (!item) return;
 
-        return item.getName() ? item.getName() : item.id;
+        return item.getName(layerInfo.uid);
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/details/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/details/lang/lang.csv
@@ -1,4 +1,5 @@
 key,enValue,enValid,frValue,frValid
 details.title,Details,1,Détails,0
 details.layers.found,Found {numResults} results in {numLayers} layers,1,Figure {numResults} résultats en {numLayers} couches,0
+details.layers.loading,The layer is loading...,1,La couche est le chargement...,0
 details.results.empty,No results found for the selected layer.,1,Aucun résultat trouvé de la couche sélectionnée.,0

--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -1,6 +1,8 @@
 <template>
     <panel-screen>
-        <template #header>{{ $t('grid.title') }}: {{ head }} </template>
+        <template #header
+            >{{ $t('grid.title') }}: {{ head || $t('grid.layer.loading') }}
+        </template>
         <template #controls>
             <input
                 @keyup="updateQuickSearch()"

--- a/packages/ramp-core/src/fixtures/grid/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/grid/lang/lang.csv
@@ -1,5 +1,6 @@
 key,enValue,enValid,frValue,frValid
 grid.title,Features,1,Éléments,1
+grid.layer.loading,The layer is loading...,1,La couche est le chargement...,0
 grid.label.columns,Columns,1,Colonnes,0
 grid.label.filters,Filters,1,Filtres,0
 grid.filters.label.global,Search table,1,Tableau de recherche,0

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -216,7 +216,6 @@ export class CommonLayer extends LayerInstance {
                 // additional asynch work to fully set things up, so we delay firing the event until
                 // that is done.
                 this.onLoad();
-                this.sawLoad = true; // TODO investigate if we need to push this to the same location that the event is fired
             } else {
                 this.updateState(statemap[newval]);
             }
@@ -290,6 +289,7 @@ export class CommonLayer extends LayerInstance {
         const loadPromises: Array<Promise<void>> = this.onLoadActions();
         Promise.all(loadPromises).then(() => {
             this.updateState(LayerState.LOADED);
+            this.sawLoad = true;
             this.loadPromise.resolveMe();
         });
     }
@@ -507,7 +507,13 @@ export class CommonLayer extends LayerInstance {
      * @returns {String} name of the layer/sublayer
      */
     getName(layerIdx: number | string | undefined = undefined): string {
-        return this.getFC(layerIdx)?.name || '';
+        if (!this.sawLoad) {
+            // layer has not been loaded yet
+            // if the config has a name defined, this.name will be set
+            // empty string will indicate the layer has not loaded and has no name defined
+            return this.name || '';
+        }
+        return this.getFC(layerIdx)?.name || this.id;
     }
 
     /**

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -400,10 +400,43 @@ class MapImageLayer extends AttribLayer {
     // so for properties that fall into this category, we intercept the common routies, and treat an undefined
     // layerIdx as targeting the layer proper (in other layers, undefined means take the default child)
 
+    /**
+     * Returns the name of the layer/sublayer.
+     *
+     * @function getName
+     * @param {Integer | String} [layerIdx] targets a layer index or uid to get the name for. Uses first/only if omitted.
+     * @returns {String} name of the layer/sublayer
+     */
     getName(layerIdx: number | string | undefined = undefined): string {
+        if (!this.sawLoad) {
+            // layer has not been loaded yet
+
+            if (typeof layerIdx === 'string') {
+                // no uids at this point so we have no idea what's being requested
+                return '';
+            } else if (typeof layerIdx === 'number') {
+                // layerIdx is a layer index
+                const layerEntries: Array<RampLayerMapImageLayerEntryConfig> =
+                    this.origRampConfig.layerEntries || [];
+                const layer = (<Array<RampLayerMapImageLayerEntryConfig>>(
+                    layerEntries
+                )).filter((layer: any) => {
+                    return layer.index === layerIdx;
+                })[0];
+                if (layer && layer.name) {
+                    return layer.name;
+                } else {
+                    return '';
+                }
+            } else {
+                // if the layer was added through the wizard, or the parent layer has a name in the config, this.name will be defined
+                return this.name || '';
+            }
+        }
         const fc = this.getFC(layerIdx, true);
         if (!fc) {
-            return this.name;
+            // layerIdx belongs to the parent layer
+            return this.name || this.id;
         } else {
             // see comment in getOpacity
             return super.getName(fc.layerIdx);


### PR DESCRIPTION
For #439.
- Improve `getName()` so that it looks in the config for layer names if the layer is not loaded
- Added `name` to one of the ` MapImageLayer` configs
- Have the details panel pass in the layer uid when it calls `getName()`
    - a side effect of this: the details panel and grid don't have matching layer names for MILs anymore because the uid of the sublayer is passed in through the details panel while the uid of the parent layer is passed in through the grid - I can revert this or, if no one says anything about it, I can make an issue about it after this PR is pulled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/508)
<!-- Reviewable:end -->
