### PR TITLE
Grid improvements, tooltips

### DIFF
--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -24,13 +24,8 @@ Vue.use(VueFormulate);
 
 //TOOLTIPS
 //@ts-ignore
-import VueTippy, { TippyComponent } from 'vue-tippy';
-Vue.use(VueTippy, {
-    aria: 'labelledby',
-    a11y: false,
-    theme: 'ramp',
-    trigger: 'mouseenter manual focus'
-});
+import VueTippy, { TippyComponent, tippy } from 'vue-tippy';
+Vue.use(VueTippy);
 Vue.component('tippy', TippyComponent);
 
 @Component({
@@ -43,6 +38,18 @@ export default class App extends Vue {
         // let ResizeObserver observe the app div
         // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
         ro.observe(this.$el);
+
+        // Set tooltip defaults, theme does not get applied properly in prod builds if setting the defaults using vue-tippy
+        // This bypasses the wrapper and sets the defaults at the tippy.js level
+        tippy.setDefaults({
+            aria: 'labelledby',
+            // keeps tooltips from changing tabindex
+            a11y: false,
+            theme: 'ramp',
+            trigger: 'mouseenter manual focus',
+            // needed to have tooltips in fullscreen, by default it appends to document.body
+            appendTo: this.$el
+        });
     }
 }
 </script>

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -39,6 +39,8 @@
             @click="onScaleClick"
             :aria-pressed="scale.isImperialScale"
             :aria-label="$t('map.toggleScaleUnits')"
+            v-tippy="{ placement: 'top', hideOnClick: false }"
+            :content="$t('map.toggleScaleUnits')"
         >
             <span
                 class="border-solid border-2 border-white border-t-0 h-5 mr-2 inline-block"

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -11,7 +11,7 @@
                         : 'panels.controls.pin'
                 )
             "
-            v-tippy="{ placement: 'bottom' }"
+            v-tippy="{ placement: 'bottom', hideOnClick: false }"
         >
             <svg
                 class="fill-current w-16 h-16"

--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -29,7 +29,12 @@
                 <span class="flex-grow my-auto text-lg px-8">
                     {{ itemName }}
                 </span>
-                <button @click="zoomToFeature()" class="text-gray-600 m-8">
+                <button
+                    :content="$t('details.item.zoom')"
+                    v-tippy="{ placement: 'bottom' }"
+                    @click="zoomToFeature()"
+                    class="text-gray-600 m-8"
+                >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
                         height="20"

--- a/packages/ramp-core/src/fixtures/details/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/details/lang/lang.csv
@@ -3,3 +3,4 @@ details.title,Details,1,Détails,0
 details.layers.found,Found {numResults} results in {numLayers} layers,1,Figure {numResults} résultats en {numLayers} couches,0
 details.layers.loading,The layer is loading...,1,La couche est le chargement...,0
 details.results.empty,No results found for the selected layer.,1,Aucun résultat trouvé de la couche sélectionnée.,0
+details.item.zoom,Zoom to feature,1,Zoom à l'élément,1

--- a/packages/ramp-core/src/fixtures/geosearch/bottom-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/bottom-filters.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="rv-geosearch-bottom-filters">
         <div class="bg-white">
-            <label class="ml-8"
+            <label class="ml-8 cursor-pointer"
                 ><input
                     type="checkbox"
-                    class="form-checkbox border-2 mx-8 border-gray-600"
+                    class="form-checkbox border-2 mx-8 border-gray-600 cursor-pointer"
                     :checked="resultsVisible"
                     @change="updateMapExtent($event.target.checked)"
                 />{{ $t('geosearch.visible') }}</label

--- a/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/top-filters.vue
@@ -2,7 +2,7 @@
     <div class="rv-geosearch-top-filters flex w-full mt-16">
         <div class="inline-block w-2/5 h-40 ml-16">
             <select
-                class="form-select border-b border-b-gray-600 w-full h-auto py-0"
+                class="form-select border-b border-b-gray-600 w-full h-auto py-0 cursor-pointer"
                 :value="queryParams.province"
                 v-on:change="setProvince($event.target.value)"
             >
