### PR TITLE
Fix panels pushing eachother off the screen

### DIFF
--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="shadow-tm bg-white h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto"
+        class="shadow-tm bg-white h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto min-w-0"
         :style="panel.style"
         :data-cy="panel.id"
     >

--- a/packages/ramp-core/src/fixtures/grid/grid.vue
+++ b/packages/ramp-core/src/fixtures/grid/grid.vue
@@ -7,6 +7,7 @@
                 v-model="quicksearch"
                 class="rv-global-search rv-input"
                 aria-invalid="false"
+                :aria-label="$t('grid.filters.label.global')"
                 :placeholder="$t('grid.filters.label.global')"
             />
             <svg
@@ -115,7 +116,7 @@ export default class Screen1 extends Vue {
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,
 .rv-global-search {
-    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2;
+    @apply bg-transparent text-black-75 h-24 pb-8 border-0 border-b-2 min-w-0;
 }
 .rv-input {
     @apply m-0 py-1;

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -14,6 +14,7 @@ class GridFixture extends GridAPI {
                         'grid-screen': GridV
                     },
                     style: {
+                        'flex-grow': '1',
                         'max-width': '900px'
                     }
                 }


### PR DESCRIPTION
#456 

Panels would push eachother off the screen if they grew in width from whatever the panel-store calculated as their allotted width. 

The `min-w-0` added to the panel container makes text blocks truncate at the proper length and not push panels to larger widths. The `min-w-0` on the search input allows the search box to shrink so that the grid title is still somewhat visible.

I attempted to get the placeholder text in the search input to truncate but chromium based browsers cant do that... https://stackoverflow.com/questions/54395523/html-input-placeholder-text-overflow-ellipsis-does-not-work-when-on-focus-webk 
It works in FF but I left it out for consistency, this may need to be revisited (I will also probably post a question or open a discussion).

DEMO: http://ramp4-app.azureedge.net/demo/users/spencerwahl/panel-overflow/host/index.html
Open up the grid with some other panels, type in the filter inputs and make sure its not pushing other panels to the side. Close some panels and see if it expands when theres free room.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/516)
<!-- Reviewable:end -->
