### PR TITLE
Clean up sample pages and add basemap copyright fetching

### DIFF
--- a/packages/ramp-core/host/index-e2e.html
+++ b/packages/ramp-core/host/index-e2e.html
@@ -23,10 +23,8 @@
         <!-- loading main RAMP file; this needs to be loaded after Vue -->
         <script src="./../dist/RAMP.umd.js"></script>
     </head>
-    <body>
+    <body style="margin: 0;">
         <div id="app"></div>
-
-        <span id="ramp-version"></span>
 
         <script>
             // get RAMP "starter" script from url param

--- a/packages/ramp-core/host/index.html
+++ b/packages/ramp-core/host/index.html
@@ -16,7 +16,7 @@
         <!-- loading main RAMP file; this needs to be loaded after Vue -->
         <script src="./../dist/RAMP.umd.js"></script>
     </head>
-    <body>
+    <body style="margin: 0;">
         <noscript>
             <strong
                 >We're sorry but ramp-core doesn't work properly without
@@ -25,8 +25,6 @@
         </noscript>
         <div id="IE"></div>
         <div id="app"></div>
-
-        <span id="ramp-version"></span>
 
         <script src="./../dist/alternate.js"></script>
         <script src="./../dist/ramp-starter.js"></script>

--- a/packages/ramp-core/public/index-e2e.html
+++ b/packages/ramp-core/public/index-e2e.html
@@ -17,13 +17,11 @@
 
         <!-- RAMP will be injected here -->
     </head>
-    <body>
+    <body style="margin: 0;">
         <!-- this fixture will load after RAMP (and Vue) are loaded (since Vue is bundled with RAMP in `dev`); `iklob` requires Vue to be exposed on the global scope -->
         <script src="../sample-fixtures/iklob-fixture.js"></script>
 
         <div id="app"></div>
-
-        <span id="ramp-version"></span>
 
         <script>
             // get RAMP "starter" script from url param

--- a/packages/ramp-core/public/index.html
+++ b/packages/ramp-core/public/index.html
@@ -13,7 +13,7 @@
 
         <!-- RAMP will be injected here -->
     </head>
-    <body>
+    <body style="margin: 0;">
         <style>
             #instance-language {
                 margin-left: 20px;
@@ -26,16 +26,10 @@
                 JavaScript enabled. Please enable it to continue.</strong
             >
         </noscript>
-        <button id="animate-status" onclick="animateToggle()">
-            Animate: on
-        </button>
-        <button onclick="switchLang()">Switch language</button
-        ><span id="instance-language"></span>
 
         <div id="IE"></div>
         <div id="app"></div>
 
-        <span id="ramp-version"></span>
         <!-- built files will be auto injected -->
 
         <script src="./alternate.js"></script>

--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -2,17 +2,18 @@ window.rInstance = null;
 
 console.log('RAMP has loaded.');
 
-document.getElementById('ramp-version').innerText =
-    'v.' +
-    RAMP.version.major +
-    '.' +
-    RAMP.version.minor +
-    '.' +
-    RAMP.version.patch +
-    ' [#' +
-    RAMP.version.hash.slice(0, 6) +
-    ']  -  built on ' +
-    new Date(RAMP.version.timestamp).toLocaleDateString();
+// TODO: Location for version string needs to be finalized
+// document.getElementById('ramp-version').innerText =
+//     'v.' +
+//     RAMP.version.major +
+//     '.' +
+//     RAMP.version.minor +
+//     '.' +
+//     RAMP.version.patch +
+//     ' [#' +
+//     RAMP.version.hash.slice(0, 6) +
+//     ']  -  built on ' +
+//     new Date(RAMP.version.timestamp).toLocaleDateString();
 
 let config = {
     en: {
@@ -41,13 +42,10 @@ let config = {
                     ],
                     attribution: {
                         text: {
-                            value: 'Custom attribution thanks'
+                            disabled: true
                         },
                         logo: {
-                            altText: 'custom logo alt text',
-                            value:
-                                'https://cdn.iconscout.com/icon/free/png-256/google-2981831-2476479.png',
-                            link: 'https://www.google.ca/'
+                            disabled: true
                         }
                     }
                 }
@@ -224,13 +222,10 @@ let config = {
                     ],
                     attribution: {
                         text: {
-                            value: 'Merci d’attribution personnalisés'
+                            disabled: true
                         },
                         logo: {
-                            altText: 'custom logo alt text',
-                            value:
-                                'https://cdn.iconscout.com/icon/free/png-256/google-2981831-2476479.png',
-                            link: 'https://www.google.ca/'
+                            disabled: true
                         }
                     }
                 }

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -1,17 +1,18 @@
 window.rInstance = null;
 document.title = 'Panel Party';
 
