### PR TITLE
WET template fixes

### DIFF
--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -58,10 +58,27 @@ export default class App extends Vue {
 </script>
 
 <style lang="scss">
+$font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica,
+    Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 @use 'directives/focus-list/focus-list';
 .ramp-app {
     @include focus-list.default-focused-styling;
     height: 100vh;
+    font-family: $font-list;
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6 {
+        font-family: $font-list;
+    }
 }
 .symbologyIcon {
     @apply bg-white inline-flex justify-center items-center overflow-hidden;

--- a/packages/ramp-core/src/app.vue
+++ b/packages/ramp-core/src/app.vue
@@ -78,6 +78,7 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
     .h5,
     .h6 {
         font-family: $font-list;
+        line-height: 1.5;
     }
 }
 .symbologyIcon {

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -167,7 +167,4 @@ export default class MapCaptionV extends Vue {
 .map-caption {
     backdrop-filter: blur(5px);
 }
-
-notification-caption-button {
-}
 </style>

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -39,7 +39,7 @@
         </span>
 
         <notifications-caption-button
-            class="sm:block hidden"
+            class="sm:block display-none"
         ></notifications-caption-button>
 
         <span class="flex-grow w-15"></span>
@@ -166,5 +166,8 @@ export default class MapCaptionV extends Vue {
 <style lang="scss" scoped>
 .map-caption {
     backdrop-filter: blur(5px);
+}
+
+notification-caption-button {
 }
 </style>

--- a/packages/ramp-core/src/components/notification-center/floating-button.vue
+++ b/packages/ramp-core/src/components/notification-center/floating-button.vue
@@ -3,7 +3,7 @@
         @click="$iApi.panel.get('notifications-panel').open()"
         class="pointer-events-auto 
                flex items-center absolute left-8 bottom-36 p-6 
-               block sm:hidden 
+               block sm:display-none 
                bg-black-75 rounded-full text-gray-400 hover:text-white"
         :content="$t('notifications.title')"
         v-tippy

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -24,7 +24,7 @@
         </component>
         <more-button id="more" v-show="overflow"></more-button>
         <notifications-appbar-button
-            class="appbar-item bottom-48 h-48 sm:hidden"
+            class="appbar-item bottom-48 h-48 sm:display-none"
         ></notifications-appbar-button>
         <nav-button id="nav"></nav-button>
     </div>

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -274,12 +274,12 @@ export default class LegendEntryV extends Vue {
 .legend-item:hover,
 .legend-item:focus-within {
     .options {
-        display: block;
+        // !important added to override WET's hidden class
+        @apply block #{!important};
     }
 }
 .disabled {
-    @apply text-gray-400;
-    cursor: default;
+    @apply text-gray-400 cursor-default;
 }
 .spinner {
     border: 2px solid rgba(0, 0, 0, 0.158);

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -274,8 +274,7 @@ export default class LegendEntryV extends Vue {
 .legend-item:hover,
 .legend-item:focus-within {
     .options {
-        // !important added to override WET's hidden class
-        @apply block #{!important};
+        @apply block;
     }
 }
 .disabled {

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -1,5 +1,5 @@
 <template>
-    <div @click.stop @mouseover.stop class="options hidden cursor-auto">
+    <div @click.stop @mouseover.stop class="options display-none cursor-auto">
         <dropdown-menu
             class="relative"
             position="left-start"

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -4,6 +4,27 @@
     word-wrap: break-word;
 
     @import 'tailwindcss/base';
+
+    @layer base {
+        [type='text'],
+        [type='email'],
+        [type='url'],
+        [type='password'],
+        [type='number'],
+        [type='date'],
+        [type='datetime-local'],
+        [type='month'],
+        [type='search'],
+        [type='tel'],
+        [type='time'],
+        [type='week'],
+        [multiple],
+        textarea,
+        select {
+            font-size: 16px;
+        }
+    }
+
     @import 'tailwindcss/components';
     @import 'tailwindcss/utilities';
 

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -6,6 +6,14 @@
     @import 'tailwindcss/base';
     @import 'tailwindcss/components';
     @import 'tailwindcss/utilities';
+
+    @layer utilities {
+        @variants container-query {
+            .display-none {
+                display: none;
+            }
+        }
+    }
 }
 
 .ramp-app button:focus {

--- a/packages/ramp-core/src/styles/main.css
+++ b/packages/ramp-core/src/styles/main.css
@@ -1,6 +1,4 @@
 .ramp-app {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
     font-size: 16px;
     line-height: 1.5;
     word-wrap: break-word;
@@ -48,6 +46,7 @@
 .tippy-tooltip.ramp-theme {
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
         Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-size: 14px;
 }
 
 .tippy-tooltip.ramp-theme svg {

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -6,6 +6,21 @@ module.exports = {
         screens: {
             // sm: '640px'
         },
+        fontSize: {
+            xs: ['12px', '16px'],
+            sm: ['14px', '20px'],
+            base: ['16px', '24px'],
+            lg: ['18px', '28px'],
+            xl: ['20px', '28px'],
+            '2xl': ['24px', '32px'],
+            '3xl': ['30px', '36px'],
+            '4xl': ['36px', '40px'],
+            '5xl': '48px',
+            '6xl': '60px',
+            '7xl': '72px',
+            '8xl': '96px',
+            '9xl': '128px'
+        },
         spacing: {
             '-36': '-36px',
             '-32': '-32px',


### PR DESCRIPTION
Closes #582 

WET was making the base font size for the page `10px` so everything using rems was based on that. I don't know why it did that because it also set the base font-size on `body` to `16px`. WET also had their own `hidden` class that has `!important` in it and was causing problems.

Font size, line height, etc. is now explicitly set in px and doesn't use REM. As far as I can tell this is fine for accessibility, text resizing seems to be acceptable if the app/page is zoomable and browsers do that by default.

Added a `display-none` class to use instead of `hidden` where needed, this gets injected into tailwind so we can use the modifiers (app size for now, can add more to the `variants` tag).

DEMO: http://ramp4-app.azureedge.net/demo/users/spencerwahl/wet-template-fix/host/index-wet.html
regular page to compare: http://ramp4-app.azureedge.net/demo/users/spencerwahl/wet-template-fix/host/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/683)
<!-- Reviewable:end -->
