### PR TITLE
Add entryIndex to config

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -161,12 +161,14 @@ rInstance = new RAMP.Instance(document.getElementById('app'), {
                                         {
                                             layerId: 'WaterQuantity',
                                             name:
-                                                'Water Quantity in Nested Group'
+                                                'Water Quantity in Nested Group',
+                                            entryIndex: 1
                                         },
                                         {
                                             layerId: 'WaterQuality',
                                             name:
-                                                'Water Quality in Nested Group'
+                                                'Water Quality in Nested Group',
+                                            entryIndex: 5
                                         }
                                     ]
                                 }


### PR DESCRIPTION
For #515. For `MapImageLayers`, the grid was showing the name of the parent layer rather than the child.

Turns out the grid and legend code were both fine, and it was actually just the config that was missing stuff.

[Demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/515-grid-sublayer-names/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/517)
<!-- Reviewable:end -->
