### PR TITLE
Export legend columns

### DIFF
--- a/packages/ramp-core/src/fixtures/export-v1/api.ts
+++ b/packages/ramp-core/src/fixtures/export-v1/api.ts
@@ -61,7 +61,9 @@ export class ExportV1API extends FixtureInstance {
             (panelWidth - GLOBAL_MARGIN.LEFT - GLOBAL_MARGIN.RIGHT) /
             fbMap.width!;
 
-        const fbLegend = await this.getSubFixture('export-v1-legend').make();
+        const fbLegend = await this.getSubFixture('export-v1-legend').make({
+            width: fbMap.width
+        });
 
         fbLegend.top = this.options.runningHeight;
         this.options.runningHeight += fbLegend.height!;


### PR DESCRIPTION
#410:
* Splits export legend into columns based to map width
* Made a best attempt at #428 to try to make things look decent
* Kinda gets messed up with very long layers (e.g. MIL with 10 sublayers) since it doesn't break up config layers

[demo](http://ramp4-app.azureedge.net/demo/users/an-w/zzz/host/index.html) 
Feel free to test with different layers, # of layers, and map widths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/600)
<!-- Reviewable:end -->
