### PR TITLE
Remove custom layer interfaces

### DIFF
--- a/packages/ramp-core/src/geo/api/index.ts
+++ b/packages/ramp-core/src/geo/api/index.ts
@@ -29,4 +29,6 @@ export * from './utils/promise';
 export * from './utils/shared-utils';
 export * from './utils/projection';
 export * from './geo-defs';
-export * from './layer/layer-base';
+
+// CUSTOM-LAYER
+// export * from './layer/layer-base';

--- a/packages/ramp-core/src/geo/api/layer/layer-base.ts
+++ b/packages/ramp-core/src/geo/api/layer/layer-base.ts
@@ -9,6 +9,9 @@
 // they probably won't have access to "class" LayerInstance when using compiled RAMP (raw javascript).
 // this pattern is stolen from the fixture class model.
 
+// CUSTOM-LAYER
+
+/*
 import {
     AttributeSet,
     Extent,
@@ -107,3 +110,4 @@ export interface LayerBase {
         layerIdx: number | string | undefined
     ): void;
 }
+*/


### PR DESCRIPTION
Donethankses #569 

Comments out stuff that supports adding custom layer definitions, so we are not locked into that after doing a v1 release.

Also cleans up some rubbish comments.

Testing is just seeing that the layers load, interact as usual. [Demo](http://ramp4-app.azureedge.net/demo/users/james-rae/jamesparty/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/570)
<!-- Reviewable:end -->
