### PR TITLE
Fix truncated tooltips

### DIFF
--- a/packages/ramp-core/src/directives/truncate/truncate.ts
+++ b/packages/ramp-core/src/directives/truncate/truncate.ts
@@ -69,9 +69,6 @@ export const Truncate: Vue.DirectiveOptions = {
  * @returns false IFF the text is not being truncated and the tooltip should not be shown
  */
 function onShow(instance: any) {
-    if (instance.content === undefined || instance.content === '') {
-        return false;
-    }
     // cancel showing the tooltip if the text isn't truncated
     // clientWidth is the visible width of the element, scrollWidth is the width of the content
     if (instance.reference.clientWidth >= instance.reference.scrollWidth) {


### PR DESCRIPTION
#143 
The last update in the previous PR actually broke the tooltips and I somehow didn't notice.

[DEMO](http://ramp4-app.azureedge.net/demo/users/spencerwahl/notification-center/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/551)
<!-- Reviewable:end -->
