### PR TITLE
Layer Reloading

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   ../../packages/ramp-core:
     specifiers:
-      '@arcgis/core': 4.19.1
+      '@arcgis/core': 4.19.3
       '@braid/vue-formulate': ~2.5.2
       '@tailwindcss/forms': ^0.2.1
       '@tailwindcss/postcss7-compat': ^2.0.2
@@ -87,7 +87,7 @@ importers:
       webpack-dev-server: 3.9.0
       wrapper-webpack-plugin: 2.1.0
     dependencies:
-      '@arcgis/core': 4.19.1
+      '@arcgis/core': 4.19.3
       '@braid/vue-formulate': 2.5.2
       ag-grid-community: 22.1.1
       ag-grid-vue: 22.1.1_4f5a95a77bad3f3a7df09d8e6767e56d
@@ -228,8 +228,8 @@ importers:
 
 packages:
 
-  /@arcgis/core/4.19.1:
-    resolution: {integrity: sha512-H7OWfmwbq/xzfVaaL25bX4gCggMrmoatK3MgEwyJQJ97IDbxpouTfM73idpBV3wN6CUe/gHqfi73qkfIdAOaTA==}
+  /@arcgis/core/4.19.3:
+    resolution: {integrity: sha512-dDNpp8fG09ZkyKlDcJmDaVRQHSRyw7hoOA8WvdmjZ8uRyppmPYrIgbFc/+Dd4RXsZFxClwu0qOzO46+jl24NWg==}
     dependencies:
       '@esri/arcgis-html-sanitizer': 2.5.0
       '@esri/calcite-colors': 5.0.0

--- a/packages/ramp-core/docs/app/defaults.md
+++ b/packages/ramp-core/docs/app/defaults.md
@@ -81,7 +81,13 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | Event Name                              | Payload                                                        | Event Announces              |
 | --------------------------------------- | -------------------------------------------------------------- | ---------------------------- |
 | COMPONENT<br>'ramp/component'           | _id_: component id                                             | A vue component registered   |
+| CONFIG_CHANGE                           | RampConfig object                                              | The config was changed       |
 | FILTER_CHANGE<br>'filter/change'        | FilterEventParam object                                        | A filter has changed         |
+| LAYER_OPACITYCHANGE<br>'layer/opacitychange' | _opacity_: new value, _uid_: affected uid                 | The layer opacity changed    |
+| LAYER_RELOADED<br>'layer/reloaded'      | LayerInstance object                                           | The layer was reloaded       |
+| LAYER_REMOVE<br>'layer/remove'          | LayerInstance object                                           | The layer was removed from the map |
+| LAYER_STATECHANGE<br>'layer/statechange' | _state_: new value, _uid_: affected uid                       | The layer state changed      |
+| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _uid_: affected uid        | The layer visibility changed |
 | MAP_BLUR<br>'map/blur'                  | FocusEvent object                                              | The map lost focus           |
 | MAP_CLICK<br>'map/click'                | MapClick object                                                | The map was clicked          |
 | MAP_CREATED<br>'map/created'            | Map API object                                                 | The map was created          |
@@ -93,7 +99,6 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_MOUSEDOWN<br>'map/mousedown'        | PointerEvent object                                            | A mouse button was depressed |
 | MAP_MOUSEMOVE<br>'map/mousemove'        | MapMove object                                                 | The mouse moved over the map |
 | MAP_BASEMAPCHANGE                       | basemapId: string                                              | The basemap was changed      |
