### PR TITLE
Add child symbology visibility toggle to legend

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -3,9 +3,9 @@
         <!-- TODO: see if getting this to use v-model works; children wouldnt update properly on initial try -->
         <input
             :type="isRadio ? 'radio' : 'checkbox'"
-            :checked="value"
-            @click.stop="legendItem.toggleVisibility()"
-            @keyup.enter.stop="legendItem.toggleVisibility()"
+            :checked="checked"
+            @click.stop="toggleVisibility(value)"
+            @keyup.enter.stop="toggleVisibility(value)"
             :class="[
                 isRadio ? 'form-radio' : 'form-checkbox rounded-none',
                 disabled ? 'text-gray-400 ' : 'text-black cursor-pointer'
@@ -14,7 +14,11 @@
             tabindex="-1"
             :disabled="disabled"
             :content="
-                $t(value ? 'legend.visibility.hide' : 'legend.visibility.show')
+                $t(
+                    checked
+                        ? 'legend.visibility.hide'
+                        : 'legend.visibility.show'
+                )
             "
             v-tippy="{ placement: 'top-end', hideOnClick: false }"
         />
@@ -23,15 +27,77 @@
 
 <script lang="ts">
 import { Vue, Component, Prop } from 'vue-property-decorator';
-
-import { LegendEntry } from '../store/legend-defs';
+import {
+    LegendEntry,
+    LegendGroup,
+    LegendItem,
+    LegendSet
+} from '../store/legend-defs';
 
 @Component
-export default class LegendCheckboxV extends Vue {
-    @Prop() value!: boolean;
-    @Prop() isRadio!: boolean;
+export default class CheckboxV extends Vue {
+    @Prop() value!: any;
     @Prop() legendItem!: LegendEntry;
+    @Prop() checked!: boolean;
+    @Prop() isRadio!: boolean;
     @Prop() disabled!: boolean;
+
+    /**
+     * Returns true if non of the child symbols are visible
+     * @returns {boolean} Boolean value that is true when no child symbols are visible
+     */
+    _noSymbolsVisible(): boolean {
+        return !this.legendItem.layer
+            ?.getLegend()
+            .some(item => item.visibility);
+    }
+
+    toggleVisibility(): void {
+        if (this.value instanceof LegendItem) {
+            // Toggle parent symbology checkbox
+
+            this.legendItem.toggleVisibility();
+        } else {
+            // Toggle child symbology checkbox
+
+            if (this._noSymbolsVisible()) {
+                // If no symbols are visible, then set the parent layer to visible
+                // since we toggled on one of the child symbols and set all other
+                // symbols to invisible (except for the one that is toggled on)
+
+                this.legendItem._layer?.getLegend().forEach(item => {
+                    item.visibility = false;
+                    item.lastVisbility = false;
+                });
+
+                this.value.visibility = true;
+                this.value.lastVisbility = true;
+
+                if (!this.legendItem.visibility) {
+                    this.legendItem.toggleVisibility(true);
+                }
+            } else {
+                // Toggle the child symbology
+                this.value.lastVisbility = !this.value.lastVisbility;
+                this.value.visibility = this.value.lastVisbility;
+            }
+
+            // If all child symbols are toggled off, then toggle off the parent layer too
+            if (this._noSymbolsVisible()) {
+                this.legendItem.toggleVisibility(false);
+            }
+        }
+
+        // Update the layer definition to filter child symbols
+        this.legendItem.layer?.setSqlFilter(
+            'symbol',
+            this.legendItem.layer
+                ?.getLegend()
+                .filter(item => item.lastVisbility === true)
+                .map(item => item.definitionClause)
+                .join(' OR ')
+        );
+    }
 }
 </script>
 

--- a/packages/ramp-core/src/fixtures/legend/components/group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/group.vue
@@ -40,7 +40,8 @@
 
                 <!-- visibility -->
                 <checkbox
-                    :value="legendItem.visibility"
+                    :checked="legendItem.visibility"
+                    :value="legendItem"
                     :isRadio="
                         legendItem.parent &&
                             legendItem.parent.type === LegendTypes.Set
@@ -53,9 +54,9 @@
         <!-- Display children of the group -->
         <div class="legend-group pl-5" v-if="legendItem.expanded">
             <legend-component
-                v-for="(item, idx) in legendItem.children"
+                v-for="item in legendItem.children"
                 :legendItem="item"
-                :key="idx"
+                :key="item.uid"
             ></legend-component>
         </div>
     </div>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -154,7 +154,7 @@ export default class LegendOptionsV extends Vue {
         if (this.legendItem._controlAvailable(Controls.Datatable)) {
             this.$iApi.event.emit(
                 GlobalEvents.GRID_TOGGLE,
-                this.legendItem.uid
+                this.legendItem.layerUID
             );
         }
     }
@@ -166,7 +166,7 @@ export default class LegendOptionsV extends Vue {
         if (this.legendItem._controlAvailable(Controls.Settings)) {
             this.$iApi.event.emit(
                 GlobalEvents.SETTINGS_TOGGLE,
-                this.legendItem.uid
+                this.legendItem.layerUID
             );
         }
     }
@@ -200,13 +200,13 @@ export default class LegendOptionsV extends Vue {
             ) {
                 // cheap hack for MIL with multiple children - set visibility to false and remove legend entry
                 // TODO get rid of this when/if MIL sublayers can be removed for real
-                this.removeLayerEntry(this.legendItem.uid!);
+                this.removeLayerEntry(this.legendItem.layerUID!);
                 this.legendItem.layer!.setVisibility(
                     false,
                     this.legendItem._layerIndex
                 );
             } else {
-                this.$iApi.geo.map.removeLayer(this.legendItem.uid!);
+                this.$iApi.geo.map.removeLayer(this.legendItem.layerUID!);
             }
         }
     }

