### PR TITLE
Fix map export when no layers are visible 

### DIFF
--- a/packages/ramp-core/src/fixtures/export-v1-legend/index.ts
+++ b/packages/ramp-core/src/fixtures/export-v1-legend/index.ts
@@ -148,6 +148,10 @@ class ExportV1LegendFixture extends FixtureInstance
         columnWidth: number,
         columns: number
     ) {
+        if (items.length === 0) {
+            return new fabric.Group();
+        }
+
         let curColumn: number = 0;
         let curTop: number = 0;
         let accumLength: number = 0;


### PR DESCRIPTION
Should not error anymore when no layers are visible #671

[demo](http://ramp4-app.azureedge.net/demo/users/an-w/zzz/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/674)
<!-- Reviewable:end -->
