### PR TITLE
Move map caption functionality to MapCaption API

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -538,7 +538,7 @@ export class EventAPI extends APIScope {
                         .getConfig()
                         .map.basemaps.find(bms => bms.id === payload);
 
-                    this.$iApi.geo.map.updateAttribution(
+                    this.$iApi.geo.map.caption.updateAttribution(
                         currentBasemapConfig?.attribution
                     );
                 };
@@ -557,7 +557,7 @@ export class EventAPI extends APIScope {
                             bms.id === this.$iApi.geo.map.getCurrentBasemapId()
                     );
 
-                    this.$iApi.geo.map.updateAttribution(
+                    this.$iApi.geo.map.caption.updateAttribution(
                         currentBasemapConfig?.attribution
                     );
                 };
@@ -570,7 +570,9 @@ export class EventAPI extends APIScope {
             case DefEH.MAP_SCALECHANGE_SCALEBAR:
                 this.$iApi.event.on(
                     GlobalEvents.MAP_SCALECHANGE,
-                    debounce(300, () => this.$iApi.geo.map.updateScale()),
+                    debounce(300, () =>
+                        this.$iApi.geo.map.caption.updateScale()
+                    ),
                     handlerName
                 );
                 break;
@@ -610,16 +612,16 @@ export class EventAPI extends APIScope {
                 this.$iApi.event.on(
                     GlobalEvents.MAP_MOUSEMOVE,
                     throttle(200, (mapMove: MapMove) => {
-                        this.$iApi.geo.utils
-                            .formatLatLongDMSString(
+                        this.$iApi.geo.map.caption
+                            .formatPoint(
                                 this.$iApi.geo.map.screenPointToMapPoint(
                                     mapMove
                                 )
                             )
-                            .then(llstring => {
+                            .then(formattedString => {
                                 this.$iApi.$vApp.$store.set(
                                     MapCaptionStore.setCursorCoords,
-                                    llstring
+                                    formattedString
                                 );
                             });
                     }),

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -142,7 +142,7 @@ export default class MapCaptionV extends Vue {
         //      we would not want to re-add them back during a projection change -- want to respect the new custom handlers.
 
         this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
-            this.$iApi.geo.map.updateScale();
+            this.$iApi.geo.map.caption.updateScale();
         });
     }
 
@@ -163,7 +163,7 @@ export default class MapCaptionV extends Vue {
      */
     onScaleClick() {
         this.$iApi.$vApp.$store.set(MapCaptionStore.toggleScale, {});
-        this.$iApi.geo.map.updateScale();
+        this.$iApi.geo.map.caption.updateScale();
     }
 }
 </script>

--- a/packages/ramp-core/src/geo/map/caption.ts
+++ b/packages/ramp-core/src/geo/map/caption.ts
@@ -1,0 +1,471 @@
+import { APIScope, InstanceAPI } from '@/api/internal';
+import { MapCaptionStore } from '@/store/modules/map-caption';
+import { Attribution, Point, ScaleBarProperties } from '@/geo/api';
+
+export class MapCaptionAPI extends APIScope {
+    // Default point formatters
+    DEFAULT_POINT_FORMATTERS: any = {
+        LAT_LONG_DMS: this.formatLatLongDMS,
+        LAT_LONG_DD: this.formatLatLongDD,
+        LAT_LONG_DDM: this.formatLatLongDDM,
+        WEB_MERCATOR: this.formatMercator,
+        CANADA_ATLAS_LAMBERT: this.formatLambert,
+        UTM: this.formatUTM,
+        BASEMAP: this.formatBasemap
+    };
+
+    // The currently selected point-formatting function
+    protected pointFormatter: (p: Point) => Promise<string>;
+
+    /**
+     * @constructor
+     * @param {InstanceAPI} iApi the RAMP instance
+     */
+    constructor(iApi: InstanceAPI) {
+        super(iApi);
+
+        // default formatter
+        // TODO: Make this a config option?
+        this.pointFormatter = this.DEFAULT_POINT_FORMATTERS.LAT_LONG_DMS;
+    }
+
+    /**
+     * Updates the attribution on the map-caption bar
+     * Applies default ESRI attribution if incoming attribution is disabled or has undefined elements
+     *
+     * Updates map-caption store to notify map-caption component observer
+     *
+     * @function updateAttribution
+     * @param {Attribution} newAttribution incoming new attribution
+     */
+    updateAttribution(newAttribution: Attribution | undefined): void {
+        // Default attribution
+        let attribution: Attribution = {
+            text: { value: 'Powered by ESRI' },
+            logo: {
+                altText: 'ESRI logo',
+                link: 'https://www.esri.com/',
+                value:
+                    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEEAAAAkCAYAAADWzlesAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAADO9JREFUeNq0Wgl0jlca/pfvzyo6qNBSmhLLKE1kKEUtB9NTat+OYnBacwwJY19DZRC7sR41th60lWaizFSqRTOEw0lsrQSJGFIESSxJ/uRfv3nef+7Vt9f3p2E695z3fMt97/3ufe+7PO+9n9n0UzELsjKyiHdUdMZnVHTl2VyFe9nO7Kc/Io+4epUxmpWxeVkbr3hvUebgFf15GL9XUwZHndtAAYI09jGvIghOuoEwLOLeYiBoXrwGfZjYYOWAvWyMGlsk2YebXeV3NUEW1qcT5BBX4jUbCYEmHwwKEfdW1gEXgoWtiIlNRFeezcrkrQaTNSuraRYDdImrR1ylAALZBPnkXIJ0wRskeG2Cj3jsoFI2HhcfDDFWA9UBNdZZyc/PP4Z3HZYsWTLGbrffond0Xb9+/Qy6P3jw4F+HDx8+mu7XrVs3c+7cuX+i+3nz5o3n/Rw4cGAdf/7hhx9SZ8yYEcffHT9+/G/8uaSkJGvDhg3D8P3moNdXrlw5UtYVFxfnXL9+/V8PHz68grr2N2/eTC4tLb2E+9+Cotq1a/dOenr6njt37nxPdOrUqd0dO3bsjromoHBQKBPkEyFUB71MH6SPbNy4cRqfkMvlenzixImtqO/x3XffbXc6nSW5ubnpOTk5J1NTU/cQH91//fXXu3/88ccLy5cvj6d34B8gaBA9JyQk/OWjjz5aIu8Fz2DiWbZs2QLx/A4m0Qf9f/n48eNsPEeDfrdly5Y/U31UVNT7dJ04ceIsGseNGzfS6DkuLq4v8YE6Y/G+93g8XKZ6QUHBRVHfAPQC0xJfCRAv65EkeUP6gFx11JEkfw/qTc8ff/zxKofDUXrv3r08rOIBeU9CWbx48SLej5y4LGlpaf9YuHDhUv5OtqH+6Vty0riPAbWjheH8n3322VYpuG+//Xa5mGB7CGM8hKN7vV5dLfHx8WNI20E1aN4WP97YZyc7d+6MM5vNHRs2bDg3NjY23e12l5w8eZJWzIUJ9IdmlI4bNy4tICAgtHbt2hGdOnXaSe3oftu2bWmBgYFOn3MwmwcQLViwIJOeYVYJGGAZVuW2zWZzCZ6hoIGapnmknUMTQnr16vUeTOKydHqyHrx9t27dunro0KEfzJw5M4Pe3bp166Z0pHXr1g0Fj2EYCw8PD+N+SjNwUuSAKnxexOkswOWxZN63b9/MAQMGzIUwx5WXl99eunTpFLx+hJU/K9o/yM7OPhgZGdk5KSkpp0WLFv+Vrq7/na5nz57dR1dM6t7hw4e3DRkyJG7WrFlxgudzukIw58TzV3SF3Z+ByUzFbTk5O9j8fVH/JV3PnTv3uRijSdSR5/empKRkT5kypQxCC+UTxMKVQXuyWBT5WbiS4VFjIZLHWQsLN1ZFgFbm0U1KSNWUUMlDp9kAh0iNdCkRwiva2FjUsjJeJ5sYRYQwCGIYNGk8tC1UCuDQoUOb+vbtuxuPRUJ4FVwIFhZ7pUD45OXEbUpo9DIz8hgAFk0BORblWypm8BiQzkKnpoRnM+PxsEWhiYfFxMTUHTx4cDOYhg7tzM7IyLhNCiYEUEbCMxsAGYuCGjl4ClKE4GY+xCnIw95zBKqxvmyCOJqT7dws5ntZzLcoaJEjQiPUahMaESzudWEqhBEeiSuZvUvzA1+lxIMEhbD7QGYKUl0rBAgxC9vlq6IzNZZ9BYt+rMw8pBDLmSZZFBPQmBC8imaofo1roa5oKH82aQaaIH0CDTZM0sCBAxvBKbZ+7bXXGr3yyisN4ZjMDx48uAeAkofQdHbt2rUXhIpJKevMJwSLfqq3bt365enTp3eFh365SZMmBGpMFRUVZcAV1wFmzs2ZMyddtCkXk9ESExOjq1Wr9iLCbwAilA9xwrnlwimS4G2ffvppj1atWrWoWbNmbWCKAtj9V5MnT84cMWJEvTfeeKM+wqSFzCEoKMgJ3HEVgO6SkTlKMwgUgImwArn2DpMmTYrDALP0XyjEA9sbjTZtQZGij7qghqBWoK4AWPswkbLK+qHIsWPHjoXgfwvUhsZAAEflg+dfg0kuBlosUuvoO2jXl65qXWZm5g7UNRPIOIQLQqpcmECMJIAuRp1UVmiCACmTxAReFx+LhnPqV1hY+O9n6evIkSObSXCEHI0WASDtMMJ0uVHb7du3E6p9HxpxQK0DjN4r0Gc9kSZYeZiSNkuaUOv06dPTO3fuPNj0DAWgKWTFihVL+vfvT0J8kfohAsobV6tWrYbP0hf460pnLE2AF2jB21DvIKO2gO6FNB+ERJtaB+xjY37NN3+LogmkHi9s2rTp3bZt277LG8NuK5AopXbv3n0O7Gtsjx49ZmNye6GOD1RBwD9MFUKoSQSc30UdzJUrV26uWrVqP7D/lt27d+9/9OhRMas7gjYbhROzkv9R2wcHBwdWshjkYL1G7SBQTXGwTwQQLLIqWsGeGFAhVyFSO6C7Naj7ADRUJENDQGMjIiLmQl0LVLUbNWrUItSPhBNcodYhFyFklwAiYf0RNKZZs2YfFhUVXYcAvhFm0FFc++fl5eX4Mxto7JnRo0cvID4yHWSz70dHRw+khAxZ6yGVH8ndftS9DWokciWNx15fTN2zZ0+f6tWr1+LS279/fwYgcz4LPzJvdyGVLUFidFiVOIRAqx8KlQysZCdKboJUXL58uRAmMLFp06aLRbh1cGhrVEiD3nzzzTXIcU5R6gC6vXfv3kuIGgSIyq1Wq6cqpmdhiNAXFtu0adNeZVq9enUWA0xywyVECC4AicwttQ2SrvpkYnfv3i1X6xo0aPAiJv2H+fPnt27UqFEN4YsCDBCk33Lt2rW8kSNHJuP2LqUc4kq+4KFAgg6LxeKtSl+a4hMC6tSp85QD27VrVy9I1U2SJaKYS/ZG8Rf5uhVXq91ud4aEhATINo0bN46glUQMv4aQV46MMpj3iRVvsGjRohFEENQtygCRmZ5B6DsqNNPFANJT5cyZM5RoPRBE/qREaJYEYm4aZ1WFwDG9ppoClebNm9czPV/xYXOo6J4xY8Z84I8Jgq9HBCDVfsKECR+mpqZ+gSQnRVQHGTm4CxcuXBP9l4qrneUNPtheVSFYKtkF/jUKqWbx2LFjUxBJViA82asSZvv06TPq+PHjE/D4GzI70jiVT+xDyBzDo8DhZyoWNXsD4Cn/FYVQLKgIofCfMIkhgKyr4bhO8pBoVGgvsEuXLq+SEIw0Qayyl5H+vIPUmJf2ZYOwz5twXE05U/369TfBZu+wvMBpkH7L3dwyYZ+l4uoRPL50FzCcQuAJstvIyMjacG5Rw4YN64b7V9XBxcbGdgJq/cZIE4TT0/2ceTyzJsiMj0JSxfnz50+rTECBUUq2aGd2WC7Izib+WFwdLJs0sczT1w+Q3d34+PhTSKQ2w4GeVL9LTtefY1Q2YEz/qxC8LIe3f/LJJ2kqU79+/WIGDRpUj+0L8N0lG7B6N+QGiS1btgxR9ha8gi949uzZ0UiENgBSR4iQyFNiL0zkrh+V/78XfjJDq1aWnJx85dixY8kqRE1KSopNSUkZ0K1btwjhsGpMmzatbVZW1nTy/JQbQHUXA26HMRul/gOQHkcBUK1BBGiJFHgtcMV7YqeXeEM7dOhQB4lXh6dCS1kZaZbDSBjinV6ZhsBkdAMz0o00SO4hhIrUl7K/7vfv37+hP0eBw8tBftFRpNNNExMThyMqlKp8SEXsADy5t1GM+qF6CHwe+hifm5t7Ta1PSEiYj7rWIhsMZaCPEkDyL+2PHj36hdqO3lGd4KkuYbN0jC5h22TPRT179pwCZ5j9rKqF0FWtd+/eL0kBA9Y2kRudvBB4og2al1CM+iFsgQFfJTCkaZrboL2DhUfd4NjAadROvHPyvUsLayxNghxaMWw0D1EhFiguqSrxXWZ/EN7IyZMnX5QHn127dk0Gxo+nnd6q9EHf2rx58zJgC1oxSrQKgR1cKl9YWJhdOFg329TlC1oBM3YYZJ8OubcozVZTJPjkzEEwOBGr1yIr+xz23xX23i48PPxVjiqRQV6GRuetXLkSbiPpCsPuTulzEAYPAh+cnzp1ao+YmJi31D5gevkwo3sZGRmn0M+RzMzMAhFtaGG0ixcvfpmfn39WbpNBC1zILK8KHqdykCsXszQ7O/sE8WMBNKGlbrxLF1HsSeQyV5JQBSrJUghLdDQmKB46ywTJFTKzfqqxftScwM1OjGXY/Vl0UU7IHcq3XMrutkz0QsX3bOwEWo5TfsNj9hMxjP5VCFR2fPl/AS4xMH7u71X6CWR92JQjer5t72AHLrpyKGRRhKbCZrNybhJg8HvBU+385Qv8DMKi/BjBEaKuHJK42YDU/x789cFhu1s5cFH/hTAp3/UqhzMm5cTM6G8br/qnyi8lTWYDoZiUP1TUEyc1Ble1D5OSA+gG7U0GR3b+fhUy+kVIN0Kb/xFgANrk0XIqRaL0AAAAAElFTkSuQmCC'
+            }
+        };
+
+        if (newAttribution) {
+            // Check if attribution logo is enabled
+            if (!newAttribution.logo.disabled) {
+                // Need to add OR (||) incase newAttribution values are undefined/empty
+                attribution.logo.altText =
+                    newAttribution.logo.altText || attribution.logo.altText;
+                attribution.logo.link =
+                    newAttribution.logo.link || attribution.logo.link;
+                attribution.logo.value =
+                    newAttribution.logo.value || attribution.logo.value;
+            }
+
+            // Check if attribution text is enabled
+            if (!newAttribution.text.disabled) {
+                // Need to add OR (||) incase newAttribution value is undefined/empty
+                attribution.text.value =
+                    newAttribution.text.value || attribution.text.value;
+            }
+
+            // Update attribution
+            this.$iApi.$vApp.$store.set(
+                MapCaptionStore.setAttribution,
+                attribution
+            );
+        }
+
+        // If the new attribution is undefined, or its text is disabled, pull text from copyright
+        if (!newAttribution || newAttribution.text.disabled) {
+            // Pull copyright text from basemap's baselayers
+
+            if (!this.$iApi.geo.map.esriMap) {
+                console.warn(
+                    'Attempted to fetch map attribution with undefined map'
+                );
+                return;
+            }
+
+            let copyrightText: string = '';
+            const loadTimeout: number = 5000;
+            const intervalTimeout: number = 20;
+
+            // Create load promises that resolve when the baseLayer loads or after a timeout
+            const baseLayerLoadPromises: Array<Promise<__esri.Layer | null>> = this.$iApi.geo.map.esriMap.basemap.baseLayers
+                .map((bl: __esri.Layer) => {
+                    return new Promise<__esri.Layer | null>((resolve, _) => {
+                        // Keep count of layer.load checks done so far
+                        let elapsedIntervals: number = 0;
+                        // The maximum number of layer.load checks we will do
+                        const maxIntervals: number =
+                            loadTimeout / intervalTimeout;
+
+                        let wait = setInterval(function() {
+                            if (bl.loaded && !bl.loadError) {
+                                clearInterval(wait);
+                                resolve(bl);
+                            } else if (elapsedIntervals > maxIntervals) {
+                                clearInterval(wait);
+                                resolve(null);
+                            }
+                            elapsedIntervals++;
+                        }, intervalTimeout);
+                    });
+                })
+                .toArray();
+
+            // Join all the copyright strings and update the attribution
+            Promise.all(baseLayerLoadPromises).then(baseLayers => {
+                copyrightText = baseLayers
+                    .filter((bl: any) => bl?.copyright)
+                    .map((bl: any) => bl.copyright)
+                    .join(' | ');
+
+                attribution.text.value =
+                    copyrightText || attribution.text.value;
+
+                // Update attribution
+                this.$iApi.$vApp.$store.set(
+                    MapCaptionStore.setAttribution,
+                    attribution
+                );
+            });
+        }
+    }
+
+    /**
+     * Calculates a scale bar for the current resolution
+     * Updates map-caption store to notify map-caption component observer
+     *
+     * @function updateScale
+     */
+    updateScale(): void {
+        const isImperialScale: boolean = (this.$iApi.$vApp.$store.get(
+            MapCaptionStore.scale
+        ) as ScaleBarProperties).isImperialScale;
+
+        // the starting length of the scale line in pixels
+        // reduce the length of the bar on extra small layouts
+        const factor = window.innerWidth > 600 ? 70 : 35;
+        const mapResolution = this.$iApi.geo.map.getResolution();
+
+        // distance in meters
+        const meters = mapResolution * factor;
+        const metersInAMile = 1609.34;
+        const metersInAFoot = 3.28084;
+
+        let distance, pixels, unit;
+
+        // If meters < 1Km, then use different scaling
+        if (meters > 1000) {
+            // get the distance in units, either miles or kilometers
+            const units =
+                (mapResolution * factor) /
+                (isImperialScale ? metersInAMile : 1000);
+            unit = isImperialScale ? 'mi' : 'km';
+
+            // length of the distance number
+            const len = Math.round(units).toString().length;
+            const div = Math.pow(10, len - 1);
+
+            // we want to round the distance to the ceiling of the highest position and display a nice number
+            // 45.637km => 50.00km; 4.368km => 5.00km
+            // 28.357mi => 30.00mi; 2.714mi => 3.00mi
+            distance = Math.ceil(units / div) * div;
+
+            // calcualte length of the scale line in pixels based on the round distance
+            pixels =
+                (distance * (isImperialScale ? metersInAMile : 1000)) /
+                mapResolution;
+        } else {
+            // Round the meters up
+            distance = Math.ceil(
+                isImperialScale ? meters * metersInAFoot : meters
+            );
+            pixels = meters / mapResolution;
+            unit = isImperialScale ? 'ft' : 'm';
+        }
+
+        this.$iApi.$vApp.$store.set(MapCaptionStore.setScale, {
+            width: `${pixels}px`,
+            label: `${distance}${unit}`,
+            isImperialScale: isImperialScale
+        });
+    }
+
+    /**
+     * Formats the map point using the selected formatting function
+     * Returns empty string if point is undefined
+     *
+     * @param { Point | undefined } p the cursor map point
+     * @returns { Promise<string> } the formatted string of the map point
+     */
+    async formatPoint(p: Point | undefined): Promise<string> {
+        if (!p) {
+            return '';
+        }
+        return await this.pointFormatter(p);
+    }
+
+    /**
+     * Sets the current point formatter
+     * Will accept the string id of a default formatter, or a new formatter with the correct formatter signature
+     * @function setPointFormatter
+     * @param {string | ((p: Point) => Promise<string>)} value
+     */
+    setPointFormatter(value: string | ((p: Point) => Promise<string>)): void {
+        if (typeof value === 'string') {
+            // value is formatter id
+            if (!(value in this.DEFAULT_POINT_FORMATTERS)) {
+                console.warn(
+                    `Could not find point formatter with id: ${value}`
+                );
+                return;
+            }
+            this.pointFormatter = this.DEFAULT_POINT_FORMATTERS[value];
+        } else {
+            // value is a function
+            this.pointFormatter = value;
+        }
+    }
+
+    /**
+     * Pad value with leading 0 to make sure there is at least 2 digits if number is below 10.
+     *
+     * @function padZero
+     * @private
+     * @param {Number} val value to pad with 0
+     * @return {String} string with at least 2 characters
+     */
+    padZero(val: number | string): string {
+        if (typeof val === 'number') {
+            return val >= 10 ? `${val}` : `0${val}`;
+        } else {
+            const floatVal = parseFloat(val);
+            return parseFloat(val) >= 10 ? `${floatVal}` : `0${floatVal}`;
+        }
+    }
+
+    /**
+     * Wraps value between the minimum and maximum value
+     * If value is between bounds, it will be returned as it is
+     *
+     * @function wrapValue
+     * @private
+     * @param {Number} val value to be wrapped
+     * @param {Number} min minimum value
+     * @param {Number} max maximum value
+     * @return {Number} the wrapped value
+     */
+    wrapValue(val: number, min: number, max: number): number {
+        return (
+            ((((val - min) % (max - min)) + (max - min)) % (max - min)) + min
+        );
+    }
+
+    /**
+     * Formats a lat/long DMS string using mouse map point coordinates
+     *
+     * @function formatLatLongDMSString
+     * @param {Point | undefined} p the cursor map point
+     * @returns {Promise<string>} the formatted string using given cursor map coordinates
+     */
+    async formatLatLongDMS(p: Point): Promise<string> {
+        // get the lat long projection
+        const latLongPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            4326,
+            p
+        );
+
+        const lat = this.wrapValue(latLongPoint.y, -90, 90);
+        const lon = this.wrapValue(latLongPoint.x, -180, 180);
+
+        const degreeSymbol = String.fromCharCode(176);
+
+        const dy = Math.floor(Math.abs(lat)) * (lat < 0 ? -1 : 1);
+        const my = Math.floor(Math.abs((lat - dy) * 60));
+        const sy = Math.floor((Math.abs(lat) - Math.abs(dy) - my / 60) * 3600);
+
+        const dx = Math.floor(Math.abs(lon)) * (lon < 0 ? -1 : 1);
+        const mx = Math.floor(Math.abs((lon - dx) * 60));
+        const sx = Math.floor((Math.abs(lon) - Math.abs(dx) - mx / 60) * 3600);
+
+        const newY = `${Math.abs(dy)}${degreeSymbol} ${this.padZero(
+            my
+        )}' ${this.padZero(sy)}"`;
+        const newX = `${Math.abs(dx)}${degreeSymbol} ${this.padZero(
+            mx
+        )}' ${this.padZero(sx)}"`;
+
+        return `${newY} ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (lat > 0 ? 'north' : 'south')
+        )} | ${newX} ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (0 > lon ? 'west' : 'east')
+        )}`;
+    }
+
+    /**
+     * Formats a lat/long DDM string using mouse map point coordinates
+     *
+     * @function formatLatLongDDM
+     * @param {Point | undefined} p the cursor map point
+     * @returns {Promise<string>} the formatted string using given cursor map coordinates
+     */
+    async formatLatLongDDM(p: Point): Promise<string> {
+        // get the lat long projection
+        const latLongPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            4326,
+            p
+        );
+
+        const lat = this.wrapValue(latLongPoint.y, -90, 90);
+        const lon = this.wrapValue(latLongPoint.x, -180, 180);
+
+        const degreeSymbol = String.fromCharCode(176);
+
+        const dy = Math.floor(Math.abs(lat)) * (lat < 0 ? -1 : 1);
+        const my = Math.abs((lat - dy) * 60).toFixed(2);
+        const newY = `${Math.abs(dy)}${degreeSymbol} ${this.padZero(my)}'`;
+
+        const dx = Math.floor(Math.abs(lon)) * (lon < 0 ? -1 : 1);
+        const mx = Math.abs((lon - dx) * 60).toFixed(2);
+        const newX = `${Math.abs(dx)}${degreeSymbol} ${this.padZero(mx)}'`;
+
+        return `${newY} ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (lat > 0 ? 'north' : 'south')
+        )} | ${newX} ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (0 > lon ? 'west' : 'east')
+        )}`;
+    }
+
+    /**
+     * Formats a lat/long DD string using mouse map point coordinates
+     *
+     * @function formatLatLongDD
+     * @param {Point | undefined} p the cursor map point
+     * @returns {Promise<string>} the formatted string using given cursor map coordinates
+     */
+    async formatLatLongDD(p: Point): Promise<string> {
+        // get the lat long projection
+        const latLongPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            4326,
+            p
+        );
+
+        const lat = this.wrapValue(latLongPoint.y, -90, 90);
+        const lon = this.wrapValue(latLongPoint.x, -180, 180);
+
+        const degreeSymbol = String.fromCharCode(176);
+
+        const dy = Math.abs(lat).toFixed(3);
+        const dx = Math.abs(lon).toFixed(3);
+
+        return `${dy}${degreeSymbol} ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (lat > 0 ? 'north' : 'south')
+        )} | ${dx}${degreeSymbol} ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (0 > lon ? 'west' : 'east')
+        )}`;
+    }
+
+    /**
+     * Formats a mercator point string using mouse map point coordinates
+     *
+     * @function formatMercator
+     * @param {Point | undefined} p the cursor map point
+     * @returns {Promise<string>} the formatted string using given cursor map coordinates
+     */
+    async formatMercator(p: Point): Promise<string> {
+        // project using Web-Mercator wkid
+        const projectedPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            3857,
+            p
+        );
+
+        return `${Math.abs(
+            Math.floor(projectedPoint.x)
+        )} m ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (0 > projectedPoint.x ? 'west' : 'east')
+        )} | ${Math.abs(
+            Math.floor(projectedPoint.y)
+        )} m ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (projectedPoint.y > 0 ? 'north' : 'south')
+        )}`;
+    }
+
+    /**
+     * Formats a lambert point string using mouse map point coordinates
+     *
+     * @function formatLambert
+     * @param {Point | undefined} p the cursor map point
+     * @returns {Promise<string>} the formatted string using given cursor map coordinates
+     */
+    async formatLambert(p: Point): Promise<string> {
+        // project using Lambert wkid
+        const projectedPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            3978,
+            p
+        );
+
+        return `${Math.abs(
+            Math.floor(projectedPoint.x)
+        )} m ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (0 > projectedPoint.x ? 'west' : 'east')
+        )} | ${Math.abs(
+            Math.floor(projectedPoint.y)
+        )} m ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (projectedPoint.y > 0 ? 'north' : 'south')
+        )}`;
+    }
+
+    /**
+     * Formats a UTM string using mouse map point coordinates
+     *
+     * @function formatUTM
+     * @param {Point | undefined} p the cursor map point
+     * @returns {Promise<string>} the formatted string using given cursor map coordinates
+     */
+    async formatUTM(p: Point): Promise<string> {
+        // get the lat long point
+        const latLongPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            4326,
+            p
+        );
+        const lat = this.wrapValue(latLongPoint.y, -90, 90);
+        const lon = this.wrapValue(latLongPoint.x, -180, 180);
+
+        // find the utm zone (each zone is 6 degrees longitude apart)
+        const zone = this.padZero(Math.ceil((lon + 180) / 6));
+
+        // project the point using the zone's utm projection
+        const projectedPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            parseInt('326' + zone),
+            p
+        );
+
+        return `${zone} ${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.' + (lat > 0 ? 'north' : 'south')
+        )} ${Math.floor(projectedPoint.x)} m${this.$iApi.$vApp.$i18n.t(
+            'map.coordinates.east'
+        )} | ${Math.abs(
+            Math.floor(projectedPoint.y)
+        )} m${this.$iApi.$vApp.$i18n.t('map.coordinates.north')}`;
+    }
+
+    /**
+     * Formats a string based on the current basemap projection using mouse map point coordinates
+     *
+     * @function formatBasemap
+     * @param {Point | undefined} p the cursor map point
+     * @returns {Promise<string>} the formatted string using given cursor map coordinates
+     */
+    async formatBasemap(p: Point): Promise<string> {
+        // project the point using the basemaps spatial reference
+        const projectedPoint: any = await this.$iApi.geo.utils.proj.projectGeometry(
+            this.$iApi.geo.map.getSR(),
+            p
+        );
+
+        return `${projectedPoint.x} | ${projectedPoint.y}`;
+    }
+}

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -9,7 +9,6 @@ import {
     MaptipAPI
 } from '@/api/internal';
 import {
-    Attribution,
     BaseGeometry,
     CoreFilterKey,
     DefPromise,
@@ -25,13 +24,12 @@ import {
     RampMapConfig,
     ScreenPoint,
     Screenshot,
-    ScaleBarProperties,
     ScaleSet,
     SpatialReference
 } from '@/geo/api';
-import { EsriGraphic, EsriLOD, EsriMapView, EsriTileLayer } from '@/geo/esri';
+import { EsriGraphic, EsriLOD, EsriMapView } from '@/geo/esri';
 import { LayerStore } from '@/store/modules/layer';
-import { MapCaptionStore } from '@/store/modules/map-caption';
+import { MapCaptionAPI } from './caption';
 
 // TODO bring in the map actions code
 
@@ -64,6 +62,9 @@ export class MapAPI extends CommonMapAPI {
     // API for managing the maptip
     maptip: MaptipAPI;
 
+    // API for managing map caption
+    caption: MapCaptionAPI;
+
     /**
      * @constructor
      * @param {InstanceAPI} iApi the RAMP instance
@@ -72,6 +73,7 @@ export class MapAPI extends CommonMapAPI {
         super(iApi);
 
         this.maptip = new MaptipAPI(iApi);
+        this.caption = new MapCaptionAPI(iApi);
         this._viewPromise = new DefPromise();
     }
 
@@ -506,165 +508,6 @@ export class MapAPI extends CommonMapAPI {
         } else {
             throw new Error('Export attempted without a map view available');
         }
-    }
-
-    /**
-     * Updates the attribution on the map-caption bar
-     * Applies default ESRI attribution if incoming attribution is disabled or has undefined elements
-     *
-     * Updates map-caption store to notify map-caption component observer
-     *
-     * @param {Attribution} newAttribution incoming new attribution
-     */
-    updateAttribution(newAttribution: Attribution | undefined): void {
-        if (!this.esriView || !this.esriMap) {
-            this.noMapErr();
-            return;
-        }
-
-        // Default attribution
-        let attribution: Attribution = {
-            text: { value: 'Powered by ESRI' },
-            logo: {
-                altText: 'ESRI logo',
-                link: 'https://www.esri.com/',
-                value:
-                    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEEAAAAkCAYAAADWzlesAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAADO9JREFUeNq0Wgl0jlca/pfvzyo6qNBSmhLLKE1kKEUtB9NTat+OYnBacwwJY19DZRC7sR41th60lWaizFSqRTOEw0lsrQSJGFIESSxJ/uRfv3nef+7Vt9f3p2E695z3fMt97/3ufe+7PO+9n9n0UzELsjKyiHdUdMZnVHTl2VyFe9nO7Kc/Io+4epUxmpWxeVkbr3hvUebgFf15GL9XUwZHndtAAYI09jGvIghOuoEwLOLeYiBoXrwGfZjYYOWAvWyMGlsk2YebXeV3NUEW1qcT5BBX4jUbCYEmHwwKEfdW1gEXgoWtiIlNRFeezcrkrQaTNSuraRYDdImrR1ylAALZBPnkXIJ0wRskeG2Cj3jsoFI2HhcfDDFWA9UBNdZZyc/PP4Z3HZYsWTLGbrffond0Xb9+/Qy6P3jw4F+HDx8+mu7XrVs3c+7cuX+i+3nz5o3n/Rw4cGAdf/7hhx9SZ8yYEcffHT9+/G/8uaSkJGvDhg3D8P3moNdXrlw5UtYVFxfnXL9+/V8PHz68grr2N2/eTC4tLb2E+9+Cotq1a/dOenr6njt37nxPdOrUqd0dO3bsjromoHBQKBPkEyFUB71MH6SPbNy4cRqfkMvlenzixImtqO/x3XffbXc6nSW5ubnpOTk5J1NTU/cQH91//fXXu3/88ccLy5cvj6d34B8gaBA9JyQk/OWjjz5aIu8Fz2DiWbZs2QLx/A4m0Qf9f/n48eNsPEeDfrdly5Y/U31UVNT7dJ04ceIsGseNGzfS6DkuLq4v8YE6Y/G+93g8XKZ6QUHBRVHfAPQC0xJfCRAv65EkeUP6gFx11JEkfw/qTc8ff/zxKofDUXrv3r08rOIBeU9CWbx48SLej5y4LGlpaf9YuHDhUv5OtqH+6Vty0riPAbWjheH8n3322VYpuG+//Xa5mGB7CGM8hKN7vV5dLfHx8WNI20E1aN4WP97YZyc7d+6MM5vNHRs2bDg3NjY23e12l5w8eZJWzIUJ9IdmlI4bNy4tICAgtHbt2hGdOnXaSe3oftu2bWmBgYFOn3MwmwcQLViwIJOeYVYJGGAZVuW2zWZzCZ6hoIGapnmknUMTQnr16vUeTOKydHqyHrx9t27dunro0KEfzJw5M4Pe3bp166Z0pHXr1g0Fj2EYCw8PD+N+SjNwUuSAKnxexOkswOWxZN63b9/MAQMGzIUwx5WXl99eunTpFLx+hJU/K9o/yM7OPhgZGdk5KSkpp0WLFv+Vrq7/na5nz57dR1dM6t7hw4e3DRkyJG7WrFlxgudzukIw58TzV3SF3Z+ByUzFbTk5O9j8fVH/JV3PnTv3uRijSdSR5/empKRkT5kypQxCC+UTxMKVQXuyWBT5WbiS4VFjIZLHWQsLN1ZFgFbm0U1KSNWUUMlDp9kAh0iNdCkRwiva2FjUsjJeJ5sYRYQwCGIYNGk8tC1UCuDQoUOb+vbtuxuPRUJ4FVwIFhZ7pUD45OXEbUpo9DIz8hgAFk0BORblWypm8BiQzkKnpoRnM+PxsEWhiYfFxMTUHTx4cDOYhg7tzM7IyLhNCiYEUEbCMxsAGYuCGjl4ClKE4GY+xCnIw95zBKqxvmyCOJqT7dws5ntZzLcoaJEjQiPUahMaESzudWEqhBEeiSuZvUvzA1+lxIMEhbD7QGYKUl0rBAgxC9vlq6IzNZZ9BYt+rMw8pBDLmSZZFBPQmBC8imaofo1roa5oKH82aQaaIH0CDTZM0sCBAxvBKbZ+7bXXGr3yyisN4ZjMDx48uAeAkofQdHbt2rUXhIpJKevMJwSLfqq3bt365enTp3eFh365SZMmBGpMFRUVZcAV1wFmzs2ZMyddtCkXk9ESExOjq1Wr9iLCbwAilA9xwrnlwimS4G2ffvppj1atWrWoWbNmbWCKAtj9V5MnT84cMWJEvTfeeKM+wqSFzCEoKMgJ3HEVgO6SkTlKMwgUgImwArn2DpMmTYrDALP0XyjEA9sbjTZtQZGij7qghqBWoK4AWPswkbLK+qHIsWPHjoXgfwvUhsZAAEflg+dfg0kuBlosUuvoO2jXl65qXWZm5g7UNRPIOIQLQqpcmECMJIAuRp1UVmiCACmTxAReFx+LhnPqV1hY+O9n6evIkSObSXCEHI0WASDtMMJ0uVHb7du3E6p9HxpxQK0DjN4r0Gc9kSZYeZiSNkuaUOv06dPTO3fuPNj0DAWgKWTFihVL+vfvT0J8kfohAsobV6tWrYbP0hf460pnLE2AF2jB21DvIKO2gO6FNB+ERJtaB+xjY37NN3+LogmkHi9s2rTp3bZt277LG8NuK5AopXbv3n0O7Gtsjx49ZmNye6GOD1RBwD9MFUKoSQSc30UdzJUrV26uWrVqP7D/lt27d+9/9OhRMas7gjYbhROzkv9R2wcHBwdWshjkYL1G7SBQTXGwTwQQLLIqWsGeGFAhVyFSO6C7Naj7ADRUJENDQGMjIiLmQl0LVLUbNWrUItSPhBNcodYhFyFklwAiYf0RNKZZs2YfFhUVXYcAvhFm0FFc++fl5eX4Mxto7JnRo0cvID4yHWSz70dHRw+khAxZ6yGVH8ndftS9DWokciWNx15fTN2zZ0+f6tWr1+LS279/fwYgcz4LPzJvdyGVLUFidFiVOIRAqx8KlQysZCdKboJUXL58uRAmMLFp06aLRbh1cGhrVEiD3nzzzTXIcU5R6gC6vXfv3kuIGgSIyq1Wq6cqpmdhiNAXFtu0adNeZVq9enUWA0xywyVECC4AicwttQ2SrvpkYnfv3i1X6xo0aPAiJv2H+fPnt27UqFEN4YsCDBCk33Lt2rW8kSNHJuP2LqUc4kq+4KFAgg6LxeKtSl+a4hMC6tSp85QD27VrVy9I1U2SJaKYS/ZG8Rf5uhVXq91ud4aEhATINo0bN46glUQMv4aQV46MMpj3iRVvsGjRohFEENQtygCRmZ5B6DsqNNPFANJT5cyZM5RoPRBE/qREaJYEYm4aZ1WFwDG9ppoClebNm9czPV/xYXOo6J4xY8Z84I8Jgq9HBCDVfsKECR+mpqZ+gSQnRVQHGTm4CxcuXBP9l4qrneUNPtheVSFYKtkF/jUKqWbx2LFjUxBJViA82asSZvv06TPq+PHjE/D4GzI70jiVT+xDyBzDo8DhZyoWNXsD4Cn/FYVQLKgIofCfMIkhgKyr4bhO8pBoVGgvsEuXLq+SEIw0Qayyl5H+vIPUmJf2ZYOwz5twXE05U/369TfBZu+wvMBpkH7L3dwyYZ+l4uoRPL50FzCcQuAJstvIyMjacG5Rw4YN64b7V9XBxcbGdgJq/cZIE4TT0/2ceTyzJsiMj0JSxfnz50+rTECBUUq2aGd2WC7Izib+WFwdLJs0sczT1w+Q3d34+PhTSKQ2w4GeVL9LTtefY1Q2YEz/qxC8LIe3f/LJJ2kqU79+/WIGDRpUj+0L8N0lG7B6N+QGiS1btgxR9ha8gi949uzZ0UiENgBSR4iQyFNiL0zkrh+V/78XfjJDq1aWnJx85dixY8kqRE1KSopNSUkZ0K1btwjhsGpMmzatbVZW1nTy/JQbQHUXA26HMRul/gOQHkcBUK1BBGiJFHgtcMV7YqeXeEM7dOhQB4lXh6dCS1kZaZbDSBjinV6ZhsBkdAMz0o00SO4hhIrUl7K/7vfv37+hP0eBw8tBftFRpNNNExMThyMqlKp8SEXsADy5t1GM+qF6CHwe+hifm5t7Ta1PSEiYj7rWIhsMZaCPEkDyL+2PHj36hdqO3lGd4KkuYbN0jC5h22TPRT179pwCZ5j9rKqF0FWtd+/eL0kBA9Y2kRudvBB4og2al1CM+iFsgQFfJTCkaZrboL2DhUfd4NjAadROvHPyvUsLayxNghxaMWw0D1EhFiguqSrxXWZ/EN7IyZMnX5QHn127dk0Gxo+nnd6q9EHf2rx58zJgC1oxSrQKgR1cKl9YWJhdOFg329TlC1oBM3YYZJ8OubcozVZTJPjkzEEwOBGr1yIr+xz23xX23i48PPxVjiqRQV6GRuetXLkSbiPpCsPuTulzEAYPAh+cnzp1ao+YmJi31D5gevkwo3sZGRmn0M+RzMzMAhFtaGG0ixcvfpmfn39WbpNBC1zILK8KHqdykCsXszQ7O/sE8WMBNKGlbrxLF1HsSeQyV5JQBSrJUghLdDQmKB46ywTJFTKzfqqxftScwM1OjGXY/Vl0UU7IHcq3XMrutkz0QsX3bOwEWo5TfsNj9hMxjP5VCFR2fPl/AS4xMH7u71X6CWR92JQjer5t72AHLrpyKGRRhKbCZrNybhJg8HvBU+385Qv8DMKi/BjBEaKuHJK42YDU/x789cFhu1s5cFH/hTAp3/UqhzMm5cTM6G8br/qnyi8lTWYDoZiUP1TUEyc1Ble1D5OSA+gG7U0GR3b+fhUy+kVIN0Kb/xFgANrk0XIqRaL0AAAAAElFTkSuQmCC'
-            }
-        };
-
-        if (newAttribution) {
-            // Check if attribution logo is enabled
-            if (!newAttribution.logo.disabled) {
-                // Need to add OR (||) incase newAttribution values are undefined/empty
-                attribution.logo.altText =
-                    newAttribution.logo.altText || attribution.logo.altText;
-                attribution.logo.link =
-                    newAttribution.logo.link || attribution.logo.link;
-                attribution.logo.value =
-                    newAttribution.logo.value || attribution.logo.value;
-            }
-
-            // Check if attribution text is enabled
-            if (!newAttribution.text.disabled) {
-                // Need to add OR (||) incase newAttribution value is undefined/empty
-                attribution.text.value =
-                    newAttribution.text.value || attribution.text.value;
-            }
-
-            // Update attribution
-            this.$iApi.$vApp.$store.set(
-                MapCaptionStore.setAttribution,
-                attribution
-            );
-        }
-
-        // If the new attribution is undefined, or its text is disabled, pull text from copyright
-        if (!newAttribution || newAttribution.text.disabled) {
-            // Pull copyright text from basemap's baselayers
-            let copyrightText: string = '';
-            const loadTimeout: number = 5000;
-            const intervalTimeout: number = 20;
-
-            // Create load promises that resolve when the baseLayer loads or after a timeout
-            const baseLayerLoadPromises: Array<Promise<__esri.Layer | null>> = this.esriMap.basemap.baseLayers
-                .map((bl: __esri.Layer) => {
-                    return new Promise<__esri.Layer | null>((resolve, _) => {
-                        // Keep count of layer.load checks done so far
-                        let elapsedIntervals: number = 0;
-                        // The maximum number of layer.load checks we will do
-                        const maxIntervals: number =
-                            loadTimeout / intervalTimeout;
-
-                        let wait = setInterval(function() {
-                            if (bl.loaded && !bl.loadError) {
-                                clearInterval(wait);
-                                resolve(bl);
-                            } else if (elapsedIntervals > maxIntervals) {
-                                clearInterval(wait);
-                                resolve(null);
-                            }
-                            elapsedIntervals++;
-                        }, intervalTimeout);
-                    });
-                })
-                .toArray();
-
-            // Join all the copyright strings and update the attribution
-            Promise.all(baseLayerLoadPromises).then(baseLayers => {
-                copyrightText = baseLayers
-                    .filter((bl: any) => bl?.copyright)
-                    .map((bl: any) => bl.copyright)
-                    .join(' | ');
-
-                attribution.text.value =
-                    copyrightText || attribution.text.value;
-
-                // Update attribution
-                this.$iApi.$vApp.$store.set(
-                    MapCaptionStore.setAttribution,
-                    attribution
-                );
-            });
-        }
-    }
-
-    /**
-     * Calculates a scale bar for the current resolution
-     * Updates map-caption store to notify map-caption component observer
-     */
-    updateScale(): void {
-        const isImperialScale: boolean = (this.$iApi.$vApp.$store.get(
-            MapCaptionStore.scale
-        ) as ScaleBarProperties).isImperialScale;
-
-        // the starting length of the scale line in pixels
-        // reduce the length of the bar on extra small layouts
-        const factor = window.innerWidth > 600 ? 70 : 35;
-        const mapResolution = this.$iApi.geo.map.getResolution();
-
-        // distance in meters
-        const meters = mapResolution * factor;
-        const metersInAMile = 1609.34;
-        const metersInAFoot = 3.28084;
-
-        let distance, pixels, unit;
-
-        // If meters < 1Km, then use different scaling
-        if (meters > 1000) {
-            // get the distance in units, either miles or kilometers
-            const units =
-                (mapResolution * factor) /
-                (isImperialScale ? metersInAMile : 1000);
-            unit = isImperialScale ? 'mi' : 'km';
-
-            // length of the distance number
-            const len = Math.round(units).toString().length;
-            const div = Math.pow(10, len - 1);
-
-            // we want to round the distance to the ceiling of the highest position and display a nice number
-            // 45.637km => 50.00km; 4.368km => 5.00km
-            // 28.357mi => 30.00mi; 2.714mi => 3.00mi
-            distance = Math.ceil(units / div) * div;
-
-            // calcualte length of the scale line in pixels based on the round distance
-            pixels =
-                (distance * (isImperialScale ? metersInAMile : 1000)) /
-                mapResolution;
-        } else {
-            // Round the meters up
-            distance = Math.ceil(
-                isImperialScale ? meters * metersInAFoot : meters
-            );
-            pixels = meters / mapResolution;
-            unit = isImperialScale ? 'ft' : 'm';
-        }
-
-        this.$iApi.$vApp.$store.set(MapCaptionStore.setScale, {
-            width: `${pixels}px`,
-            label: `${distance}${unit}`,
-            isImperialScale: isImperialScale
-        });
     }
 
     /**

--- a/packages/ramp-core/src/geo/utils/utils.ts
+++ b/packages/ramp-core/src/geo/utils/utils.ts
@@ -10,7 +10,7 @@ import {
     QueryAPI,
     SymbologyAPI
 } from '@/api/internal';
-import { GeometryAPI, Point, ProjectionAPI, SharedUtilsAPI } from '@/geo/api';
+import { GeometryAPI, ProjectionAPI, SharedUtilsAPI } from '@/geo/api';
 
 /*
 import HighlightService from './HighlightService';
@@ -41,69 +41,5 @@ export class UtilsAPI extends APIScope {
         /*
         this.highlight = new HighlightService(infoBundle);
         */
-    }
-
-    // TODO: Not the final location, will be moved once co-ords formatting is figured out
-    /**
-     * Formats a lat/long DMS string using mouse map point coordinates
-     * Returns empty string if no map point is provided
-     *
-     * @param {Point | undefined} mapPoint the cursor map point
-     * @returns { lat: string; lon: string } the formatted string using given cursor map coordinates
-     */
-    async formatLatLongDMSString(mapPoint: Point | undefined): Promise<string> {
-        if (!mapPoint) {
-            return '';
-        }
-
-        const latLongPoint: any = await RAMP.GEO.proj.projectGeometry(
-            4326,
-            mapPoint
-        );
-
-        const lat = latLongPoint.y;
-        const lon = latLongPoint.x;
-
-        if (lat < -90 || lat > 90 || lon < -180 || lon > 180) {
-            console.warn(
-                `formatLatLongDMSString received invalid lat/long coordinates: (${lat}, ${lon})`
-            );
-            return '';
-        }
-
-        const degreeSymbol = String.fromCharCode(176);
-
-        const dy = Math.floor(Math.abs(lat)) * (lat < 0 ? -1 : 1);
-        const my = Math.floor(Math.abs((lat - dy) * 60));
-        const sy = Math.floor((Math.abs(lat) - Math.abs(dy) - my / 60) * 3600);
-
-        const dx = Math.floor(Math.abs(lon)) * (lon < 0 ? -1 : 1);
-        const mx = Math.floor(Math.abs((lon - dx) * 60));
-        const sx = Math.floor((Math.abs(lon) - Math.abs(dx) - mx / 60) * 3600);
-
-        const newY = `${Math.abs(dy)}${degreeSymbol} ${padZero(my)}' ${padZero(
-            sy
-        )}"`;
-        const newX = `${Math.abs(dx)}${degreeSymbol} ${padZero(mx)}' ${padZero(
-            sx
-        )}"`;
-
-        return `${newY} ${this.$iApi.$vApp.$i18n.t(
-            'map.coordinates.' + (lat > 0 ? 'north' : 'south')
-        )} | ${newX} ${this.$iApi.$vApp.$i18n.t(
-            'map.coordinates.' + (0 > lon ? 'west' : 'east')
-        )}`;
-
-        /**
-         * Pad value with leading 0 to make sure there is always 2 digits if number is below 10.
-         *
-         * @function padZero
-         * @private
-         * @param {Number} val value to pad with 0
-         * @return {String} string with always 2 characters
-         */
-        function padZero(val: number) {
-            return val >= 10 ? `${val}` : `0${val}`;
-        }
     }
 }


