### PR TITLE
Fix WMS duplicate keys bug

### DIFF
--- a/packages/ramp-core/src/fixtures/wizard/screen.vue
+++ b/packages/ramp-core/src/fixtures/wizard/screen.vue
@@ -345,7 +345,7 @@ export default class WizardScreenV extends Vue {
 
     // options for sublayers selector
     get sublayerOptions() {
-        return this.layerInfo!.layers.map((layer: any) => {
+        return this.layerInfo!.layers.map((layer: any, idx: number) => {
             return {
                 label: `${layer.indent}${layer.name}`,
                 value:
@@ -358,7 +358,7 @@ export default class WizardScreenV extends Vue {
                           {
                               id: layer.id
                           },
-                id: layer.id
+                id: `${layer.indent}${layer.name}-${idx}`
             };
         });
     }


### PR DESCRIPTION
Related issue: #555 

[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/555/host/index.html)
Testing:
- Load WMS layer: https://geo.weather.gc.ca/geomet-climate?SERVICE=WMS&VERSION=1.3.0
- Check for Vue warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/556)
<!-- Reviewable:end -->
