### PR TITLE
Create config properties for point formatter and scalebar

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -28,6 +28,14 @@ let config = {
                     latestWkid: 3857
                 }
             },
+            caption: {
+                mouseCoords: {
+                    formatter: 'WEB_MERCATOR'
+                },
+                scaleBar: {
+                    imperialScale: true
+                }
+            },
             lods: RAMP.GEO.defaultLODs(RAMP.GEO.defaultTileSchemas()[1]), // idx 1 = mercator
             tileSchemas: [
                 {

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1785,6 +1785,44 @@
                         "$ref": "#/$defs/basemapNode"
                     },
                     "minItems": 1
+                },
+                "caption": {
+                    "type": "object",
+                    "description": "Configuration for the components in the map caption bar",
+                    "properties": {
+                        "mouseCoords": {
+                            "type": "object",
+                            "description": "Configuration for mouse co-ords",
+                            "properties": {
+                                "disabled": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "formatter": {
+                                    "type": "string",
+                                    "description": "ID of the initial mouse point formatter",
+                                    "default": "LAT_LONG_DMS",
+                                    "enum": ["LAT_LONG_DMS", "LAT_LONG_DD", "LAT_LONG_DDM", "WEB_MERCATOR", "CANADA_ATLAS_LAMBERT", "UTM", "BASEMAP"]
+                                }
+                            }
+                        },
+                        "scaleBar": {
+                            "type": "object",
+                            "description": "Configuration for the scale bar",
+                            "properties": {
+                                "disabled": {
+                                    "type": "boolean",
+                                    "default": false
+                                },
+                                "imperialScale": {
+                                    "type": "boolean",
+                                    "description": "Use imperial scale distance units",
+                                    "default": false
+                                }
+                            }
+                        }
+                    },
+                    "required": ["mouseCoords", "scaleBar"]
                 }
             },
             "required": ["tileSchemas", "baseMaps"],

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -9,9 +9,9 @@ import { LegendAPI } from '@/fixtures/legend/api/legend';
 import { LegendStore } from '@/fixtures/legend/store';
 import { GridStore, GridAction } from '@/fixtures/grid/store';
 import {
-    Attribution,
     MapClick,
     MapMove,
+    MouseCoords,
     RampBasemapConfig,
     ScreenPoint
 } from '@/geo/api';
