### PR TITLE
Add optional chaining to some elements and tippy

### DIFF
--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -174,7 +174,7 @@ class FocusListManager {
             (item as any)._tippy.hide();
         }
         if (item.getAttribute(ITEM_ATTR) === SHOW_TRUNCATE) {
-            (item.querySelector(`[${TRUNCATE_ATTR}]`)! as any)._tippy.hide();
+            (item.querySelector(`[${TRUNCATE_ATTR}]`)! as any)?._tippy?.hide();
         }
     }
 
@@ -191,7 +191,7 @@ class FocusListManager {
             (item as any)._tippy.show();
         }
         if (item.getAttribute(ITEM_ATTR) === SHOW_TRUNCATE) {
-            (item.querySelector(`[${TRUNCATE_ATTR}]`)! as any)._tippy.show();
+            (item.querySelector(`[${TRUNCATE_ATTR}]`)! as any)?._tippy?.show();
         }
     }
 
@@ -391,7 +391,7 @@ class FocusListManager {
             ) {
                 (this.highlightedItem.querySelector(
                     `[${TRUNCATE_ATTR}]`
-                )! as any)._tippy.show();
+                )! as any)?._tippy?.show();
             }
         }
 
@@ -425,7 +425,7 @@ class FocusListManager {
             ) {
                 (this.highlightedItem.querySelector(
                     `[${TRUNCATE_ATTR}]`
-                )! as any)._tippy.hide();
+                )! as any)?._tippy?.hide();
             }
         }
     }


### PR DESCRIPTION
Adds typescript optional chaining operators to some elements and tippy to prevent errors being thrown.

[Demo](http://ramp4-app.azureedge.net/demo/users/milespetrov/558-panel-errors/host/index.html)
Closes #558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/572)
<!-- Reviewable:end -->
