### PR TITLE
Fix appbar gap if appbar is not in use

### DIFF
--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="map-caption absolute bottom-0 flex justify-center pointer-events-none text-gray-400 bg-black-75 left-32 sm:left-64 right-0 py-2"
+        class="map-caption absolute bottom-0 flex justify-center pointer-events-none text-gray-400 bg-black-75 left-0 right-0 py-2"
     >
         <span
             class="relative ml-10 truncate top-1"

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="absolute top-0 left-0 z-50 flex flex-col items-stretch w-40 h-full pointer-events-auto appbar bg-black-75 sm:w-64"
+        class="absolute top-0 left-0 bottom-28 z-50 flex flex-col items-stretch w-40 pointer-events-auto appbar bg-black-75 sm:w-64"
         v-focus-list
     >
         <component


### PR DESCRIPTION
#379 

Map caption now goes under the appbar and spans the entire app, appbar no longer goes right to the bottom. This is following Aleks' designs.

![image](https://user-images.githubusercontent.com/8732588/121726229-45df7e00-cab8-11eb-94d6-d02135af9603.png)

Map caption will now look the same whether or not the appbar is there.

demo:
http://ramp4-app.azureedge.net/demo/users/spencerwahl/appbar-gap/host/index.html w/ appbar
http://ramp4-app.azureedge.net/demo/users/spencerwahl/appbar-gap/host/index-e2e.html?script=basemap-only w/o appbar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/526)
<!-- Reviewable:end -->