-| CONFIG_CHANGE                           | RampConfig object                                              | The config was changed       |
 
 ### Core Fixture Events
 

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -13,7 +13,7 @@
         "docs:build": "typedoc && vuepress build docs"
     },
     "dependencies": {
-        "@arcgis/core": "4.19.1",
+        "@arcgis/core": "4.19.3",
         "@braid/vue-formulate": "~2.5.2",
         "ag-grid-community": "^22.1.1",
         "ag-grid-vue": "^22.1.1",

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -21,9 +21,10 @@ export enum GlobalEvents {
     FILTER_CHANGE = 'filter/change',
 
     LAYER_OPACITYCHANGE = 'layer/opacitychange',
+    LAYER_RELOADED = 'layer/reloaded', // Payload: `(layer: LayerInstance)`
+    LAYER_REMOVE = 'layer/remove', // Payload: `(layer: LayerInstance)`
     LAYER_STATECHANGE = 'layer/statechange',
     LAYER_VISIBILITYCHANGE = 'layer/visibilitychange',
-    LAYER_REMOVE = 'layer/remove', // Payload: `(layer: LayerInstance)`
 
     /**
      * Fires when the config file changes

--- a/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
+++ b/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
@@ -55,7 +55,7 @@ export default class CrosshairsV extends Vue {
     visible: boolean = false;
 
     mounted() {
-        this.$iApi.geo.map.viewPromise.getPromise().then(() => {
+        this.$iApi.geo.map.viewPromise.then(() => {
             this.left =
                 (this.$iApi.geo.map.getPixelWidth() -
                     this.$el.getBoundingClientRect().width) /

--- a/packages/ramp-core/src/fixtures/panguard/panguard.vue
+++ b/packages/ramp-core/src/fixtures/panguard/panguard.vue
@@ -16,7 +16,7 @@ export default class MapPanguard extends Vue {
         const pointers = new Map();
 
         // prevent possible issues with esri event registration if this fixture runs before the map has built itself
-        this.$iApi.geo.map.viewPromise.getPromise().then(() => {
+        this.$iApi.geo.map.viewPromise.then(() => {
             // TODO: when projection change is implemented check that the below events track any changes to
             // the esriView or update MapAPI to be raising pointer events on the EventAPI, and this will listen to for those events
             this.$iApi.geo.map.esriView!.on('pointer-down', e => {

--- a/packages/ramp-core/src/geo/api/layer/layer-base.ts
+++ b/packages/ramp-core/src/geo/api/layer/layer-base.ts
@@ -34,8 +34,10 @@ export interface LayerBase {
     esriLayer: __esri.Layer | undefined;
     esriView: __esri.LayerView | undefined;
 
+    initialized: boolean;
     initiate(): Promise<void>;
     terminate(): Promise<void>;
+    reload(): Promise<void>;
 
     supportsIdentify: boolean;
     state: LayerState;

--- a/packages/ramp-core/src/geo/layer/attrib-layer.ts
+++ b/packages/ramp-core/src/geo/layer/attrib-layer.ts
@@ -11,17 +11,12 @@ import {
     GetGraphicParams,
     GeometryType,
     RampLayerConfig,
-    TabularAttributeSet,
-    TreeNode
+    TabularAttributeSet
 } from '@/geo/api';
 
 export class AttribLayer extends CommonLayer {
-    protected constructor(
-        rampConfig: RampLayerConfig,
-        $iApi: InstanceAPI,
-        reloadTree?: TreeNode
-    ) {
-        super(rampConfig, $iApi, reloadTree);
+    protected constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
+        super(rampConfig, $iApi);
         this.supportsIdentify = true;
     }
 

--- a/packages/ramp-core/src/geo/layer/esriFeature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriFeature/index.ts
@@ -15,7 +15,7 @@ import { EsriFeatureLayer } from '@/geo/esri';
 import { FeatureFC } from './feature-fc';
 
 class FeatureLayer extends AttribLayer {
-    esriLayer: EsriFeatureLayer | undefined;
+    declare esriLayer: EsriFeatureLayer | undefined;
 
     constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);

--- a/packages/ramp-core/src/geo/layer/esriImagery/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriImagery/index.ts
@@ -5,7 +5,7 @@ import { LayerType, RampLayerConfig, TreeNode } from '@/geo/api';
 import { EsriImageryLayer } from '@/geo/esri';
 
 class ImageryLayer extends CommonLayer {
-    esriLayer: EsriImageryLayer | undefined;
+    declare esriLayer: EsriImageryLayer | undefined;
 
     constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -20,7 +20,7 @@ import { MapImageFC } from './map-image-fc';
 class MapImageLayer extends AttribLayer {
     // indicates if sublayers can have opacity adjusted
     isDynamic: boolean;
-    esriLayer: EsriMapImageLayer | undefined;
+    declare esriLayer: EsriMapImageLayer | undefined;
 
     constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);

--- a/packages/ramp-core/src/geo/layer/esriTile/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriTile/index.ts
@@ -5,7 +5,7 @@ import { LayerType, RampLayerConfig, TreeNode } from '@/geo/api';
 import { EsriTileLayer } from '@/geo/esri';
 
 class TileLayer extends CommonLayer {
-    esriLayer: EsriTileLayer | undefined;
+    declare esriLayer: EsriTileLayer | undefined;
 
     constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);

--- a/packages/ramp-core/src/geo/layer/ogcWms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/index.ts
@@ -15,7 +15,7 @@ import { EsriRequest, EsriWMSLayer } from '@/geo/esri';
 import { WmsFC } from './wms-fc';
 
 export default class WmsLayer extends CommonLayer {
-    esriLayer: EsriWMSLayer | undefined;
+    declare esriLayer: EsriWMSLayer | undefined;
     sublayerNames: Array<string>;
     readonly mimeType: string;
 

--- a/packages/ramp-core/src/geo/map/overview-map.ts
+++ b/packages/ramp-core/src/geo/map/overview-map.ts
@@ -15,7 +15,12 @@ export class OverviewMapAPI extends CommonMapAPI {
      * @private
      */
     esriView: __esri.MapView | undefined;
-    viewPromise: DefPromise; // a promise that resolves when a layer view has been created on the map. helps bridge the view handler with the layer load handler
+    protected _viewPromise: DefPromise;
+
+    // a promise that resolves when a layer view has been created on the map. helps bridge the view handler with the layer load handler
+    get viewPromise(): Promise<void> {
+        return this._viewPromise.getPromise();
+    }
 
     /**
      * The map spatial reference in RAMP API Spatial Reference format.
@@ -31,7 +36,7 @@ export class OverviewMapAPI extends CommonMapAPI {
     constructor(iApi: InstanceAPI) {
         super(iApi);
 
-        this.viewPromise = new DefPromise();
+        this._viewPromise = new DefPromise();
     }
 
     /**
@@ -100,7 +105,7 @@ export class OverviewMapAPI extends CommonMapAPI {
             e.preventDefault();
         });
 
-        this.viewPromise.resolveMe();
+        this._viewPromise.resolveMe();
     }
 
     /**

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -45,7 +45,12 @@ export class MapAPI extends CommonMapAPI {
      * @private
      */
     esriView: __esri.MapView | undefined;
-    viewPromise: DefPromise; // a promise that resolves when a layer view has been created on the map. helps bridge the view handler with the layer load handler
+    protected _viewPromise: DefPromise;
+
+    // a promise that resolves when a layer view has been created on the map. helps bridge the view handler with the layer load handler
+    get viewPromise(): Promise<void> {
+        return this._viewPromise.getPromise();
+    }
 
     /**
      * The map spatial reference in RAMP API Spatial Reference format.
@@ -61,7 +66,7 @@ export class MapAPI extends CommonMapAPI {
     constructor(iApi: InstanceAPI) {
         super(iApi);
 
-        this.viewPromise = new DefPromise();
+        this._viewPromise = new DefPromise();
     }
 
     /**
@@ -178,7 +183,7 @@ export class MapAPI extends CommonMapAPI {
             e.preventDefault();
         });
 
-        this.viewPromise.resolveMe();
+        this._viewPromise.resolveMe();
 
         // emit basemap changed event
         this.$iApi.event.emit(
@@ -291,17 +296,7 @@ export class MapAPI extends CommonMapAPI {
             layerInstance = layer;
         } else {
             // Layer is a string id
-            layerInstance = this.$iApi.$vApp.$store.get(
-                LayerStore.getLayerById,
-                layer
-            );
-            if (!layerInstance) {
-                // Check if layer is a string uid
-                layerInstance = this.$iApi.$vApp.$store.get(
-                    LayerStore.getLayerByUid,
-                    layer
-                );
-            }
+            layerInstance = this.$iApi.geo.layer.getLayer(layer);
         }
 
         // Error checking


### PR DESCRIPTION
Donethankses #500 , #501 , #502

- Adds function on Layer interface to trigger a reload
- Adds new event that signals a layer reloaded
- Implements proper layer cleanup in the `terminate` function
- New helper function `getLayer` on `api.geo.layer`
- Removes `reloadTree` parameter from layer constructors
- Cleans up promise exposure on Map classes
- Updates ESRI API to `v4.19.3`

To test.
1. Run demo, close all panels except legend so you can see map
2. Add code snippet below in console.
3. Water Quality layer should flicker.
4. Water Quality should remain below WMS Layer. Can test overlapping points at west end of Great Bear Lake. 
5. Water Quality should remain above Water Quantity. Can test that yellow diamonds in south Saskatchewan are above fancy triangles.
6. Water Quality legend visibility toggle should toggle layer.
7. Click a yellow diamond on the map, see an identify result appear
8. Click Water Quality in the legend. Enjoy the grid that appears.
9. View reload completion and reload event messages in the console.

```text
rInstance.event.on('layer/reloaded', x => { console.log('i saw reload event!!', x); });
var testLayer = rInstance.geo.layer.getLayer('WaterQuality');
testLayer.reload().then(() => { console.log('reload finished'); });
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/530)
<!-- Reviewable:end -->
