### PR TITLE
Fixture Added Event, Nice Recusion, Async GeoJSON Projections

### DIFF
--- a/packages/ramp-core/docs/app/defaults.md
+++ b/packages/ramp-core/docs/app/defaults.md
@@ -78,27 +78,28 @@ These events will always be present, regardless of what fixtures are active. Eve
 
 TODO if we have API docs that expose the payload interfaces, link to those definitions. Otherwise we'll need to put the interface specs here
 
-| Event Name                              | Payload                                                        | Event Announces              |
-| --------------------------------------- | -------------------------------------------------------------- | ---------------------------- |
-| COMPONENT<br>'ramp/component'           | _id_: component id                                             | A vue component registered   |
-| CONFIG_CHANGE                           | RampConfig object                                              | The config was changed       |
-| FILTER_CHANGE<br>'filter/change'        | FilterEventParam object                                        | A filter has changed         |
-| LAYER_OPACITYCHANGE<br>'layer/opacitychange' | _opacity_: new value, _uid_: affected uid                 | The layer opacity changed    |
-| LAYER_RELOADED<br>'layer/reloaded'      | LayerInstance object                                           | The layer was reloaded       |
-| LAYER_REMOVE<br>'layer/remove'          | LayerInstance object                                           | The layer was removed from the map |
-| LAYER_STATECHANGE<br>'layer/statechange' | _state_: new value, _uid_: affected uid                       | The layer state changed      |
-| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _uid_: affected uid        | The layer visibility changed |
-| MAP_BLUR<br>'map/blur'                  | FocusEvent object                                              | The map lost focus           |
-| MAP_CLICK<br>'map/click'                | MapClick object                                                | The map was clicked          |
-| MAP_CREATED<br>'map/created'            | Map API object                                                 | The map was created          |
-| MAP_DOUBLECLICK<br>'map/doubleclick'    | MapClick object                                                | The map was double clicked   |
-| MAP_EXTENTCHANGE<br>'map/extentchanged' | RAMP Extent object                                             | The map extent changed       |
-| MAP_IDENTIFY<br>'map/identify'          | _results_: Array of IdentifyResult<br>_click_: MapClick object | A map identify was requested |
-| MAP_KEYDOWN<br>'map/keydown'            | KeyboardEvent object                                           | A key was pressed            |
-| MAP_KEYUP<br>'map/keyup'                | KeyboardEvent object                                           | A key was released           |
-| MAP_MOUSEDOWN<br>'map/mousedown'        | PointerEvent object                                            | A mouse button was depressed |
-| MAP_MOUSEMOVE<br>'map/mousemove'        | MapMove object                                                 | The mouse moved over the map |
-| MAP_BASEMAPCHANGE                       | basemapId: string                                              | The basemap was changed      |
+| Event Name                                         | Payload                                                        | Event Announces                    |
+| -------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------- |
+| COMPONENT<br>'ramp/component'                      | _id_: component id                                             | A vue component registered         |
+| CONFIG_CHANGE                                      | RampConfig object                                              | The config was changed             |
+| FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed               |
+| FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added           |
+| LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, _uid_: affected uid                      | The layer opacity changed          |
+| LAYER_RELOADED<br>'layer/reloaded'                 | LayerInstance object                                           | The layer was reloaded             |
+| LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map |
+| LAYER_STATECHANGE<br>'layer/statechange'           | _state_: new value, _uid_: affected uid                        | The layer state changed            |
+| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _uid_: affected uid                   | The layer visibility changed       |
+| MAP_BLUR<br>'map/blur'                             | FocusEvent object                                              | The map lost focus                 |
+| MAP_CLICK<br>'map/click'                           | MapClick object                                                | The map was clicked                |
+| MAP_CREATED<br>'map/created'                       | Map API object                                                 | The map was created                |
+| MAP_DOUBLECLICK<br>'map/doubleclick'               | MapClick object                                                | The map was double clicked         |
+| MAP_EXTENTCHANGE<br>'map/extentchanged'            | RAMP Extent object                                             | The map extent changed             |
+| MAP_IDENTIFY<br>'map/identify'                     | _results_: Array of IdentifyResult<br>_click_: MapClick object | A map identify was requested       |
+| MAP_KEYDOWN<br>'map/keydown'                       | KeyboardEvent object                                           | A key was pressed                  |
+| MAP_KEYUP<br>'map/keyup'                           | KeyboardEvent object                                           | A key was released                 |
+| MAP_MOUSEDOWN<br>'map/mousedown'                   | PointerEvent object                                            | A mouse button was depressed       |
+| MAP_MOUSEMOVE<br>'map/mousemove'                   | MapMove object                                                 | The mouse moved over the map       |
+| MAP_BASEMAPCHANGE                                  | basemapId: string                                              | The basemap was changed            |
 
 ### Core Fixture Events
 

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -325,6 +325,14 @@ let options = {
 };
 
 rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
