### PR TITLE
Add throttle to map nav zoom buttons (and RAMP injection into WET template)

### DIFF
--- a/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/buttons/zoom-nav.vue
@@ -29,7 +29,7 @@
 
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
-
+import { throttle } from 'throttle-debounce';
 import DividerNavV from './divider-nav.vue';
 
 @Component({
@@ -38,13 +38,8 @@ import DividerNavV from './divider-nav.vue';
     }
 })
 export default class FullscreenNavV extends Vue {
-    zoomIn(): void {
-        this.$iApi.geo.map.zoomIn();
-    }
-
-    zoomOut(): void {
-        this.$iApi.geo.map.zoomOut();
-    }
+    zoomIn = throttle(400, true, () => this.$iApi.geo.map.zoomIn());
+    zoomOut = throttle(400, true, () => this.$iApi.geo.map.zoomOut());
 }
 </script>
 

--- a/packages/ramp-core/vue.config.js
+++ b/packages/ramp-core/vue.config.js
@@ -81,6 +81,9 @@ module.exports = {
             config
                 .plugin('html-test')
                 .tap(args => [{ ...args[0], inject: 'head' }]);
+            config
+                .plugin('html-wet')
+                .tap(args => [{ ...args[0], inject: 'head' }]);
         });
 
         // PROD-specific configuration


### PR DESCRIPTION
Related issue: #479

This bug is hard to reproduce, but using a little bit of `throttle`, it can be avoided.

Changes in this PR:
- Added a `400ms` throttle to the zoom buttons to avoid spamming
- **Updated `vue.config` to inject `RAMP` into the `index-wet` template**
    **- This is a bug @JahidAhmed noticed and I am pushing a fix along with this PR** 

[Demo zoom](http://ramp4-app.azureedge.net/demo/users/sharvenp/479/host/index.html)
[Demo WET template](http://ramp4-app.azureedge.net/demo/users/sharvenp/479/host/index-wet.html)

To test zoom:
- Load RAMP
- Spam the zoom buttons and check if the zoom buttons ever stop working
- Additionally, check if you are able to zoom during the zoom animation
    - If you are able to do this, then the `throttle` delay needs to be slightly increased

To test WET template:
- Load WET template for RAMP
- The map should load properly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/583)
<!-- Reviewable:end -->
