### PR TITLE
Implement Layer Removal Map API Function

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -23,6 +23,7 @@ export enum GlobalEvents {
     LAYER_OPACITYCHANGE = 'layer/opacitychange',
     LAYER_STATECHANGE = 'layer/statechange',
     LAYER_VISIBILITYCHANGE = 'layer/visibilitychange',
+    LAYER_REMOVE = 'layer/remove', // Payload: `(layer: LayerInstance)`
 
     /**
      * Fires when the config file changes

--- a/packages/ramp-core/src/store/modules/layer/layer-store.ts
+++ b/packages/ramp-core/src/store/modules/layer/layer-store.ts
@@ -112,6 +112,12 @@ const actions = {
             });
         });
         */
+    },
+    removeLayer: (context: LayerContext, layer: LayerInstance) => {
+        context.commit('REMOVE_LAYER', layer);
+    },
+    removeLayerConfig: (context: LayerContext, layerId: string) => {
+        context.commit('REMOVE_LAYER_CONFIG', layerId);
     }
 };
 
@@ -133,6 +139,20 @@ const mutations = {
     ) => {
         state.layers.splice(state.layers.indexOf(layer), 1);
         state.layers.splice(index, 0, layer);
+    },
+    REMOVE_LAYER: (state: LayerState, value: LayerInstance) => {
+        // copy to new array so watchers will have a reference to the old value
+        const filteredLayers = state.layers.filter(layer => {
+            return layer.id !== value.id || layer.uid !== value.uid;
+        });
+        state.layers = filteredLayers;
+    },
+    REMOVE_LAYER_CONFIG: (state: LayerState, layerId: string) => {
+        // copy to new array so watchers will have a reference to the old value
+        const filteredLayerConfigs = state.layerConfigs.filter(layerConfig => {
+            return layerConfig.id !== layerId;
+        });
+        state.layerConfigs = filteredLayerConfigs;
     }
 };
 
@@ -158,13 +178,21 @@ export enum LayerStore {
      */
     addLayers = 'layer/addLayers!',
     /**
+     * (Action) removeLayer: (layer: LayerInstance)
+     */
+    removeLayer = 'layer/removeLayer!',
+    /**
      * (State) layerConfigs: RampLayerConfig[]
      */
     layerConfigs = 'layer/layerConfigs',
     /**
      * (Action) addLayerConfigs: (layerConfigs: RampLayerConfig[])
      */
-    addLayerConfigs = 'layer/addLayerConfigs!'
+    addLayerConfigs = 'layer/addLayerConfigs!',
+    /**
+     * (Action) removeLayerConfig: (layerId: string)
+     */
+    removeLayerConfig = 'layer/removeLayerConfig!'
 }
 
 export function layer() {


### PR DESCRIPTION
Related issue: #266

Implemented `removeLayer` function in the `MapAPI` that can be called by other components to remove layers.

The function takes in three possible inputs:
- `LayerInstance` object
- `string` layer id
- `string` layer uid 

Note that this does not interact with the legend UI (this is issue #512). It only removes the layer from the map model and fires a `LAYER_REMOVE` event which can be used to update the UI and other components if needed.

Event listeners and other properties on the removed layer will be cleaned up when the `terminate` function is called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/510)
<!-- Reviewable:end -->
