### PR TITLE
Display WMS symbology

### DIFF
--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -53,7 +53,7 @@ let config = {
                     visibility: true
                 },
                 layerEntries: [
-                    { id: 'railway' },
+                    { id: 'railway', name: 'Railway' },
                     { id: 'railway.structure.line' },
                     { id: 'railway.structure.point' },
                     { id: 'railway.track' },
@@ -76,7 +76,8 @@ let config = {
                 },
                 layerEntries: [
                     {
-                        id: 'GDPS.ETA_NT'
+                        id: 'RDPA.24F_PR',
+                        currentStyle: 'PRECIPMM'
                     }
                 ],
                 featureInfoMimeType: 'text/plain'
@@ -226,7 +227,14 @@ Vue.component('GeoMet-Template', {
 
 rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
 rInstance.fixture
-    .addDefaultFixtures(['mapnav', 'legend', 'appbar', 'grid', 'details'])
+    .addDefaultFixtures([
+        'mapnav',
+        'legend',
+        'appbar',
+        'grid',
+        'details',
+        'wizard'
+    ])
     .then(() => {
         rInstance.panel.open('legend-panel');
     });

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1138,12 +1138,21 @@
                     "default": "",
                     "description": "A descriptive name for the layer. To be used in the legend."
                 },
-                "allStyles": {
+                "styleLegends": {
                     "type": "array",
-                    "default": [],
-                    "description": "All styles for layer entry in the WMS.",
+                    "description": "List of map of all styles to legend graphic URL for layer entry in the WMS. Overrides the URLs from the WMS service.",
                     "items": {
-                        "type": "string"
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "The name of the style."
+                            },
+                            "url": {
+                                "type": "string",
+                                "description": "The URL to the legend graphic."
+                            }
+                        }
                     }
                 },
                 "currentStyle": {

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -86,27 +86,48 @@
         >
             <!-- display each symbol -->
             <div
-                class="p-5 flex items-center"
+                class="m-5"
                 v-for="(item, idx) in legendItem.layer.getLegend(
                     legendItem.layerUID
                 )"
                 :key="idx"
             >
-                <div class="symbologyIcon">
-                    <span v-html="item.svgcode"></span>
+                <!-- for WMS layers -->
+                <div
+                    v-if="layerType === 'ogcWms'"
+                    class="items-center grid-cols-1"
+                >
+                    <div
+                        v-if="item.imgHeight"
+                        class="symbologyIcon w-full p-5"
+                        v-html="getLegendGraphic(item)"
+                    ></div>
+                    <div
+                        v-if="item.label"
+                        class="flex-1 p-5 bg-black-75 text-white"
+                        v-truncate
+                    >
+                        {{ item.label }}
+                    </div>
                 </div>
-
-                <div class="flex-1 ml-15" v-truncate>{{ item.label }}</div>
-
-                <checkbox
-                    v-if="
-                        legendItem.layer.getLegend(legendItem.layerUID).length >
-                            1
-                    "
-                    :checked="item.visibility"
-                    :value="item"
-                    :legendItem="legendItem"
-                />
+                <!-- for non-WMS layers -->
+                <div v-else class="flex items-center">
+                    <div class="symbologyIcon">
+                        <span v-html="item.svgcode"></span>
+                    </div>
+                    <div class="flex-1 ml-15" v-truncate>
+                        {{ item.label }}
+                    </div>
+                    <checkbox
+                        v-if="
+                            legendItem.layer.getLegend(legendItem.layerUID)
+                                .length > 1
+                        "
+                        :checked="item.visibility"
+                        :value="item"
+                        :legendItem="legendItem"
+                    />
+                </div>
             </div>
         </div>
     </div>
@@ -183,6 +204,25 @@ export default class LegendEntryV extends Vue {
 
     get shellEl() {
         return this.$refs.shell;
+    }
+
+    get layerType() {
+        return this.legendItem.layer?.layerType;
+    }
+
+    /**
+     * Returns a span containing the resized legend graphic.
+     */
+    getLegendGraphic(item: any): string | undefined {
+        const span = document.createElement('span');
+        span.innerHTML = item.svgcode;
+        const svg = span.firstElementChild;
+        // The legend graphic will display either in its original size, or resized to fit the width of the legend item.
+        svg?.classList.add('max-w-full');
+        svg?.classList.add('h-full');
+        svg?.setAttribute('height', item.imgHeight);
+        svg?.setAttribute('width', item.imgWidth);
+        return span.outerHTML;
     }
 
     removeLayer() {

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -266,15 +266,14 @@ export interface TabularAttributeSet {
 
 export interface LegendSymbology {
     label: string;
-    definitionClause: string;
+    definitionClause?: string;
     svgcode: string;
-    drawPromise: Promise<void>;
-
+    drawPromise: Promise<string | void>;
+    imgHeight?: string; // height of the original legend graphic (for wms layers)
+    imgWidth?: string; // width of the original legend graphic (for wms layers)
     // TODO: Reduce this to one visibility flag (or move visibility state management another place altogether)
-    visibility: boolean; // Used by the checkbox in the legend
-    lastVisbility: boolean; // Used to create SQL definition and remembers the visibility value even after the parent layer is toggled off
-
-    // TODO might need to add something to support image-based legends we find in WMS or custom stacks from the config
+    visibility?: boolean; // Used by the checkbox in the legend
+    lastVisbility?: boolean; // Used to create SQL definition and remembers the visibility value even after the parent layer is toggled off
 }
 
 export interface ArcGisServerUrl {
@@ -445,8 +444,8 @@ export interface RampLayerWmsLayerEntryConfig {
     state?: RampLayerStateConfig;
     // following items need to be flushed out
     controls?: any;
-    currentStyle?: string;
-    styleToURL?: { [key: string]: string }; // are we migrating this functionality?
+    currentStyle?: string; // style to be used
+    styleLegends?: Array<{ name: string; url: string }>; // map of styles to legend graphic url. overrides service urls.
     // more...
 }
 

--- a/packages/ramp-core/src/geo/layer/ogc-utils.ts
+++ b/packages/ramp-core/src/geo/layer/ogc-utils.ts
@@ -231,13 +231,17 @@ export class OgcUtils extends APIScope {
                             const resource = style.LegendURL.OnlineResource;
                             // Yucky naming means no dot notation
                             const styleURL = resource['@_xlink:href'];
-                            styleToURL[styleName] = styleURL;
+                            // decode '&amp;' -> '&', which was encoded by XMLSerializer
+                            styleToURL[styleName] = styleURL.replaceAll(
+                                '&amp;',
+                                '&'
+                            );
                         }
                     });
                 }
                 return {
                     name: nameNode ? nameNode : null,
-                    desc: titleNode,
+                    title: titleNode,
                     queryable: layer['@_queryable'] === '1',
                     layers: getLayers(layer),
                     allStyles: allStyles,
@@ -268,10 +272,8 @@ export class OgcUtils extends APIScope {
                 ignoreAttributes: false // check for tag attributes
             };
             const jsonObj: any = parse(xmlData, options);
-            // We get an XML with a <ServiceExceptionReport> tag back
-            // when something goes wrong with the request.
-            // Might be able to get rid of this now that we are appending
-            // missing parameters to the URL.
+            // We get an XML with a <ServiceExceptionReport> tag back when something goes wrong with the request.
+            // Might be able to get rid of this now that we are appending missing parameters to the URL.
             if ('ServiceExceptionReport' in jsonObj) {
                 console.error(jsonObj.ServiceExceptionReport.ServiceException);
                 return [];

--- a/packages/ramp-core/src/geo/layer/ogcWms/wms-fc.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/wms-fc.ts
@@ -1,57 +1,8 @@
 // TODO add proper comments
 
 import { CommonFC } from '@/api/internal';
-import { DataFormat } from '@/geo/api';
+import { DataFormat, LegendSymbology } from '@/geo/api';
 import WmsLayer from './index';
-
-/**
- * Searches for a layer title defined by a wms.
- * @function getWMSLayerTitle
- * @private
- * @param  {Object} wmsLayer     esri layer object for the wms
- * @param  {String} wmsLayerId   layers id as defined in the wms (i.e. not wmsLayer.id)
- * @return {String}              layer title as defined on the service, '' if no title defined
- */
-// TODO this code has yet to be migrated to ESRI 4. Required for symbology support for wms
-/*
-function getWMSLayerTitle(wmsLayer: EsriWMSLayer, wmsLayerId: string): string {
-    // TODO move this to ogc.js module?
-
-    let targetEntry = '';
-
-    // crawl esri layerInfos (which is a nested structure),
-    // returns sublayer that has matching id or null if not found.
-    // written as function to allow recursion
-    const crawlSubLayers = (subLayerInfos, wmsLayerId) => {
-
-        // we use .some to allow the search to stop when we find something
-        subLayerInfos.some(layerInfo => {
-            // wms ids are stored in .name
-            if (layerInfo.name === wmsLayerId) {
-                // found it. save it and exit the search
-                targetEntry = layerInfo;
-                return true;
-            } else if (layerInfo.subLayers) {
-                // search children. if in children, will exit search, else will continue
-                return crawlSubLayers(layerInfo.subLayers, wmsLayerId);
-            } else {
-                // continue search
-                return false;
-            }
-        });
-
-        return targetEntry;
-    };
-
-    // init search on root layerInfos, then process result
-    const match = crawlSubLayers(wmsLayer.layerInfos, wmsLayerId);
-    if (match && match.title) {
-        return match.title;
-    } else {
-        return ''; // falsy!
-    }
-}
-*/
 
 export class WmsFC extends CommonFC {
     // @ts-ignore
@@ -63,45 +14,68 @@ export class WmsFC extends CommonFC {
     }
 
     /**
+     * Searches for a layer title defined by a wms.
+     * @function getWMSLayerTitle
+     * @private
+     * @param  {String} wmsLayerId   layer id as defined in the wms (i.e. not wmsLayer.id)
+     * @return {String}              layer title as defined on the service, '' if no title defined
+     */
+    getWMSLayerTitle(wmsLayerId: string): string {
+        // TODO move this to ogc.js module?
+        if (!this.parentLayer.esriLayer) {
+            return '';
+        }
+        let targetEntry;
+        // we use .some to allow the search to stop when we find something
+        this.parentLayer.esriLayer.allSublayers.some((sl: any) => {
+            // wms ids are stored in .name
+            if (sl.name === wmsLayerId) {
+                targetEntry = sl.title;
+                return true;
+            }
+        });
+
+        return targetEntry || '';
+    }
+
+    /**
      * Download or refresh the internal symbology for the FC.
      *
      * @function loadSymbology
      * @returns {Promise}         resolves when symbology has been downloaded
      */
-    // TODO this code has yet to be migrated to ESRI 4. Required for symbology support for wms
-    /*
-    loadSymbology () {
-        const configLayerEntries =  this._parent.config.layerEntries;
-        const gApi = this._parent._apiRef;
-        const legendArray = gApi.layer.ogc
-            .getLegendUrls(this._parent._layer, configLayerEntries.map(le => {
-                return {
-                    id: le.id,
-                    styleToURL: le.styleToURL,
-                    currentStyle: le.currentStyle
-                }
-            }))
+    loadSymbology() {
+        const configLayerEntries = this.parentLayer.config.layerEntries;
+        const legendArray = this.parentLayer
+            .getLegendUrls(
+                configLayerEntries.map((le: any) => {
+                    return {
+                        id: le.id,
+                        styleLegends: le.styleLegends,
+                        currentStyle: le.currentStyle
+                    };
+                })
+            )
             .map((imageUri, idx) => {
-
-                const symbologyItem = {
-                    name: null,
-                    svgcode: null
-                };
-
                 // config specified name || server specified name || config id
-                const name = configLayerEntries[idx].name ||
-                    getWMSLayerTitle(this._parent._layer, configLayerEntries[idx].id) ||
+                const name =
+                    configLayerEntries[idx].name ||
+                    this.getWMSLayerTitle(configLayerEntries[idx].id) ||
                     configLayerEntries[idx].id;
-
-                gApi.symbology.generateWMSSymbology(name, imageUri).then(data => {
-                    symbologyItem.name = data.name;
-                    symbologyItem.svgcode = data.svgcode;
-                });
-
+                const symbologyItem: LegendSymbology = {
+                    label: name,
+                    svgcode: '',
+                    drawPromise: this.parentLayer.$iApi.geo.utils.symbology
+                        .generateWMSSymbology(imageUri)
+                        .then((data: any) => {
+                            symbologyItem.svgcode = data.svgcode;
+                            symbologyItem.imgHeight = data.imgHeight;
+                            symbologyItem.imgWidth = data.imgWidth;
+                        })
+                };
                 return symbologyItem;
             });
-        this.symbology = legendArray;
+        this.legend = legendArray;
         return Promise.resolve();
     }
-    */
 }


### PR DESCRIPTION
For #559 and #518
- Implement `loadSymbology()` for WMSLayers (and other associated functions)
    - Schema changes are because there was a mismatch between the schema and geo-defs
- Update WMSLayer construction for ESRI 4
- Display WMS symbology in the legend
    - Not a css/styling expert.  I tried to mimic the r2 design, but let me know if I should make changes to it
- Tweaks to `parseCapabilities()`
- Make a smaller `GetCapabilities` call for geomet layers

[Demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/559-wms-symbology/host/index-e2e.html?script=wms-layer) - you can use [this layer](https://maps.geogratis.gc.ca/wms/hydro_network_en?service=wms&version=1.3.0&request=getcapabilities&legend_format=image/png&feature_info_type=text/) if you need something to test adding through the wizard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/599)
<!-- Reviewable:end -->
