### PR TITLE
Fix Layer Reload Visibility Errors/Bugs

### DIFF
--- a/packages/ramp-core/docs/app/defaults.md
+++ b/packages/ramp-core/docs/app/defaults.md
@@ -85,7 +85,8 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed               |
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added           |
 | LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, _uid_: affected uid                      | The layer opacity changed          |
-| LAYER_RELOADED<br>'layer/reloaded'                 | LayerInstance object                                           | The layer was reloaded             |
+| LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading       |
+| LAYER_RELOAD_START<br>'layer/reloadstart'          | LayerInstance object                                           | The layer started reloading        |
 | LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map |
 | LAYER_STATECHANGE<br>'layer/statechange'           | _state_: new value, _uid_: affected uid                        | The layer state changed            |
 | LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _uid_: affected uid                   | The layer visibility changed       |

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -31,7 +31,8 @@ export enum GlobalEvents {
     FIXTURE_ADDED = 'fixture/added', // Payload is FixtureInstance
 
     LAYER_OPACITYCHANGE = 'layer/opacitychange',
-    LAYER_RELOADED = 'layer/reloaded', // Payload: `(layer: LayerInstance)`
+    LAYER_RELOAD_END = 'layer/reloadend', // Payload: `(layer: LayerInstance)`
+    LAYER_RELOAD_START = 'layer/reloadstart', // Payload: `(layer: LayerInstance)`
     LAYER_REMOVE = 'layer/remove', // Payload: `(layer: LayerInstance)`
     LAYER_STATECHANGE = 'layer/statechange',
     LAYER_VISIBILITYCHANGE = 'layer/visibilitychange',
@@ -650,7 +651,7 @@ export class EventAPI extends APIScope {
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.LAYER_RELOADED,
+                    GlobalEvents.LAYER_RELOAD_START,
                     zeHandler,
                     handlerName
                 );

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -270,6 +270,7 @@ export class CommonLayer extends LayerInstance {
             //      could do that here. Alternative is to not, and let whomever is calling this save state before
             //      and restore state after. Might be more flexible.
 
+            this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_START, this);
             await this.terminate();
         }
 
@@ -286,7 +287,7 @@ export class CommonLayer extends LayerInstance {
 
         // if we did any state storage above, would restore here.
 
-        this.$iApi.event.emit(GlobalEvents.LAYER_RELOADED, this);
+        this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_END, this);
     }
 
     // TODO strongly type if it makes sense. unsure if we want client config definitions in here

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -285,10 +285,15 @@ class MapImageLayer extends AttribLayer {
                 parentTreeNode.children.push(treeLeaf);
 
                 subLayer.watch('visible', () => {
-                    // TODO implementing same as pre-no-dojo. might want to add a sublayer vis change event as well.
+                    // Parent layer visibility
                     this.$iApi.event.emit(GlobalEvents.LAYER_VISIBILITYCHANGE, {
                         visibility: this.getVisibility(),
                         uid: this.uid
+                    });
+                    // Sublayer visibility
+                    this.$iApi.event.emit(GlobalEvents.LAYER_VISIBILITYCHANGE, {
+                        visibility: this.fcs[sid].getVisibility(),
+                        uid: this.fcs[sid].uid
                     });
                 });
             }


### PR DESCRIPTION
## Related issue: #593

## Fixes in this PR
- [FIX] Layer reload when the symbology is expanded no longer throws errors
- [FIX] Layer settings menu visibility properly updates along with the layer visibility
- [FIX] Parent legend items will update their visibility when an invisible child legend entry reloads
- [FEAT] `LAYER_RELOADED` event is now broken down to `LAYER_RELOAD_START` and `LAYER_RELOAD_END` that mark the start and end of the layer reload process, respectively
- [FEAT] Visibility changes to MIL sublayers will fire two `LAYER_VISIBILITYCHANGE` events: one with parent visibility/uid and one with child visibility/uid

## Further work/comments/questions
None

## Steps to test
[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/593/host/index.html)

1. Load demo
2. Ensure layer and child symbology visibility still works
3. Open the settings panel for a layer and toggle the layer visibility - the setting's panel visibility should also update
4. Test if legend groups update their visibility properly
    - Set the "Water Quality" and "Water Quantity" to invisible (this should make the parent group item "Group in Set" invisible)
    - Now reload one of the layers and the parent group should become visible again
5. The steps above should not throw any errors in the console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/633)
<!-- Reviewable:end -->