@@ -19,7 +19,7 @@
         </div>
         <div class="inline-block w-2/5 h-40 mx-16">
             <select
-                class="form-select border-b border-b-gray-600 w-full h-auto py-0"
+                class="form-select border-b border-b-gray-600 w-full h-auto py-0 cursor-pointer"
                 :value="queryParams.type"
                 v-on:change="setType($event.target.value)"
             >
@@ -32,9 +32,11 @@
             </select>
         </div>
         <button
-            class="inline-block flex text-gray-500 w-1/8 hover:text-black float-right"
+            class="inline-block flex text-gray-400 w-1/8 hover:text-black float-right disabled:cursor-default disabled:text-gray-400"
             :disabled="!queryParams.type && !queryParams.province"
             v-on:click="clearFilters"
+            :content="$t('geosearch.filters.clear')"
+            v-tippy="{ placement: 'bottom' }"
         >
             <div class="rv-geosearch-icon">
                 <svg class="fill-current w-18 h-18 mr-16" viewBox="0 0 23 21">
@@ -42,10 +44,6 @@
                         d="M 14.7574,20.8284L 17.6036,17.9822L 14.7574,15.1716L 16.1716,13.7574L 19.0178,16.568L 21.8284,13.7574L 23.2426,15.1716L 20.432,17.9822L 23.2426,20.8284L 21.8284,22.2426L 19.0178,19.3964L 16.1716,22.2426L 14.7574,20.8284 Z M 2,2L 19.9888,2.00001L 20,2.00001L 20,2.01122L 20,3.99999L 19.9207,3.99999L 13,10.9207L 13,22.909L 8.99999,18.909L 8.99999,10.906L 2.09405,3.99999L 2,3.99999L 2,2 Z "
                     />
                 </svg>
-                <span
-                    class="text-center text-white rounded absolute bg-gray-200 invisible group-hover:visible w-28 top-400 left-200 -ml-64 z-4"
-                    >{{ $t('geosearch.filters.clear') }}</span
-                >
             </div>
         </button>
     </div>

--- a/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
+++ b/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
@@ -23,7 +23,6 @@
                         ></path>
                     </g>
                 </svg>
-                {{ $t('grid.label.columns') }}
             </div>
         </template>
         <a

--- a/packages/ramp-core/src/fixtures/grid/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/grid/lang/lang.csv
@@ -1,11 +1,19 @@
 key,enValue,enValid,frValue,frValid
 grid.title,Features,1,Éléments,1
 grid.layer.loading,The layer is loading...,1,La couche est le chargement...,0
-grid.label.columns,Columns,1,Colonnes,0
-grid.label.filters,Filters,1,Filtres,0
+grid.label.columns,Hide columns,1,Masquer les colonnes,0
+grid.label.filters.show,Show filters,1,Afficher les filtres,1
+grid.label.filters.hide,Hide filters,1,Cacher les filtres,0
+grid.header.sort.0,Sort ascending,1,Trier par ordre ascendant,0
+grid.header.sort.1,Sort descending,1,Le tri descendant,0
+grid.header.sort.2,Sort default,1,Trier par défaut,0
+grid.header.reorder.left,Move left,1,Aller de gauche,0
+grid.header.reorder.right,Move right,1,Aller droit,0
 grid.filters.label.global,Search table,1,Tableau de recherche,0
 grid.filters.column.label.text,text,0,texte,0
 grid.filters.clear,Clear filters,1,Effacer les filtres,0
 grid.filters.label.info,{range} of {total} entries shown,1,Affichage de l'élément {range} sur {total} éléments,0
 grid.filters.label.filtered,(filtered from {max} total entries),1,(filtrés de {max} éléments au total),0
+grid.cells.zoom,Zoom to feature,1,Zoom à l'élément,1
+grid.cells.details,Details,1,Détails,1
 grid.button.title,Grid,1,Grille,0

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -31,8 +31,12 @@
                 <button
                     class="w-64"
                     @click="toggleShowFilters()"
