### PR TITLE
Fix WMS checkbox and symbology bugs (+ other fixes)

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -96,6 +96,7 @@ import GridCustomHeaderV from './templates/custom-header.vue';
 // grid button templates
 import DetailsButtonRendererV from './templates/details-button-renderer.vue';
 import ZoomButtonRendererV from './templates/zoom-button-renderer.vue';
+import { LayerType } from '@/geo/api';
 
 // these should match up with the `type` value returned by the attribute promise.
 const NUM_TYPES: string[] = ['oid', 'double', 'integer'];
@@ -163,6 +164,11 @@ export default class GridTableComponentV extends Vue {
             // this really shouldn't happen unless the wrong API call is made, but maybe we should
             // do something else here anyway.
             console.error(`Could not find layer with uid ${this.layerUid}.`);
+            return;
+        }
+
+        if (fancyLayer.layerType === LayerType.WMS) {
+            // Table does not support WMS layers
             return;
         }
 

--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -26,13 +26,9 @@
 </template>
 
 <script lang="ts">
+import { LayerType } from '@/geo/api';
 import { Vue, Component, Prop } from 'vue-property-decorator';
-import {
-    LegendEntry,
-    LegendGroup,
-    LegendItem,
-    LegendSet
-} from '../store/legend-defs';
+import { LegendEntry, LegendItem } from '../store/legend-defs';
 
 @Component
 export default class CheckboxV extends Vue {
@@ -89,14 +85,17 @@ export default class CheckboxV extends Vue {
         }
 
         // Update the layer definition to filter child symbols
-        this.legendItem.layer?.setSqlFilter(
-            'symbol',
-            this.legendItem.layer
-                ?.getLegend()
-                .filter(item => item.lastVisbility === true)
-                .map(item => item.definitionClause)
-                .join(' OR ')
-        );
+        // WMS layers do not have child symbology
+        if (this.legendItem.layer?.layerType !== LayerType.WMS) {
+            this.legendItem.layer?.setSqlFilter(
+                'symbol',
+                this.legendItem.layer
+                    ?.getLegend()
+                    .filter(item => item.lastVisbility === true)
+                    .map(item => item.definitionClause)
+                    .join(' OR ')
+            );
+        }
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -134,7 +134,7 @@
 </template>
 
 <script lang="ts">
-import { GlobalEvents, LayerInstance } from '@/api';
+import { GlobalEvents } from '@/api';
 import { Vue, Component, Prop } from 'vue-property-decorator';
 
 import { LegendEntry, Controls } from '../store/legend-defs';
@@ -142,7 +142,6 @@ import { LegendEntry, Controls } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
 import LegendSymbologyStackV from './symbology-stack.vue';
 import LegendOptionsV from './legend-options.vue';
-import { LayerType } from '@/geo/api';
 
 @Component({
     components: {
@@ -153,46 +152,6 @@ import { LayerType } from '@/geo/api';
 })
 export default class LegendEntryV extends Vue {
     @Prop() legendItem!: LegendEntry;
-
-    // Making handlers a list in case more are added in the future
-    handlers: Array<string> = [];
-
-    mounted() {
-        // Update checkbox value when the layer reloads
-        this.handlers.push(
-            this.$iApi.event.on(
-                GlobalEvents.LAYER_RELOAD_END,
-                (reloadedLayer: LayerInstance) => {
-                    let updateVisibilityFlag: boolean = false;
-                    if (reloadedLayer.layerType === LayerType.MAPIMAGE) {
-                        // Check if this.uid is a child of reloadedLayer
-                        if (
-                            this.legendItem.layerUID &&
-                            reloadedLayer
-                                .getLayerTree()
-                                .findChildByUid(this.legendItem.layerUID)
-                        ) {
-                            updateVisibilityFlag = true;
-                        }
-                    } else if (this.legendItem.layerUID === reloadedLayer.uid) {
-                        updateVisibilityFlag = true;
-                    }
-
-                    if (updateVisibilityFlag) {
-                        // Wait for layer to fully load
-                        this.legendItem.layer?.isLayerLoaded().then(() => {
-                            this.legendItem.toggleVisibility(true);
-                        });
-                    }
-                }
-            )
-        );
-    }
-
-    unmounted() {
-        // Remove all event handlers for this component
-        this.handlers.forEach(handler => this.$iApi.event.off(handler));
-    }
 
     /**
      * Display symbology stack for the layer.

--- a/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
@@ -44,10 +44,11 @@ import { LayerStore } from '@/store/modules/layer';
 import { LayerInstance } from '@/api/internal';
 
 import { LegendStore } from '../store';
-import { LegendEntry, LegendTypes } from '../store/legend-defs';
+import { LegendEntry, LegendGroup, LegendTypes } from '../store/legend-defs';
 
 import LegendCheckboxV from './checkbox.vue';
 import LegendSymbologyStackV from './symbology-stack.vue';
+import { LegendSymbology } from '@/geo/api';
 
 @Component({
     components: {
@@ -68,19 +69,30 @@ export default class LegendPlaceholderV extends Vue {
         );
 
         if (this.layer !== undefined) {
-            this.layer.isLayerLoaded().then(r => {
-                this.legendItem._layer = this.layer;
-                this.legendItem._type = LegendTypes.Entry;
-                this.legendItem._uid =
-                    this.layer!.getLayerTree().findChildByIdx(
-                        this.legendItem._layerIndex!
-                    )?.uid || this.layer!.uid;
-                if (this.legendItem.isDefault) {
-                    this.$store.set(
-                        LegendStore.updateDefaultEntry,
-                        this.legendItem.id
-                    );
-                }
+            this.layer.isLayerLoaded().then(() => {
+                // Wait for symbology to load too
+                Promise.all(
+                    this.layer!.getLegend().map(
+                        (item: LegendSymbology) => item.drawPromise
+                    )
+                ).then(() => {
+                    this.legendItem._layer = this.layer;
+                    this.legendItem._type = LegendTypes.Entry;
+                    this.legendItem._uid =
+                        this.layer!.getLayerTree().findChildByIdx(
+                            this.legendItem._layerIndex!
+                        )?.uid || this.layer!.uid;
+                    if (this.legendItem.isDefault) {
+                        this.$store.set(
+                            LegendStore.updateDefaultEntry,
+                            this.legendItem.id
+                        );
+                    }
+
+                    if (this.legendItem.parent instanceof LegendGroup) {
+                        this.legendItem.parent.checkVisibility(this.legendItem);
+                    }
+                });
             });
         }
     }

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -121,6 +121,7 @@ export default class SettingsScreenV extends Vue {
     @Prop() legendItem!: LegendEntry;
 
     // Models.
+    layerName: string = '';
     visibilityModel: boolean = this.layer.getVisibility(this.uid);
     opacityModel: number = this.layer.getOpacity(this.uid) * 100;
     snapshotToggle: boolean = false;
@@ -131,6 +132,7 @@ export default class SettingsScreenV extends Vue {
         this.layer.isLayerLoaded().then(() => {
             this.visibilityModel = this.layer.getVisibility(this.uid);
             this.opacityModel = this.layer.getOpacity(this.uid) * 100;
+            this.layerName = this.layer.getName(this.uid);
         });
 
         this.handlers.push(
@@ -186,13 +188,6 @@ export default class SettingsScreenV extends Vue {
     toggleSnapshot() {
         this.snapshotToggle = !this.snapshotToggle;
         // TODO: make necessary changes to layer
-    }
-
-    get layerName() {
-        if (this.layer) {
-            return this.layer.getName(this.uid);
-        }
-        return '';
     }
 }
 </script>


### PR DESCRIPTION
## Related issues: #652, #656

## Changes in this PR
+ [FIX] Checkbox visibility toggle now checks if the layer isn't a WMS layer before updating child symbology visibility 
+ [FIX] WMS symbology will load when the layer reloads
    + Additionally, all legend entries will be in placeholder state until its symbology fully loads 
+ [FIX] Settings panel no longer throws error if layer is reloaded while it is open
+ [FIX] Parent legend components will properly update their visibility when a child layer reloads 
+ [FIX] Data table now avoids fetching tabular attributes if the layer is a WMS layer

## Further work/comments/questions
None

## Steps to test
[Demo - Ramp Starter](http://ramp4-app.azureedge.net/demo/users/sharvenp/652/host/index.html)
[Demo - WMS Layer](http://ramp4-app.azureedge.net/demo/users/sharvenp/652/host/index-e2e.html?script=wms-layer)

WMS layers:
1. Load WMS layer demo
2. Expand the symbology of a layer and refresh it - check if the symbology loads again
4. Toggle the layer's checkbox - there should be no errors thrown in the console
5. Open the layer's data table - table should be empty and no errors thrown in the console

Settings panel:
1. Load RAMP starter demo
2. Open the settings panel of the layer and toggle layer visibility - settings panel should update the visibility slider too
3. Set the visibility to off and reload layer - settings panel should properly update visibility and no errors in the console

Parent legend item visibility:
1. Load RAMP starter demo
2. Toggle "Water Quantity" and "Water Quality" off - "Group in Set" legend group should be toggled off
3. Refresh one of these layers - "Group in Set" legend group should be toggled back on