-document.getElementById('ramp-version').innerText =
-    'v.' +
-    RAMP.version.major +
-    '.' +
-    RAMP.version.minor +
-    '.' +
-    RAMP.version.patch +
-    ' [#' +
-    RAMP.version.hash.slice(0, 6) +
-    ']  -  built on ' +
-    new Date(RAMP.version.timestamp).toLocaleDateString();
+// TODO: Location for version string needs to be finalized
+// document.getElementById('ramp-version').innerText =
+//     'v.' +
+//     RAMP.version.major +
+//     '.' +
+//     RAMP.version.minor +
+//     '.' +
+//     RAMP.version.patch +
+//     ' [#' +
+//     RAMP.version.hash.slice(0, 6) +
+//     ']  -  built on ' +
+//     new Date(RAMP.version.timestamp).toLocaleDateString();
 
 let config = {
     en: {

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -7,7 +7,13 @@ import { GridAPI } from '@/fixtures/grid/api/grid';
 import { WizardAPI } from '@/fixtures/wizard/api/wizard';
 import { LegendAPI } from '@/fixtures/legend/api/legend';
 import { LegendStore } from '@/fixtures/legend/store';
-import { MapClick, MapMove, RampBasemapConfig, ScreenPoint } from '@/geo/api';
+import {
+    Attribution,
+    MapClick,
+    MapMove,
+    RampBasemapConfig,
+    ScreenPoint
+} from '@/geo/api';
 import { RampConfig } from '@/types';
 import { debounce, throttle } from 'throttle-debounce';
 import { MapCaptionStore } from '@/store/modules/map-caption';
@@ -530,15 +536,8 @@ export class EventAPI extends APIScope {
                         .getConfig()
                         .map.basemaps.find(bms => bms.id === payload);
 
-                    if (
-                        !currentBasemapConfig ||
-                        !currentBasemapConfig.attribution
-                    ) {
-                        return;
-                    }
-
                     this.$iApi.geo.map.updateAttribution(
-                        currentBasemapConfig.attribution
+                        currentBasemapConfig?.attribution
                     );
                 };
                 this.$iApi.event.on(
@@ -556,15 +555,8 @@ export class EventAPI extends APIScope {
                             bms.id === this.$iApi.geo.map.getCurrentBasemapId()
                     );
 
-                    if (
-                        !currentBasemapConfig ||
-                        !currentBasemapConfig.attribution
-                    ) {
-                        return;
-                    }
-
                     this.$iApi.geo.map.updateAttribution(
-                        currentBasemapConfig.attribution
+                        currentBasemapConfig?.attribution
                     );
                 };
                 this.$iApi.event.on(

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -51,7 +51,7 @@ export default class App extends Vue {
 @use 'directives/focus-list/focus-list';
 .ramp-app {
     @include focus-list.default-focused-styling;
-    height: 700px;
+    height: 100vh;
 }
 .symbologyIcon {
     @apply bg-white inline-flex justify-center items-center overflow-hidden;

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -30,7 +30,7 @@
 
         <!-- TODO: find out if any ARIA attributes are needed for the map scale -->
 
-        <span class="flex-shrink-0 relative top-1 pr-14">
+        <span class="flex-shrink-0 relative top-1 pr-14 pl-14">
             {{ cursorCoords }}
         </span>
 

--- a/packages/ramp-core/src/geo/map/maptip.ts
+++ b/packages/ramp-core/src/geo/map/maptip.ts
@@ -74,13 +74,9 @@ export class MaptipAPI extends APIScope {
         // Update the content
         // TODO: Update to custom templates when they are implemented
         this.setContent(
-            `<b style="color: yellow">✨ ${layerInstance.getName(
+            `${graphicIconSVG}<br><b>${layerInstance.getName(
                 graphicHit.layerIdx
-            )} ✨</b><br>${graphicIconSVG}<br><b>OID: ${
-                graphicHit.oid
-            }</b> | <b>LayerID: ${graphicHit.layerId}</b> | <b>LayerIdx: ${
-                graphicHit.layerIdx
-            }</b>`
+            )}</b><br>ObjectID: ${graphicHit.oid}`
         );
     }
 

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -29,7 +29,7 @@ import {
     ScaleSet,
     SpatialReference
 } from '@/geo/api';
-import { EsriGraphic, EsriLOD, EsriMapView } from '@/geo/esri';
+import { EsriGraphic, EsriLOD, EsriMapView, EsriTileLayer } from '@/geo/esri';
 import { LayerStore } from '@/store/modules/layer';
 import { MapCaptionStore } from '@/store/modules/map-caption';
 
@@ -125,6 +125,9 @@ export class MapAPI extends CommonMapAPI {
                 filterKey: CoreFilterKey.EXTENT
             });
         });
+
+        // Rewove all ui components
+        this.esriView.ui.components = [];
 
         this.esriView.watch('scale', (newval: number) => {
             this.$iApi.event.emit(GlobalEvents.MAP_SCALECHANGE, newval);
@@ -506,43 +509,97 @@ export class MapAPI extends CommonMapAPI {
      *
      * @param {Attribution} newAttribution incoming new attribution
      */
-    updateAttribution(newAttribution: Attribution): void {
-        if (!newAttribution) {
+    updateAttribution(newAttribution: Attribution | undefined): void {
+        if (!this.esriView || !this.esriMap) {
+            this.noMapErr();
             return;
         }
 
-        // Reset the attribution
+        // Default attribution
         let attribution: Attribution = {
             text: { value: 'Powered by ESRI' },
             logo: {
                 altText: 'ESRI logo',
-                link: 'http://www.esri.com/',
+                link: 'https://www.esri.com/',
                 value:
                     'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEEAAAAkCAYAAADWzlesAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAADO9JREFUeNq0Wgl0jlca/pfvzyo6qNBSmhLLKE1kKEUtB9NTat+OYnBacwwJY19DZRC7sR41th60lWaizFSqRTOEw0lsrQSJGFIESSxJ/uRfv3nef+7Vt9f3p2E695z3fMt97/3ufe+7PO+9n9n0UzELsjKyiHdUdMZnVHTl2VyFe9nO7Kc/Io+4epUxmpWxeVkbr3hvUebgFf15GL9XUwZHndtAAYI09jGvIghOuoEwLOLeYiBoXrwGfZjYYOWAvWyMGlsk2YebXeV3NUEW1qcT5BBX4jUbCYEmHwwKEfdW1gEXgoWtiIlNRFeezcrkrQaTNSuraRYDdImrR1ylAALZBPnkXIJ0wRskeG2Cj3jsoFI2HhcfDDFWA9UBNdZZyc/PP4Z3HZYsWTLGbrffond0Xb9+/Qy6P3jw4F+HDx8+mu7XrVs3c+7cuX+i+3nz5o3n/Rw4cGAdf/7hhx9SZ8yYEcffHT9+/G/8uaSkJGvDhg3D8P3moNdXrlw5UtYVFxfnXL9+/V8PHz68grr2N2/eTC4tLb2E+9+Cotq1a/dOenr6njt37nxPdOrUqd0dO3bsjromoHBQKBPkEyFUB71MH6SPbNy4cRqfkMvlenzixImtqO/x3XffbXc6nSW5ubnpOTk5J1NTU/cQH91//fXXu3/88ccLy5cvj6d34B8gaBA9JyQk/OWjjz5aIu8Fz2DiWbZs2QLx/A4m0Qf9f/n48eNsPEeDfrdly5Y/U31UVNT7dJ04ceIsGseNGzfS6DkuLq4v8YE6Y/G+93g8XKZ6QUHBRVHfAPQC0xJfCRAv65EkeUP6gFx11JEkfw/qTc8ff/zxKofDUXrv3r08rOIBeU9CWbx48SLej5y4LGlpaf9YuHDhUv5OtqH+6Vty0riPAbWjheH8n3322VYpuG+//Xa5mGB7CGM8hKN7vV5dLfHx8WNI20E1aN4WP97YZyc7d+6MM5vNHRs2bDg3NjY23e12l5w8eZJWzIUJ9IdmlI4bNy4tICAgtHbt2hGdOnXaSe3oftu2bWmBgYFOn3MwmwcQLViwIJOeYVYJGGAZVuW2zWZzCZ6hoIGapnmknUMTQnr16vUeTOKydHqyHrx9t27dunro0KEfzJw5M4Pe3bp166Z0pHXr1g0Fj2EYCw8PD+N+SjNwUuSAKnxexOkswOWxZN63b9/MAQMGzIUwx5WXl99eunTpFLx+hJU/K9o/yM7OPhgZGdk5KSkpp0WLFv+Vrq7/na5nz57dR1dM6t7hw4e3DRkyJG7WrFlxgudzukIw58TzV3SF3Z+ByUzFbTk5O9j8fVH/JV3PnTv3uRijSdSR5/empKRkT5kypQxCC+UTxMKVQXuyWBT5WbiS4VFjIZLHWQsLN1ZFgFbm0U1KSNWUUMlDp9kAh0iNdCkRwiva2FjUsjJeJ5sYRYQwCGIYNGk8tC1UCuDQoUOb+vbtuxuPRUJ4FVwIFhZ7pUD45OXEbUpo9DIz8hgAFk0BORblWypm8BiQzkKnpoRnM+PxsEWhiYfFxMTUHTx4cDOYhg7tzM7IyLhNCiYEUEbCMxsAGYuCGjl4ClKE4GY+xCnIw95zBKqxvmyCOJqT7dws5ntZzLcoaJEjQiPUahMaESzudWEqhBEeiSuZvUvzA1+lxIMEhbD7QGYKUl0rBAgxC9vlq6IzNZZ9BYt+rMw8pBDLmSZZFBPQmBC8imaofo1roa5oKH82aQaaIH0CDTZM0sCBAxvBKbZ+7bXXGr3yyisN4ZjMDx48uAeAkofQdHbt2rUXhIpJKevMJwSLfqq3bt365enTp3eFh365SZMmBGpMFRUVZcAV1wFmzs2ZMyddtCkXk9ESExOjq1Wr9iLCbwAilA9xwrnlwimS4G2ffvppj1atWrWoWbNmbWCKAtj9V5MnT84cMWJEvTfeeKM+wqSFzCEoKMgJ3HEVgO6SkTlKMwgUgImwArn2DpMmTYrDALP0XyjEA9sbjTZtQZGij7qghqBWoK4AWPswkbLK+qHIsWPHjoXgfwvUhsZAAEflg+dfg0kuBlosUuvoO2jXl65qXWZm5g7UNRPIOIQLQqpcmECMJIAuRp1UVmiCACmTxAReFx+LhnPqV1hY+O9n6evIkSObSXCEHI0WASDtMMJ0uVHb7du3E6p9HxpxQK0DjN4r0Gc9kSZYeZiSNkuaUOv06dPTO3fuPNj0DAWgKWTFihVL+vfvT0J8kfohAsobV6tWrYbP0hf460pnLE2AF2jB21DvIKO2gO6FNB+ERJtaB+xjY37NN3+LogmkHi9s2rTp3bZt277LG8NuK5AopXbv3n0O7Gtsjx49ZmNye6GOD1RBwD9MFUKoSQSc30UdzJUrV26uWrVqP7D/lt27d+9/9OhRMas7gjYbhROzkv9R2wcHBwdWshjkYL1G7SBQTXGwTwQQLLIqWsGeGFAhVyFSO6C7Naj7ADRUJENDQGMjIiLmQl0LVLUbNWrUItSPhBNcodYhFyFklwAiYf0RNKZZs2YfFhUVXYcAvhFm0FFc++fl5eX4Mxto7JnRo0cvID4yHWSz70dHRw+khAxZ6yGVH8ndftS9DWokciWNx15fTN2zZ0+f6tWr1+LS279/fwYgcz4LPzJvdyGVLUFidFiVOIRAqx8KlQysZCdKboJUXL58uRAmMLFp06aLRbh1cGhrVEiD3nzzzTXIcU5R6gC6vXfv3kuIGgSIyq1Wq6cqpmdhiNAXFtu0adNeZVq9enUWA0xywyVECC4AicwttQ2SrvpkYnfv3i1X6xo0aPAiJv2H+fPnt27UqFEN4YsCDBCk33Lt2rW8kSNHJuP2LqUc4kq+4KFAgg6LxeKtSl+a4hMC6tSp85QD27VrVy9I1U2SJaKYS/ZG8Rf5uhVXq91ud4aEhATINo0bN46glUQMv4aQV46MMpj3iRVvsGjRohFEENQtygCRmZ5B6DsqNNPFANJT5cyZM5RoPRBE/qREaJYEYm4aZ1WFwDG9ppoClebNm9czPV/xYXOo6J4xY8Z84I8Jgq9HBCDVfsKECR+mpqZ+gSQnRVQHGTm4CxcuXBP9l4qrneUNPtheVSFYKtkF/jUKqWbx2LFjUxBJViA82asSZvv06TPq+PHjE/D4GzI70jiVT+xDyBzDo8DhZyoWNXsD4Cn/FYVQLKgIofCfMIkhgKyr4bhO8pBoVGgvsEuXLq+SEIw0Qayyl5H+vIPUmJf2ZYOwz5twXE05U/369TfBZu+wvMBpkH7L3dwyYZ+l4uoRPL50FzCcQuAJstvIyMjacG5Rw4YN64b7V9XBxcbGdgJq/cZIE4TT0/2ceTyzJsiMj0JSxfnz50+rTECBUUq2aGd2WC7Izib+WFwdLJs0sczT1w+Q3d34+PhTSKQ2w4GeVL9LTtefY1Q2YEz/qxC8LIe3f/LJJ2kqU79+/WIGDRpUj+0L8N0lG7B6N+QGiS1btgxR9ha8gi949uzZ0UiENgBSR4iQyFNiL0zkrh+V/78XfjJDq1aWnJx85dixY8kqRE1KSopNSUkZ0K1btwjhsGpMmzatbVZW1nTy/JQbQHUXA26HMRul/gOQHkcBUK1BBGiJFHgtcMV7YqeXeEM7dOhQB4lXh6dCS1kZaZbDSBjinV6ZhsBkdAMz0o00SO4hhIrUl7K/7vfv37+hP0eBw8tBftFRpNNNExMThyMqlKp8SEXsADy5t1GM+qF6CHwe+hifm5t7Ta1PSEiYj7rWIhsMZaCPEkDyL+2PHj36hdqO3lGd4KkuYbN0jC5h22TPRT179pwCZ5j9rKqF0FWtd+/eL0kBA9Y2kRudvBB4og2al1CM+iFsgQFfJTCkaZrboL2DhUfd4NjAadROvHPyvUsLayxNghxaMWw0D1EhFiguqSrxXWZ/EN7IyZMnX5QHn127dk0Gxo+nnd6q9EHf2rx58zJgC1oxSrQKgR1cKl9YWJhdOFg329TlC1oBM3YYZJ8OubcozVZTJPjkzEEwOBGr1yIr+xz23xX23i48PPxVjiqRQV6GRuetXLkSbiPpCsPuTulzEAYPAh+cnzp1ao+YmJi31D5gevkwo3sZGRmn0M+RzMzMAhFtaGG0ixcvfpmfn39WbpNBC1zILK8KHqdykCsXszQ7O/sE8WMBNKGlbrxLF1HsSeQyV5JQBSrJUghLdDQmKB46ywTJFTKzfqqxftScwM1OjGXY/Vl0UU7IHcq3XMrutkz0QsX3bOwEWo5TfsNj9hMxjP5VCFR2fPl/AS4xMH7u71X6CWR92JQjer5t72AHLrpyKGRRhKbCZrNybhJg8HvBU+385Qv8DMKi/BjBEaKuHJK42YDU/x789cFhu1s5cFH/hTAp3/UqhzMm5cTM6G8br/qnyi8lTWYDoZiUP1TUEyc1Ble1D5OSA+gG7U0GR3b+fhUy+kVIN0Kb/xFgANrk0XIqRaL0AAAAAElFTkSuQmCC'
             }
         };
 
-        // Check if attribution text is enabled
-        // Need to add OR (||) incase newAttribution value is undefined/empty
-        if (!newAttribution.text.disabled) {
-            attribution.text.value =
-                newAttribution.text.value || attribution.text.value;
+        if (newAttribution) {
+            // Check if attribution logo is enabled
+            if (!newAttribution.logo.disabled) {
+                // Need to add OR (||) incase newAttribution values are undefined/empty
+                attribution.logo.altText =
+                    newAttribution.logo.altText || attribution.logo.altText;
+                attribution.logo.link =
+                    newAttribution.logo.link || attribution.logo.link;
+                attribution.logo.value =
+                    newAttribution.logo.value || attribution.logo.value;
+            }
+
+            // Check if attribution text is enabled
+            if (!newAttribution.text.disabled) {
+                // Need to add OR (||) incase newAttribution value is undefined/empty
+                attribution.text.value =
+                    newAttribution.text.value || attribution.text.value;
+            }
+
+            // Update attribution
+            this.$iApi.$vApp.$store.set(
+                MapCaptionStore.setAttribution,
+                attribution
+            );
         }
 
-        // Need to add OR (||) incase newAttribution values are undefined/empty
-        if (!newAttribution.logo.disabled) {
-            attribution.logo.altText =
-                newAttribution.logo.altText || attribution.logo.altText;
-            attribution.logo.link =
-                newAttribution.logo.link || attribution.logo.link;
-            attribution.logo.value =
-                newAttribution.logo.value || attribution.logo.value;
-        }
+        // If the new attribution is undefined, or its text is disabled, pull text from copyright
+        if (!newAttribution || newAttribution.text.disabled) {
+            // Pull copyright text from basemap's baselayers
+            let copyrightText: string = '';
+            const loadTimeout: number = 5000;
+            const intervalTimeout: number = 20;
 
-        this.$iApi.$vApp.$store.set(
-            MapCaptionStore.setAttribution,
-            attribution
-        );
+            // Create load promises that resolve when the baseLayer loads or after a timeout
+            const baseLayerLoadPromises: Array<Promise<__esri.Layer | null>> = this.esriMap.basemap.baseLayers
+                .map((bl: __esri.Layer) => {
+                    return new Promise<__esri.Layer | null>((resolve, _) => {
+                        // Keep count of layer.load checks done so far
+                        let elapsedIntervals: number = 0;
+                        // The maximum number of layer.load checks we will do
+                        const maxIntervals: number =
+                            loadTimeout / intervalTimeout;
+
+                        let wait = setInterval(function() {
+                            if (bl.loaded && !bl.loadError) {
+                                clearInterval(wait);
+                                resolve(bl);
+                            } else if (elapsedIntervals > maxIntervals) {
+                                clearInterval(wait);
+                                resolve(null);
+                            }
+                            elapsedIntervals++;
+                        }, intervalTimeout);
+                    });
+                })
+                .toArray();
+
+            // Join all the copyright strings and update the attribution
+            Promise.all(baseLayerLoadPromises).then(baseLayers => {
+                copyrightText = baseLayers
+                    .filter((bl: any) => bl?.copyright)
+                    .map((bl: any) => bl.copyright)
+                    .join(' | ');
+
+                attribution.text.value =
+                    copyrightText || attribution.text.value;
+
+                // Update attribution
+                this.$iApi.$vApp.$store.set(
+                    MapCaptionStore.setAttribution,
+                    attribution
+                );
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Related issue: #549 

Changes in this PR:
- The sample pages have been cleaned up:
    - Removed white block at the bottom of the page
    - Removed animation/language config buttons and RAMP version text
        - Animation and language config buttons will be placed in the hamburger menu 
        - Version text will be moved to location agreed upon in discussion [#580]
    - Simplified the content for maptips
- Enhanced attribution code to display the `copyright` property of `basemap`  layers
    - ~~I noticed that the simpler sample pages (i.e.[ `basemap-only`](http://ramp4-app.azureedge.net/demo/users/sharvenp/549/host/index-e2e.html?script=basemap-only) or [`mapnav`](http://ramp4-app.azureedge.net/demo/users/sharvenp/549/host/index-e2e.html?script=mapnav)) do not show the contents of the map caption bar~~
    - ~~Not sure if this is a bug, or if it is not loaded in by the script~~
    - This is expected behavior since some of the starter scripts have `loadDefaultEvents` set to `false` ([#584](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/584#issuecomment-877189779))
  
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/549/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/579)
<!-- Reviewable:end -->
