### PR TITLE
Grid keyboard navigation

### DIFF
--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -77,7 +77,7 @@ export default class DropdownMenuV extends Vue {
         });
     }
 
-    unmounted() {
+    beforeDestroy() {
         window.removeEventListener(
             'click',
             event => {

--- a/packages/ramp-core/src/directives/focus-list/focus-item.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-item.ts
@@ -32,7 +32,7 @@ export const FocusItem: Vue.DirectiveOptions = {
     }
 };
 
-function generateID(): string {
+export function generateID(): string {
     let newID;
     do {
         newID =

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -354,14 +354,28 @@ export class FocusListManager {
      * @param {MouseEvent} event click event
      */
     onClick(event: MouseEvent) {
-        event.stopPropagation();
         this.defocusItem(this.highlightedItem);
 
-        const targetElement = event.target as HTMLElement;
+        let targetElement = event.target as HTMLElement;
+
+        // This block restricts the search space to valid choices.
+        if (!targetElement.hasAttribute(LIST_ATTR)) {
+            // if we're in a sublist => loop
+            while (
+                targetElement.parentElement!.closest(`[${LIST_ATTR}]`) !==
+                this.element
+            ) {
+                targetElement = targetElement.parentElement!.closest(
+                    `[${LIST_ATTR}]`
+                )! as HTMLElement;
+            }
+            // targetElement is now the root of the closest sublist to *this* focus list
+        }
+
         this.highlightedItem =
-            (targetElement.closest(
-                `[${ITEM_ATTR}],[${LIST_ATTR}]`
-            ) as HTMLElement) || this.highlightedItem;
+            (targetElement.closest(`[${ITEM_ATTR}]`) as HTMLElement) ||
+            (targetElement.closest(`[${LIST_ATTR}]`) as HTMLElement) ||
+            this.highlightedItem;
 
         // if target element is a focus item then focus the list
         if (targetElement.hasAttribute(`${ITEM_ATTR}`)) {

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -95,7 +95,7 @@ function syncTabIndex(element: HTMLElement) {
  * Each instance of this class is tied to an element. These are created in the bind function for the `FocusList` directive.
  * This class manages the focus within the element, mainly moving between `focus-item`s with arrow keys.
  */
-class FocusListManager {
+export class FocusListManager {
     element: HTMLElement;
     highlightedItem: HTMLElement;
     isHorizontal: boolean;

--- a/packages/ramp-core/src/fixtures/grid/accessibility.ts
+++ b/packages/ramp-core/src/fixtures/grid/accessibility.ts
@@ -34,6 +34,13 @@ export default class GridAccessibilityManager {
             this.element.querySelectorAll(HEADER_ROW_SELECTOR)
         ) as HTMLElement[];
 
+        this.element
+            .querySelector('.ag-center-cols-viewport')
+            ?.classList.add('overflow-hidden');
+        this.element
+            .querySelector('.ag-body-horizontal-scroll-viewport')
+            ?.setAttribute('tabindex', '-1');
+
         this.observer = new MutationObserver(mutations => {
             const el = mutations[0].target as HTMLElement;
             this.manageHeaderScrolling(el);

--- a/packages/ramp-core/src/fixtures/grid/accessibility.ts
+++ b/packages/ramp-core/src/fixtures/grid/accessibility.ts
@@ -1,0 +1,230 @@
+import { ColumnApi, GridApi } from 'ag-grid-community';
+import { FocusListManager, generateID } from '@/directives/focus-list';
+
+const FOCUS_LIST_ATTR = 'focus-list';
+const FOCUS_ITEM_ATTR = 'focus-item';
+const GRID_BODY_SELECTOR = '.ag-body-viewport';
+const HEADER_ROW_SELECTOR = '.ag-header-viewport .ag-header-row';
+
+export default class GridAccessibilityManager {
+    element: HTMLElement;
+    gridBody: HTMLElement;
+    headerRows: HTMLElement[];
+    gridApi: GridApi;
+    columnApi: ColumnApi;
+    observer: MutationObserver;
+
+    mousedown: boolean = false;
+
+    /**
+     * Initializes focus lists and listeners for grid keyboard navigation.
+     *
+     * @param {HTMLElement} element The grid element
+     * @param {GridApi} gridApi The ag-grid grid api
+     * @param {ColumnApi} columnApi The ag-grid column api
+     */
+    constructor(element: HTMLElement, gridApi: GridApi, columnApi: ColumnApi) {
+        this.element = element;
+        this.gridApi = gridApi;
+        this.columnApi = columnApi;
+        this.gridBody = this.element.querySelector(
+            GRID_BODY_SELECTOR
+        )! as HTMLElement;
+        this.headerRows = Array.prototype.slice.call(
+            this.element.querySelectorAll(HEADER_ROW_SELECTOR)
+        ) as HTMLElement[];
+
+        this.observer = new MutationObserver(mutations => {
+            const el = mutations[0].target as HTMLElement;
+            this.manageHeaderScrolling(el);
+        });
+
+        this.initAccessibilityListeners();
+        this.gridBody.toggleAttribute(FOCUS_LIST_ATTR, true);
+        new FocusListManager(this.gridBody as HTMLElement, '');
+    }
+
+    /**
+     * Set up the listeners for the grid
+     */
+    private initAccessibilityListeners() {
+        this.gridBody.addEventListener('keydown', event => {
+            this.onKeydown(event);
+        });
+        this.gridBody.addEventListener(
+            'focus',
+            () => {
+                this.onFocus();
+            },
+            false
+        );
+        this.element.addEventListener('mousedown', () => {
+            this.onMousedown();
+        });
+        this.element.addEventListener('mouseup', () => {
+            this.onMouseup();
+        });
+
+        this.headerRows.forEach((row, index) => {
+            // Force rows to not be tabbable
+            // since they are created after everything has rendered the parent focus-lists will not be able to toggle them off before user input
+            row.setAttribute('tabindex', '-1');
+            row.toggleAttribute(FOCUS_LIST_ATTR, true);
+            this.observer.observe(row, {
+                attributeFilter: ['aria-activedescendant']
+            });
+            row.addEventListener('focus', () => {
+                this.manageHeaderScrolling(row);
+            });
+            if (index > 0) {
+                row.addEventListener('keydown', (event: KeyboardEvent) => {
+                    this.shiftTabHandler(event);
+                });
+            }
+
+            // set up cells as focus list items, need to manually add ID since we can't use the directive
+            const headerCells = Array.prototype.slice.call(
+                row.querySelectorAll('.ag-header-cell')
+            ) as HTMLElement[];
+            headerCells.forEach(cell => {
+                cell.toggleAttribute('focus-item', true);
+                cell.id = generateID();
+                cell.classList.add('default-focus-style');
+            });
+
+            new FocusListManager(row as HTMLElement, 'horizontal');
+        });
+    }
+
+    /**
+     * Remove all accessibility listeners from the grid
+     */
+    removeAccessibilityListeners() {
+        this.gridBody.removeEventListener('keydown', event => {
+            this.onKeydown(event);
+        });
+        this.gridBody.removeEventListener(
+            'focus',
+            () => {
+                this.onFocus();
+            },
+            true
+        );
+        this.element.removeEventListener('mousedown', () => {
+            this.onMousedown();
+        });
+        this.element.removeEventListener('mouseup', () => {
+            this.onMouseup();
+        });
+        this.observer.disconnect();
+
+        this.headerRows.forEach(row => {
+            row.removeEventListener('focus', () => {
+                this.manageHeaderScrolling(row);
+            });
+        });
+    }
+
+    /**
+     * Callback for the keydown event.
+     * On tab focuses the first cell if needed. On shift+tab backs out to the last header row.
+     *
+     * @param {KeyboardEvent} event the keyboard event that triggered the callback
+     */
+    private onKeydown(event: KeyboardEvent) {
+        const focusedCell = this.gridApi.getFocusedCell();
+
+        if (event.key === 'Tab' && focusedCell === null) {
+            // if first tab into grid body automatically focus on first cell
+            const firstCol = this.columnApi.getAllDisplayedColumns()[0];
+            this.gridApi.setFocusedCell(0, firstCol);
+        } else if (event.key === 'Tab' && event.shiftKey) {
+            // Get visible headers, there are invisible ones but they aren't under `.ag-header-viewport`
+            const headers = this.element.querySelectorAll(HEADER_ROW_SELECTOR);
+            // Prevent the real shift + tab event from happening after focus leaves the grid
+            event.preventDefault();
+            // Force focus onto the last header
+            (headers[headers.length - 1] as HTMLElement).focus();
+        }
+    }
+
+    /**
+     * Helper function to handle the mousedown event
+     */
+    private onMousedown() {
+        this.mousedown = true;
+    }
+
+    /**
+     * Helper function to handle the mouseup event
+     */
+    private onMouseup() {
+        this.mousedown = false;
+    }
+
+    /**
+     * Callback for the focus event on the grid body.
+     * Manages the grid's focused cell when the grid itself is given focus.
+     */
+    private onFocus() {
+        // Don't want to adjust focused cell if focus was gained via mouseclick
+        if (!this.mousedown) {
+            let firstCol = this.columnApi.getAllDisplayedColumns()[0];
+
+            const focusedCell = this.gridApi.getFocusedCell();
+            if (!this.gridApi.getFocusedCell()) {
+                // focus first cell if nothing was focused
+                this.gridApi.setFocusedCell(0, firstCol);
+                this.gridApi.ensureIndexVisible(0);
+                this.gridApi.ensureColumnVisible(firstCol);
+            } else {
+                this.gridApi.setFocusedCell(
+                    focusedCell.rowIndex,
+                    focusedCell.column
+                );
+            }
+        }
+    }
+
+    /**
+     * Makes sure the currently selected header cell is always visible
+     * @param row the header row to manage
+     */
+    private manageHeaderScrolling(row: Element) {
+        if (this.mousedown) {
+            return;
+        }
+
+        const id = row.getAttribute('aria-activedescendant');
+        if (id) {
+            row.querySelectorAll(`[${FOCUS_ITEM_ATTR}]`).forEach(
+                (cell: Element, index: number) => {
+                    if (cell.id === id) {
+                        this.gridApi.ensureColumnVisible(
+                            this.columnApi.getAllDisplayedColumns()[index]
+                        );
+                    }
+                }
+            );
+        } else {
+            this.gridApi.ensureColumnVisible(
+                this.columnApi.getAllDisplayedColumns()[0]
+            );
+        }
+    }
+
+    //TODO: Grid wasn't scrolling to column properly when something inside the header was focused, see if we can make that work
+    /**
+     * Callback for keydown event on header rows
+     * Moves focus to previous header row on shift + tab (instead of anything inside the row)
+     *
+     * @param event
+     */
+    private shiftTabHandler(event: KeyboardEvent) {
+        if (event.key === 'Tab' && event.shiftKey) {
+            event.preventDefault();
+            const index = this.headerRows.indexOf(event.target as HTMLElement);
+            this.headerRows[index - 1].focus();
+        }
+    }
+}

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -85,6 +85,7 @@ import { AgGridVue } from 'ag-grid-vue';
 import GridColumnDropdownV from './column-dropdown.vue';
 import { GridConfig } from './store';
 import TableStateManager from './store/table-state-manager';
+import GridAccessibilityManager from './accessibility';
 
 // custom filter templates
 import GridCustomNumberFilterV from './templates/custom-number-filter.vue';
@@ -126,6 +127,8 @@ export default class GridTableComponentV extends Vue {
     rowData: any = [];
     oidField: string = 'OBJECTID';
 
+    gridAccessibilityManager: GridAccessibilityManager | undefined;
+
     quicksearch = '';
     filterInfo = {
         firstRow: 0,
@@ -149,12 +152,18 @@ export default class GridTableComponentV extends Vue {
 
         // set up grid options
         this.gridOptions = {
+            // lets header navigation be predictable, otherwise focus lists will be out of sync as soon as a column is shifted
+            ensureDomOrder: true,
             floatingFilter: this.config.state.colFilter,
             suppressRowTransform: true,
             onFilterChanged: this.updateFilterInfo,
             onBodyScroll: this.updateFilterInfo,
             rowBuffer: 0,
-            suppressColumnVirtualisation: true
+            suppressColumnVirtualisation: true,
+            // remove tab navigation between cells
+            tabToNextCell: () => {
+                return null;
+            }
         };
 
         const fancyLayer: LayerInstance | undefined = this.getLayerByUid(
@@ -250,6 +259,10 @@ export default class GridTableComponentV extends Vue {
         });
     }
 
+    unmounted() {
+        this.gridAccessibilityManager?.removeAccessibilityListeners();
+    }
+
     onGridReady(params: any) {
         this.gridApi = params.api;
         this.columnApi = params.columnApi;
@@ -266,6 +279,12 @@ export default class GridTableComponentV extends Vue {
     gridRendered() {
         // size grid columns
         this.columnApi.autoSizeAllColumns();
+
+        this.gridAccessibilityManager = new GridAccessibilityManager(
+            this.$el as HTMLElement,
+            this.gridApi,
+            this.columnApi
+        );
     }
 
     // Updates the global search value.
@@ -585,5 +604,10 @@ interface ColumnDefinition {
 <style scoped>
 ::v-deep .ag-header-cell-sortable {
     cursor: default;
+}
+
+::v-deep .ag-header-cell {
+    background: none;
+    border: none;
 }
 </style>

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -259,7 +259,7 @@ export default class GridTableComponentV extends Vue {
         });
     }
 
-    unmounted() {
+    beforeDestroy() {
         this.gridAccessibilityManager?.removeAccessibilityListeners();
     }
 

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="h-full flex items-center justify-center">
         <div class="inline float-left text-xs w-1/2">
             <input
                 class="rv-input"

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -106,6 +106,12 @@ export default class GridCustomHeaderV extends Vue {
         });
     }
 
+    unmounted() {
+        this.params.column.removeEventListener('leftChanged', () => {
+            this.onColumnReorder();
+        });
+    }
+
     onColumnReorder() {
         const columns: any = this.columnApi.getAllDisplayedColumns();
         const columnIdx: number = columns.indexOf(this.params.column);
@@ -165,3 +171,5 @@ export default interface GridCustomHeader {
     params: any;
 }
 </script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -106,7 +106,7 @@ export default class GridCustomHeaderV extends Vue {
         });
     }
 
-    unmounted() {
+    beforeDestroy() {
         this.params.column.removeEventListener('leftChanged', () => {
             this.onColumnReorder();
         });

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="h-full flex items-center justify-center">
         <input
             class="rv-min rv-input"
             style="width: 45%;"

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="h-full flex items-center justify-center">
         <select
             class="rv-input w-full"
             v-model="selectedOption"

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div class="h-full flex items-center justify-center">
         <input
             class="rv-input w-full"
             type="text"

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -4,6 +4,7 @@
         :content="$t('grid.cells.details')"
         v-tippy="{ placement: 'top' }"
         @click="openDetails"
+        tabindex="-1"
     >
         <svg
             class="m-auto"

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -4,6 +4,7 @@
         :content="$t('grid.cells.zoom')"
         v-tippy="{ placement: 'top' }"
         @click="zoomToFeature"
+        tabindex="-1"
     >
         <svg
             class="m-auto"

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -167,7 +167,7 @@ export default class SettingsScreenV extends Vue {
         );
     }
 
-    unmounted() {
+    beforeDestroy() {
         // Remove all event handlers for this component
         this.handlers.forEach(handler => this.$iApi.event.off(handler));
     }


### PR DESCRIPTION
closes #587 

New stuff/changes:
- Grid header rows are now focus lists
- Set ag-grid to preserve DOM order for columns (this fixes tabbing being out of sync when columns are moved)
- Every time a focus list is navigated the grid is told to make the selected column visible, this is also done when tabbing/shift-tabbing to a header row or the grid body
- Tabbing from a cell in the grid will move past the grid instead of to the next cell

Normally shift tabbing to a focus list would select the last thing within the active focus item (I.e. focus on a button instead of the list), I had to force it to select the lists as the grid would not properly show the column (I do not know why but I left a TODO).

DEMO: http://ramp4-app.azureedge.net/demo/users/spencerwahl/grid-keyboard-nav/host/index.html
No real steps just try to interact with the grid with the keyboard. Try clicking on things as well, things should work as they did before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/661)
<!-- Reviewable:end -->