### PR DESCRIPTION
## Closes #662 

## Changes in this PR
- [FEAT] Created new MapCaption API nugget: `$iApi.geo.map.caption`
- [FEAT] Previous map caption functionality (updating attribution and scale bar) has been moved from the `MapAPI` to this new `MapCaptionAPI`
- [FEAT] Implemented "Fancy Formatting Suite" custom point formatter design from discussion #575 
- [FEAT] Created default point formatters:
    - DMS
    - DDM
    - DD
    - Web_Mercator
    - Canada_Atlas_Lambert 
    - UTM
    - Basemap
- [FIX] Fixed warnings thrown by formatter due to invalid points returned by `projectGeometry` (#666 👻)
    - Note that this is fixed by manually wrapping values in the formatter
    - The `ProjectionAPI` still needs to be fixed so that it does not return invalid coordinates 

## Further work/comments/questions
- **Further Work:**
    - Support French number formatting: #668
        - For some point formats (e.g. Mercator/Lambert), the values can be more than 3 digits
            - Values like `1,000` should be formatted as `1 000` (though currently the values are not displayed with commas)
        - Some point formats (e.g. DD or DDM) display decimal values
            - Values like `1,000.21` should be formatted as `1 000,21`
        - Suggesting to set up [Vue `i18n` number localization](https://kazupon.github.io/vue-i18n/guide/number.html)  so that it can be used throughout the app
    - Specify default formatter in the config: #670 

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/662/host/index.html)
### Steps to test:
1. Load Demo
2. Mouse around the map - the default point format should be DMS
3. Change the point format by running this line:
```js
window.rInstance.geo.map.caption.setPointFormatter(<FORMATTER_ID>)
// FORMATTER_ID can be one of:
//     "LAT_LONG_DMS"
//     "LAT_LONG_DD"
//     "LAT_LONG_DDM"
//     "WEB_MERCATOR"
//     "CANADA_ATLAS_LAMBERT"
//     "UTM"
//     "BASEMAP"
``` 
4. Mouse around the map and check if the new format is working
5. Change the point format to a newly defined function:
```js
window.rInstance.geo.map.caption.setPointFormatter((p) => Promise.resolve(`X: ${p.x}, Y: ${p.y}`))
```
6. Mouse around the map and check if the new function is working

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/667)
<!-- Reviewable:end -->
