### PR TITLE
Add keyboard instructions modal

### DIFF
--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "serve": "vue-cli-service serve",
+        "serve": "cross-env NODE_ENV=development TAILWIND_MODE=watch vue-cli-service serve --host localhost",
         "build": "cross-env VUE_APP_BUILD_TARGET=lib vue-cli-service build --target lib --formats umd --name RAMP src/main-build.ts 2>&1 && rm ./dist/demo.html",
         "test:unit": "vue-cli-service test:unit",
         "test:e2e": "vue-cli-service test:e2e",

--- a/packages/ramp-core/src/components/keyboard-instructions.vue
+++ b/packages/ramp-core/src/components/keyboard-instructions.vue
@@ -1,0 +1,71 @@
+<template>
+    <div
+        class="absolute inset-0 flex justify-center items-center bg-opacity-30 bg-black z-50 pointer-events-auto"
+        v-if="open"
+        @click="open = false"
+        @keydown="onKeydown"
+    >
+        <div
+            class="bg-white w-500 pointer-events-auto shadow-2xl p-20 flex flex-col"
+            @click.stop.prevent
+            tabindex="0"
+            ref="firstEl"
+        >
+            <div class="flex items-center mb-20">
+                <h2 class="text-xl">{{ $t('keyboardInstructions.title') }}</h2>
+                <close class="ml-auto" @click="open = false"></close>
+            </div>
+            <p
+                class="whitespace-pre-line pb-10"
+                v-for="section in instructionSections"
+                :key="section"
+            >
+                {{ $t(`keyboardInstructions.${section}`) }}
+            </p>
+            <button
+                class="mt-auto self-end mr-10 mb-10 px-20 py-10"
+                @click="open = false"
+                ref="lastEl"
+            >
+                {{ $t('keyboardInstructions.OK') }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Vue, Component } from 'vue-property-decorator';
+
+@Component
+export default class KeyboardInstructionsModalV extends Vue {
+    open: boolean = false;
+
+    instructionSections: string[] = ['app', 'lists', 'map'];
+
+    mounted() {
+        this.$iApi.event.on('openKeyboardInstructions', () => {
+            this.open = true;
+            this.$nextTick(() => {
+                (this.$refs.firstEl as HTMLElement)?.focus();
+            });
+        });
+    }
+
+    onKeydown(event: KeyboardEvent) {
+        if (event.key === 'Tab') {
+            if (event.shiftKey && event.target === this.$refs.firstEl) {
+                event.preventDefault();
+                (this.$refs.lastEl as HTMLElement).focus();
+            } else if (!event.shiftKey && event.target == this.$refs.lastEl) {
+                event.preventDefault();
+                (this.$refs.firstEl as HTMLElement).focus();
+            }
+        } else if (event.key === 'Escape') {
+            event.preventDefault();
+            this.open = false;
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -12,19 +12,17 @@
                 pointer-events-none
             "
         >
+            <div class="absolute top-8 w-full flex justify-center">
+                <button
+                    class="bg-white opacity-0 focus:opacity-100 z-50 shadow-md px-10"
+                    @click="openKeyboardInstructions"
+                >
+                    {{ $t('keyboardInstructions.open') }}
+                </button>
+            </div>
+            <keyboard-instructions-modal></keyboard-instructions-modal>
             <panel-stack
-                class="
-                    sm:flex
-                    absolute
-                    inset-0
-                    overflow-hidden
-                    xs:pl-40
-                    sm:p-12
-                    sm:pl-80
-                    z-10
-                    sm:pb-36
-                    xs:pb-28
-                "
+                class="panel-stack sm:flex absolute inset-0 overflow-hidden xs:pl-40 sm:p-12 sm:pl-80 z-10 sm:pb-36 xs:pb-28"
             ></panel-stack>
             <notification-floating-button
                 v-if="!appbarFixture"
@@ -46,6 +44,7 @@ import EsriMapV from '@/components/map/esri-map.vue';
 import PanelStackV from '@/components/panel-stack/panel-stack.vue';
 import MapCaptionV from '@/components/map/map-caption.vue';
 import NotificationsFloatingButtonV from '@/components/notification-center/floating-button.vue';
+import KeyboardInstructionsModalV from './keyboard-instructions.vue';
 import { Get } from 'vuex-pathify';
 import { FixtureInstance } from '@/api';
 import { GlobalEvents } from '@/api';
@@ -55,7 +54,8 @@ import { GlobalEvents } from '@/api';
         'esri-map': EsriMapV,
         'panel-stack': PanelStackV,
         'map-caption': MapCaptionV,
-        'notification-floating-button': NotificationsFloatingButtonV
+        'notification-floating-button': NotificationsFloatingButtonV,
+        'keyboard-instructions-modal': KeyboardInstructionsModalV
     }
 })
 export default class Shell extends Vue {
@@ -71,6 +71,10 @@ export default class Shell extends Vue {
             this.$iApi.event.emit(GlobalEvents.MAP_START);
             this.start = true;
         }
+    }
+
+    openKeyboardInstructions() {
+        this.$iApi.event.emit('openKeyboardInstructions');
     }
 }
 </script>

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -28,7 +28,10 @@ class AppbarFixture extends AppbarAPI {
         const innerShell = this.$vApp.$el.getElementsByClassName(
             'inner-shell'
         )[0];
-        innerShell.insertBefore(appbarInstance.$el, innerShell.children[0]);
+        innerShell.insertBefore(
+            appbarInstance.$el,
+            innerShell.querySelector('.panel-stack')
+        );
 
         this._parseConfig(this.config);
         this.$vApp.$watch(

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -4,6 +4,12 @@ lang-dir,ltr,1,ltr,1
 lang-en,English,1,French,1
 lang-fr,anglais,1,français,1
 lang-native,English,1,Français,1
+keyboardInstructions.title,Keyboard Instructions,1,Les instructions du clavier,0
+keyboardInstructions.open,Open keyboard instructions,1,Ouvrir les instructions du clavier,0
+keyboardInstructions.app,"Use 'Tab' to navigate between sections of the application.",1,"Utiliser « Tab » pour naviguer entre les différentes sections de l’application",0
+keyboardInstructions.lists,"Use the arrow keys to move between items in lists. With a list item selected you can press 'Space' or 'Enter' to click the item. You can also navigate within the list item using 'Tab'.",1,"Utilisez les touches fléchées pour déplacer entre les articles dans les listes. Avec un élément de la liste sélectionnée, vous pouvez appuyer sur « espace » ou « entrer ». Cliquer sur le poste. Vous pouvez aussi naviguer dans l’élément de la liste en utilisant « Tab ».",0
+keyboardInstructions.map,"When the map is selected, use the arrow keys to move around and 'Enter' to select a point.",1,"Lorsque la carte est sélectionnée, utilisez les touches fléchées pour déplacer et la touche « entrer » pour sélectionner un point.",0
+keyboardInstructions.OK,OK,1,OK,0
 map.toggleScaleUnits,Toggle between imperial and metric map scale,1,Basculer entre les échelles métriques et impériales pour la carte,1
 map.coordinates.east,E,1,E,1
 map.coordinates.west,W,1,O,1


### PR DESCRIPTION
Closes #663 

Adds a modal for keyboard instructions based on feedback for keyboard instructions from RAMP 2/3. The modal retains focus until dismissed and is focused automatically on opening.

Bonus: hot-reload for serve builds should work properly now, there shouldn't be a need to refresh after a code or css change.

DEMO: http://ramp4-app.azureedge.net/demo/users/spencerwahl/grid-keyboard-nav/host/index.html

Instructions; when you tab into the app you should see a button appear saying "Open keyboard instructions", pressing enter on that should bring up a modal with instructions, close and OK buttons should dismiss the modal.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/681)
<!-- Reviewable:end -->
