### PR TITLE
Fix numeric filter placeholder text alignment

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <input
-            class="rv-min"
+            class="rv-min rv-input"
             style="width: 45%;"
             type="text"
             v-model="minVal"
@@ -9,7 +9,7 @@
             placeholder="min"
         />
         <input
-            class="rv-max"
+            class="rv-max rv-input"
             style="width: 45%;"
             type="text"
             v-model="maxVal"


### PR DESCRIPTION
Related issue: #466

Changes in this PR:
- Numeric filter now has the `rv-input` class, which seems to have pushed it slightly up and keeps it in-line with the other filter fields

[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/466/host/index.html)

To test:
- Load RAMP
- Open the grid for any layer with a numeric filter
- Numeric filter fields should be in-line with other filter fields
- Numeric filter should still be functional

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/581)
<!-- Reviewable:end -->
