### PR TITLE
Layer reordering

### DIFF
--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -28,7 +28,7 @@ export default class EsriMap extends Vue {
     }
 
     @Watch('layerConfigs')
-    onLayerConfigArrayChange(
+    async onLayerConfigArrayChange(
         newValue: RampLayerConfig[],
         oldValue: RampLayerConfig[]
     ) {
@@ -42,51 +42,60 @@ export default class EsriMap extends Vue {
             return;
         }
 
-        newValue
-            .filter(lc => !oldValue.includes(lc))
-            .forEach(layerConfig => {
-                let defLoadProm: Promise<string>;
+        const layers = await Promise.all(
+            newValue
+                .filter(lc => !oldValue.includes(lc))
+                .map(layerConfig => {
+                    return new Promise<LayerInstance>(async resolve => {
+                        let defLoadProm: Promise<string>;
 
-                // check if we need to load the layer class
-                if (
-                    this.$iApi.geo.layer.layerDefExists(layerConfig.layerType)
-                ) {
-                    defLoadProm = Promise.resolve(layerConfig.layerType);
-                } else {
-                    // if the definition is a custom number, the site host would have had to add the
-                    // definition already. this block should only run for layer types that are bundled
-                    // in the ramp core codebase.
-                    defLoadProm = this.$iApi.geo.layer.addLayerDef(
-                        layerConfig.layerType
-                    );
-                }
+                        // check if we need to load the layer class
+                        if (
+                            this.$iApi.geo.layer.layerDefExists(
+                                layerConfig.layerType
+                            )
+                        ) {
+                            defLoadProm = Promise.resolve(
+                                layerConfig.layerType
+                            );
+                        } else {
+                            // if the definition is a custom number, the site host would have had to add the
+                            // definition already. this block should only run for layer types that are bundled
+                            // in the ramp core codebase.
+                            defLoadProm = this.$iApi.geo.layer.addLayerDef(
+                                layerConfig.layerType
+                            );
+                        }
 
-                // wait for definition to load, or ride the resolve if already loaded
-                defLoadProm.then(() => {
-                    // create the layer instantiation
-                    this.$iApi.geo.layer
-                        .createLayer(layerConfig)
-                        .then(layer => {
-                            // TODO call the new layer load method.
-                            //      might need to wait on that (think file layers that are making asynch calls prior to creating esri layer)
-                            //      see if layers are going to expose an "esri layer exists" promise, leverage that if they do
-                            layer.initiate().then(() => {
-                                // TODO do we need to care about map layer order?
-                                this.map.addLayer(layer);
-                            });
+                        // wait for definition to load, or ride the resolve if already loaded
+                        await defLoadProm;
+                        // create the layer instantiation
+                        const layer = await this.$iApi.geo.layer.createLayer(
+                            layerConfig
+                        );
+                        // TODO call the new layer load method.
+                        //      might need to wait on that (think file layers that are making asynch calls prior to creating esri layer)
+                        //      see if layers are going to expose an "esri layer exists" promise, leverage that if they do
+                        await layer.initiate();
+                        this.map.addLayer(layer);
 
-                            // add layer to layer store
-                            // TODO need to revisit https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/328
-                            //      as we may be causing lots of problems putting these objects in vuex store.
-                            this.$iApi.$vApp.$store.set(LayerStore.addLayers, [
-                                layer
-                            ]);
-                        });
-                });
+                        // add layers to layer store
+                        // TODO need to revisit https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/328
+                        //      as we may be causing lots of problems putting these objects in vuex store.
+                        this.$iApi.$vApp.$store.set(LayerStore.addLayers, [
+                            layer
+                        ]);
 
-                // a bit dangerous but ideally https://github.com/ramp4-pcar4/ramp4-pcar4/issues/126 and https://github.com/ramp4-pcar4/ramp4-pcar4/issues/173
-                // will make this more seamless and not need to worry about having multiple listeners.
-            });
+                        resolve(layer);
+                    });
+                })
+        );
+
+        // need to wait for all layers before reordering since esri reorder does
+        // not allow reordering/inserting into arbitrary indices (i.e. no holes)
+        layers.forEach((layer: LayerInstance, index: number) => {
+            this.$iApi.geo.map.reorder(layer, oldValue.length + index);
+        });
     }
 
     @Watch('mapConfig')

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -230,6 +230,28 @@ export class MapAPI extends CommonMapAPI {
     }
 
     /**
+     * Reorders a layer on the map
+     *
+     * @param {LayerInstance} layer the Ramp layer to be moved
+     * @param {number} index the index for placing the layer
+     */
+    reorder(layer: LayerInstance, index: number): void {
+        if (!this.esriMap) {
+            this.noMapErr();
+            return;
+        }
+        // await layer.isReadyForMap();
+        if (layer.esriLayer) {
+            this.esriMap.reorder(layer.esriLayer, index);
+        } else {
+            // TODO maybe we should call layer.initiate() and block? Could be a nice shortcut. But also might have unintended effects.
+            console.error(
+                'Attempted reorder without an esri layer. Likely layer.initiate() was not called or had not finished.'
+            );
+        }
+    }
+
+    /**
      * Adds a highlight layer to the map
      *
      * @param {HighlightLayer} highlightLayer the highlight

--- a/packages/ramp-core/src/store/modules/layer/layer-store.ts
+++ b/packages/ramp-core/src/store/modules/layer/layer-store.ts
@@ -62,6 +62,12 @@ const actions = {
             context.commit('ADD_LAYER_CONFIG', lc);
         });
     },
+    reorderLayer: (
+        context: LayerContext,
+        { layer, index }: { layer: LayerInstance; index: number }
+    ) => {
+        context.commit('REORDER_LAYER', { layer, index });
+    },
     addLayers: (context: LayerContext, layers: LayerInstance[]) => {
         // TODO we are getting frequent errors at startup; something passes in an
         //      undefined layerConfigs. kicking out for now to make demos work.
@@ -117,6 +123,16 @@ const mutations = {
     ADD_LAYER: (state: LayerState, value: LayerInstance) => {
         // copy to new array so watchers will have a reference to the old value
         state.layers = [...state.layers, value];
+    },
+    REORDER_LAYER: (
+        state: LayerState,
+        {
+            layer,
+            index = state.layers.length
+        }: { layer: LayerInstance; index: number }
+    ) => {
+        state.layers.splice(state.layers.indexOf(layer), 1);
+        state.layers.splice(index, 0, layer);
     }
 };
 
@@ -133,6 +149,10 @@ export enum LayerStore {
      * (State) layers: LayerInstance[]
      */
     layers = 'layer/layers',
+    /**
+     * (Action) reorderLayer: ({ layer: LayerInstance, index: number })
+     */
+    reorderLayer = 'layer/reorderLayer!',
     /**
      * (Action) addLayers: (layers: LayerInstance[])
      */


### PR DESCRIPTION
Added map API method to reorder layers on map and syncs initial layer order with config order. #378, #435
Also partially fixes map export. #432
[🔗](http://ramp4-app.azureedge.net/demo/users/an-w/zzz/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/509)
<!-- Reviewable:end -->
