### PR TITLE
Link legend with layer remove

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
@@ -48,6 +48,7 @@
                             :visible="displaySymbology"
                             :layer="legendItem.layer"
                             :uid="legendItem.uid"
+                            :key="legendItem.uid"
                         />
                     </button>
                 </div>
@@ -168,6 +169,27 @@
                                 />
                             </svg>
                             {{ $t('legend.entry.controls.symbology') }}
+                        </a>
+                        <!-- Remove -->
+                        <a
+                            href="#"
+                            class="flex leading-snug items-center w-auto"
+                            :class="{
+                                disabled: !legendItem._controlAvailable(
+                                    `remove`
+                                )
+                            }"
+                            @click="removeLayer"
+                        >
+                            <svg
+                                class="fill-current w-18 h-18 mr-10"
+                                viewBox="0 0 23 21"
+                            >
+                                <path
+                                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                ></path>
+                            </svg>
+                            {{ 'remove' }}
                         </a>
                     </dropdown-menu>
                 </div>
@@ -300,6 +322,10 @@ export default class LegendEntryV extends Vue {
 
     get shellEl() {
         return this.$refs.shell;
+    }
+
+    removeLayer() {
+        this.$iApi.geo.map.removeLayer(this.legendItem.uid!);
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-entry.vue
@@ -29,7 +29,7 @@
                         }"
                         :disabled="!legendItem._controlAvailable('symbology')"
                         :content="
-                            displaySymbology
+                            legendItem.displaySymbology
                                 ? $t('legend.symbology.hide')
                                 : $t('legend.symbology.expand')
                         "
@@ -45,7 +45,7 @@
                                 )
                             }"
                             class="w-32 h-32"
-                            :visible="displaySymbology"
+                            :visible="legendItem.displaySymbology"
                             :layer="legendItem.layer"
                             :uid="legendItem.uid"
                             :key="legendItem.uid"
@@ -62,142 +62,15 @@
                 </div>
 
                 <!-- options dropdown menu -->
