### PR TITLE
Legend reload UI

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -6,6 +6,7 @@ import { HelpAPI } from '@/fixtures/help/api/help';
 import { GridAPI } from '@/fixtures/grid/api/grid';
 import { WizardAPI } from '@/fixtures/wizard/api/wizard';
 import { LegendAPI } from '@/fixtures/legend/api/legend';
+import { LegendStore } from '@/fixtures/legend/store';
 import { MapClick, MapMove, RampBasemapConfig, ScreenPoint } from '@/geo/api';
 import { RampConfig } from '@/types';
 import { debounce, throttle } from 'throttle-debounce';
@@ -102,7 +103,9 @@ enum DefEH {
     MAP_SCALECHANGE_SCALEBAR = 'updates_map_caption_scale',
     OPEN_MAP_FEATURE_MAPTIP = 'open_feature_maptip',
     EXTENT_CHANGE_FEATURE_MAPTIP = 'updates_feature_maptip_extent_change',
-    MAP_UPDATE_CAPTION_COORDS = 'updates_map_caption_coords'
+    MAP_UPDATE_CAPTION_COORDS = 'updates_map_caption_coords',
+    LEGEND_REMOVES_LAYER_ENTRY = 'legend_removes_layer_entry',
+    LEGEND_RELOADS_LAYER_ENTRY = 'legend_reloads_layer_entry'
 }
 
 // private for EventBus internals, so don't export
@@ -357,7 +360,9 @@ export class EventAPI extends APIScope {
                 DefEH.MAP_SCALECHANGE_SCALEBAR,
                 DefEH.OPEN_MAP_FEATURE_MAPTIP,
                 DefEH.EXTENT_CHANGE_FEATURE_MAPTIP,
-                DefEH.MAP_UPDATE_CAPTION_COORDS
+                DefEH.MAP_UPDATE_CAPTION_COORDS,
+                DefEH.LEGEND_REMOVES_LAYER_ENTRY,
+                DefEH.LEGEND_RELOADS_LAYER_ENTRY
             ];
         }
 
@@ -624,6 +629,36 @@ export class EventAPI extends APIScope {
                                 );
                             });
                     }),
+                    handlerName
+                );
+                break;
+            case DefEH.LEGEND_REMOVES_LAYER_ENTRY:
+                zeHandler = (layer: LayerInstance) => {
+                    if (this.$iApi.$vApp.$store.hasModule('legend')) {
+                        this.$iApi.$vApp.$store.dispatch(
+                            LegendStore.removeLayerEntry,
+                            layer.uid
+                        );
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.LAYER_REMOVE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.LEGEND_RELOADS_LAYER_ENTRY:
+                zeHandler = (layer: LayerInstance) => {
+                    if (this.$iApi.$vApp.$store.hasModule('legend')) {
+                        this.$iApi.$vApp.$store.dispatch(
+                            LegendStore.reloadLayerEntry,
+                            layer.uid
+                        );
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.LAYER_RELOADED,
+                    zeHandler,
                     handlerName
                 );
                 break;

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -112,10 +112,10 @@ export class LegendAPI extends FixtureInstance {
             return;
         }
 
-        // TODO add name when #439 is done
         const entry = new LegendEntry(
             {
                 layerId: layer.id,
+                name: layer.getName(),
                 isDefault: true,
                 layers: this.$vApp.$store.get(LayerStore.layers)
             },

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -100,6 +100,22 @@
                 </svg>
                 {{ $t('legend.entry.controls.remove') }}
             </a>
+            <!-- Reload -->
+            <a
+                href="#"
+                class="flex leading-snug items-center w-auto"
+                :class="{
+                    disabled: !legendItem._controlAvailable(`reload`)
+                }"
+                @click="reloadLayer"
+            >
+                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                    <path
+                        d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                    ></path>
+                </svg>
+                {{ $t('legend.entry.controls.reload') }}
+            </a>
         </dropdown-menu>
     </div>
 </template>
@@ -191,6 +207,15 @@ export default class LegendOptionsV extends Vue {
             } else {
                 this.$iApi.geo.map.removeLayer(this.legendItem.uid!);
             }
+        }
+    }
+
+    /**
+     * Reloads a layer on the map.
+     */
+    reloadLayer() {
+        if (this.legendItem._controlAvailable(Controls.Reload)) {
+            this.legendItem.layer!.reload();
         }
     }
 }

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -34,33 +34,10 @@ class LegendFixture extends LegendAPI {
             () => this.config,
             (value: any) => this._parseConfig(value)
         );
-
-        this.$iApi.event.on(
-            GlobalEvents.LAYER_REMOVE,
-            (layer: LayerInstance) => {
-                this.$iApi.$vApp.$store.dispatch(
-                    LegendStore.removeLayerEntry,
-                    layer.uid
-                );
-            },
-            'legend_removes_layer_entry'
-        );
-
-        this.$iApi.event.on(
-            GlobalEvents.LAYER_RELOADED,
-            (layer: LayerInstance) => {
-                this.$iApi.$vApp.$store.dispatch(
-                    LegendStore.reloadLayerEntry,
-                    layer.uid
-                );
-            }
-        );
     }
 
     removed() {
         this.$vApp.$store.unregisterModule('legend');
-
-        this.$iApi.event.off('legend_removes_layer_entry');
     }
 }
 

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -45,6 +45,16 @@ class LegendFixture extends LegendAPI {
             },
             'legend_removes_layer_entry'
         );
+
+        this.$iApi.event.on(
+            GlobalEvents.LAYER_RELOADED,
+            (layer: LayerInstance) => {
+                this.$iApi.$vApp.$store.dispatch(
+                    LegendStore.reloadLayerEntry,
+                    layer.uid
+                );
+            }
+        );
     }
 
     removed() {

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -20,3 +20,4 @@ legend.entry.controls.settings,Settings,1,Paramètres,1
 legend.entry.controls.datatable,Datatable,1,Tableau de données,1
 legend.entry.controls.symbology,Legend,1,Légende,1
 legend.entry.controls.remove,Remove,1,Retirer,1
+legend.entry.controls.reload,Reload,1,Recharger,1

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -135,7 +135,7 @@ const actions = {
     removeLayerEntry: (context: LegendContext, uid: string) => {
         context.commit('REMOVE_LAYER_ENTRY', uid);
     },
-    /** Reload layer's corresponding entry from the store */
+    /** Reload layer's corresponding legend entry */
     reloadLayerEntry: (context: LegendContext, uid: string) => {
         context.commit('RELOAD_LAYER_ENTRY', uid);
     },


### PR DESCRIPTION
Legend reloading, works basically the same as remove. #503

Legend dropdown button to trigger reload; default handler listens for `reload` event and tells legend store to change the entry to its `placeholder` state.

Not too sure about `event.ts` accessing the legend store, might make sense to wrap the store calls and put it under `LegendAPI`?

[demo](http://ramp4-app.azureedge.net/demo/users/an-w/legend/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/571)
<!-- Reviewable:end -->