+
+var iklobLoad = rInstance.event.on('fixture/added', fixture => {
+    if (fixture.id === 'iklob') {
+        rInstance.event.off(iklobLoad);
+        rInstance.panel.open('iklob-p1');
+    }
+});
+
 rInstance.fixture.addDefaultFixtures().then(() => {
     rInstance.panel.open('geosearch-panel');
     rInstance.panel.open('basemap-panel');
@@ -512,11 +520,6 @@ rInstance.fixture.add('diligord', window.hostFixtures.diligord).then(() => {
 rInstance.fixture.add('mouruge', window.hostFixtures.mouruge).then(() => {
     rInstance.panel.open('mouruge-p1');
 });
-
-// TODO: temp fix since iklob is added after the instance is instantiated. replace once we have a 'fixture added' event.
-setTimeout(() => {
-    rInstance.panel.open('iklob-p1');
-}, 5000);
 
 // add export-v1 fixtures
 rInstance.fixture.add('export-v1');

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -22,6 +22,8 @@ export enum GlobalEvents {
     // TODO document payload
     FILTER_CHANGE = 'filter/change',
 
+    FIXTURE_ADDED = 'fixture/added', // Payload is FixtureInstance
+
     LAYER_OPACITYCHANGE = 'layer/opacitychange',
     LAYER_RELOADED = 'layer/reloaded', // Payload: `(layer: LayerInstance)`
     LAYER_REMOVE = 'layer/remove', // Payload: `(layer: LayerInstance)`

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -7,6 +7,7 @@ import {
     FixtureBaseSet
 } from '@/store/modules/fixture';
 import { i18n } from '@/lang';
+import { GlobalEvents } from './event';
 
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;
 
@@ -67,6 +68,8 @@ export class FixtureAPI extends APIScope {
         this.$vApp.$store.set(`fixture/${FixtureMutation.ADD_FIXTURE}!`, {
             value: fixture
         });
+
+        this.$iApi.event.emit(GlobalEvents.FIXTURE_ADDED, fixture);
 
         return fixture;
     }

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -1,13 +1,12 @@
 import Vue, { VueConstructor, ComponentOptions } from 'vue';
 
-import { APIScope, InstanceAPI } from './internal';
+import { APIScope, GlobalEvents, InstanceAPI } from './internal';
 import {
     FixtureBase,
     FixtureMutation,
     FixtureBaseSet
 } from '@/store/modules/fixture';
 import { i18n } from '@/lang';
-import { GlobalEvents } from './event';
 
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;
 

--- a/packages/ramp-core/src/geo/api/layer/tree-node.ts
+++ b/packages/ramp-core/src/geo/api/layer/tree-node.ts
@@ -24,7 +24,15 @@ export class TreeNode {
         if (this.uid === uid) {
             return this;
         } else {
-            return this.children.map(t => t.findChildByUid(uid)).find(Boolean);
+            let hit: TreeNode | undefined;
+
+            // using .some will cause the loop to stop when it gets a hit
+            this.children.some(t => {
+                return (hit = t.findChildByUid(uid));
+            });
+
+            // return nothing, or the bubbled up tree node, not the child (t) that was being iterated on
+            return hit;
         }
     }
 
@@ -34,7 +42,15 @@ export class TreeNode {
         if (this.layerIdx === idx) {
             return this;
         } else {
-            return this.children.map(t => t.findChildByIdx(idx)).find(Boolean);
+            let hit: TreeNode | undefined;
+
+            // using .some will cause the loop to stop when it gets a hit
+            this.children.some(t => {
+                return (hit = t.findChildByIdx(idx));
+            });
+
+            // return nothing, or the bubbled up tree node, not the child (t) that was being iterated on
+            return hit;
         }
     }
 }

--- a/packages/ramp-core/src/geo/layer/file-utils.ts
+++ b/packages/ramp-core/src/geo/layer/file-utils.ts
@@ -283,7 +283,11 @@ export class FileUtils extends APIScope {
         // project data and convert to esri json format
         const fancySR = new EsriSpatialReference(targetSR);
 
-        this.$iApi.geo.utils.proj.projectGeoJson(geoJson, srcProj, destProj);
+        await this.$iApi.geo.utils.proj.projectGeoJson(
+            geoJson,
+            srcProj,
+            destProj
+        );
 
         // terraformer has no support for non-wkid layers. can also do funny things if source is 102100.
         // use 8888 as placehold then adjust below


### PR DESCRIPTION
Donethankses #200 , #533 , #553

- makes `projectGeoJson` async and now performs checks / lookups on the spatial references
- adds the Fixture Added event, makes Iklob sample use it to load better
- makes the layer tree search functions a tiny bit more efficient

No real way to test since everything is in the guts. I did some console log checks locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/564)
<!-- Reviewable:end -->