--- a/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/symbology-stack.vue
@@ -44,15 +44,16 @@
 </template>
 
 <script lang="ts">
+import { LayerInstance } from '@/api';
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
-import { LayerInstance } from '@/api/internal';
+import { LegendEntry } from '../store/legend-defs';
 
 @Component
 export default class LegendSymbologyStackV extends Vue {
     @Prop() visible!: boolean;
+    @Prop() legendItem!: LegendEntry;
     @Prop() layer!: LayerInstance;
-    @Prop() uid!: string;
 
     stack: any = [];
 
@@ -60,7 +61,7 @@ export default class LegendSymbologyStackV extends Vue {
         // TODO ramp2 would create a placeholder stack if the layer wasn't loaded. Icon would be first letter of layer
         //      see if we should be doing that here as well, or if we are fine with empty icons.
         // When the layer is loaded, get the icon.
-        this.layer.isLayerLoaded().then(() => {
+        this.legendItem.loadPromise.then(() => {
             this.getSymbologyStack();
         });
     }
@@ -69,11 +70,15 @@ export default class LegendSymbologyStackV extends Vue {
      * Retrieves the symbology stack. Waits on all symbols in the stack to finish loading before displaying.
      */
     getSymbologyStack(): any {
-        Promise.all(
-            this.layer.getLegend(this.uid).map((l: any) => l.drawPromise)
-        ).then((r: any) => {
-            this.stack = this.layer.getLegend(this.uid);
-        });
+        if (this.legendItem.layerUID) {
+            Promise.all(
+                this.layer
+                    .getLegend(this.legendItem.layerUID)
+                    .map((l: any) => l.drawPromise)
+            ).then((r: any) => {
+                this.stack = this.layer.getLegend(this.legendItem.layerUID);
+            });
+        }
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
@@ -43,7 +43,7 @@
 
                 <!-- visibility -->
                 <checkbox
-                    :value="legendItem.visibility"
+                    :value="legendItem"
                     :isRadio="
                         legendItem.parent &&
                             legendItem.parent.type === LegendTypes.Set
@@ -56,9 +56,9 @@
         <!-- Display the children of the group -->
         <div class="legend-group pl-5" v-if="legendItem.expanded">
             <legend-component
-                v-for="(item, idx) in legendItem.children"
+                v-for="item in legendItem.children"
                 :legendItem="item"
-                :key="idx"
+                :key="item.uid"
             ></legend-component>
         </div>
     </div>

--- a/packages/ramp-core/src/fixtures/legend/screen.vue
+++ b/packages/ramp-core/src/fixtures/legend/screen.vue
@@ -13,9 +13,9 @@
             <legend-header></legend-header>
             <div v-focus-list>
                 <legend-component
-                    v-for="(item, idx) in children"
+                    v-for="item in children"
                     :legendItem="item"
-                    :key="idx"
+                    :key="item.uid"
                 ></legend-component>
             </div>
         </template>

--- a/packages/ramp-core/src/fixtures/settings/api/settings.ts
+++ b/packages/ramp-core/src/fixtures/settings/api/settings.ts
@@ -1,4 +1,5 @@
 import { FixtureInstance, LayerInstance } from '@/api';
+import { LegendStore } from '@/fixtures/legend/store';
 
 export class SettingsAPI extends FixtureInstance {
     /**
@@ -6,19 +7,26 @@ export class SettingsAPI extends FixtureInstance {
      * @param layer
      */
     toggleSettings(uid: string): void {
-        const layer = this.$iApi.$vApp.$store.get('layer/getLayerByUid', uid);
+        const layer: LayerInstance | undefined = this.$iApi.$vApp.$store.get(
+            'layer/getLayerByUid',
+            uid
+        );
         const panel = this.$iApi.panel.get('settings-panel');
+        const legendItem = this.$iApi.$vApp.$store.get(
+            LegendStore.getChildById,
+            layer?.id
+        );
         if (!panel.isOpen) {
             this.$iApi.panel.open({
                 id: 'settings-panel',
-                props: { layer: layer, uid: uid }
+                props: { layer: layer, uid: uid, legendItem: legendItem }
             });
         } else {
             const currentUid = (panel.route.props! as any).uid;
             if (currentUid !== uid) {
                 panel.show({
                     screen: 'settings-screen-content',
-                    props: { layer: layer, uid: uid }
+                    props: { layer: layer, uid: uid, legendItem: legendItem }
                 });
             } else {
                 panel.close();

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -105,7 +105,8 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { PanelInstance } from '@/api';
 
 import SettingsComponentV from './component.vue';
-import { LayerInstance } from '@/api/internal';
+import { GlobalEvents, LayerInstance } from '@/api/internal';
+import { LegendEntry } from '../legend/store/legend-defs';
 
 @Component({
     components: {
@@ -116,6 +117,7 @@ export default class SettingsScreenV extends Vue {
     @Prop() panel!: PanelInstance;
     @Prop() layer!: LayerInstance;
     @Prop() uid!: string;
+    @Prop() legendItem!: LegendEntry;
 
     // Models.
     visibilityModel: boolean = this.layer.getVisibility(this.uid);
@@ -128,12 +130,21 @@ export default class SettingsScreenV extends Vue {
             this.visibilityModel = this.layer.getVisibility(this.uid);
             this.opacityModel = this.layer.getOpacity(this.uid) * 100;
         });
+
+        this.$iApi.event.on(
+            GlobalEvents.LAYER_VISIBILITYCHANGE,
+            (newVisibility: any) => {
+                if (this.uid === newVisibility.uid) {
+                    this.visibilityModel = newVisibility.visibility;
+                }
+            }
+        );
     }
 
     // Update the layer visibility.
     updateVisibility(val: any) {
+        this.legendItem.toggleVisibility(val.value);
         this.visibilityModel = val.value;
-        this.layer.setVisibility(this.visibilityModel, this.uid);
     }
 
     // Update the layer opacity.

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -269,6 +269,11 @@ export interface LegendSymbology {
     definitionClause: string;
     svgcode: string;
     drawPromise: Promise<void>;
+
+    // TODO: Reduce this to one visibility flag (or move visibility state management another place altogether)
+    visibility: boolean; // Used by the checkbox in the legend
+    lastVisbility: boolean; // Used to create SQL definition and remembers the visibility value even after the parent layer is toggled off
+
     // TODO might need to add something to support image-based legends we find in WMS or custom stacks from the config
 }
 

--- a/packages/ramp-core/src/geo/api/utils/shared-utils.ts
+++ b/packages/ramp-core/src/geo/api/utils/shared-utils.ts
@@ -14,7 +14,14 @@ export class SharedUtilsAPI {
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
             // do math!
             /*jslint bitwise: true */
-            const r = (d + Math.random() * 16) % 16 | 0;
+            // TODO: Come up with cheaper solution that doesn't use the crypto API and satifies CodeQL
+            const r =
+                (d +
+                    window.crypto.getRandomValues(new Uint32Array(1))[0] *
+                        Math.pow(2, -32) *
+                        16) %
+                    16 |
+                0;
             d = Math.floor(d / 16);
             return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
             /*jslint bitwise: false */

--- a/packages/ramp-core/src/geo/layer/attrib-fc.ts
+++ b/packages/ramp-core/src/geo/layer/attrib-fc.ts
@@ -771,6 +771,17 @@ export class AttribFC extends CommonFC {
     }
 
     /**
+     * Returns a SQL WHERE condition that is combination of active filters.
+     *
+     * @method getCombinedSqlFilter
+     * @param {Array} [exclusions] list of any filter keys to exclude from the result. omission includes all filters
+     * @returns {String} all non-excluded sql statements connected with AND operators.
+     */
+    getCombinedSqlFilter(exclusions?: string[]): string {
+        return this.filter.getCombinedSql(exclusions);
+    }
+
+    /**
      * Applies the current filter settings to the physical map layer.
      *
      * @function applySqlFilter

--- a/packages/ramp-core/src/geo/layer/esriFeature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriFeature/index.ts
@@ -239,6 +239,8 @@ class FeatureLayer extends AttribLayer {
             qOpts.filterGeometry = options.geometry;
         }
 
+        qOpts.filterSql = myFC.getCombinedSqlFilter();
+
         result.done = myFC.queryFeatures(qOpts).then(results => {
             // TODO might be a problem overwriting the array if something is watching/binding to the original
             innerResult.items = results.map(gr => {

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -642,6 +642,7 @@ class MapImageLayer extends AttribLayer {
                 }
 
                 qOpts.outFields = fc.fieldList;
+                qOpts.filterSql = fc.getCombinedSqlFilter();
 
                 return fc.queryFeatures(qOpts).then(results => {
                     // TODO might be a problem overwriting the array if something is watching/binding to the original

--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -297,6 +297,9 @@ export class FileLayer extends AttribLayer {
             qOpts.filterGeometry = options.geometry;
         }
 
+        // TODO: Test if works after #206 is implemented
+        qOpts.filterSql = myFC.getCombinedSqlFilter();
+
         result.done = myFC.queryFeatures(qOpts).then(results => {
             // TODO might be a problem overwriting the array if something is watching/binding to the original
             innerResult.items = results.map(gr => {

--- a/packages/ramp-core/src/geo/utils/symbology.ts
+++ b/packages/ramp-core/src/geo/utils/symbology.ts
@@ -831,6 +831,8 @@ export class SymbologyAPI extends APIScope {
                               .map(su => su.definitionClause)
                               .join(' OR ')})`,
                 svgcode: '', // TODO is '' ok? maybe we need white square svg? or some loading icon?
+                visibility: true,
+                lastVisbility: true,
                 drawPromise: this.symbolToSvg(firstSu.symbol).then(svg => {
                     // update the legend symbol object
                     legendSym.svgcode = svg;


### PR DESCRIPTION
## Related issue: #221

## Changes in this PR
- [FEAT] Child symbology of layers with more than one child can be toggled
- [FEAT] Identify service will exclude invisible symbology from results
- [FIX] Layers with one child will not have a checkbox to toggle the child symbology and will only have a checkbox for the parent layer
- [FIX] Group legend entries properly update and modify their children visibility
- [FIX] Symbology stack will wait until the layer legend entry is fully loaded to avoid "uid not found" errors
- [FIX] Used more secure `crypto` API for `shared-utils` UID generation so that CodeQL is happy

## Further work/comments/questions
- **Further Work:** 
    - There is a bug with the visibility set rules that is not fixed in this PR - #588
    - The data table needs to be enhanced to exclude invisible symbology from the table - #597
- **Comments:** 
    - Currently Vue is notified about legend entry updates by generating a new `uid` of the `LegendItem` object
        - This is the recommended way to re-render UI components, but we need a better update method to avoid having to generate a new `uid` each time
        - ~~This method also causes the [CodeQL to fail](https://github.com/ramp4-pcar4/ramp4-pcar4/pull/596/checks?check_run_id=3116108447) as the randomness of the uid generation is seen as a security threat~~
             - This has been fixed by using the `crypto` API for random number generation 
    -  A known bug with the symbology toggle is that if all the child symbols are toggled off and then a single child is toggled on, all symbols will briefly flash for a second and then the visibility will apply
        - Not really sure what is the cause, or how to fix this
- **Questions:** 
    - The identify service for Feature and MapImage layers have been updated to exclude invisible symbology. Are there other layers that need this too?

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/221/host/index.html)

No defined steps to test this feature, try to break it as much as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/596)
<!-- Reviewable:end -->