-                    :content="$t('grid.label.filters')"
-                    v-tippy="{ placement: 'bottom' }"
+                    :content="
+                        gridOptions.floatingFilter
+                            ? $t('grid.label.filters.hide')
+                            : $t('grid.label.filters.show')
+                    "
+                    v-tippy="{ placement: 'bottom', hideOnClick: false }"
                 >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -50,7 +54,6 @@
                             ></path>
                         </g>
                     </svg>
-                    {{ $t('grid.label.filters') }}
                 </button>
             </div>
         </div>
@@ -74,8 +77,7 @@
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync } from 'vuex-pathify';
-import { GlobalEvents, LayerInstance } from '@/api/internal';
-import deepmerge from 'deepmerge';
+import { LayerInstance } from '@/api/internal';
 
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-material.css';
@@ -91,8 +93,9 @@ import GridCustomSelectorFilterV from './templates/custom-selector-filter.vue';
 import GridCustomDateFilterV from './templates/custom-date-filter.vue';
 import GridCustomHeaderV from './templates/custom-header.vue';
 
-import DetailsButtonRenderer from './templates/details-button-renderer.vue';
-import ZoomButtonRenderer from './templates/zoom-button-renderer.vue';
+// grid button templates
+import DetailsButtonRendererV from './templates/details-button-renderer.vue';
+import ZoomButtonRendererV from './templates/zoom-button-renderer.vue';
 
 // these should match up with the `type` value returned by the attribute promise.
 const NUM_TYPES: string[] = ['oid', 'double', 'integer'];
