### PR TITLE
File and class name changes

### DIFF
--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -21,10 +21,9 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 @Component
-export default class MenuV extends Vue {
+export default class DropdownMenuV extends Vue {
     @Prop({ default: 'bottom-right' }) position!: string;
     @Prop() tooltip?: string;
     @Prop({ default: 'bottom' }) tooltipPlacement?: string;

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -17,18 +17,18 @@
 
 <script lang="ts">
 import { Vue, Watch, Component } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 import { RampLayerConfig, RampMapConfig } from '@/geo/api';
 import { GlobalEvents, LayerInstance, MapAPI } from '@/api/internal';
 
 import { ConfigStore } from '@/store/modules/config';
-import { LayerStore, layer } from '@/store/modules/layer';
+import { LayerStore } from '@/store/modules/layer';
 
 import to from 'await-to-js';
 import { MaptipStore } from '@/store/modules/maptip';
 
 @Component
-export default class EsriMap extends Vue {
+export default class EsriMapV extends Vue {
     @Get(ConfigStore.getMapConfig) mapConfig!: RampMapConfig;
 
     @Get(LayerStore.layers) layers!: LayerInstance[];

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -68,8 +68,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Watch, Prop, Inject } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
 import { Attribution, MapMove, Point } from '@/geo/api';
 import { GlobalEvents } from '@/api';
 import { MapCaptionStore } from '@/store/modules/mapcaption';

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -23,10 +23,9 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 @Component
-export default class CloseV extends Vue {
+export default class BackV extends Vue {
     @Prop() active!: boolean;
 }
 </script>

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -22,7 +22,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 @Component({})
 export default class CloseV extends Vue {

--- a/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
@@ -21,9 +21,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
-
-import TooltipV from '@/components/util/tooltip.vue';
 
 @Component({})
 export default class MinimizeV extends Vue {

--- a/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/panel-options-menu.vue
@@ -16,8 +16,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
 @Component({
@@ -25,7 +24,7 @@ import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
         'dropdown-menu': DropdownMenuV
     }
 })
-export default class MenuV extends Vue {
+export default class PanelOptionsMenuV extends Vue {
     data() {
         return {
             open: false

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -28,8 +28,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 
 @Component
 export default class PinV extends Vue {

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -26,7 +26,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 import anime from 'animejs';
 

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -36,7 +36,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 import { PanelInstance } from '@/api';
 
 @Component

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -16,13 +16,13 @@
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get, Sync } from 'vuex-pathify';
 
 import anime from 'animejs';
 
 import { PanelInstance } from '@/api';
 
-import PanelV from './panel-container.vue';
+import PanelContainerV from './panel-container.vue';
 
 declare class ResizeObserver {
     constructor(callback: Function);
@@ -33,7 +33,7 @@ declare class ResizeObserver {
 
 @Component({
     components: {
-        'panel-container': PanelV
+        'panel-container': PanelContainerV
     }
 })
 export default class PanelStackV extends Vue {

--- a/packages/ramp-core/src/components/panel-stack/screen-spinner.vue
+++ b/packages/ramp-core/src/components/panel-stack/screen-spinner.vue
@@ -8,8 +8,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
 export default class ScreenSpinnerV extends Vue {}

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -16,15 +16,14 @@
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import EsriMap from '@/components/map/esri-map.vue';
+import EsriMapV from '@/components/map/esri-map.vue';
 import PanelStackV from '@/components/panel-stack/panel-stack.vue';
 import MapCaptionV from '@/components/map/map-caption.vue';
 
 @Component({
     components: {
-        EsriMap,
+        'esri-map': EsriMapV,
         'panel-stack': PanelStackV,
         'map-caption': MapCaptionV
     }

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -26,8 +26,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
 import { AppbarItemInstance } from './store';
 import DividerV from './divider.vue';
 import AppbarButtonV from './button.vue';

--- a/packages/ramp-core/src/fixtures/appbar/divider.vue
+++ b/packages/ramp-core/src/fixtures/appbar/divider.vue
@@ -3,8 +3,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
 export default class DividerV extends Vue {}

--- a/packages/ramp-core/src/fixtures/basemap/index.ts
+++ b/packages/ramp-core/src/fixtures/basemap/index.ts
@@ -1,4 +1,4 @@
-import BasemapComponent from './basemap.vue';
+import BasemapScreenV from './screen.vue';
 import { BasemapAPI } from './api/basemap';
 import { basemap } from './store/index';
 import BasemapAppbarButtonV from './appbar-button.vue';
@@ -19,7 +19,7 @@ class BasemapFixture extends BasemapAPI {
             {
                 id: 'basemap-panel',
                 config: {
-                    screens: { 'basemap-component': BasemapComponent }
+                    screens: { 'basemap-component': BasemapScreenV }
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/basemap/item.vue
+++ b/packages/ramp-core/src/fixtures/basemap/item.vue
@@ -85,12 +85,12 @@
 
 <script lang="ts">
 import { Vue, Prop, Component } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get, Call } from 'vuex-pathify';
 
 import { BasemapStore } from './store';
 
 @Component
-export default class BasemapItem extends Vue {
+export default class BasemapItemV extends Vue {
     @Prop() basemap!: any;
     @Get(BasemapStore.selectedBasemap) selectedBasemap!: any;
 

--- a/packages/ramp-core/src/fixtures/basemap/screen.vue
+++ b/packages/ramp-core/src/fixtures/basemap/screen.vue
@@ -72,19 +72,19 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
 import { PanelInstance } from '@/api';
 
 import { BasemapStore } from './store';
-import BasemapItem from './basemap-item.vue';
+import BasemapItemV from './item.vue';
 
 @Component({
     components: {
-        BasemapItem
+        'basemap-item': BasemapItemV
     }
 })
-export default class BasemapComponent extends Vue {
+export default class BasemapScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch basemap store properties/data
     @Get(BasemapStore.tileSchemas) tileSchemas!: Array<any>;

--- a/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
+++ b/packages/ramp-core/src/fixtures/crosshairs/crosshairs.vue
@@ -44,9 +44,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
-import { FixtureInstance, GlobalEvents } from '@/api';
+import { Vue, Component } from 'vue-property-decorator';
+import { GlobalEvents } from '@/api';
 
 @Component({})
 export default class CrosshairsV extends Vue {

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -1,9 +1,9 @@
 import { DetailsAPI } from './api/details';
 import { details } from './store';
 import DetailsAppbarButtonV from './appbar-button.vue';
-import DetailsLayerV from './details-layers.vue';
-import DetailsResultV from './details-result.vue';
-import DetailsItemV from './details-item.vue';
+import DetailsLayerScreenV from './layers-screen.vue';
+import DetailsResultScreenV from './result-screen.vue';
+import DetailsItemScreenV from './item-screen.vue';
 import messages from './lang/lang.csv';
 
 class DetailsFixture extends DetailsAPI {
@@ -12,9 +12,9 @@ class DetailsFixture extends DetailsAPI {
             {
                 'details-panel': {
                     screens: {
-                        'details-screen-layers': DetailsLayerV,
-                        'details-screen-result': DetailsResultV,
-                        'details-screen-item': DetailsItemV
+                        'details-screen-layers': DetailsLayerScreenV,
+                        'details-screen-result': DetailsResultScreenV,
+                        'details-screen-item': DetailsItemScreenV
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -54,16 +54,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 import { DetailsStore, DetailsItemInstance } from './store';
 
 import { LayerInstance, PanelInstance } from '@/api/internal';
-import {
-    IdentifyItem,
-    IdentifyResult,
-    IdentifyResultFormat,
-    IdentifyResultSet
-} from '@/geo/api';
+import { IdentifyResult, IdentifyResultFormat } from '@/geo/api';
 
 import ESRIDefaultV from './templates/esri-default.vue';
 import HTMLDefaultV from './templates/html-default.vue';
@@ -74,7 +69,7 @@ import HTMLDefaultV from './templates/html-default.vue';
         'html-default': HTMLDefaultV
     }
 })
-export default class DetailsItemV extends Vue {
+export default class DetailsItemScreenV extends Vue {
     @Get('details/items') templateBindings!: {
         [id: string]: DetailsItemInstance;
     };

--- a/packages/ramp-core/src/fixtures/details/layers-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/layers-screen.vue
@@ -34,14 +34,14 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 import { DetailsStore } from './store';
 
 import { LayerInstance, PanelInstance } from '@/api';
 import { IdentifyResult } from '@/geo/api';
 
 @Component({})
-export default class DetailsLayersV extends Vue {
+export default class DetailsLayersScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Get(DetailsStore.payload) payload!: IdentifyResult[];
     @Get('layer/getLayerByUid') getLayerByUid!: (

--- a/packages/ramp-core/src/fixtures/details/result-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/result-screen.vue
@@ -36,14 +36,14 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 import { DetailsStore } from './store';
 
 import { LayerInstance, PanelInstance } from '@/api';
 import { IdentifyResult } from '@/geo/api';
 
 @Component({})
-export default class DetailsResultV extends Vue {
+export default class DetailsResultScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() resultIndex!: number;
 

--- a/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
@@ -14,15 +14,8 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelInstance } from '@/api';
-import {
-    IdentifyItem,
-    IdentifyResult,
-    IdentifyResultFormat,
-    IdentifyResultSet
-} from '@/geo/api';
+import { IdentifyItem } from '@/geo/api';
 
 @Component({})
 export default class ESRIDefaultV extends Vue {

--- a/packages/ramp-core/src/fixtures/details/templates/html-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/html-default.vue
@@ -9,9 +9,7 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import { PanelInstance } from '@/api';
 import { IdentifyItem } from '@/geo/api';
 
 @Component({})

--- a/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/appbar-button.vue
@@ -7,7 +7,7 @@
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
 @Component
-export default class GazeboAppbarButton extends Vue {
+export default class GazeboAppbarButtonV extends Vue {
     @Prop({ default: { colour: 'auto' } }) options!: { colour: string };
 
     onClick() {

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -1,13 +1,13 @@
 import { FixtureInstance } from '@/api';
 
-import GazeboAppbarButton from './appbar-button.vue';
+import GazeboAppbarButtonV from './appbar-button.vue';
 
-import P1Screen1V from './p1-screen-1.vue';
-import P1Screen2V from './p1-screen-2.vue';
+import GazeboP1Screen1V from './p1-screen-1.vue';
+import GazeboP1Screen2V from './p1-screen-2.vue';
 
-/* import P2Screen1V from './p2-screen-1.vue';
-import P2Screen2V from './p2-screen-2.vue'; */
-import P2Screen3V from './p2-screen-3.vue';
+// import GazeboP2Screen1V from './p2-screen-1.vue';
+// import GazeboP2Screen2V from './p2-screen-2.vue';
+import GazeboP2Screen3V from './p2-screen-3.vue';
 
 import { AsyncComponentEh } from '@/store/modules/panel';
 
@@ -21,7 +21,7 @@ class GazeboFixture extends FixtureInstance {
 
         this.$iApi.event.registerEventName(BEHOLD_TEXT_EVENT);
 
-        this.$iApi.component('gazebo-appbar-button', GazeboAppbarButton);
+        this.$iApi.component('gazebo-appbar-button', GazeboAppbarButtonV);
 
         this.$iApi.panel.register(
             {
@@ -29,8 +29,8 @@ class GazeboFixture extends FixtureInstance {
                 // it generally avoids using API and goes straight to the store; fixtures/panels/screens should not do that;
                 p1: {
                     screens: {
-                        'p-1-screen-1': P1Screen1V,
-                        'p-1-screen-2': P1Screen2V
+                        'p-1-screen-1': GazeboP1Screen1V,
+                        'p-1-screen-2': GazeboP1Screen2V
                     }
                 },
                 // panel-2 has examples of how properly bind things and interact with stuff; good panel ✔
@@ -59,11 +59,11 @@ class GazeboFixture extends FixtureInstance {
                         'p-2-screen-2': 'gazebo/p2-screen-2.vue',
 
                         // importing directly; no lazy-loading
-                        'p-2-screen-3': P2Screen3V
+                        'p-2-screen-3': GazeboP2Screen3V
 
                         // returning a `VueConstructor` in a promise also works
                         // 'p-2-screen-3': () => {
-                        //     return new Promise<AsyncComponentEh>(resolve => resolve(P2Screen3V));
+                        //     return new Promise<AsyncComponentEh>(resolve => resolve(GazeboP2Screen3V));
                         // }
                     },
                     style: {

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-1.vue
@@ -37,14 +37,14 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Sync } from 'vuex-pathify';
 
 import { PanelConfigRoute } from '@/store/modules/panel';
 import { PanelInstance } from '../../api';
 
 @Component
-export default class P1Screen1V extends Vue {
+export default class GazeboP1Screen1V extends Vue {
     // ❌ this is a horrible way, don't do that! this is directly tapping into the store and two-way binds `route` property fro a specific panel
     // this will work, but all possible interactions should go through the API, because the store implementation might change and this will break
     // 👇

--- a/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p1-screen-2.vue
@@ -31,11 +31,10 @@
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 import { PanelInstance } from '../../api';
 
 @Component({})
-export default class P1Scree2V extends Vue {
+export default class GazeboP1Scree2V extends Vue {
     url: string =
         'https://i2.wp.com/freepngimages.com/wp-content/uploads/2016/02/garden-shed-transparent-image-2.png?w=693';
 

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-1.vue
@@ -50,12 +50,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
 
 @Component
-export default class P2Screen1V extends Vue {
+export default class GazeboP2Screen1V extends Vue {
     // ✔ this prop is always present and it's set by the panel-container component
     @Prop() panel!: PanelInstance;
 

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-2.vue
@@ -51,12 +51,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
 
 @Component({})
-export default class P2Screen2V extends Vue {
+export default class GazeboP2Screen2V extends Vue {
     // ✔ this prop is always present and it's set by the panel-container component
     @Prop() panel!: PanelInstance;
 

--- a/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
+++ b/packages/ramp-core/src/fixtures/gazebo/p2-screen-3.vue
@@ -59,7 +59,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
 
@@ -72,7 +71,7 @@ import { PanelInstance } from '@/api';
         }
     }
 })
-export default class P2Screen3V extends Vue {
+export default class GazeboP2Screen3V extends Vue {
     // ✔ this prop is always present and it's set by the panel-container component
     @Prop() panel!: PanelInstance;
 }

--- a/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/appbar-button.vue
@@ -16,8 +16,6 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 
-import GeosearchComponent from './geosearch-component.vue';
-
 @Component
 export default class GeosearchAppbarButtonV extends Vue {
     onClick() {

--- a/packages/ramp-core/src/fixtures/geosearch/bottom-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/bottom-filters.vue
@@ -14,15 +14,15 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get, Call } from 'vuex-pathify';
 import { GlobalEvents } from '@/api/internal';
 import { Extent } from '@/geo/api';
 import { GeosearchStore } from './store';
 import { debounce } from 'debounce';
 
 @Component
-export default class GeosearchBottomFilters extends Vue {
+export default class GeosearchBottomFiltersV extends Vue {
     @Get(GeosearchStore.resultsVisible) resultsVisible!: any;
 
     // import required geosearch store actions

--- a/packages/ramp-core/src/fixtures/geosearch/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/index.ts
@@ -1,4 +1,4 @@
-import GeosearchComponent from './geosearch-component.vue';
+import GeosearchScreenV from './screen.vue';
 import { GeosearchAPI } from './api/geosearch';
 import { geosearch } from './store/index';
 import GeosearchAppbarButtonV from './appbar-button.vue';
@@ -18,7 +18,7 @@ class GeosearchFixture extends GeosearchAPI {
             {
                 id: 'geosearch-panel',
                 config: {
-                    screens: { 'geosearch-component': GeosearchComponent }
+                    screens: { 'geosearch-component': GeosearchScreenV }
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/geosearch/loading-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/loading-bar.vue
@@ -13,10 +13,10 @@
 </template>
 
 <script>
-import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class LoadingBar extends Vue {}
+export default class GeosearchLoadingBarV extends Vue {}
 </script>
 
 <style scoped>

--- a/packages/ramp-core/src/fixtures/geosearch/screen.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/screen.vue
@@ -97,25 +97,25 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 import { PanelInstance } from '@/api';
 
 import { GeosearchStore } from './store';
 
-import GeosearchBar from './geosearch-bar.vue';
-import GeosearchTopFilters from './geosearch-top-filters.vue';
-import GeosearchBottomFilters from './geosearch-bottom-filters.vue';
-import LoadingBar from './loading-bar.vue';
+import GeosearchSearchBarV from './search-bar.vue';
+import GeosearchTopFiltersV from './top-filters.vue';
+import GeosearchBottomFiltersV from './bottom-filters.vue';
+import GeosearchLoadingBarV from './loading-bar.vue';
 
 @Component({
     components: {
-        GeosearchBar,
-        GeosearchTopFilters,
-        GeosearchBottomFilters,
-        LoadingBar
+        'geosearch-bar': GeosearchSearchBarV,
+        'geosearch-top-filters': GeosearchTopFiltersV,
+        'geosearch-bottom-filters': GeosearchBottomFiltersV,
+        'loading-bar': GeosearchLoadingBarV
     }
 })
-export default class GeosearchComponent extends Vue {
+export default class GeosearchScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
     @Get(GeosearchStore.searchVal) searchVal!: string;

--- a/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/search-bar.vue
@@ -11,14 +11,14 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get, Call } from 'vuex-pathify';
 
 import { GeosearchStore } from './store';
 import { debounce } from 'debounce';
 
 @Component
-export default class GeosearchBar extends Vue {
+export default class GeosearchSearchBarV extends Vue {
     // fetch geosearch search value from store
     @Get(GeosearchStore.searchVal) searchVal!: string;
 

--- a/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
@@ -52,14 +52,13 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get, Call } from 'vuex-pathify';
 
 import { GeosearchStore } from './store';
-import { ConfigStore } from '@/store/modules/config';
 
 @Component
-export default class GeosearchTopFilters extends Vue {
+export default class GeosearchTopFiltersV extends Vue {
     // fetch defined province/type filters + filter params from store
     @Get(GeosearchStore.getProvinces) provinces!: Array<any>;
     @Get(GeosearchStore.getTypes) types!: Array<any>;

--- a/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
+++ b/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
@@ -53,11 +53,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 
 @Component
-export default class ColumnDropdown extends Vue {
+export default class GridColumnDropdownV extends Vue {
     @Prop() columnDefs!: Array<Object>;
     @Prop() columnApi!: Object;
 }

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -1,7 +1,7 @@
 import { GridAPI } from './api/grid';
 import { grid } from './store/index';
 
-import GridV from './grid.vue';
+import GridScreenV from './screen.vue';
 import GridAppbarButtonV from './appbar-button.vue';
 
 import messages from './lang/lang.csv';
@@ -12,7 +12,7 @@ class GridFixture extends GridAPI {
             {
                 'grid-panel': {
                     screens: {
-                        'grid-screen': GridV
+                        'grid-screen': GridScreenV
                     },
                     style: {
                         'flex-grow': '1',

--- a/packages/ramp-core/src/fixtures/grid/screen.vue
+++ b/packages/ramp-core/src/fixtures/grid/screen.vue
@@ -50,30 +50,30 @@
             <close @click="panel.close()" />
         </template>
         <template #content>
-            <TableComponent
+            <table-component
                 class="rv-grid"
                 ref="rvGrid"
                 :layerUid="currentUid"
-            ></TableComponent>
+            ></table-component>
         </template>
     </panel-screen>
 </template>
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 
 import { LayerInstance, PanelInstance } from '@/api';
-import TableComponent from '@/fixtures/grid/table/table.vue';
+import GridTableComponentV from '@/fixtures/grid/table-component.vue';
 
-import { LayerStore, layer } from '@/store/modules/layer';
+import { LayerStore } from '@/store/modules/layer';
 
 @Component({
     components: {
-        TableComponent
+        'table-component': GridTableComponentV
     }
 })
-export default class Screen1 extends Vue {
+export default class GridScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() header!: String;
 

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -72,26 +72,24 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get, Sync } from 'vuex-pathify';
 import { GlobalEvents, LayerInstance } from '@/api/internal';
 import deepmerge from 'deepmerge';
-
-import { LayerStore, layer } from '@/store/modules/layer';
 
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-material.css';
 import { AgGridVue } from 'ag-grid-vue';
-import ColumnDropdown from '../column-dropdown.vue';
-import { GridStore, GridConfig, GridState } from '../store';
-import TableStateManager from '../store/table-state-manager';
+import GridColumnDropdownV from './column-dropdown.vue';
+import { GridConfig } from './store';
+import TableStateManager from './store/table-state-manager';
 
 // custom filter templates
-import CustomNumberFilter from './CustomNumberFilter.vue';
-import CustomTextFilter from './CustomTextFilter.vue';
-import CustomSelectorFilter from './CustomSelectorFilter.vue';
-import CustomDateFilter from './CustomDateFilter.vue';
-import CustomHeader from './CustomHeader.vue';
+import GridCustomNumberFilterV from './templates/custom-number-filter.vue';
+import GridCustomTextFilterV from './templates/custom-text-filter.vue';
+import GridCustomSelectorFilterV from './templates/custom-selector-filter.vue';
+import GridCustomDateFilterV from './templates/custom-date-filter.vue';
+import GridCustomHeaderV from './templates/custom-header.vue';
 
 // these should match up with the `type` value returned by the attribute promise.
 const NUM_TYPES: string[] = ['oid', 'double', 'integer'];
@@ -100,16 +98,16 @@ const TEXT_TYPE: string = 'string';
 
 @Component({
     components: {
-        'column-dropdown': ColumnDropdown,
+        'column-dropdown': GridColumnDropdownV,
         AgGridVue,
-        CustomNumberFilter,
-        CustomSelectorFilter,
-        CustomDateFilter,
-        CustomTextFilter,
-        CustomHeader
+        GridCustomNumberFilterV,
+        GridCustomSelectorFilterV,
+        GridCustomDateFilterV,
+        GridCustomTextFilterV,
+        GridCustomHeaderV
     }
 })
-export default class TableComponent extends Vue {
+export default class GridTableComponentV extends Vue {
     @Prop() layerUid!: string;
     @Get('layer/getLayerByUid') getLayerByUid!: (
         uid: string
@@ -135,11 +133,11 @@ export default class TableComponent extends Vue {
 
         // imported separate components
         this.frameworkComponents = {
-            agColumnHeader: CustomHeader,
-            numberFloatingFilter: CustomNumberFilter,
-            textFloatingFilter: CustomTextFilter,
-            selectorFloatingFilter: CustomSelectorFilter,
-            dateFloatingFilter: CustomDateFilter
+            agColumnHeader: GridCustomHeaderV,
+            numberFloatingFilter: GridCustomNumberFilterV,
+            textFloatingFilter: GridCustomTextFilterV,
+            selectorFloatingFilter: GridCustomSelectorFilterV,
+            dateFloatingFilter: GridCustomDateFilterV
         };
 
         // set up grid options

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
@@ -22,10 +22,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class CustomNumberFilter extends Vue {
+export default class GridCustomNumberFilterV extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)
         this.minVal =
@@ -122,7 +122,7 @@ export default class CustomNumberFilter extends Vue {
     }
 }
 
-export default interface CustomNumberFilter {
+export default interface GridCustomNumberFilter {
     minVal: any;
     maxVal: any;
     colDef: any;

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -70,10 +70,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class CustomHeader extends Vue {
+export default class GridCustomHeaderV extends Vue {
     sort: number = 0;
     sortable: boolean = false;
 
@@ -132,7 +132,7 @@ export default class CustomHeader extends Vue {
     }
 }
 
-export default interface CustomHeader {
+export default interface GridCustomHeader {
     sort: number;
     sortable: boolean;
     gridApi: any;

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
@@ -20,10 +20,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class CustomNumberFilter extends Vue {
+export default class GridCustomNumberFilterV extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)
         this.minVal = this.params.stateManager.getColumnFilter(
@@ -122,7 +122,7 @@ export default class CustomNumberFilter extends Vue {
     }
 }
 
-export default interface CustomNumberFilter {
+export default interface GridCustomNumberFilter {
     minVal: any;
     maxVal: any;
     colDef: any;

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -13,10 +13,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class CustomSelectorFilter extends Vue {
+export default class GridCustomSelectorFilterV extends Vue {
     beforeMount() {
         // Load previously stored value (if saved in table state manager)
         this.selectedOption = this.params.stateManager.getColumnFilter(
@@ -82,7 +82,7 @@ export default class CustomSelectorFilter extends Vue {
     }
 }
 
-export default interface CustomSelectorFilter {
+export default interface GridCustomSelectorFilter {
     selectedOption: string;
     colDef: any;
     options: any;

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
@@ -11,10 +11,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class CustomTextFilter extends Vue {
+export default class GridCustomTextFilterV extends Vue {
     beforeMount() {
         // Load previously stored value (if saved in table state manager)
         this.filterValue = this.params.stateManager.getColumnFilter(
@@ -61,7 +61,7 @@ export default class CustomTextFilter extends Vue {
     }
 }
 
-export default interface CustomTextFilter {
+export default interface GridCustomTextFilter {
     filterValue: string;
     colDef: any;
     params: any;

--- a/packages/ramp-core/src/fixtures/help/index.ts
+++ b/packages/ramp-core/src/fixtures/help/index.ts
@@ -1,7 +1,7 @@
 import { HelpAPI } from './api/help';
 import { help } from './store/index';
-import HelpV from './help.vue';
-import HelpNavV from './nav-button.vue';
+import HelpScreenV from './screen.vue';
+import HelpNavButtonV from './nav-button.vue';
 
 import messages from './lang/lang.csv';
 
@@ -9,7 +9,7 @@ class HelpFixture extends HelpAPI {
     added() {
         console.log(`[fixture] ${this.id} added`);
 
-        this.$iApi.component('help-nav-button', HelpNavV);
+        this.$iApi.component('help-nav-button', HelpNavButtonV);
 
         this.$vApp.$store.registerModule('help', help());
 
@@ -17,7 +17,7 @@ class HelpFixture extends HelpAPI {
             {
                 'help-panel': {
                     screens: {
-                        'help-screen': HelpV
+                        'help-screen': HelpScreenV
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/help/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/help/nav-button.vue
@@ -18,7 +18,7 @@ import { Vue, Component } from 'vue-property-decorator';
 import { GlobalEvents } from '../../api/internal';
 
 @Component
-export default class HelpNavV extends Vue {
+export default class HelpNavButtonV extends Vue {
     onClick() {
         this.$iApi.event.emit(GlobalEvents.HELP_TOGGLE);
     }

--- a/packages/ramp-core/src/fixtures/help/screen.vue
+++ b/packages/ramp-core/src/fixtures/help/screen.vue
@@ -20,14 +20,12 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component, Prop } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
-import { RampConfig } from '@/types';
 import { HelpStore } from './store';
-import { ConfigStore } from '@/store/modules/config';
-import HelpSectionV from './help-section.vue';
+import HelpSectionV from './section.vue';
 
 // TODO check if we actually need this library. Does vue have its own internal web request library?
 import axios from 'axios';
@@ -38,7 +36,7 @@ import marked from 'marked';
         'help-section': HelpSectionV
     }
 })
-export default class HelpV extends Vue {
+export default class HelpScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Get(HelpStore.folderName) folderName!: string;
 

--- a/packages/ramp-core/src/fixtures/help/section.vue
+++ b/packages/ramp-core/src/fixtures/help/section.vue
@@ -37,8 +37,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
-import { PanelInstance } from '@/api';
 
 @Component({})
 export default class HelpSectionV extends Vue {

--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -23,12 +23,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 import { LegendEntry } from '../store/legend-defs';
 
 @Component
-export default class CheckboxV extends Vue {
+export default class LegendCheckboxV extends Vue {
     @Prop() value!: boolean;
     @Prop() isRadio!: boolean;
     @Prop() legendItem!: LegendEntry;

--- a/packages/ramp-core/src/fixtures/legend/components/component.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/component.vue
@@ -9,15 +9,13 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import { LegendStore } from '../store';
 import { LegendItem, LegendTypes } from '../store/legend-defs';
 
-import LayerEntryV from './legend-entry.vue';
-import LegendGroupV from './legend-group.vue';
-import LegendVisibilitySetV from './legend-visibility-set.vue';
-import LegendPlaceholderV from './legend-placeholder.vue';
+import LayerEntryV from './entry.vue';
+import LegendGroupV from './group.vue';
+import LegendVisibilitySetV from './visibility-set.vue';
+import LegendPlaceholderV from './placeholder.vue';
 
 @Component
 export default class LegendComponentV extends Vue {

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -107,19 +107,17 @@
 <script lang="ts">
 import { GlobalEvents } from '@/api';
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import { LegendStore } from '../store';
 import { LegendEntry, Controls } from '../store/legend-defs';
 
-import CheckboxV from './checkbox.vue';
-import SymbologyStack from './symbology-stack.vue';
+import LegendCheckboxV from './checkbox.vue';
+import LegendSymbologyStackV from './symbology-stack.vue';
 import LegendOptionsV from './legend-options.vue';
 
 @Component({
     components: {
-        checkbox: CheckboxV,
-        'symbology-stack': SymbologyStack,
+        checkbox: LegendCheckboxV,
+        'symbology-stack': LegendSymbologyStackV,
         options: LegendOptionsV
     }
 })

--- a/packages/ramp-core/src/fixtures/legend/components/group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/group.vue
@@ -34,10 +34,7 @@
                 </div>
 
                 <!-- name -->
-                <div
-                    class="flex-1 pointer-events-none"
-                    v-truncate="{ externalTrigger: true }"
-                >
+                <div class="flex-1 pointer-events-none" v-truncate>
                     <span>{{ legendItem.name }}</span>
                 </div>
 
@@ -53,7 +50,7 @@
             </div>
         </div>
 
-        <!-- Display the children of the group -->
+        <!-- Display children of the group -->
         <div class="legend-group pl-5" v-if="legendItem.expanded">
             <legend-component
                 v-for="(item, idx) in legendItem.children"
@@ -66,20 +63,18 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import { LegendStore } from '../store';
-import { LegendSet, LegendTypes } from '../store/legend-defs';
-import CheckboxV from './checkbox.vue';
+import { LegendGroup, LegendTypes } from '../store/legend-defs';
+import LegendCheckboxV from './checkbox.vue';
 
 @Component({
     components: {
-        LegendComponent: () => import('./legend-component.vue'),
-        checkbox: CheckboxV
+        LegendComponent: () => import('./component.vue'),
+        checkbox: LegendCheckboxV
     }
 })
-export default class LegendVisibilitySetV extends Vue {
-    @Prop() legendItem!: LegendSet;
+export default class LegendGroupV extends Vue {
+    @Prop() legendItem!: LegendGroup;
 
     // make vue stop hating enums
     LegendTypes = LegendTypes;

--- a/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
@@ -38,21 +38,21 @@
 
 <script lang="ts">
 import { Vue, Component, Prop, Watch } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 
-import { LayerStore, layer } from '@/store/modules/layer';
+import { LayerStore } from '@/store/modules/layer';
 import { LayerInstance } from '@/api/internal';
 
 import { LegendStore } from '../store';
 import { LegendEntry, LegendTypes } from '../store/legend-defs';
 
-import CheckboxV from './checkbox.vue';
-import SymbologyStack from './symbology-stack.vue';
+import LegendCheckboxV from './checkbox.vue';
+import LegendSymbologyStackV from './symbology-stack.vue';
 
 @Component({
     components: {
-        checkbox: CheckboxV,
-        'symbology-stack': SymbologyStack
+        checkbox: LegendCheckboxV,
+        'symbology-stack': LegendSymbologyStackV
     }
 })
 export default class LegendPlaceholderV extends Vue {

--- a/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
@@ -45,13 +45,11 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import { LegendItem } from '../store/legend-defs';
 import { LayerInstance } from '@/api/internal';
 
 @Component
-export default class SymbologyStack extends Vue {
+export default class LegendSymbologyStackV extends Vue {
     @Prop() visible!: boolean;
     @Prop() layer!: LayerInstance;
     @Prop() uid!: string;

--- a/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
@@ -34,7 +34,10 @@
                 </div>
 
                 <!-- name -->
-                <div class="flex-1 pointer-events-none" v-truncate>
+                <div
+                    class="flex-1 pointer-events-none"
+                    v-truncate="{ externalTrigger: true }"
+                >
                     <span>{{ legendItem.name }}</span>
                 </div>
 
@@ -50,7 +53,7 @@
             </div>
         </div>
 
-        <!-- Display children of the group -->
+        <!-- Display the children of the group -->
         <div class="legend-group pl-5" v-if="legendItem.expanded">
             <legend-component
                 v-for="(item, idx) in legendItem.children"
@@ -63,20 +66,18 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
-import { LegendStore } from '../store';
-import { LegendGroup, LegendTypes } from '../store/legend-defs';
-import CheckboxV from './checkbox.vue';
+import { LegendSet, LegendTypes } from '../store/legend-defs';
+import LegendCheckboxV from './checkbox.vue';
 
 @Component({
     components: {
-        LegendComponent: () => import('./legend-component.vue'),
-        checkbox: CheckboxV
+        LegendComponent: () => import('./component.vue'),
+        checkbox: LegendCheckboxV
     }
 })
-export default class LegendGroupV extends Vue {
-    @Prop() legendItem!: LegendGroup;
+export default class LegendVisibilitySetV extends Vue {
+    @Prop() legendItem!: LegendSet;
 
     // make vue stop hating enums
     LegendTypes = LegendTypes;

--- a/packages/ramp-core/src/fixtures/legend/header.vue
+++ b/packages/ramp-core/src/fixtures/legend/header.vue
@@ -76,8 +76,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Call } from 'vuex-pathify';
 
 import { LegendStore } from './store';
 import { GlobalEvents } from '../../api/internal';

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -1,6 +1,6 @@
 import { LegendAPI } from './api/legend';
-import { LegendStore, legend } from './store';
-import LegendV from './legend.vue';
+import { LegendStore, legend } from './store/index';
+import LegendScreenV from './screen.vue';
 import LegendAppbarButtonV from './appbar-button.vue';
 import { GlobalEvents, LayerInstance } from '@/api';
 
@@ -13,7 +13,7 @@ class LegendFixture extends LegendAPI {
             {
                 'legend-panel': {
                     screens: {
-                        'legend-screen': LegendV
+                        'legend-screen': LegendScreenV
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/legend/screen.vue
+++ b/packages/ramp-core/src/fixtures/legend/screen.vue
@@ -24,13 +24,13 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Get } from 'vuex-pathify';
 import { PanelInstance } from '@/api';
 
 import { LegendStore } from './store';
-import { LegendItem, LegendEntry, LegendGroup } from './store/legend-defs';
-import LegendHeaderV from './legend-header.vue';
-import LegendComponentV from './components/legend-component.vue';
+import { LegendEntry, LegendGroup } from './store/legend-defs';
+import LegendHeaderV from './header.vue';
+import LegendComponentV from './components/component.vue';
 
 @Component({
     components: {
@@ -38,7 +38,7 @@ import LegendComponentV from './components/legend-component.vue';
         'legend-component': LegendComponentV
     }
 })
-export default class LegendV extends Vue {
+export default class LegendScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     // fetch store properties/data
     @Get(LegendStore.children) children!: Array<LegendEntry | LegendGroup>;

--- a/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/fullscreen-nav.vue
@@ -30,7 +30,6 @@
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
-import screenfull from 'screenfull';
 
 @Component
 export default class FullscreenNavV extends Vue {

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -23,10 +23,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Watch } from 'vue-property-decorator';
-import { Get, Call } from 'vuex-pathify';
-
-import { GlobalEvents } from '@/api';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
 
 import FullscreenNavV from './buttons/fullscreen-nav.vue';
 import HomeNavV from './buttons/home-nav.vue';

--- a/packages/ramp-core/src/fixtures/metadata/index.ts
+++ b/packages/ramp-core/src/fixtures/metadata/index.ts
@@ -1,7 +1,7 @@
 import { MetadataAPI } from './api/metadata';
 import MetadataAppbarButtonV from './appbar-button.vue';
 
-import ScreenV from './screen.vue';
+import MetadataScreenV from './screen.vue';
 
 import messages from './lang/lang.csv';
 
@@ -11,7 +11,7 @@ class MetadataFixture extends MetadataAPI {
             {
                 'metadata-panel': {
                     screens: {
-                        'metadata-screen-content': ScreenV
+                        'metadata-screen-content': MetadataScreenV
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/metadata/screen.vue
+++ b/packages/ramp-core/src/fixtures/metadata/screen.vue
@@ -52,7 +52,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
 import { MetadataPayload, MetadataResult, MetadataState } from './definitions';
@@ -61,7 +60,7 @@ import XSLT_en from './files/xstyle_default_en.xsl';
 import XSLT_fr from './files/xstyle_default_fr.xsl';
 
 @Component
-export default class MetadataV extends Vue {
+export default class MetadataScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() payload!: MetadataPayload;
 

--- a/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
+++ b/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
@@ -8,8 +8,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
 import { NortharrowStore } from './store';
 import { GlobalEvents } from '@/api/internal';
 import { Extent, Point } from '@/geo/api';

--- a/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
+++ b/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
@@ -51,8 +51,8 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
+import { Vue, Component } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
 import { Extent, RampMapConfig } from '@/geo/api';
 import { GlobalEvents, OverviewMapAPI } from '@/api/internal';
 import { OverviewmapStore } from './store';

--- a/packages/ramp-core/src/fixtures/panguard/index.ts
+++ b/packages/ramp-core/src/fixtures/panguard/index.ts
@@ -1,5 +1,5 @@
 import messages from './lang/lang.csv';
-import PanguardV from './panguard.vue';
+import PanguardV from './map-panguard.vue';
 import { FixtureInstance } from '@/api';
 
 class PanguardFixture extends FixtureInstance {

--- a/packages/ramp-core/src/fixtures/panguard/map-panguard.vue
+++ b/packages/ramp-core/src/fixtures/panguard/map-panguard.vue
@@ -8,7 +8,7 @@
 import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class MapPanguard extends Vue {
+export default class MapPanguardV extends Vue {
     timeoutID: number | undefined = undefined;
 
     mounted(): void {

--- a/packages/ramp-core/src/fixtures/scrollguard/index.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/index.ts
@@ -1,5 +1,5 @@
 import messages from './lang/lang.csv';
-import ScrollguardV from './scrollguard.vue';
+import ScrollguardV from './map-scrollguard.vue';
 import { FixtureInstance } from '@/api';
 
 class ScrollguardFixture extends FixtureInstance {

--- a/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
+++ b/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
@@ -8,7 +8,7 @@
 import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class MapScrollguard extends Vue {
+export default class MapScrollguardV extends Vue {
     mounted(): void {
         (this.$iApi.$vApp.$el.querySelector(
             '.inner-shell + .esri-view'

--- a/packages/ramp-core/src/fixtures/settings/component.vue
+++ b/packages/ramp-core/src/fixtures/settings/component.vue
@@ -9,9 +9,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
-
-import { PanelInstance } from '@/api';
 
 // Import control templates.
 import SliderControl from './templates/slider-control.vue';

--- a/packages/ramp-core/src/fixtures/settings/index.ts
+++ b/packages/ramp-core/src/fixtures/settings/index.ts
@@ -1,7 +1,7 @@
 import { SettingsAPI } from './api/settings';
 import SettingsAppbarButtonV from './appbar-button.vue';
 
-import ScreenV from './settings.vue';
+import SettingsScreenV from './screen.vue';
 
 import messages from './lang/lang.csv';
 
@@ -11,7 +11,7 @@ class SettingsFixture extends SettingsAPI {
             {
                 'settings-panel': {
                     screens: {
-                        'settings-screen-content': ScreenV
+                        'settings-screen-content': SettingsScreenV
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -104,15 +104,15 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 
 import { PanelInstance } from '@/api';
 
-import SettingsComponent from './SettingsComponentV.vue';
+import SettingsComponentV from './component.vue';
 import { LayerInstance } from '@/api/internal';
 
 @Component({
     components: {
-        'settings-component': SettingsComponent
+        'settings-component': SettingsComponentV
     }
 })
-export default class SettingsV extends Vue {
+export default class SettingsScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() layer!: LayerInstance;
     @Prop() uid!: string;

--- a/packages/ramp-core/src/fixtures/snowman/snowman.vue
+++ b/packages/ramp-core/src/fixtures/snowman/snowman.vue
@@ -6,7 +6,6 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 import { FixtureInstance } from '@/api';
 
 // this is an example of a on-map component (doesn't use panels)

--- a/packages/ramp-core/src/fixtures/wizard/index.ts
+++ b/packages/ramp-core/src/fixtures/wizard/index.ts
@@ -1,5 +1,5 @@
 import { WizardAPI } from './api/wizard';
-import WizardV from './wizard.vue';
+import WizardScreenV from './screen.vue';
 import { wizard } from './store/index';
 import { LayerSource } from './store/layer-source';
 import messages from './lang/lang.csv';
@@ -12,7 +12,7 @@ class WizardFixture extends WizardAPI {
             {
                 'wizard-panel': {
                     screens: {
-                        'wizard-screen': WizardV
+                        'wizard-screen': WizardScreenV
                     },
                     style: {
                         width: '350px'

--- a/packages/ramp-core/src/fixtures/wizard/screen.vue
+++ b/packages/ramp-core/src/fixtures/wizard/screen.vue
@@ -174,7 +174,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop } from 'vue-property-decorator';
+import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync, Call } from 'vuex-pathify';
 
 import { PanelInstance } from '@/api';
@@ -195,7 +195,7 @@ import StepperV from './stepper.vue';
         stepper: StepperV
     }
 })
-export default class WizardV extends Vue {
+export default class WizardScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Get(WizardStore.layerSource) layerSource!: LayerSource;
 

--- a/packages/ramp-core/src/fixtures/wizard/stepper-item.vue
+++ b/packages/ramp-core/src/fixtures/wizard/stepper-item.vue
@@ -51,10 +51,10 @@
 </template>
 
 <script lang="ts">
-import { Vue, Watch, Component, Prop, Inject } from 'vue-property-decorator';
+import { Vue, Component, Prop, Inject } from 'vue-property-decorator';
 
 @Component
-export default class StepperItemV extends Vue {
+export default class WizardStepperItemV extends Vue {
     @Prop() title!: string;
     @Prop() summary!: string;
 

--- a/packages/ramp-core/src/fixtures/wizard/stepper.vue
+++ b/packages/ramp-core/src/fixtures/wizard/stepper.vue
@@ -6,10 +6,9 @@
 
 <script lang="ts">
 import { Vue, Component, Watch, Prop, Provide } from 'vue-property-decorator';
-import { Get, Sync, Call } from 'vuex-pathify';
 
 @Component
-export default class StepperV extends Vue {
+export default class WizardStepperV extends Vue {
     @Prop({ default: 0 }) activeStep!: number;
     @Provide() stepper = { activeIndex: this.activeStep, numSteps: 0 };
 


### PR DESCRIPTION
For #372 and #373

- File names are all lower case with dashes (e.g. `appbar-button.vue`)
- Vue component classes for fixtures all prefixed with the fixture name and suffixed with V (e.g. `GazeboAppbarButtonV`)
- Vue component file names and class names are consistent (e.g. `dropdown-menu.vue` -> `DropdownMenuV`)
- Drop the name of the fixture in the file name for brevity (e.g. `GeosearchTopFiltersV` -> `geosearch/top-filters.vue`)
- For fixtures with a panel, call the file that has the panel `screen.vue` (rather than `component` or `panel` or just the fixture name)
    - For fixtures with multiple screens, can prefix the name with some identifying word (e.g. `details` has `item-screen.vue`, `layers-screen.vue`, and `result-screen.vue`)
    - NOTE: `gazebo` is particular - has `p1` and `p2` prefixes, and screens are only differentiated by number
- Remove unused imports

The code changes are pretty mundane and miniscule but if you have a second to play around with the [demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/372-373-naming/host/index-e2e.html?script=panel-party) to see if any errors pop up, that would be appreciated. There were alot of chances for me to miss updating something when changing the names around.

P.S. good luck with merges

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/554)
<!-- Reviewable:end -->
