### PR TITLE
EPSG lookup customize function

### DIFF
--- a/packages/ramp-core/src/api/index.ts
+++ b/packages/ramp-core/src/api/index.ts
@@ -10,11 +10,6 @@ declare const __VERSION__: AppVersion;
 // install/register mixin plugin with Vue, so it's available on all Vue instances
 Vue.use(mixin);
 
-// TODO some of the stateless geoapi stuff needs to be still available.
-//      e.g. we need default LODs to be there before an instance is created.
-//      might as well make the geometry stuff available too? We can always expose later.
-//      The files that expose this will need to be in classes that do not require a an instance on the constructor
-
 export interface APIInterface {
     Instance: typeof InstanceAPI;
 
@@ -26,13 +21,13 @@ export interface APIInterface {
      */
     version: AppVersion;
 
+    /**
+     * Common Geo classes and utilities not tied to a RAMP instance
+     */
     GEO: GeoCommonAPI;
 }
 
-// Load geoapi
-// moved from `main-build` since it was being attached to the api object anyways
-// TODO revist this after no-dojo migration. this approach might be dumb without geoapi promise
-let geocommon: GeoCommonAPI = new GeoCommonAPI(); // TODO: pass in EpsgLookup function here if there is one
+let geocommon: GeoCommonAPI = new GeoCommonAPI();
 
 const api: APIInterface = {
     Instance: InstanceAPI,

--- a/packages/ramp-core/src/geo/api/geo-common.ts
+++ b/packages/ramp-core/src/geo/api/geo-common.ts
@@ -2,7 +2,6 @@
 
 import {
     Extent,
-    EpsgLookup,
     GeometryAPI,
     LinearRing,
     LineString,
@@ -44,8 +43,8 @@ export class GeoCommonAPI {
     geom: GeometryAPI;
     sharedUtils: SharedUtilsAPI;
 
-    constructor(epsgFunction: EpsgLookup | undefined = undefined) {
-        this.proj = new ProjectionAPI(epsgFunction);
+    constructor() {
+        this.proj = new ProjectionAPI();
         this.geom = new GeometryAPI();
         this.sharedUtils = new SharedUtilsAPI();
     }

--- a/packages/ramp-core/src/geo/api/utils/projection.ts
+++ b/packages/ramp-core/src/geo/api/utils/projection.ts
@@ -22,12 +22,8 @@ const latLongProj = 'EPSG:4326';
 export class ProjectionAPI {
     protected espgWorker: EpsgLookup;
 
-    constructor(epsgFunction: EpsgLookup | undefined = undefined) {
-        if (epsgFunction) {
-            this.espgWorker = epsgFunction; // override with client-defined function
-        } else {
-            this.espgWorker = this.defaultEpsgLookup;
-        }
+    constructor() {
+        this.espgWorker = this.defaultEpsgLookup;
 
         // cook in useful things to proj4 that won't be available via epsgLookup
         proj4.defs(
@@ -102,8 +98,27 @@ export class ProjectionAPI {
         });
     }
 
+    /**
+     * Fetch a projection string from an EPSG service
+     * @param { String | Number } code an EPSG projection code to look up
+     * @returns { Promise<String> } resolves with proj4 projection string, or rejects if not found
+     */
     epsgLookup(code: string | number): Promise<string> {
         return this.espgWorker(code);
+    }
+
+    /**
+     * Provide an alternate lookup function to find proj4 projection strings based off EPSG codes. Be aware this setting
+     * is page-wide, and will impact any instance of RAMP running.
+     * Function signature should be `f(code: string | number): Promise<string>`.
+     * The function should be able to parse codes that are
+     * - just the integer part of an EPSG code (e.g. 1234)
+     * - a string in EPSG format (e.g. 'EPSG:1234')
+     * - a string in URN format (e.g. 'urn:ogc:def:crs:EPSG::1234')
+     * @param lookupFunction
+     */
+    setEpsgLookup(lookupFunction: EpsgLookup): void {
+        this.espgWorker = lookupFunction;
     }
 
     /**

--- a/packages/ramp-core/src/geo/geo.ts
+++ b/packages/ramp-core/src/geo/geo.ts
@@ -28,7 +28,7 @@ export class GeoAPI extends APIScope {
         super(iApi);
 
         this.map = new MapAPI(iApi);
-        this.utils = new UtilsAPI(iApi); // TODO add the EPSG function parameter here. probably needs to get passed to GeoAPI constructor
+        this.utils = new UtilsAPI(iApi);
         this.layer = new LayerAPI(iApi);
     }
 }

--- a/ramp4-pcar4.code-workspace
+++ b/ramp4-pcar4.code-workspace
@@ -8,9 +8,6 @@
             "path": "packages/ramp-core"
         },
         {
-            "path": "packages/ramp-geoapi"
-        },
-        {
             "path": "packages/ramp-locale-loader"
         },
         {


### PR DESCRIPTION
Donethankses #576 

A way to test. [DEMO LINK](http://ramp4-app.azureedge.net/demo/users/james-rae/jamesparty/host/index.html)
Load ramp page.  In console, enter.

```
RAMP.GEO.proj.setEpsgLookup(()=> { console.log('I AM FANCY'); return Promise.resolve('+proj=aea +lat_1=42.122774 +lat_2=49.01518 +lat_0=45.568977 +lon_0=-84.455955 +x_0=1000000 +y_0=1000000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs'); });
```

Then create a text file with `.json` extension, containing

```
{
  "type": "FeatureCollection",
  "crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::3174"}},
  "features": [
    {
      "type": "Feature",
      "properties": {"name":"4905 Duffers"},
      "geometry": {
        "type": "Point",
        "coordinates": [
          1400729.1329429878,
          813466.9383310359
        ]
      }
    }
  ]
}
```

Load the file via the wizard (as GeoJSON).
Should see `I AM FANCY` in the console, and a point appear at the Downsview office

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/577)
<!-- Reviewable:end -->
