### PR TITLE
Make settings panel use MIL sublayer name

### DIFF
--- a/packages/ramp-core/src/fixtures/settings/index.ts
+++ b/packages/ramp-core/src/fixtures/settings/index.ts
@@ -1,7 +1,7 @@
 import { SettingsAPI } from './api/settings';
 import SettingsAppbarButtonV from './appbar-button.vue';
 
-import ScreenV from './SettingsV.vue';
+import ScreenV from './settings.vue';
 
 import messages from './lang/lang.csv';
 

--- a/packages/ramp-core/src/fixtures/settings/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/settings/lang/lang.csv
@@ -1,5 +1,6 @@
 key,enValue,enValid,frValue,frValid
 settings.title,Settings,1,Paramètres,1
+settings.layer.loading,The layer is loading...,1,La couche est le chargement...,0
 settings.label.display,Display,1,Affichage,1
 settings.label.visibility,Show layer,1,Afficher la couche,1
 settings.label.opacity,Opacity,1,Opacité,1

--- a/packages/ramp-core/src/fixtures/settings/settings.vue
+++ b/packages/ramp-core/src/fixtures/settings/settings.vue
@@ -1,7 +1,8 @@
 <template>
     <panel-screen>
         <template #header>
-            {{ $t('settings.title') }}: {{ layer.getName() }}
+            {{ $t('settings.title') }}:
+            {{ layerName || $t('settings.layer.loading') }}
         </template>
 
         <template #controls>
@@ -100,7 +101,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
 
@@ -146,6 +146,13 @@ export default class SettingsV extends Vue {
     toggleSnapshot() {
         this.snapshotToggle = !this.snapshotToggle;
         // TODO: make necessary changes to layer
+    }
+
+    get layerName() {
+        if (this.layer) {
+            return this.layer.getName(this.uid);
+        }
+        return '';
     }
 }
 </script>


### PR DESCRIPTION
For #546. Changes settings panel so that it uses sublayer name instead of parent name for `MapImageLayers`.

Also renamed the file in accordance with #372 to see if it would delete and make a new file or be smart enough to recognize that it was just renamed (its smart).

[Demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/546-settings-getname/host/index.html#)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/547)
<!-- Reviewable:end -->