-                <div
-                    @click.stop
-                    @mouseover.stop
-                    class="options hidden cursor-auto"
-                >
-                    <dropdown-menu
-                        position="right"
-                        :tooltip="$t('legend.entry.options')"
-                        tooltip-placement="left"
-                    >
-                        <template #header>
-                            <div class="flex">
-                                <svg
-                                    class="fill-current w-18 h-18 mx-8"
-                                    viewBox="0 0 23 21"
-                                >
-                                    <path
-                                        d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
-                                    />
-                                </svg>
-                            </div>
-                        </template>
-                        <!-- metadata -->
-                        <a
-                            href="#"
-                            class="flex leading-snug items-start w-auto"
-                            :class="{
-                                disabled: !legendItem._controlAvailable(
-                                    `metadata`
-                                )
-                            }"
-                            @click="toggleMetadata"
-                        >
-                            <svg
-                                class="fill-current w-18 h-18 mr-10"
-                                viewBox="0 0 23 21"
-                            >
-                                <path
-                                    d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
-                                />
-                            </svg>
-                            {{ $t('legend.entry.controls.metadata') }}
-                        </a>
-                        <!-- settings -->
-                        <a
-                            href="#"
-                            class="flex leading-snug items-center w-auto"
-                            :class="{
-                                disabled: !legendItem._controlAvailable(
-                                    `settings`
-                                )
-                            }"
-                            @click="toggleSettings"
-                        >
-                            <svg
-                                class="fill-current w-18 h-18 mr-10"
-                                viewBox="0 0 23 21"
-                            >
-                                <g id="tune">
-                                    <path
-                                        d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "
-                                    />
-                                </g>
-                            </svg>
-                            {{ $t('legend.entry.controls.settings') }}
-                        </a>
-                        <!-- datatable -->
-                        <a
-                            href="#"
-                            class="flex leading-snug items-center w-auto"
-                            :class="{
-                                disabled: !legendItem._controlAvailable(
-                                    `datatable`
-                                )
-                            }"
-                            @click="toggleGrid"
-                        >
-                            <svg
-                                class="fill-current w-18 h-18 mr-10"
-                                viewBox="0 0 23 21"
-                            >
-                                <path
-                                    d="M 4.00002,3L 20,3C 21.1046,3 22,3.89543 22,5L 22,20C 22,21.1046 21.1046,22 20,22L 4.00001,22C 2.89544,22 2.00001,21.1046 2.00001,20L 2.00002,5C 2.00002,3.89543 2.89545,3 4.00002,3 Z M 4.00002,7L 4.00001,10L 8,10L 8,7.00001L 4.00002,7 Z M 10,7.00001L 9.99999,10L 14,10L 14,7.00001L 10,7.00001 Z M 20,10L 20,7L 16,7.00001L 16,10L 20,10 Z M 4.00002,12L 4.00002,15L 8,15L 8,12L 4.00002,12 Z M 4.00001,20L 8,20L 8,17L 4.00002,17L 4.00001,20 Z M 9.99999,12L 9.99999,15L 14,15L 14,12L 9.99999,12 Z M 9.99999,20L 14,20L 14,17L 9.99999,17L 9.99999,20 Z M 20,20L 20,17L 16,17L 16,20L 20,20 Z M 20,12L 16,12L 16,15L 20,15L 20,12 Z "
-                                />
-                            </svg>
-                            {{ $t('legend.entry.controls.datatable') }}
-                        </a>
-                        <!-- symbology stack -->
-                        <a
-                            href="#"
-                            class="flex leading-snug items-center w-auto"
-                            :class="{
-                                disabled: !legendItem._controlAvailable(
-                                    `symbology`
-                                )
-                            }"
-                            @click="toggleSymbology"
-                        >
-                            <svg
-                                class="fill-current w-18 h-18 mr-10"
-                                viewBox="0 0 23 21"
-                            >
-                                <path
-                                    d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
-                                />
-                            </svg>
-                            {{ $t('legend.entry.controls.symbology') }}
-                        </a>
-                        <!-- Remove -->
-                        <a
-                            href="#"
-                            class="flex leading-snug items-center w-auto"
-                            :class="{
-                                disabled: !legendItem._controlAvailable(
-                                    `remove`
-                                )
-                            }"
-                            @click="removeLayer"
-                        >
-                            <svg
-                                class="fill-current w-18 h-18 mr-10"
-                                viewBox="0 0 23 21"
-                            >
-                                <path
-                                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
-                                ></path>
-                            </svg>
-                            {{ 'remove' }}
-                        </a>
-                    </dropdown-menu>
-                </div>
+                <options :legendItem="legendItem"></options>
 
                 <!-- visibility -->
                 <checkbox
                     :value="visibility"
-                    :isRadio="props && props.isVisibilitySet"
+                    :isRadio="
+                        legendItem.parent &&
+                            legendItem.parent.type === 'VisibilitySet'
+                    "
                     :legendItem="legendItem"
                     :disabled="!legendItem._controlAvailable('visibility')"
                 />
@@ -205,7 +78,11 @@
         </div>
 
         <!-- Symbology Stack Section -->
-        <div v-if="displaySymbology" v-focus-item class="default-focus-style">
+        <div
+            v-if="legendItem.displaySymbology"
+            v-focus-item
+            class="default-focus-style"
+        >
             <!-- display each symbol -->
             <div
                 class="p-5 flex items-center"
@@ -237,18 +114,18 @@ import { LegendEntry, Controls } from '../store/legend-defs';
 
 import CheckboxV from './checkbox.vue';
 import SymbologyStack from './symbology-stack.vue';