@@ -617,16 +617,27 @@ export class EventAPI extends APIScope {
                 this.$iApi.event.on(
                     GlobalEvents.MAP_MOUSEMOVE,
                     throttle(200, (mapMove: MapMove) => {
+                        // check if cursor coords are disabled
+                        // if it is, then do not update it
+                        const currentCursorCoords:
+                            | MouseCoords
+                            | undefined = this.$iApi.$vApp.$store.get(
+                            MapCaptionStore.cursorCoords
+                        );
+                        if (currentCursorCoords?.disabled) {
+                            return;
+                        }
+
                         this.$iApi.geo.map.caption
                             .formatPoint(
                                 this.$iApi.geo.map.screenPointToMapPoint(
                                     mapMove
                                 )
                             )
-                            .then(formattedString => {
+                            .then(fs => {
                                 this.$iApi.$vApp.$store.set(
                                     MapCaptionStore.setCursorCoords,
-                                    formattedString
+                                    { formattedString: fs }
                                 );
                             });
                     }),

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -382,10 +382,17 @@ export interface Attribution {
 }
 
 // Contains properties needed to display scale on the map-caption bar
-export interface ScaleBarProperties {
-    label: string;
-    width: string;
-    isImperialScale: boolean;
+export interface ScaleBar {
+    disabled?: boolean;
+    label?: string;
+    width?: string;
+    isImperialScale?: boolean;
+}
+
+// Contains properties needed to display mouse co-ords on the map-caption bar
+export interface MouseCoords {
+    disabled?: boolean;
+    formattedString?: string;
 }
 
 // ----------------------- CLIENT CONFIG INTERFACES -----------------------------------
@@ -498,6 +505,12 @@ export interface RampTileSchemaConfig {
     hasNorthPole?: boolean;
 }
 
+// Contains properties for compoents on the map caption bar
+export interface MapCaptionConfig {
+    mouseCoords: { disabled?: boolean; formatter?: string };
+    scaleBar: { disabled?: boolean; imperialScale?: boolean };
+}
+
 // TODO actual ramp config is kinda wonky, split over lots of classes
 //      for now this will just serve as a nice type for the config
 export interface RampMapConfig {
@@ -506,4 +519,5 @@ export interface RampMapConfig {
     basemaps: Array<RampBasemapConfig>;
     tileSchemas: Array<RampTileSchemaConfig>;
     initialBasemapId: string;
+    caption?: MapCaptionConfig;
 }

--- a/packages/ramp-core/src/store/modules/map-caption/map-caption-state.ts
+++ b/packages/ramp-core/src/store/modules/map-caption/map-caption-state.ts
@@ -1,14 +1,14 @@
-import { Attribution, ScaleBarProperties } from '@/geo/api';
+import { Attribution, ScaleBar, MouseCoords } from '@/geo/api';
 
 export class MapCaptionState {
     attribution: Attribution;
-    scale: ScaleBarProperties;
-    cursorCoords: string;
+    scale: ScaleBar;
+    cursorCoords: MouseCoords;
 
     constructor(
         attrib: Attribution,
-        scale: ScaleBarProperties,
-        cursorCoords: string
+        scale: ScaleBar,
+        cursorCoords: MouseCoords
     ) {
         this.attribution = attrib;
         this.scale = scale;

--- a/packages/ramp-core/src/store/modules/map-caption/map-caption-store.ts
+++ b/packages/ramp-core/src/store/modules/map-caption/map-caption-store.ts
@@ -3,7 +3,7 @@ import { make } from 'vuex-pathify';
 
 import { MapCaptionState } from './map-caption-state';
 import { RootState } from '@/store';
-import { Attribution, ScaleBarProperties } from '@/geo/api';
+import { Attribution, MouseCoords, ScaleBar } from '@/geo/api';
 
 type MapCaptionContext = ActionContext<MapCaptionState, RootState>;
 
@@ -13,14 +13,17 @@ const actions = {
     setAttribution: (context: MapCaptionContext, attribution: Attribution) => {
         context.commit('SET_ATTRIBUTION', attribution);
     },
-    setCursorCoords: (context: MapCaptionContext, cursorCoords: string) => {
+    setCursorCoords: (
+        context: MapCaptionContext,
+        cursorCoords: MouseCoords
+    ) => {
         context.commit('SET_CURSOR_COORDS', cursorCoords);
     },
-    setScale: (context: MapCaptionContext, scale: ScaleBarProperties) => {
+    setScale: (context: MapCaptionContext, scale: ScaleBar) => {
         context.commit('SET_SCALE', scale);
     },
-    toggleScale: (context: MapCaptionContext) => {
-        context.commit('TOGGLE_SCALE');
+    toggleScale: (context: MapCaptionContext, useImperial?: boolean) => {
+        context.commit('TOGGLE_SCALE', useImperial);
     }
 };
 
@@ -28,14 +31,18 @@ const mutations = {
     SET_ATTRIBUTION: (state: MapCaptionState, value: Attribution) => {
         state.attribution = value;
     },
-    SET_CURSOR_COORDS: (state: MapCaptionState, value: string) => {
+    SET_CURSOR_COORDS: (state: MapCaptionState, value: MouseCoords) => {
         state.cursorCoords = value;
     },
-    SET_SCALE: (state: MapCaptionState, value: ScaleBarProperties) => {
+    SET_SCALE: (state: MapCaptionState, value: ScaleBar) => {
         state.scale = value;
     },
-    TOGGLE_SCALE: (state: MapCaptionState) => {
-        state.scale.isImperialScale = !state.scale.isImperialScale;
+    TOGGLE_SCALE: (state: MapCaptionState, value: boolean) => {
+        if (value !== undefined) {
+            state.scale.isImperialScale = value;
+        } else {
+            state.scale.isImperialScale = !state.scale.isImperialScale;
+        }
     }
 };
 
@@ -45,27 +52,27 @@ export enum MapCaptionStore {
      */
     attribution = 'mapcaption/attribution',
     /**
-     * (Action) setAttribution: (attribution: any)
+     * (Action) setAttribution: (attribution: Attribution)
      */
     setAttribution = 'mapcaption/setAttribution!',
     /**
-     * (State) cursorCoords: string
+     * (State) cursorCoords: MouseCoords
      */
     cursorCoords = 'mapcaption/cursorCoords',
     /**
-     * (Action) setCursorCoords: (cursorCoords: string)
+     * (Action) setCursorCoords: (cursorCoords: MouseCoords)
      */
     setCursorCoords = 'mapcaption/setCursorCoords!',
     /**
-     * (State) scale: any
+     * (State) scale: ScaleBar
      */
     scale = 'mapcaption/scale',
     /**
-     * (Action) setScale: (scale: any)
+     * (Action) setScale: (scale: ScaleBar)
      */
     setScale = 'mapcaption/setScale!',
     /**
-     * (Action) toggleScale: ()
+     * (Action) toggleScale: (useImperial?: boolean)
      */
     toggleScale = 'mapcaption/toggleScale!'
 }
@@ -73,11 +80,11 @@ export enum MapCaptionStore {
 export function mapcaption() {
     const state = new MapCaptionState(
         {
-            text: { disabled: true },
-            logo: { disabled: true }
+            text: {},
+            logo: {}
         },
-        { label: '0km', width: '0px', isImperialScale: false },
-        ''
+        {},
+        {}
     );
 
     return {


### PR DESCRIPTION
## Closes #670 

## Changes in this PR
- [FEAT] The map caption bar now has its own config (see "caption" under the map config schema for specification)
    - Config allows the user to specify the starting point formatter and also if the scale bar should use imperial units
    - Also allows the user to completely disable the mouse co-ords and scalebar
    - This schema follows the R2 schema, so it can be easily mapped (the mouse co-ords formatter will need to be adapted to R4)
- [FEAT] Renamed `ScaleBarProperties` type to `ScaleBar` and added optional `disabled?` property
- [FEAT] Mouse co-ords also uses its own type interface `MouseCoords` which stores the formatted string and also has a property for `disabled`

### [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/670/host/index.html)
You should see that when the demo loads, the point formatter uses the `WEB_MERCATOR` format and the scalebar uses imperial units. This is specified in the config as:
```ts
caption: {
  mouseCoords: {
      formatter: 'WEB_MERCATOR'
  },
  scaleBar: {
      imperialScale: true
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/678)
<!-- Reviewable:end -->