@@ -442,12 +445,12 @@ export default class GridTableComponentV extends Vue {
                 lockPosition: true,
                 isStatic: true,
                 maxWidth: 40,
-                cellStyle: (cell: any) => {
+                cellStyle: () => {
                     return {
                         padding: '0px'
                     };
                 },
-                cellRendererFramework: DetailsButtonRenderer,
+                cellRendererFramework: DetailsButtonRendererV,
                 cellRendererParams: {
                     uid: this.layerUid,
                     $iApi: this.$iApi
@@ -461,12 +464,12 @@ export default class GridTableComponentV extends Vue {
                 lockPosition: true,
                 isStatic: true,
                 maxWidth: 40,
-                cellStyle: (cell: any) => {
+                cellStyle: () => {
                     return {
                         padding: '0px'
                     };
                 },
-                cellRendererFramework: ZoomButtonRenderer,
+                cellRendererFramework: ZoomButtonRendererV,
                 cellRendererParams: {
                     uid: this.layerUid,
                     $iApi: this.$iApi,

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -91,6 +91,9 @@ import GridCustomSelectorFilterV from './templates/custom-selector-filter.vue';
 import GridCustomDateFilterV from './templates/custom-date-filter.vue';
 import GridCustomHeaderV from './templates/custom-header.vue';
 
+import DetailsButtonRenderer from './templates/details-button-renderer.vue';
+import ZoomButtonRenderer from './templates/zoom-button-renderer.vue';
+
 // these should match up with the `type` value returned by the attribute promise.
 const NUM_TYPES: string[] = ['oid', 'double', 'integer'];
 const DATE_TYPE: string = 'date';
@@ -439,26 +442,15 @@ export default class GridTableComponentV extends Vue {
                 lockPosition: true,
                 isStatic: true,
                 maxWidth: 40,
-                cellRenderer: (cell: any) => {
-                    return '<button><svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="16"><path d="M0 0h24v24H0z" fill="none"/><path d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg></button>';
-                },
                 cellStyle: (cell: any) => {
                     return {
-                        padding: '0px',
-                        paddingTop: '3px',
-                        textAlign: 'center',
-                        justifyContent: 'center',
-                        alignItems: 'center'
+                        padding: '0px'
                     };
                 },
-                onCellClicked: (cell: any) => {
-                    const fakeIdentifyItem = deepmerge({}, { data: cell.data });
-                    delete fakeIdentifyItem['data']['rvInteractive'];
-                    delete fakeIdentifyItem['data']['rvSymbol'];
-                    this.$iApi.event.emit(GlobalEvents.DETAILS_OPEN, {
-                        identifyItem: fakeIdentifyItem,
-                        uid: this.layerUid
-                    });
+                cellRendererFramework: DetailsButtonRenderer,
+                cellRendererParams: {
+                    uid: this.layerUid,
+                    $iApi: this.$iApi
                 }
             };
             colDef.push(detailsDef);
@@ -469,34 +461,16 @@ export default class GridTableComponentV extends Vue {
                 lockPosition: true,
                 isStatic: true,
                 maxWidth: 40,
-                cellRenderer: (cell: any) => {
-                    return '<button class="text-gray-600"><svg xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="16"><path d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/><path d="M0 0h24v24H0V0z" fill="none"/><path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"/></svg></button>';
-                },
                 cellStyle: (cell: any) => {
                     return {
-                        padding: '0px',
-                        paddingTop: '3px',
-                        textAlign: 'center',
-                        justifyContent: 'center',
-                        alignItems: 'center'
+                        padding: '0px'
                     };
                 },
-                onCellClicked: (cell: any) => {
-                    const layer: LayerInstance | undefined = this.getLayerByUid(
-                        this.layerUid
-                    );
-                    if (layer === undefined) return;
-                    const oid = cell.data[this.oidField];
-                    const opts = { getGeom: true };
-                    layer.getGraphic(oid, opts, this.layerUid).then(g => {
-                        if (g.geometry === undefined) {
-                            console.error(
-                                `Could not find graphic for objectid ${oid}`
-                            );
-                        } else {
-                            this.$iApi.geo.map.zoomMapTo(g.geometry, 50000);
-                        }
-                    });
+                cellRendererFramework: ZoomButtonRenderer,
+                cellRendererParams: {
+                    uid: this.layerUid,
+                    $iApi: this.$iApi,
+                    oidField: this.oidField
                 }
             };
             colDef.push(zoomDef);

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
@@ -25,7 +25,7 @@
 import { Vue, Component } from 'vue-property-decorator';
 
 @Component
-export default class GridCustomNumberFilterV extends Vue {
+export default class GridCustomDateFilterV extends Vue {
     beforeMount() {
         // Load previously stored values (if saved in table state manager)
         this.minVal =
@@ -122,7 +122,7 @@ export default class GridCustomNumberFilterV extends Vue {
     }
 }
 
-export default interface GridCustomNumberFilter {
+export default interface GridCustomDateFilter {
     minVal: any;
     maxVal: any;
     colDef: any;

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -5,7 +5,7 @@
                 @click="onSortRequested('asc', $event)"
                 :content="$t(`grid.header.sort.${sort}`)"
                 v-tippy="{ placement: 'top', hideOnClick: false }"
-                class="customHeaderLabel hover:bg-gray-300 font-bold p-8"
+                class="customHeaderLabel hover:bg-gray-300 font-bold p-8 max-w-full"
                 role="columnheader"
                 truncate-trigger
             >
@@ -13,6 +13,12 @@
                     {{ params.displayName }}
                 </div>
             </button>
+        </div>
+        <span v-else class="customHeaderLabel" role="columnheader" v-truncate>{{
+            params.displayName
+        }}</span>
+
+        <div v-if="sortable" class="flex">
             <span
                 v-if="params.enableSorting && sort === 1"
                 class="customSortDownLabel"
@@ -41,12 +47,6 @@
                     </svg>
                 </div>
             </span>
-        </div>
-        <span v-else class="customHeaderLabel" role="columnheader" v-truncate>{{
-            params.displayName
-        }}</span>
-
-        <div v-if="sortable">
             <button
                 :content="$t(`grid.header.reorder.left`)"
                 v-tippy="{ placement: 'top' }"

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -1,0 +1,45 @@
+<template>
+    <button
+        class="w-38 h-48"
+        :content="`open details`"
+        v-tippy="{ placement: 'right' }"
+        @click="buttonClicked()"
+    >
+        <svg
+            class="m-auto"
+            xmlns="http://www.w3.org/2000/svg"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+        >
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path
+                d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
+            />
+        </svg>
+    </button>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+import deepmerge from 'deepmerge';
+import { GlobalEvents } from '@/api/internal';
+
+@Component
+export default class DetailsButtonRendererV extends Vue {
+    params: any;
+
+    buttonClicked() {
+        const fakeIdentifyItem = deepmerge({}, { data: this.params.data });
+        delete fakeIdentifyItem['data']['rvInteractive'];
+        delete fakeIdentifyItem['data']['rvSymbol'];
+        this.$iApi.event.emit(GlobalEvents.DETAILS_OPEN, {
+            identifyItem: fakeIdentifyItem,
+            uid: this.params.uid
+        });
+    }
+}
+
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -1,8 +1,8 @@
 <template>
     <button
         class="w-38 h-48"
-        :content="`open details`"
-        v-tippy="{ placement: 'right' }"
+        :content="$t('grid.cells.details')"
+        v-tippy="{ placement: 'top' }"
         @click="buttonClicked()"
     >
         <svg
@@ -39,7 +39,6 @@ export default class DetailsButtonRendererV extends Vue {
         });
     }
 }
-
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -3,7 +3,7 @@
         class="w-38 h-48"
         :content="$t('grid.cells.details')"
         v-tippy="{ placement: 'top' }"
-        @click="buttonClicked()"
+        @click="openDetails"
     >
         <svg
             class="m-auto"
@@ -29,7 +29,25 @@ import { GlobalEvents } from '@/api/internal';
 export default class DetailsButtonRendererV extends Vue {
     params: any;
 
-    buttonClicked() {
+    mounted() {
+        // need to hoist events to top level cell wrapper to be keyboard accessible
+        this.params.eGridCell.addEventListener(
+            'keydown',
+            (e: KeyboardEvent) => {
+                if (e.key === 'Enter') {
+                    this.openDetails();
+                }
+            }
+        );
+        this.params.eGridCell.addEventListener('focus', () => {
+            (this.$el as any)._tippy.show();
+        });
+        this.params.eGridCell.addEventListener('blur', () => {
+            (this.$el as any)._tippy.hide();
+        });
+    }
+
+    openDetails() {
         const fakeIdentifyItem = deepmerge({}, { data: this.params.data });
         delete fakeIdentifyItem['data']['rvInteractive'];
         delete fakeIdentifyItem['data']['rvSymbol'];

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -3,7 +3,7 @@
         class="w-38 h-48"
         :content="$t('grid.cells.zoom')"
         v-tippy="{ placement: 'top' }"
-        @click="buttonClicked()"
+        @click="zoomToFeature"
     >
         <svg
             class="m-auto"
@@ -34,7 +34,25 @@ export default class ZoomButtonRendererV extends Vue {
 
     params: any;
 
-    buttonClicked() {
+    mounted() {
+        // need to hoist events to top level cell wrapper to be keyboard accessible
+        this.params.eGridCell.addEventListener(
+            'keydown',
+            (e: KeyboardEvent) => {
+                if (e.key === 'Enter') {
+                    this.zoomToFeature();
+                }
+            }
+        );
+        this.params.eGridCell.addEventListener('focus', () => {
+            (this.$el as any)._tippy.show();
+        });
+        this.params.eGridCell.addEventListener('blur', () => {
+            (this.$el as any)._tippy.hide();
+        });
+    }
+
+    zoomToFeature() {
         const layer: LayerInstance | undefined = this.getLayerByUid(
             this.params.uid
         );

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -1,8 +1,8 @@
 <template>
     <button
         class="w-38 h-48"
-        :content="`zume 2 feechure`"
-        v-tippy="{ placement: 'right' }"
+        :content="$t('grid.cells.zoom')"
+        v-tippy="{ placement: 'top' }"
         @click="buttonClicked()"
     >
         <svg
@@ -50,7 +50,6 @@ export default class ZoomButtonRendererV extends Vue {
         });
     }
 }
-
 </script>
 
 <style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -1,0 +1,56 @@
+<template>
+    <button
+        class="w-38 h-48"
+        :content="`zume 2 feechure`"
+        v-tippy="{ placement: 'right' }"
+        @click="buttonClicked()"
+    >
+        <svg
+            class="m-auto"
+            xmlns="http://www.w3.org/2000/svg"
+            height="16"
+            viewBox="0 0 24 24"
+            width="16"
+        >
+            <path
+                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+            />
+            <path d="M0 0h24v24H0V0z" fill="none" />
+            <path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z" />
+        </svg>
+    </button>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+import { Get } from 'vuex-pathify';
+import { LayerInstance } from '@/api/internal';
+
+@Component
+export default class ZoomButtonRendererV extends Vue {
+    @Get('layer/getLayerByUid') getLayerByUid!: (
+        uid: string
+    ) => LayerInstance | undefined;
+
+    params: any;
+
+    buttonClicked() {
+        const layer: LayerInstance | undefined = this.getLayerByUid(
+            this.params.uid
+        );
+        if (layer === undefined) return;
+        const oid = this.params.data[this.params.oidField];
+        const opts = { getGeom: true };
+        layer.getGraphic(oid, opts, this.params.uid).then(g => {
+            if (g.geometry === undefined) {
+                console.error(`Could not find graphic for objectid ${oid}`);
+            } else {
+                this.$iApi.geo.map.zoomMapTo(g.geometry, 50000);
+            }
+        });
+    }
+}
+
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/help/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/help/lang/lang.csv
@@ -1,2 +1,4 @@
 key,enValue,enValid,frValue,frValid
 help.title,Help,1,Aide,1
+help.section.expand,Expand section,1,Élargir la section,0
+help.section.collapse,Collapse section,1,L’effondrement de l’article,0

--- a/packages/ramp-core/src/fixtures/help/section.vue
+++ b/packages/ramp-core/src/fixtures/help/section.vue
@@ -4,6 +4,14 @@
             <button
                 class="help-section-header flex items-center py-15 px-25 hover:bg-gray-200 cursor-pointer select-none w-full"
                 @click="toggleExpanded()"
+                :content="
+                    $t(
+                        expanded
+                            ? 'help.section.collapse'
+                            : 'help.section.expand'
+                    )
+                "
+                v-tippy="{ placement: 'top-end', hideOnClick: false }"
             >
                 <!-- name -->
                 <span class="text-lg text-left flex-grow">{{

--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -16,7 +16,7 @@
             :content="
                 $t(value ? 'legend.visibility.hide' : 'legend.visibility.show')
             "
-            v-tippy="{ placement: 'top-end' }"
+            v-tippy="{ placement: 'top-end', hideOnClick: false }"
         />
     </div>
 </template>

--- a/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
+++ b/packages/ramp-core/src/fixtures/overviewmap/overviewmap.vue
@@ -25,7 +25,7 @@
                                 : 'overviewmap.minimize'
                         )
                     "
-                    v-tippy="{ placement: 'left' }"
+                    v-tippy="{ placement: 'left', hideOnClick: false }"
                 >
                     <svg
                         class="absolute fill-current text-gray-500 transition-all duration-300 ease-out"

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -50,6 +50,10 @@
         Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }
 
+.tippy-tooltip.ramp-theme svg {
+    display: inline;
+}
+
 @font-face {
     font-family: 'Montserrat';
     src: url('font/Montserrat-Reg-webfont.woff2') format('woff2');

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -123,7 +123,13 @@ module.exports = {
             minWidth: ['responsive', 'container-query'],
             objectFit: ['responsive', 'container-query'],
             objectPosition: ['responsive', 'container-query'],
-            opacity: ['responsive', 'container-query', 'hover', 'focus'],
+            opacity: [
+                'responsive',
+                'container-query',
+                'hover',
+                'focus',
+                'disabled'
+            ],
             order: ['responsive', 'container-query'],
             outline: ['responsive', 'container-query', 'focus'],
             overflow: ['responsive', 'container-query'],


### PR DESCRIPTION
Couple changes in this PR:
* added missing tooltips, mostly on grid; can add any that I missed (#552)
* some of the tooltips before got hidden when the button was clicked when really they should still be showing (e.g. overviewmap toggle, panel pin), setting `hideOnClick: false` on them seemed to fix it but not totally sure if that's the correct way
* changed the grid reorder arrows to be disabled when they should be (first column can't go left, last can't go right)
* should be able to press `enter` on the grid cell buttons now (#585)

[link](http://ramp4-app.azureedge.net/demo/users/an-w/grid/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/586)
<!-- Reviewable:end -->