+import LegendOptionsV from './legend-options.vue';
 
 @Component({
     components: {
         checkbox: CheckboxV,
-        'symbology-stack': SymbologyStack
+        'symbology-stack': SymbologyStack,
+        options: LegendOptionsV
     }
 })
 export default class LegendEntryV extends Vue {
     @Prop() legendItem!: LegendEntry;
-    @Prop() props!: any;
 
-    displaySymbology: boolean = false;
     visibility: boolean | undefined = this.legendItem.visibility;
 
     mounted(): void {
@@ -277,7 +154,8 @@ export default class LegendEntryV extends Vue {
      */
     toggleSymbology(): void {
         if (this.legendItem._controlAvailable(Controls.Symbology)) {
-            this.displaySymbology = !this.displaySymbology;
+            this.legendItem.displaySymbology = !this.legendItem
+                .displaySymbology;
         }
     }
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
@@ -41,7 +41,10 @@
                 <!-- visibility -->
                 <checkbox
                     :value="legendItem.visibility"
-                    :isRadio="props && props.isVisibilitySet"
+                    :isRadio="
+                        legendItem.parent &&
+                            legendItem.parent.type === 'VisibilitySet'
+                    "
                     :legendItem="legendItem"
                 />
             </div>
@@ -74,7 +77,6 @@ import CheckboxV from './checkbox.vue';
 })
 export default class LegendGroupV extends Vue {
     @Prop() legendItem!: LegendGroup;
-    @Prop() props!: any;
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-group.vue
@@ -43,7 +43,7 @@
                     :value="legendItem.visibility"
                     :isRadio="
                         legendItem.parent &&
-                            legendItem.parent.type === 'VisibilitySet'
+                            legendItem.parent.type === LegendTypes.Set
                     "
                     :legendItem="legendItem"
                 />
@@ -66,7 +66,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { LegendStore } from '../store';
-import { LegendGroup } from '../store/legend-defs';
+import { LegendGroup, LegendTypes } from '../store/legend-defs';
 import CheckboxV from './checkbox.vue';
 
 @Component({
@@ -77,6 +77,9 @@ import CheckboxV from './checkbox.vue';
 })
 export default class LegendGroupV extends Vue {
     @Prop() legendItem!: LegendGroup;
+
+    // make vue stop hating enums
+    LegendTypes = LegendTypes;
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -98,7 +98,7 @@
                         d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
                     ></path>
                 </svg>
-                {{ 'remove' }}
+                {{ $t('legend.entry.controls.remove') }}
             </a>
         </dropdown-menu>
     </div>
@@ -170,22 +170,27 @@ export default class LegendOptionsV extends Vue {
     }
 
     /**
-     * Removes layer.
+     * Removes layer from map.
      */
     removeLayer() {
-        const layerTree = this.legendItem.layer!.getLayerTree();
-        if (
-            !(layerTree.children.length === 1 && layerTree.children[0].isLayer)
-        ) {
-            // cheap hack for MIL with multiple children - set visibility to false and remove legend entry
-            // TODO get rid of this when/if MIL children can be removed for real
-            this.removeLayerEntry(this.legendItem.uid!);
-            this.legendItem.layer!.setVisibility(
-                false,
-                this.legendItem._layerIndex
-            );
-        } else {
-            this.$iApi.geo.map.removeLayer(this.legendItem.uid!);
+        if (this.legendItem._controlAvailable(Controls.Remove)) {
+            const layerTree = this.legendItem.layer!.getLayerTree();
+            if (
+                !(
+                    layerTree.children.length === 1 &&
+                    layerTree.children[0].isLayer
+                )
+            ) {
+                // cheap hack for MIL with multiple children - set visibility to false and remove legend entry
+                // TODO get rid of this when/if MIL sublayers can be removed for real
+                this.removeLayerEntry(this.legendItem.uid!);
+                this.legendItem.layer!.setVisibility(
+                    false,
+                    this.legendItem._layerIndex
+                );
+            } else {
+                this.$iApi.geo.map.removeLayer(this.legendItem.uid!);
+            }
         }
     }
 }
@@ -193,7 +198,6 @@ export default class LegendOptionsV extends Vue {
 
 <style lang="scss" scoped>
 .disabled {
-    @apply text-gray-400;
-    cursor: default;
+    @apply text-gray-400 cursor-default;
 }
 </style>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -1,0 +1,199 @@
+<template>
+    <div @click.stop @mouseover.stop class="options hidden cursor-auto">
+        <dropdown-menu
+            position="right"
+            :tooltip="$t('legend.entry.options')"
+            tooltip-placement="left"
+            :key="legendItem.uid"
+        >
+            <template #header>
+                <div class="flex">
+                    <svg
+                        class="fill-current w-18 h-18 mx-8"
+                        viewBox="0 0 23 21"
+                    >
+                        <path
+                            d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                        />
+                    </svg>
+                </div>
+            </template>
+            <!-- metadata -->
+            <a
+                href="#"
+                class="flex leading-snug items-start w-auto"
+                :class="{
+                    disabled: !legendItem._controlAvailable(`metadata`)
+                }"
+                @click="toggleMetadata"
+            >
+                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                    <path
+                        d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+                    />
+                </svg>
+                {{ $t('legend.entry.controls.metadata') }}
+            </a>
+            <!-- settings -->
+            <a
+                href="#"
+                class="flex leading-snug items-center w-auto"
+                :class="{
+                    disabled: !legendItem._controlAvailable(`settings`)
+                }"
+                @click="toggleSettings"
+            >
+                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                    <g id="tune">
+                        <path
+                            d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "
+                        />
+                    </g>
+                </svg>
+                {{ $t('legend.entry.controls.settings') }}
+            </a>
+            <!-- datatable -->
+            <a
+                href="#"
+                class="flex leading-snug items-center w-auto"
+                :class="{
+                    disabled: !legendItem._controlAvailable(`datatable`)
+                }"
+                @click="toggleGrid"
+            >
+                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                    <path
+                        d="M 4.00002,3L 20,3C 21.1046,3 22,3.89543 22,5L 22,20C 22,21.1046 21.1046,22 20,22L 4.00001,22C 2.89544,22 2.00001,21.1046 2.00001,20L 2.00002,5C 2.00002,3.89543 2.89545,3 4.00002,3 Z M 4.00002,7L 4.00001,10L 8,10L 8,7.00001L 4.00002,7 Z M 10,7.00001L 9.99999,10L 14,10L 14,7.00001L 10,7.00001 Z M 20,10L 20,7L 16,7.00001L 16,10L 20,10 Z M 4.00002,12L 4.00002,15L 8,15L 8,12L 4.00002,12 Z M 4.00001,20L 8,20L 8,17L 4.00002,17L 4.00001,20 Z M 9.99999,12L 9.99999,15L 14,15L 14,12L 9.99999,12 Z M 9.99999,20L 14,20L 14,17L 9.99999,17L 9.99999,20 Z M 20,20L 20,17L 16,17L 16,20L 20,20 Z M 20,12L 16,12L 16,15L 20,15L 20,12 Z "
+                    />
+                </svg>
+                {{ $t('legend.entry.controls.datatable') }}
+            </a>
+            <!-- symbology stack -->
+            <a
+                href="#"
+                class="flex leading-snug items-center w-auto"
+                :class="{
+                    disabled: !legendItem._controlAvailable(`symbology`)
+                }"
+                @click="toggleSymbology"
+            >
+                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                    <path
+                        d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
+                    />
+                </svg>
+                {{ $t('legend.entry.controls.symbology') }}
+            </a>
+            <!-- Remove -->
+            <a
+                href="#"
+                class="flex leading-snug items-center w-auto"
+                :class="{
+                    disabled: !legendItem._controlAvailable(`remove`)
+                }"
+                @click="removeLayer"
+            >
+                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                    <path
+                        d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                    ></path>
+                </svg>
+                {{ 'remove' }}
+            </a>
+        </dropdown-menu>
+    </div>
+</template>
+
+<script lang="ts">
+import { GlobalEvents } from '@/api';
+import { LayerType } from '@/geo/api';
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync, Call } from 'vuex-pathify';
+
+import { LegendStore } from '../store';
+import { LegendEntry, Controls } from '../store/legend-defs';
+
+@Component({})
+export default class LegendOptionsV extends Vue {
+    @Prop() legendItem!: LegendEntry;
+    @Call(LegendStore.removeLayerEntry) removeLayerEntry!: (
+        entry: string
+    ) => void;
+
+    /**
+     * Display symbology stack for the layer.
+     */
+    toggleSymbology(): void {
+        if (this.legendItem._controlAvailable(Controls.Symbology)) {
+            this.legendItem.displaySymbology = !this.legendItem
+                .displaySymbology;
+        }
+    }
+
+    /**
+     * Toggles data table panel to open/close for the LegendItem.
+     */
+    toggleGrid() {
+        if (this.legendItem._controlAvailable(Controls.Datatable)) {
+            this.$iApi.event.emit(
+                GlobalEvents.GRID_TOGGLE,
+                this.legendItem.uid
+            );
+        }
+    }
+
+    /**
+     * Toggles settings panel to open/close type for the LegendItem.
+     */
+    toggleSettings() {
+        if (this.legendItem._controlAvailable(Controls.Settings)) {
+            this.$iApi.event.emit(
+                GlobalEvents.SETTINGS_TOGGLE,
+                this.legendItem.uid
+            );
+        }
+    }
+
+    /**
+     * Toggles metadata panel to open/close for the LegendItem.
+     */
+    toggleMetadata() {
+        if (this.legendItem._controlAvailable(Controls.Metadata)) {
+            // TODO: toggle metadata panel through API/store call
+            // this.$iApi.event.emit('metadata/open', {
+            //     type: 'html',
+            //     layer: 'Sample Layer Name',
+            //     url:
+            //         'https://ryan-coulson.com/RAMPMetadataDemo.html'
+            // });
+        }
+    }
+
+    /**
+     * Removes layer.
+     */
+    removeLayer() {
+        const layerTree = this.legendItem.layer!.getLayerTree();
+        if (
+            !(layerTree.children.length === 1 && layerTree.children[0].isLayer)
+        ) {
+            // cheap hack for MIL with multiple children - set visibility to false and remove legend entry
+            // TODO get rid of this when/if MIL children can be removed for real
+            this.removeLayerEntry(this.legendItem.uid!);
+            this.legendItem.layer!.setVisibility(
+                false,
+                this.legendItem._layerIndex
+            );
+        } else {
+            this.$iApi.geo.map.removeLayer(this.legendItem.uid!);
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.disabled {
+    @apply text-gray-400;
+    cursor: default;
+}
+</style>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-visibility-set.vue
@@ -44,7 +44,10 @@
                 <!-- visibility -->
                 <checkbox
                     :value="legendItem.visibility"
-                    :isRadio="props && props.isVisibilitySet"
+                    :isRadio="
+                        legendItem.parent &&
+                            legendItem.parent.type === 'VisibilitySet'
+                    "
                     :legendItem="legendItem"
                 />
             </div>
@@ -56,7 +59,6 @@
                 v-for="(item, idx) in legendItem.children"
                 :legendItem="item"
                 :key="idx"
-                :props="{ isVisibilitySet: true }"
             ></legend-component>
         </div>
     </div>
@@ -78,7 +80,6 @@ import CheckboxV from './checkbox.vue';
 })
 export default class LegendVisibilitySetV extends Vue {
     @Prop() legendItem!: LegendSet;
-    @Prop() props!: any;
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-visibility-set.vue
@@ -46,7 +46,7 @@
                     :value="legendItem.visibility"
                     :isRadio="
                         legendItem.parent &&
-                            legendItem.parent.type === 'VisibilitySet'
+                            legendItem.parent.type === LegendTypes.Set
                     "
                     :legendItem="legendItem"
                 />
@@ -69,7 +69,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { LegendStore } from '../store';
-import { LegendSet } from '../store/legend-defs';
+import { LegendSet, LegendTypes } from '../store/legend-defs';
 import CheckboxV from './checkbox.vue';
 
 @Component({
@@ -80,6 +80,9 @@ import CheckboxV from './checkbox.vue';
 })
 export default class LegendVisibilitySetV extends Vue {
     @Prop() legendItem!: LegendSet;
+
+    // make vue stop hating enums
+    LegendTypes = LegendTypes;
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -1,7 +1,8 @@
 import { LegendAPI } from './api/legend';
-import { legend } from './store/index';
+import { LegendStore, legend } from './store';
 import LegendV from './legend.vue';
 import LegendAppbarButtonV from './appbar-button.vue';
+import { GlobalEvents, LayerInstance } from '@/api';
 
 import messages from './lang/lang.csv';
 
@@ -33,10 +34,23 @@ class LegendFixture extends LegendAPI {
             () => this.config,
             (value: any) => this._parseConfig(value)
         );
+
+        this.$iApi.event.on(
+            GlobalEvents.LAYER_REMOVE,
+            (layer: LayerInstance) => {
+                this.$iApi.$vApp.$store.dispatch(
+                    LegendStore.removeLayerEntry,
+                    layer.uid
+                );
+            },
+            'legend_removes_layer_entry'
+        );
     }
 
     removed() {
         this.$vApp.$store.unregisterModule('legend');
+
+        this.$iApi.event.off('legend_removes_layer_entry');
     }
 }
 

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -19,3 +19,4 @@ legend.entry.controls.metadata,Metadata,1,Métadonnées,1
 legend.entry.controls.settings,Settings,1,Paramètres,1
 legend.entry.controls.datatable,Datatable,1,Tableau de données,1
 legend.entry.controls.symbology,Legend,1,Légende,1
+legend.entry.controls.remove,Remove,1,Retirer,1

--- a/packages/ramp-core/src/fixtures/legend/legend.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend.vue
@@ -25,10 +25,10 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
-import { PanelInstance } from '@/api';
+import { PanelInstance, GlobalEvents, LayerInstance } from '@/api';
 
 import { LegendStore } from './store';
-import { LegendItem } from './store/legend-defs';
+import { LegendItem, LegendEntry, LegendGroup } from './store/legend-defs';
 import LegendHeaderV from './legend-header.vue';
 import LegendComponentV from './components/legend-component.vue';
 
@@ -41,7 +41,17 @@ import LegendComponentV from './components/legend-component.vue';
 export default class LegendV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
-    @Get(LegendStore.children) children!: Array<LegendItem>;
+    @Get(LegendStore.children) children!: Array<LegendEntry | LegendGroup>;
+    @Call(LegendStore.removeLayer) removeLayer!: (layer: LayerInstance) => void;
+
+    mounted() {
+        this.$iApi.event.on(
+            GlobalEvents.LAYER_REMOVE,
+            (layer: LayerInstance) => {
+                this.removeLayer(layer);
+            }
+        );
+    }
 
     get isPinned(): boolean {
         return this.panel.isPinned;

--- a/packages/ramp-core/src/fixtures/legend/legend.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend.vue
@@ -25,7 +25,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
-import { PanelInstance, GlobalEvents, LayerInstance } from '@/api';
+import { PanelInstance } from '@/api';
 
 import { LegendStore } from './store';
 import { LegendItem, LegendEntry, LegendGroup } from './store/legend-defs';
@@ -42,18 +42,6 @@ export default class LegendV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
     @Get(LegendStore.children) children!: Array<LegendEntry | LegendGroup>;
-    @Call(LegendStore.removeLayerEntry) removeLayerEntry!: (
-        uid: string
-    ) => void;
-
-    mounted() {
-        this.$iApi.event.on(
-            GlobalEvents.LAYER_REMOVE,
-            (layer: LayerInstance) => {
-                this.removeLayerEntry(layer.uid);
-            }
-        );
-    }
 
     get isPinned(): boolean {
         return this.panel.isPinned;

--- a/packages/ramp-core/src/fixtures/legend/legend.vue
+++ b/packages/ramp-core/src/fixtures/legend/legend.vue
@@ -42,13 +42,15 @@ export default class LegendV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
     @Get(LegendStore.children) children!: Array<LegendEntry | LegendGroup>;
-    @Call(LegendStore.removeLayer) removeLayer!: (layer: LayerInstance) => void;
+    @Call(LegendStore.removeLayerEntry) removeLayerEntry!: (
+        uid: string
+    ) => void;
 
     mounted() {
         this.$iApi.event.on(
             GlobalEvents.LAYER_REMOVE,
             (layer: LayerInstance) => {
-                this.removeLayer(layer);
+                this.removeLayerEntry(layer.uid);
             }
         );
     }

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -118,6 +118,7 @@ export class LegendEntry extends LegendItem {
     _isLoaded: boolean;
     _symbologyStack: any;
     _isDefault: boolean | undefined;
+    _displaySymbology: boolean;
 
     /**
      * Creates a new single legend entry.
@@ -140,6 +141,8 @@ export class LegendEntry extends LegendItem {
 
         this._isLoaded =
             this._layer !== undefined ? this._layer.isValidState() : true;
+
+        this._displaySymbology = false;
 
         // check if a layer has been bound to this entry and is done loading. If not, set the type to "placeholder".
         if (this._layer === undefined || !this._isLoaded) {
@@ -204,6 +207,16 @@ export class LegendEntry extends LegendItem {
     /** Returns true if entry is not from config. */
     get isDefault(): boolean | undefined {
         return this._isDefault;
+    }
+
+    /** Returns true if symbology stack is expanded. */
+    get displaySymbology(): boolean {
+        return this._displaySymbology;
+    }
+
+    /** Sets state of symbology stack. */
+    set displaySymbology(display: boolean) {
+        this._displaySymbology = display;
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -71,6 +71,11 @@ export class LegendItem {
         return this._children;
     }
 
+    /** Sets children of the legend entry */
+    set children(children: Array<LegendGroup | LegendEntry>) {
+        this._children = children;
+    }
+
     /**
      * Removes element from legend and removes layer if it's the last reference to it.
      */

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -25,7 +25,7 @@ const getters = {
                 checkExpanded(entry, expanded)
         );
     },
-    getAllVisibility: function(state: LegendState, visible: boolean): boolean {
+    getAllVisibility: (state: LegendState, visible: boolean): boolean => {
         return state.children.every((entry: LegendEntry | LegendGroup) =>
             checkVisibility(entry, visible)
         );
@@ -43,8 +43,8 @@ const mutations = {
         const index = state.children.findIndex(child => child.id === id);
         Vue.set(state.children, index, entry);
     },
-    REMOVE_ITEM: (state: LegendState, layer: LayerInstance) => {
-        state.children = removeEntry(state.children, layer);
+    REMOVE_LAYER_ENTRY: (state: LegendState, uid: string) => {
+        state.children = removeLayerEntry(state.children, uid);
     }
 };
 
@@ -77,9 +77,9 @@ const actions = {
     addEntry: (context: LegendContext, item: LegendEntry) => {
         context.commit('ADD_ITEM', item);
     },
-    /** Add legend entry to store */
-    removeLayer: (context: LegendContext, layer: LayerInstance) => {
-        context.commit('REMOVE_ITEM', layer);
+    /** Remove layer's corresponding entry from the store */
+    removeLayerEntry: (context: LegendContext, uid: string) => {
+        context.commit('REMOVE_LAYER_ENTRY', uid);
     },
     /** Replaces default placeholder after layer is loaded */
     updateDefaultEntry: (context: LegendContext, id: string) => {
@@ -212,17 +212,19 @@ function toggle(child: LegendEntry | LegendGroup, options: any) {
     }
 }
 
-function removeEntry(
+function removeLayerEntry(
     children: (LegendEntry | LegendGroup)[],
-    layer: LayerInstance
+    uid: string
 ) {
     children = children.filter(
-        entry => entry instanceof LegendGroup || entry.layer !== layer
+        entry =>
+            entry instanceof LegendGroup ||
+            (entry.layer!.uid !== uid && entry.uid !== uid)
     );
     children
         .filter(entry => entry instanceof LegendGroup)
         .forEach(
-            group => (group.children = removeEntry(group.children, layer))
+            group => (group.children = removeLayerEntry(group.children, uid))
         );
     return children;
 }
@@ -255,7 +257,7 @@ export enum LegendStore {
     /**
      * (Action) removeLayer - remove layer's corresponding entry from the store
      */
-    removeLayer = 'legend/removeLayer',
+    removeLayerEntry = 'legend/removeLayerEntry',
     /**
      * (Action) updateDefaultEntry - replaces default placeholder after layer has loaded
      */

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -42,6 +42,9 @@ const mutations = {
     ) => {
         const index = state.children.findIndex(child => child.id === id);
         Vue.set(state.children, index, entry);
+    },
+    REMOVE_ITEM: (state: LegendState, layer: LayerInstance) => {
+        state.children = removeEntry(state.children, layer);
     }
 };
 
@@ -73,6 +76,10 @@ const actions = {
     /** Add legend entry to store */
     addEntry: (context: LegendContext, item: LegendEntry) => {
         context.commit('ADD_ITEM', item);
+    },
+    /** Add legend entry to store */
+    removeLayer: (context: LegendContext, layer: LayerInstance) => {
+        context.commit('REMOVE_ITEM', layer);
     },
     /** Replaces default placeholder after layer is loaded */
     updateDefaultEntry: (context: LegendContext, id: string) => {
@@ -205,6 +212,21 @@ function toggle(child: LegendEntry | LegendGroup, options: any) {
     }
 }
 
+function removeEntry(
+    children: (LegendEntry | LegendGroup)[],
+    layer: LayerInstance
+) {
+    children = children.filter(
+        entry => entry instanceof LegendGroup || entry.layer !== layer
+    );
+    children
+        .filter(entry => entry instanceof LegendGroup)
+        .forEach(
+            group => (group.children = removeEntry(group.children, layer))
+        );
+    return children;
+}
+
 export enum LegendStore {
     /**
      * (State) children: Array<LegendItem>
@@ -230,6 +252,10 @@ export enum LegendStore {
      * (Action) addEntry - add entry to legend store
      */
     addEntry = 'legend/addEntry!',
+    /**
+     * (Action) removeLayer - remove layer's corresponding entry from the store
+     */
+    removeLayer = 'legend/removeLayer',
     /**
      * (Action) updateDefaultEntry - replaces default placeholder after layer has loaded
      */

--- a/packages/ramp-core/src/geo/api/layer/tree-node.ts
+++ b/packages/ramp-core/src/geo/api/layer/tree-node.ts
@@ -24,7 +24,7 @@ export class TreeNode {
         if (this.uid === uid) {
             return this;
         } else {
-            return this.children.map(c => c.findChildByUid(uid)).find(Boolean);
+            return this.children.map(t => t.findChildByUid(uid)).find(Boolean);
         }
     }
 
@@ -34,7 +34,7 @@ export class TreeNode {
         if (this.layerIdx === idx) {
             return this;
         } else {
-            return this.children.map(c => c.findChildByIdx(idx)).find(Boolean);
+            return this.children.map(t => t.findChildByIdx(idx)).find(Boolean);
         }
     }
 }

--- a/packages/ramp-core/src/geo/api/layer/tree-node.ts
+++ b/packages/ramp-core/src/geo/api/layer/tree-node.ts
@@ -24,7 +24,7 @@ export class TreeNode {
         if (this.uid === uid) {
             return this;
         } else {
-            return this.children.find(t => t.findChildByUid(uid));
+            return this.children.map(c => c.findChildByUid(uid)).find(Boolean);
         }
     }
 
@@ -34,7 +34,7 @@ export class TreeNode {
         if (this.layerIdx === idx) {
             return this;
         } else {
-            return this.children.find(t => t.findChildByIdx(idx));
+            return this.children.map(c => c.findChildByIdx(idx)).find(Boolean);
         }
     }
 }


### PR DESCRIPTION
Legend and layer remove for #512, #525
* Added button to legend entry that triggers `removeLayer()` 
* Legend reacts to `LAYER_REMOVE` event and removes legend entries corresponding to layer; if entry is the last child in a group, the group is removed too
* If a MIL sublayer with siblings is removed through the legend, only the legend entry is removed and the layer is set to invisible (no actual removal is done)

[demo](http://ramp4-app.azureedge.net/demo/users/an-w/legend/host/index.html)

note - the legend options dropdown is a bit finicky right now because the `...` button can't retain focus, should be fixed with #542

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/544)
<!-- Reviewable:end -->
