### PR TITLE
fix language button overflow

### DIFF
--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -50,6 +50,9 @@ export default class App extends Vue {
             // needed to have tooltips in fullscreen, by default it appends to document.body
             appendTo: this.$el
         });
+
+        let parent = this.$el.parentElement;
+        parent?.style.setProperty('overflow', 'hidden');
     }
 }
 </script>

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -1,6 +1,19 @@
 <template>
     <div
-        class="map-caption absolute bottom-0 flex justify-center pointer-events-none text-gray-400 bg-black-75 left-0 right-0 py-2 z-50"
+        class="
+            map-caption
+            absolute
+            bottom-0
+            flex
+            justify-center
+            pointer-events-none
+            text-gray-400
+            bg-black-75
+            left-0
+            right-0
+            py-2
+            z-50
+        "
     >
         <span
             class="relative ml-10 truncate top-1"
@@ -35,7 +48,15 @@
         </span>
 
         <button
-            class="flex-shrink-0 mx-10 px-4 pointer-events-auto h-20 cursor-pointer border-none"
+            class="
+                flex-shrink-0
+                mx-10
+                px-4
+                pointer-events-auto
+                h-20
+                cursor-pointer
+                border-none
+            "
             @click="onScaleClick"
             :aria-pressed="scale.isImperialScale"
             :aria-label="$t('map.toggleScaleUnits')"
@@ -43,14 +64,26 @@
             :content="$t('map.toggleScaleUnits')"
         >
             <span
-                class="border-solid border-2 border-white border-t-0 h-5 mr-2 inline-block"
+                class="
+                    border-solid border-2 border-white border-t-0
+                    h-5
+                    mr-2
+                    inline-block
+                "
                 :style="{ width: scale.width }"
             ></span>
             {{ scale.label }}
         </button>
 
         <dropdown-menu
-            class="relative pointer-events-auto h-20 focus:outline-none px-4 mr-4"
+            class="
+                flex-shrink-0
+                pointer-events-auto
+                h-20
+                focus:outline-none
+                px-4
+                mr-4
+            "
             position="top-right"
             :tooltip="$t('map.changeLanguage')"
             tooltip-placement="top"


### PR DESCRIPTION
Add class 'flex-shrink-0' to language button for #589.

demo: [link](http://ramp4-app.azureedge.net/demo/users/avocadoes/hamburger/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/590)
<!-- Reviewable:end -->
