### PR TITLE
Update tippy theme name to fix missing class

### DIFF
--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -28,7 +28,6 @@ import VueTippy, { TippyComponent } from 'vue-tippy';
 Vue.use(VueTippy, {
     aria: 'labelledby',
     a11y: false,
-    theme: 'ramp',
     trigger: 'mouseenter manual focus'
 });
 Vue.component('tippy', TippyComponent);

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -6,7 +6,6 @@
             flip: false,
             allowHTML: true,
             zIndex: 5,
-            theme: 'ramp',
             trigger: 'manual',
             arrow: false,
             delay: 200,

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -45,7 +45,8 @@
     stroke-width: 2px;
 }
 
-.tippy-tooltip.ramp-theme {
+/* Keep the name dark-theme since tippy insists on using this theme for prod builds */
+.tippy-tooltip.dark-theme {
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
         Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }


### PR DESCRIPTION
A little mystery here...

For development builds like `rush serve` tippy applies the correct class `ramp-theme` to the tippy element and all is well. For production builds like `rush build` tippy does not apply `ramp-theme` but rather `dark-theme`. In all cases the `ramp-theme` css is present in `RAMP.css`, so purgecss isn't touching it. 

I don't see anything in our code that would alter tippy to switch to its default dark theme based on the development environment. A possible guess where it could go wrong [is here](https://github.com/KABBOUCHI/vue-tippy/blob/master/src/index.js#L101) since our startup code varies slightly based on if we're building or serving (and if the latter then `window.Vue` is added). 

Before I debug tippy itself the easy solution is to rename the theme from `ramp-theme` to `dark-theme`. 

[Demo](http://ramp4-app.azureedge.net/demo/users/milespetrov/545-css-prod/host/index.html)
Closes #545

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/562)
<!-- Reviewable:end -->
