### PR TITLE
Fix Basemap Panel Layout

### DIFF
--- a/packages/ramp-core/src/fixtures/basemap/item.vue
+++ b/packages/ramp-core/src/fixtures/basemap/item.vue
@@ -1,14 +1,15 @@
 <template>
     <div class="mb-10">
         <button
-            class="bg-gray-300"
+            class="basemap-item-button bg-gray-300"
             :aria-label="$t('basemap.select')"
             @click="selectBasemap(basemap)"
+            v-focus-item
         >
             <div>
                 <div v-if="basemap.wkid === 3978">
                     <div
-                        class="flex h-180 hover:opacity-50"
+                        class="flex h-180 hover:opacity-50 basemap-item-image"
                         v-for="layer in basemap.layers"
                         v-bind:key="layer.id"
                     >
@@ -26,7 +27,7 @@
                 </div>
                 <div v-else-if="basemap.wkid === 102100">
                     <div
-                        class="flex h-180 hover:opacity-50"
+                        class="flex h-180 hover:opacity-50 basemap-item-image"
                         v-for="layer in basemap.layers"
                         v-bind:key="layer.id"
                     >
@@ -45,7 +46,7 @@
             </div>
 
             <div
-                class="absolute flex w-full bg-black opacity-75 text-white h-30 bottom-0 items-center"
+                class="absolute flex w-full bg-black opacity-75 text-white h-30 bottom-6 items-center"
             >
                 <div class="pl-5" v-truncate>
                     <span>{{ basemap.name }}</span>
@@ -100,6 +101,16 @@ export default class BasemapItemV extends Vue {
 </script>
 
 <style lang="scss" scoped>
+[focus-list]:focus [focus-item].focused.basemap-item-button {
+    border: solid black 2px;
+}
+
+[focus-list]:focus
+    [focus-item].focused.basemap-item-button
+    .basemap-item-image {
+    opacity: 0.5;
+}
+
 .rv-basemap-check {
     &::before {
         content: '';

--- a/packages/ramp-core/src/fixtures/basemap/screen.vue
+++ b/packages/ramp-core/src/fixtures/basemap/screen.vue
@@ -20,34 +20,34 @@
             <div class="h-600 overflow-y-auto">
                 <div
                     class="mx-5"
-                    v-for="tileSchema in tileSchemas"
-                    v-bind:key="tileSchema.id"
+                    v-for="(tileSchema, idx) in tileSchemas"
+                    :key="tileSchema.id"
                 >
-                    <div class="mt-10 mb-5 flex">
-                        <h3>
+                    <!-- use mt-5 if it's the first basemap title schema, use mt-36 otherwise -->
+                    <div :class="(idx === 0 ? 'mt-5' : 'mt-36') + ' flex mb-5'">
+                        <h3 class="font-bold text-xl" v-truncate>
                             {{ tileSchema.name }}
                         </h3>
                         <!-- TODO: check if current basemap matches projection, if not need "Map Refresh required" warning here -->
-                        <div
-                            class="flex px-5 ml-auto"
-                            v-if="
-                                tileSchema.id !== selectedBasemap.tileSchemaId
-                            "
-                            v-truncate
+                    </div>
+
+                    <div
+                        class="flex"
+                        v-if="tileSchema.id !== selectedBasemap.tileSchemaId"
+                        v-truncate
+                    >
+                        <svg
+                            class="fill-current w-20 h-20"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
                         >
-                            <svg
-                                class="fill-current w-16 h-16"
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 24 24"
-                            >
-                                <path
-                                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                                />
-                            </svg>
-                            <span class="text-blue-600 pl-5">{{
-                                $t('basemap.refresh')
-                            }}</span>
-                        </div>
+                            <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                        </svg>
+                        <span class="text-blue-600 pl-5" v-truncate>{{
+                            $t('basemap.refresh')
+                        }}</span>
                     </div>
 
                     <ul
@@ -57,7 +57,7 @@
                     >
                         <li
                             v-for="basemap in filterBasemaps(tileSchema.id)"
-                            v-bind:key="basemap.id"
+                            :key="basemap.id"
                         >
                             <basemap-item
                                 :basemap="basemap"


### PR DESCRIPTION
## Related issue: #557 

## Changes in this PR
- [FEAT] The `(i) Map Refresh Required` message displays properly
- [FEAT] The difference between the two projection lists is more pronounced (bolder + larger text)
- [FIX] Move basemap item label a bit higher so that it is inline with the preview image
- [FIX] Add `focus-list` to basemap panel so that items can be tabbed

Old vs. New:
<p>
  <img src="https://user-images.githubusercontent.com/34178949/126827764-93ff0d26-47b8-4dbf-a2d8-3bfd7737f13c.png" width="300" />
  <img src="https://user-images.githubusercontent.com/34178949/126827829-9a26546f-c15a-400d-9157-9460b88ea2a4.png" width="300" /> 
</p>
<p>
  <img src="https://user-images.githubusercontent.com/34178949/126828120-34727411-58eb-48bb-9d27-306190daf4b0.png" width="300" />
  <img src="https://user-images.githubusercontent.com/34178949/126828196-bf0026c9-a984-4f1f-a1d7-6d7eb9650fc3.png" width="300" /> 
</p>

## Further work/comments/questions
- None

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/557/host/index.html)

Test if the basemap panel items can be tabbed through
1. Load the demo
2. Open the basemap panel
3. Try to focus the basemap items by pressing TAB
4. Use the UP/DOWN arrow keys to navigate through the items 
5. The basemap item navigation should be separate for each basemap type (i.e. Lambert and Mercator should have their own focus lists)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/601)
<!-- Reviewable:end -->
