### PR TITLE
Fix navbar button icons

### DIFF
--- a/packages/ramp-core/src/fixtures/mapnav/button.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/button.vue
@@ -10,7 +10,7 @@
             :content="tooltip"
             v-tippy="{ placement: 'left' }"
         >
-            <slot name="icon"></slot>
+            <slot></slot>
         </button>
     </div>
 </template>


### PR DESCRIPTION
#527 

Fixed the base template for navbar buttons, icons show up again.

demo: https://ramp4-app.azureedge.net/demo/users/spencerwahl/navbar-icons/host/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/528)
<!-- Reviewable:end -->
