### PR TITLE
Grid filters

### DIFF
--- a/packages/ramp-core/.eslintrc.js
+++ b/packages/ramp-core/.eslintrc.js
@@ -7,7 +7,8 @@ module.exports = {
     rules: {
         'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
         'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-        'no-dupe-class-members': 'off' // `no-dupe-class-members` complains when function overloads are used
+        'no-dupe-class-members': 'off', // `no-dupe-class-members` complains when function overloads are used
+        'no-useless-escape': 'off'
     },
     parserOptions: {
         parser: '@typescript-eslint/parser'

--- a/packages/ramp-core/src/fixtures/grid/api/grid.ts
+++ b/packages/ramp-core/src/fixtures/grid/api/grid.ts
@@ -1,5 +1,5 @@
 import { FixtureInstance } from '@/api';
-import { GridConfig } from '../store';
+import { GridConfig, GridStore } from '../store';
 import TableStateManager from '../store/table-state-manager';
 
 export class GridAPI extends FixtureInstance {
@@ -13,7 +13,7 @@ export class GridAPI extends FixtureInstance {
     toggleGrid(uid: string, open?: boolean): void {
         // get GridConfig for specified uid
         let gridSettings: GridConfig | undefined = this.$vApp.$store.get(
-            `grid/grids@${uid}`
+            `${GridStore.grids}@${uid}`
         );
 
         // if no GridConfig exists for the given uid, create it.
@@ -32,10 +32,10 @@ export class GridAPI extends FixtureInstance {
         }
 
         const prevUid = this.$vApp.$store.get(
-            'grid/currentUid',
+            GridStore.currentUid,
             uid ? uid : null
         );
-        this.$vApp.$store.set('grid/currentUid', uid ? uid : null);
+        this.$vApp.$store.set(GridStore.currentUid, uid ? uid : null);
 
         const panel = this.$iApi.panel.get('grid-panel');
 

--- a/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
+++ b/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
@@ -10,8 +10,8 @@
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
                     fit=""
-                    height="16px"
-                    width="16px"
+                    height="24px"
+                    width="24px"
                     preserveAspectRatio="xMidYMid meet"
                     viewBox="0 0 24 24"
                     focusable="false"

--- a/packages/ramp-core/src/fixtures/grid/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/grid/lang/lang.csv
@@ -4,6 +4,7 @@ grid.layer.loading,The layer is loading...,1,La couche est le chargement...,0
 grid.label.columns,Hide columns,1,Masquer les colonnes,0
 grid.label.filters.show,Show filters,1,Afficher les filtres,1
 grid.label.filters.hide,Hide filters,1,Cacher les filtres,0
+grid.label.filters.apply,Apply filters to map,1,Appliquer des filtres à la carte,0
 grid.header.sort.0,Sort ascending,1,Trier par ordre ascendant,0
 grid.header.sort.1,Sort descending,1,Le tri descendant,0
 grid.header.sort.2,Sort default,1,Trier par défaut,0

--- a/packages/ramp-core/src/fixtures/grid/screen.vue
+++ b/packages/ramp-core/src/fixtures/grid/screen.vue
@@ -65,6 +65,7 @@ import { Get } from 'vuex-pathify';
 
 import { LayerInstance, PanelInstance } from '@/api';
 import GridTableComponentV from '@/fixtures/grid/table-component.vue';
+import { GridStore } from './store';
 
 import { LayerStore } from '@/store/modules/layer';
 
@@ -75,40 +76,40 @@ import { LayerStore } from '@/store/modules/layer';
 })
 export default class GridScreenV extends Vue {
     @Prop() panel!: PanelInstance;
-    @Prop() header!: String;
+    @Prop() header!: string;
 
     @Get(LayerStore.layers) layers!: LayerInstance[];
-    @Get('grid/currentUid') currentUid: any;
+    @Get(GridStore.currentUid) currentUid!: string;
 
-    quicksearch: String = '';
-    grid: any = undefined;
-    head: String = '';
-    layer: any = undefined;
+    quicksearch: string = '';
+    grid: GridTableComponentV | undefined;
+    head: string = '';
+    layer: LayerInstance | undefined = undefined;
 
     mounted() {
-        this.grid = this.$refs.rvGrid;
+        this.grid = this.$refs.rvGrid as GridTableComponentV;
         this.head = this.layerName;
     }
 
     updateQuickSearch(): void {
-        this.grid.quicksearch = this.quicksearch;
-        this.grid.updateQuickSearch();
+        this.grid!.quicksearch = this.quicksearch;
+        this.grid!.updateQuickSearch();
     }
 
     resetQuickSearch(): void {
-        this.grid.quicksearch = this.quicksearch = '';
-        this.grid.updateQuickSearch();
+        this.grid!.quicksearch = this.quicksearch = '';
+        this.grid!.updateQuickSearch();
     }
 
     clearFilters(): void {
         this.resetQuickSearch();
-        this.grid.clearFilters();
+        this.grid!.clearFilters();
     }
 
     get layerName() {
         if (this.grid) {
             this.layer = this.grid.getLayerByUid(this.grid.layerUid);
-            return this.layer.getName(this.grid.layerUid);
+            return this.layer!.getName(this.grid.layerUid);
         }
         return '';
     }

--- a/packages/ramp-core/src/fixtures/grid/store/grid-state.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/grid-state.ts
@@ -24,7 +24,7 @@ export class GridState {
      * @type {(string | null)}
      * @memberof GridState
      */
-    currentUid: String | null = null;
+    currentUid: string | null = null;
 }
 
 export interface GridConfig {

--- a/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
@@ -32,7 +32,8 @@ const mutations = {
 };
 
 export enum GridStore {
-    grids = 'grid/grids'
+    grids = 'grid/grids',
+    currentUid = 'grid/currentUid'
 }
 
 export function grid() {

--- a/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
+++ b/packages/ramp-core/src/fixtures/grid/store/grid-store.ts
@@ -1,5 +1,6 @@
 import { ActionContext, Action, Mutation } from 'vuex';
 import { make } from 'vuex-pathify';
+import Vue from 'vue';
 
 import { GridState, GridConfig } from './grid-state';
 import { RootState } from '@/store/state';
@@ -7,11 +8,13 @@ import { RootState } from '@/store/state';
 type GridContext = ActionContext<GridState, RootState>;
 
 export enum GridAction {
-    addGrid = 'addGrid'
+    addGrid = 'addGrid',
+    removeGrid = 'removeGrid'
 }
 
 export enum GridMutation {
-    ADD_GRID = 'ADD_GRID'
+    ADD_GRID = 'ADD_GRID',
+    REMOVE_GRID = 'REMOVE_GRID'
 }
 
 const getters = {
@@ -23,11 +26,17 @@ const getters = {
 const actions = {
     [GridAction.addGrid](context: GridContext, value: GridConfig): void {
         context.commit(GridMutation.ADD_GRID, value);
+    },
+    [GridAction.removeGrid](context: GridContext, uid: string): void {
+        context.commit(GridMutation.REMOVE_GRID, uid);
     }
 };
 const mutations = {
     [GridMutation.ADD_GRID](state: GridState, value: GridConfig): void {
         state.grids = { ...state.grids, [value.uid]: value };
+    },
+    [GridMutation.REMOVE_GRID](state: GridState, uid: string): void {
+        Vue.delete(state.grids, uid);
     }
 };
 

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -20,6 +20,30 @@
             </span>
             <div class="flex-grow"></div>
 
+            <button
+                class="p-8 disabled:opacity-30 disabled:cursor-default"
+                @click="applyFiltersToMap"
+                :content="$t('grid.label.filters.apply')"
+                v-tippy="{ placement: 'bottom', hideOnClick: false }"
+                :disabled="filterSync"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fit=""
+                    height="24px"
+                    width="24px"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                    focusable="false"
+                >
+                    <g id="map-refresh">
+                        <path
+                            d="m 15.585999,21.223066 2.414,-2.414 v 1.811 A 3.616,3.616 0 0 0 21.2,15.309066 l 0.881,-0.881 a 4.82,4.82 0 0 1 -4.080001,7.4 v 1.811 z m -13.5859988,-9.224 a 10,10 0 1 1 19.9999998,0 c 0,0.172 0,0.346 -0.013,0.517 a 5.971,5.971 0 0 0 -2.014001,-1.184001 7.935,7.935 0 0 0 -4.973,-6.742999 v 0.41 a 2,2 0 0 1 -2,2 h -2 v 2 A 1,1 0 0 1 10,9.9990662 H 8.0000002 v 1.9999998 h 5.9999988 a 1,1 0 0 1 0.495,0.131 6,6 0 0 0 -0.184,9.6 10.009,10.009 0 0 1 -12.3109988,-9.731 z m 2,0 a 8,8 0 0 0 6.9999988,7.93 v -1.93 a 2,2 0 0 1 -1.9999988,-2 v -1 l -4.79,-4.79 a 8.07,8.07 0 0 0 -0.21,1.79 z m 9.1729988,5 a 4.827,4.827 0 0 1 4.827,-4.828 v -1.81 l 2.414,2.414 -2.414,2.413 v -1.809 a 3.623,3.623 0 0 0 -3.62,3.62 3.537,3.537 0 0 0 0.42,1.69 l -0.881,0.881 a 4.787,4.787 0 0 1 -0.746,-2.571 z"
+                        ></path>
+                    </g>
+                </svg>
+            </button>
+
             <!-- show/hide columns -->
             <column-dropdown
                 :columnApi="columnApi"
@@ -27,35 +51,33 @@
             ></column-dropdown>
 
             <!-- toggle column filters -->
-            <div>
-                <button
-                    class="w-64"
-                    @click="toggleShowFilters()"
-                    :content="
-                        gridOptions.floatingFilter
-                            ? $t('grid.label.filters.hide')
-                            : $t('grid.label.filters.show')
-                    "
-                    v-tippy="{ placement: 'bottom', hideOnClick: false }"
+            <button
+                class="p-8"
+                @click="toggleShowFilters()"
+                :content="
+                    gridOptions.floatingFilter
+                        ? $t('grid.label.filters.hide')
+                        : $t('grid.label.filters.show')
+                "
+                v-tippy="{ placement: 'bottom', hideOnClick: false }"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    fit=""
+                    height="24px"
+                    width="24px"
+                    preserveAspectRatio="xMidYMid meet"
+                    viewBox="0 0 24 24"
+                    focusable="false"
+                    class="inline"
                 >
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        fit=""
-                        height="16px"
-                        width="16px"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 24 24"
-                        focusable="false"
-                        class="inline"
-                    >
-                        <g id="filter_cache958">
-                            <path
-                                d="M 3,2L 20.9888,2L 21,2L 21,2.01122L 21,3.99999L 20.9207,3.99999L 14,10.9207L 14,22.909L 9.99999,18.909L 10,10.906L 3.09405,3.99999L 3,3.99999L 3,2 Z "
-                            ></path>
-                        </g>
-                    </svg>
-                </button>
-            </div>
+                    <g id="filter_cache958">
+                        <path
+                            d="M 3,2L 20.9888,2L 21,2L 21,2.01122L 21,3.99999L 20.9207,3.99999L 14,10.9207L 14,22.909L 9.99999,18.909L 10,10.906L 3.09405,3.99999L 3,3.99999L 3,2 Z "
+                        ></path>
+                    </g>
+                </svg>
+            </button>
         </div>
 
         <!-- main grid component -->
@@ -81,6 +103,7 @@ import { Vue, Component, Prop } from 'vue-property-decorator';
 import { Get, Sync } from 'vuex-pathify';
 import { LayerInstance, GlobalEvents } from '@/api/internal';
 import { LayerStore } from '@/store/modules/layer';
+import { CoreFilter } from '@/geo/api';
 
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-material.css';
@@ -101,6 +124,8 @@ import GridCustomHeaderV from './templates/custom-header.vue';
 import DetailsButtonRendererV from './templates/details-button-renderer.vue';
 import ZoomButtonRendererV from './templates/zoom-button-renderer.vue';
 import { LayerType } from '@/geo/api';
+
+import { debounce } from 'throttle-debounce';
 
 // these should match up with the `type` value returned by the attribute promise.
 const NUM_TYPES: string[] = ['oid', 'double', 'integer'];
@@ -125,6 +150,8 @@ export default class GridTableComponentV extends Vue {
     ) => LayerInstance | undefined;
     @Sync(GridStore.grids) grids!: { [uid: string]: GridConfig };
 
+    handlers: Array<string> = [];
+
     columnApi: any = null;
     columnDefs: any = [];
     rowData: any = [];
@@ -139,9 +166,10 @@ export default class GridTableComponentV extends Vue {
         visibleRows: 0
     };
 
+    filterSync: boolean = true;
     filteredOids: number[] | undefined;
 
-    async beforeMount() {
+    beforeMount() {
         // load the grid config for this layer
         this.config = this.grids[this.layerUid];
 
@@ -160,14 +188,20 @@ export default class GridTableComponentV extends Vue {
             ensureDomOrder: true,
             floatingFilter: this.config.state.colFilter,
             suppressRowTransform: true,
-            onFilterChanged: this.updateFilterInfo,
+            onFilterChanged: () => {
+                this.filterSync = this.gridFiltersApplied();
+                this.updateFilterInfo();
+            },
             onBodyScroll: this.updateFilterInfo,
             rowBuffer: 0,
             suppressColumnVirtualisation: true,
             // remove tab navigation between cells
             tabToNextCell: () => {
                 return null;
-            }
+            },
+            onModelUpdated: debounce(300, () =>
+                this.columnApi.autoSizeAllColumns()
+            )
         };
 
         const fancyLayer: LayerInstance | undefined = this.getLayerByUid(
@@ -264,6 +298,8 @@ export default class GridTableComponentV extends Vue {
     }
 
     beforeDestroy() {
+        // Remove all event handlers for this component
+        this.handlers.forEach(handler => this.$iApi.event.off(handler));
         this.gridAccessibilityManager?.removeAccessibilityListeners();
     }
 
@@ -280,52 +316,36 @@ export default class GridTableComponentV extends Vue {
         }
 
         // listen for layer filter and visibility events and update grid appropriately
-        this.$iApi.event.on(
-            GlobalEvents.FILTER_CHANGE,
-            ({ uid, filterKey }: { uid: string; filterKey: string }) => {
-                if (uid === this.layerUid) {
-                    this.applyLayerFilters();
+        this.handlers.push(
+            this.$iApi.event.on(
+                GlobalEvents.FILTER_CHANGE,
+                ({ uid, filterKey }: { uid: string; filterKey: string }) => {
+                    if (
+                        filterKey !== CoreFilter.GRID &&
+                        uid &&
+                        (uid === this.layerUid ||
+                            this.getLayerByUid(uid)!.uid == this.layerUid)
+                    ) {
+                        this.applyLayerFilters();
+                    }
                 }
-            }
+            )
         );
-        this.$iApi.event.on(
-            GlobalEvents.LAYER_VISIBILITYCHANGE,
-            ({ visibility, uid }: { visibility: boolean; uid: string }) => {
-                if (
-                    uid === this.layerUid ||
-                    uid === this.getLayerByUid(this.layerUid)!.uid
-                ) {
-                    this.applyLayerFilters();
+        this.handlers.push(
+            this.$iApi.event.on(
+                GlobalEvents.LAYER_VISIBILITYCHANGE,
+                ({ visibility, uid }: { visibility: boolean; uid: string }) => {
+                    if (
+                        uid &&
+                        (uid === this.layerUid ||
+                            uid === this.getLayerByUid(this.layerUid)!.uid)
+                    ) {
+                        this.applyLayerFilters();
+                    }
                 }
-            }
+            )
         );
         this.applyLayerFilters();
-    }
-
-    // checks if any external (layer) filters are applied
-    isExternalFilterPresent() {
-        return this.filteredOids !== undefined;
-    }
-
-    // filters row based on layer filter
-    doesExternalFilterPass(node: any) {
-        return this.filteredOids!.includes(node.data[this.oidField]);
-    }
-
-    // updates external grid filter based on layer filter and rerenders grid
-    async applyLayerFilters() {
-        const layer = this.getLayerByUid(this.layerUid)!;
-        if (!layer.getVisibility(this.layerUid)) {
-            this.filteredOids = [];
-        } else {
-            this.filteredOids = await layer.getFilterOIDs(
-                undefined,
-                undefined,
-                this.layerUid
-            );
-        }
-        this.gridApi.onFilterChanged();
-        this.columnApi.autoSizeAllColumns();
     }
 
     gridRendered() {
@@ -588,14 +608,246 @@ export default class GridTableComponentV extends Vue {
         }
     }
 
-    clearColumnFilters() {
-        // Reset the global search filter.
-        this.gridApi.setQuickFilter(null);
-        this.quicksearch = '';
+    // checks if any external (layer) filters are applied
+    isExternalFilterPresent() {
+        return this.filteredOids !== undefined;
+    }
 
-        // Clear any existing column filters.
-        this.gridOptions.api.setFilterModel({});
-        this.gridApi.refreshHeader();
+    // filters row based on layer filter
+    doesExternalFilterPass(node: any) {
+        return this.filteredOids!.includes(node.data[this.oidField]);
+    }
+
+    // updates external grid filter based on layer filter and rerenders grid
+    async applyLayerFilters() {
+        const layer = this.getLayerByUid(this.layerUid)!;
+        if (!layer.getVisibility(this.layerUid)) {
+            this.filteredOids = [];
+        } else {
+            this.filteredOids = await layer.getFilterOIDs(
+                [CoreFilter.GRID],
+                undefined,
+                this.layerUid
+            );
+        }
+        this.gridApi.onFilterChanged();
+    }
+
+    applyFiltersToMap() {
+        const mapFilterQuery = this.getFiltersQuery();
+        const layer = this.getLayerByUid(this.layerUid);
+        layer!.setSqlFilter(CoreFilter.GRID, mapFilterQuery, this.layerUid);
+        this.filterSync = true;
+    }
+
+    // get filter SQL query string
+    getFiltersQuery() {
+        const filterModel = this.gridApi.getFilterModel();
+        let colStrs: any = [];
+        Object.keys(filterModel).forEach(col => {
+            colStrs.push(this.filterToSql(col, filterModel[col]));
+        });
+        if (this.quicksearch && this.quicksearch.length > 0) {
+            const globalSearchVal = this.globalSearchToSql() || '1=2';
+            if (globalSearchVal.length > 0) {
+                // do not push an empty global search
+                colStrs.push(`(${globalSearchVal})`);
+            }
+        }
+        return colStrs.join(' AND ');
+    }
+
+    // converts columns filter to SQL
+    filterToSql(col: string, colFilter: any): any {
+        const column = this.columnApi.getColumn(col).colDef;
+        switch (colFilter.filterType) {
+            case 'number':
+                switch (colFilter.type) {
+                    case 'greaterThanOrEqual':
+                        return `${col} >= ${colFilter.filter}`;
+                    case 'lessThanOrEqual':
+                        return `${col} <= ${colFilter.filter}`;
+                    case 'inRange':
+                        return `${col} >= ${colFilter.filter} AND ${col} <= ${colFilter.filterTo}`;
+                    default:
+                        break;
+                }
+                break;
+            case 'text':
+                if (column.isSelector) {
+                    return `UPPER(${col}) IN (${colFilter.filter.toUpperCase()})`;
+                } else {
+                    let val = colFilter.filter.replace(/'/g, /''/);
+                    if (val !== '') {
+                        // following code is to UNESCAPE all special chars for ESRI and geoApi SQL to parse properly (remove the backslash)
+                        const escRegex = /\\[(!"#$&'+,.\\/:;<=>?@[\]^`{|}~)]/g;
+                        // remVal stores the remaining string text after the last special char (or the entire string, if there are no special chars at all)
+                        let remVal = val;
+                        let newVal = '';
+                        let escMatch = escRegex.exec(val);
+                        // lastIdx stores the last found index of the start of an escaped special char
+                        let lastIdx = 0;
+                        while (escMatch) {
+                            // update all variables after finding an escaped special char, preserving all text except the backslash
+                            newVal =
+                                newVal +
+                                val.substr(lastIdx, escMatch.index - lastIdx) +
+                                escMatch[0].slice(-1);
+                            lastIdx = escMatch.index + 2;
+                            remVal = val.substr(escMatch.index + 2);
+                            escMatch = escRegex.exec(val);
+                        }
+                        newVal = newVal + remVal;
+
+                        // add ௌ before % and/or _ to act as the escape character
+                        // can change to MOST other characters and should still work (ideally want an escape char no one will search for) - just replace all instances of ௌ
+                        newVal = newVal.replace(/%/g, 'ௌ%');
+                        newVal = newVal.replace(/_/g, 'ௌ_');
+                        const filterVal = `*${newVal}`;
+                        newVal = filterVal.split(' ').join('*');
+                        // if val contains a % or _, add ESCAPE 'ௌ' at the end of the query
+                        let sqlWhere = `UPPER(${col}) LIKE \'${newVal
+                            .replace(/\*/g, '%')
+                            .toUpperCase()}%\'`;
+                        return sqlWhere.includes('ௌ%') ||
+                            sqlWhere.includes('ௌ_')
+                            ? `${sqlWhere} ESCAPE \'ௌ\'`
+                            : sqlWhere;
+                    }
+                }
+                break;
+            case 'date': {
+                const dateFrom = new Date(colFilter.dateFrom);
+                const dateTo = new Date(colFilter.dateTo);
+                const from = dateFrom
+                    ? `${dateFrom.getMonth() +
+                          1}/${dateFrom.getDate()}/${dateFrom.getFullYear()}`
+                    : undefined;
+                const to = dateTo
+                    ? `${dateTo.getMonth() +
+                          1}/${dateTo.getDate()}/${dateTo.getFullYear()}`
+                    : undefined;
+                switch (colFilter.type) {
+                    case 'greaterThanOrEqual':
+                        return `${col} >= DATE '${from}'`;
+                    case 'lessThanOrEqual':
+                        return `${col} <= DATE '${from}'`; // ag-grid uses from for a single upper limit as well
+                    case 'inRange':
+                        return `${col} >= DATE '${from}' AND ${col} <= DATE '${to}'`;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+
+    // convert global search to SQL string filter of columns excluding unfiltered columns
+    globalSearchToSql(): string {
+        // TODO: support for global search on dates
+        let val = this.quicksearch.replace(/'/g, "''");
+        // to implement quick filters, first need to split the search text on white space
+        const searchVals = val.split(' ');
+
+        const sortedRows = this.gridApi.rowModel.rowsToDisplay;
+        this.columnApi;
+        const columns = this.columnApi
+            .getAllDisplayedColumns()
+            .filter(
+                (column: any) =>
+                    column.colDef.filter === 'agTextColumnFilter' ||
+                    column.colDef.filter === 'agNumberColumnFilter'
+            );
+
+        let filteredColumns: any = [];
+
+        sortedRows.forEach((row: any) => {
+            let rowMatch = true;
+            let rowSql = '';
+            // each row must contain all of the split search values
+            for (let searchVal of searchVals) {
+                const re = new RegExp(
+                    `.*${searchVal
+                        .split(' ')
+                        .join('.*')
+                        .toUpperCase()}`
+                );
+                const filterVal = `%${searchVal
+                    .replace(/\*/g, '%')
+                    .split(' ')
+                    .join('%')
+                    .toUpperCase()}`;
+                // if any column data matches the search val in regex form, set foundVal to true and proceed to next search term
+                let foundVal = false;
+                for (let column of columns) {
+                    // process global search sql independently for text and number columnns
+                    if (column.colDef.filter === 'agTextColumnFilter') {
+                        const cellData =
+                            row.data[column.colId] === null
+                                ? null
+                                : row.data[column.colId].toString();
+                        if (
+                            cellData !== null &&
+                            re.test(cellData.toUpperCase())
+                        ) {
+                            rowSql
+                                ? (rowSql = rowSql.concat(
+                                      ' AND ',
+                                      `(UPPER(${column.colId}) LIKE \'${filterVal}%\')`
+                                  ))
+                                : (rowSql = rowSql.concat(
+                                      '(',
+                                      `(UPPER(${column.colId}) LIKE \'${filterVal}%\')`
+                                  ));
+                            // if we have already stored the current sql break from loop
+                            filteredColumns.includes(rowSql + ')')
+                                ? (foundVal = false)
+                                : (foundVal = true);
+                            break;
+                        }
+                    } else if (
+                        column.colDef.filter === 'agNumberColumnFilter'
+                    ) {
+                        const cellData =
+                            row.data[column.colId] === null
+                                ? null
+                                : row.data[column.colId];
+                        if (cellData !== null && re.test(cellData)) {
+                            rowSql
+                                ? (rowSql = rowSql.concat(
+                                      ' AND ',
+                                      `(${column.colId} = ${cellData})`
+                                  ))
+                                : (rowSql = rowSql.concat(
+                                      '(',
+                                      `(${column.colId} = ${cellData})`
+                                  ));
+                            filteredColumns.includes(rowSql + ')')
+                                ? (foundVal = false)
+                                : (foundVal = true);
+                            break;
+                        }
+                    }
+                }
+                // otherwise if any split search value is not found, set rowMatch to false and break because it has failed to meet criteria for quick search filters
+                if (!foundVal) {
+                    rowMatch = false;
+                    break;
+                }
+            }
+            // sql is added to array iff all split search values have been found somewhere in the current row data
+            if (rowMatch) {
+                filteredColumns.push(rowSql + ')');
+            }
+        });
+        return filteredColumns.join(' OR ');
+    }
+
+    // checks if current grid filters are applied to map
+    gridFiltersApplied() {
+        const gridQuery = this.getFiltersQuery();
+        const layer = this.getLayerByUid(this.layerUid);
+        const layerQuery = layer!.getSqlFilter(CoreFilter.GRID, this.layerUid);
+        return gridQuery === layerQuery;
     }
 
     stopArrowKeyProp(event: KeyboardEvent) {

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -177,13 +177,6 @@ export enum IdentifyMode {
     Haze = 'haze'
 }
 
-export enum CoreFilter {
-    SYMBOL = 'symbol',
-    GRID = 'grid',
-    EXTENT = 'extent',
-    API = 'api' // this would be a default api key. e.g. if someone just does an API filter set with no key parameter, it would use this.
-}
-
 export interface EpsgLookup {
     (code: string | number): Promise<string>;
 }
@@ -370,11 +363,11 @@ export interface FilterEventParam {
 
 // these represent filter keys that the core reserves. the above interface does not use it for typing as
 // 3rd parties can define their own keys.
-export enum CoreFilterKey {
+export enum CoreFilter {
     SYMBOL = 'symbol',
     GRID = 'grid',
     EXTENT = 'extent',
-    API = 'api'
+    API = 'api' // this would be a default api key. e.g. if someone just does an API filter set with no key parameter, it would use this.
 }
 
 // Attribution interface that contains all the core attributes of the attribution node

--- a/packages/ramp-core/src/geo/layer/attrib-fc.ts
+++ b/packages/ramp-core/src/geo/layer/attrib-fc.ts
@@ -16,7 +16,7 @@ import {
 import {
     Attributes,
     BaseGeometry,
-    CoreFilterKey,
+    CoreFilter,
     DataFormat,
     Extent,
     FieldDefinition,

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -11,7 +11,7 @@ import {
 import {
     Attribution,
     BaseGeometry,
-    CoreFilterKey,
+    CoreFilter,
     DefPromise,
     Extent,
     GeometryType,
@@ -122,7 +122,7 @@ export class MapAPI extends CommonMapAPI {
             this.$iApi.event.emit(GlobalEvents.MAP_EXTENTCHANGE, newExtent);
             this.$iApi.event.emit(GlobalEvents.FILTER_CHANGE, {
                 extent: newExtent,
-                filterKey: CoreFilterKey.EXTENT
+                filterKey: CoreFilter.EXTENT
             });
         });
 

--- a/packages/ramp-core/src/store/modules/panel/panel-store.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-store.ts
@@ -172,10 +172,12 @@ const mutations = {
         { panel }: { panel: PanelInstance }
     ): void {
         const index = state.orderedItems.indexOf(panel);
-        state.orderedItems = [
-            ...state.orderedItems.slice(0, index),
-            ...state.orderedItems.slice(index + 1)
-        ];
+        if (index !== -1) {
+            state.orderedItems = [
+                ...state.orderedItems.slice(0, index),
+                ...state.orderedItems.slice(index + 1)
+            ];
+        }
     }
 };
 


### PR DESCRIPTION
Syncing grid filters with map filters:
* applying a filter on a layer (through legend symbology checkboxes or API) will also filter the grid results for that layer #597
* invisible layers no longer show on the grid
* added `apply filters` button on the grid that will take the grid filters and apply equivalent SQL filters on the map layer (most logic for this was copy/paste from RAMP2) #653
* removed redundant `CoreFilterKey` enum

[demo](http://ramp4-app.azureedge.net/demo/users/an-w/grid/host/index.html)

will need a rebase after the other grid PR is merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/664)
<!-- Reviewable:end -->
