### PR TITLE
Custom maptips

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -71,6 +71,8 @@ export enum GlobalEvents {
      */
     MAP_SCALECHANGE = 'map/scalechanged',
     MAP_RESIZE = 'map/resized',
+
+    MAP_GRAPHICHIT = 'map/graphichit',
     SETTINGS_TOGGLE = 'settings/toggle',
     DETAILS_OPEN = 'details/open',
     HELP_TOGGLE = 'help/toggle',
@@ -113,8 +115,9 @@ enum DefEH {
     MAP_BASEMAPCHANGE_ATTRIBUTION = 'updates_map_caption_attribution_basemap',
     CONFIG_CHANGE_ATTRIBUTION = 'updates_map_caption_attribution_config',
     MAP_SCALECHANGE_SCALEBAR = 'updates_map_caption_scale',
-    OPEN_MAP_FEATURE_MAPTIP = 'open_feature_maptip',
-    EXTENT_CHANGE_FEATURE_MAPTIP = 'updates_feature_maptip_extent_change',
+    MOUSE_MOVE_MAPTIP_CHECK = 'open_feature_maptip',
+    EXTENT_CHANGE_MAPTIP_CHECK = 'updates_feature_maptip_extent_change',
+    SHOW_DEFAULT_MAPTIP = 'show_default_maptip',
     MAP_UPDATE_CAPTION_COORDS = 'updates_map_caption_coords',
     LEGEND_REMOVES_LAYER_ENTRY = 'legend_removes_layer_entry',
     LEGEND_RELOADS_LAYER_ENTRY = 'legend_reloads_layer_entry',
@@ -166,7 +169,7 @@ export class EventAPI extends APIScope {
         // getting enum values is a mess. this code does it but assumes
         // all event names in global events use the slash format
         this._nameRegister = Object.values(GlobalEvents).filter(
-            (e) => typeof e === 'string' && e.indexOf('/') > -1
+            e => typeof e === 'string' && e.indexOf('/') > -1
         );
     }
 
@@ -179,7 +182,7 @@ export class EventAPI extends APIScope {
      * @private
      */
     private findHandler(handlerName: string): EventHandler | undefined {
-        return this._eventRegister.find((eh) => eh.handlerName === handlerName);
+        return this._eventRegister.find(eh => eh.handlerName === handlerName);
     }
 
     /**
@@ -203,7 +206,7 @@ export class EventAPI extends APIScope {
      */
     registerEventName(names: string | Array<string>): void {
         const arrr = Array.isArray(names) ? names : [names];
-        arrr.forEach((n) => {
+        arrr.forEach(n => {
             // don't add if name is already registered
             if (this._nameRegister.indexOf(n) === -1) {
                 this._nameRegister.push(n);
@@ -328,11 +331,11 @@ export class EventAPI extends APIScope {
         // TODO add a filter if we implement disabled events
 
         if (event === '') {
-            return this._eventRegister.map((eh) => eh.handlerName);
+            return this._eventRegister.map(eh => eh.handlerName);
         }
         return this._eventRegister
-            .filter((eh) => eh.eventName === event)
-            .map((eh) => eh.handlerName);
+            .filter(eh => eh.eventName === event)
+            .map(eh => eh.handlerName);
     }
 
     /**
@@ -371,8 +374,9 @@ export class EventAPI extends APIScope {
                 DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION,
                 DefEH.CONFIG_CHANGE_ATTRIBUTION,
                 DefEH.MAP_SCALECHANGE_SCALEBAR,
-                DefEH.OPEN_MAP_FEATURE_MAPTIP,
-                DefEH.EXTENT_CHANGE_FEATURE_MAPTIP,
+                DefEH.MOUSE_MOVE_MAPTIP_CHECK,
+                DefEH.EXTENT_CHANGE_MAPTIP_CHECK,
+                DefEH.SHOW_DEFAULT_MAPTIP,
                 DefEH.MAP_UPDATE_CAPTION_COORDS,
                 DefEH.LEGEND_REMOVES_LAYER_ENTRY,
                 DefEH.LEGEND_RELOADS_LAYER_ENTRY,
@@ -381,7 +385,7 @@ export class EventAPI extends APIScope {
         }
 
         // add all the requested default event handlers.
-        return eventHandlerNames.map((hn) => this.defaultHandlerFactory(hn));
+        return eventHandlerNames.map(hn => this.defaultHandlerFactory(hn));
     }
 
     /**
@@ -407,8 +411,9 @@ export class EventAPI extends APIScope {
             case DefEH.IDENTIFY_DETAILS:
                 // when identify runs, open details fixture and show the results
                 zeHandler = (identifyParam: any) => {
-                    const detailFix: DetailsAPI =
-                        this.$iApi.fixture.get('details');
+                    const detailFix: DetailsAPI = this.$iApi.fixture.get(
+                        'details'
+                    );
                     if (detailFix) {
                         detailFix.openDetails(identifyParam.results);
                     }
@@ -417,8 +422,9 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.TOGGLE_SETTINGS:
                 zeHandler = (payload: any) => {
-                    const settingsFixture: SettingsAPI =
-                        this.$iApi.fixture.get('settings');
+                    const settingsFixture: SettingsAPI = this.$iApi.fixture.get(
+                        'settings'
+                    );
                     if (settingsFixture) {
                         settingsFixture.toggleSettings(payload);
                     }
@@ -432,8 +438,9 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.OPEN_DETAILS:
                 zeHandler = (payload: any) => {
-                    const detailsFixture: DetailsAPI =
-                        this.$iApi.fixture.get('details');
+                    const detailsFixture: DetailsAPI = this.$iApi.fixture.get(
+                        'details'
+                    );
                     if (detailsFixture) {
                         detailsFixture.openFeature(
                             payload.identifyItem,
@@ -475,8 +482,9 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.OPEN_WIZARD:
                 zeHandler = () => {
-                    const wizardFixture: WizardAPI =
-                        this.$iApi.fixture.get('wizard');
+                    const wizardFixture: WizardAPI = this.$iApi.fixture.get(
+                        'wizard'
+                    );
                     if (wizardFixture) {
                         wizardFixture.openWizard();
                     }
@@ -489,8 +497,9 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.GENERATE_LEGEND:
                 zeHandler = (layer: LayerInstance, parent?: any) => {
-                    const legendFixture: LegendAPI =
-                        this.$iApi.fixture.get('legend');
+                    const legendFixture: LegendAPI = this.$iApi.fixture.get(
+                        'legend'
+                    );
                     if (legendFixture) {
                         legendFixture.generateDefaultLegend(layer, parent);
                     }
@@ -533,10 +542,11 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION:
                 zeHandler = (payload: string) => {
-                    let currentBasemapConfig: RampBasemapConfig | undefined =
-                        this.$iApi
-                            .getConfig()
-                            .map.basemaps.find((bms) => bms.id === payload);
+                    let currentBasemapConfig:
+                        | RampBasemapConfig
+                        | undefined = this.$iApi
+                        .getConfig()
+                        .map.basemaps.find(bms => bms.id === payload);
 
                     this.$iApi.geo.map.caption.updateAttribution(
                         currentBasemapConfig?.attribution
@@ -550,12 +560,12 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.CONFIG_CHANGE_ATTRIBUTION:
                 zeHandler = (payload: RampConfig) => {
-                    let currentBasemapConfig: RampBasemapConfig | undefined =
-                        payload.map.basemaps.find(
-                            (bms) =>
-                                bms.id ===
-                                this.$iApi.geo.map.getCurrentBasemapId()
-                        );
+                    let currentBasemapConfig:
+                        | RampBasemapConfig
+                        | undefined = payload.map.basemaps.find(
+                        bms =>
+                            bms.id === this.$iApi.geo.map.getCurrentBasemapId()
+                    );
 
                     this.$iApi.geo.map.caption.updateAttribution(
                         currentBasemapConfig?.attribution
@@ -576,9 +586,9 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
-            case DefEH.OPEN_MAP_FEATURE_MAPTIP:
+            case DefEH.MOUSE_MOVE_MAPTIP_CHECK:
                 zeHandler = (mapMove: MapMove) => {
-                    this.$iApi.geo.map.maptip.updateAtCoord({
+                    this.$iApi.geo.map.maptip.checkAtCoord({
                         screenX: mapMove.screenX,
                         screenY: mapMove.screenY
                     });
@@ -589,15 +599,14 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
-            case DefEH.EXTENT_CHANGE_FEATURE_MAPTIP:
+            case DefEH.EXTENT_CHANGE_MAPTIP_CHECK:
                 zeHandler = () => {
                     if (this.$iApi.geo.map.keysActive) {
                         // The user is using the crosshairs, perform hit-test using center of screens
-                        let screenCenter: ScreenPoint =
-                            this.$iApi.geo.map.mapPointToScreenPoint(
-                                this.$iApi.geo.map.getExtent().center()
-                            );
-                        this.$iApi.geo.map.maptip.updateAtCoord(screenCenter);
+                        let screenCenter: ScreenPoint = this.$iApi.geo.map.mapPointToScreenPoint(
+                            this.$iApi.geo.map.getExtent().center()
+                        );
+                        this.$iApi.geo.map.maptip.checkAtCoord(screenCenter);
                     } else {
                         // regular extent change, hide maptip
                         this.$iApi.geo.map.maptip.clear();
@@ -609,16 +618,29 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
+            case DefEH.SHOW_DEFAULT_MAPTIP:
+                zeHandler = (tooltipInfo: any) => {
+                    this.$iApi.geo.map.maptip.generateDefaultMaptip(
+                        tooltipInfo
+                    );
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_GRAPHICHIT,
+                    zeHandler,
+                    handlerName
+                );
+                break;
             case DefEH.MAP_UPDATE_CAPTION_COORDS:
                 this.$iApi.event.on(
                     GlobalEvents.MAP_MOUSEMOVE,
                     throttle(200, (mapMove: MapMove) => {
                         // check if cursor coords are disabled
                         // if it is, then do not update it
-                        const currentCursorCoords: MouseCoords | undefined =
-                            this.$iApi.$vApp.$store.get(
-                                MapCaptionStore.cursorCoords
-                            );
+                        const currentCursorCoords:
+                            | MouseCoords
+                            | undefined = this.$iApi.$vApp.$store.get(
+                            MapCaptionStore.cursorCoords
+                        );
                         if (currentCursorCoords?.disabled) {
                             return;
                         }
@@ -629,7 +651,7 @@ export class EventAPI extends APIScope {
                                     mapMove
                                 )
                             )
-                            .then((fs) => {
+                            .then(fs => {
                                 this.$iApi.$vApp.$store.set(
                                     MapCaptionStore.setCursorCoords,
                                     {

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -7,7 +7,8 @@
             v-tippy="{
                 placement: tooltipPlacement,
                 theme: tooltipTheme,
-                animation: tooltipAnimation
+                animation: tooltipAnimation,
+                appendTo: 'parent'
             }"
             ref="dropdown-trigger"
         >

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -8,6 +8,7 @@
             zIndex: 5,
             theme: 'ramp4',
             trigger: 'manual',
+            appendTo: 'parent',
             arrow: false,
             delay: 200,
             duration: [200, 200]
@@ -47,15 +48,14 @@ export default defineComponent({
     },
 
     watch: {
-        maptipProperties() {
-            if (this.maptipProperties) {
+        maptipPoint() {
+            if (this.maptipPoint) {
                 // Calculate offset from mappoint
                 let offsetX, offsetY: number;
                 const originX: number = this.$iApi.geo.map.getPixelWidth() / 2;
                 const originY: number = 0;
-                const screenPointFromMapPoint = this.$iApi.geo.map.mapPointToScreenPoint(
-                    this.maptipProperties.mapPoint
-                );
+                const screenPointFromMapPoint =
+                    this.$iApi.geo.map.mapPointToScreenPoint(this.maptipPoint);
                 offsetX = screenPointFromMapPoint.screenX - originX;
                 offsetY = originY - screenPointFromMapPoint.screenY;
                 this.maptipInstance.setProps({
@@ -136,10 +136,10 @@ export default defineComponent({
 
             const layers = await Promise.all(
                 newValue
-                    .filter(lc => !oldValue.includes(lc))
-                    .map(layerConfig => {
+                    .filter((lc) => !oldValue.includes(lc))
+                    .map((layerConfig) => {
                         return new Promise<LayerInstance | null>(
-                            async resolve => {
+                            async (resolve) => {
                                 let defLoadProm: Promise<string>;
 
                                 // check if we need to load the layer class
@@ -155,9 +155,10 @@ export default defineComponent({
                                     // if the definition is a custom number, the site host would have had to add the
                                     // definition already. this block should only run for layer types that are bundled
                                     // in the ramp core codebase.
-                                    defLoadProm = this.$iApi.geo.layer.addLayerDef(
-                                        layerConfig.layerType
-                                    );
+                                    defLoadProm =
+                                        this.$iApi.geo.layer.addLayerDef(
+                                            layerConfig.layerType
+                                        );
                                 }
 
                                 // wait for definition to load, or ride the resolve if already loaded

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -34,8 +34,9 @@ export default defineComponent({
             mapConfig: get(ConfigStore.getMapConfig),
             layers: get(LayerStore.layers),
             layerConfigs: get(LayerStore.layerConfigs),
-            maptipProperties: get(MaptipStore.maptipProperties),
+            maptipPoint: get(MaptipStore.maptipPoint),
             maptipInstance: get(MaptipStore.maptipInstance),
+            maptipContent: get(MaptipStore.content),
             map: ref() // TODO assuming we need this as a local property for vue binding. if we don't, remove it and just use $iApi.geo.map
         };
     },
@@ -52,15 +53,27 @@ export default defineComponent({
                 let offsetX, offsetY: number;
                 const originX: number = this.$iApi.geo.map.getPixelWidth() / 2;
                 const originY: number = 0;
-                const screenPointFromMapPoint =
-                    this.$iApi.geo.map.mapPointToScreenPoint(
-                        this.maptipProperties.mapPoint
-                    );
+                const screenPointFromMapPoint = this.$iApi.geo.map.mapPointToScreenPoint(
+                    this.maptipProperties.mapPoint
+                );
                 offsetX = screenPointFromMapPoint.screenX - originX;
                 offsetY = originY - screenPointFromMapPoint.screenY;
                 this.maptipInstance.setProps({
                     offset: [offsetX, offsetY]
                 });
+                if (this.maptipContent && this.maptipContent !== '') {
+                    this.maptipInstance.show();
+                }
+            } else {
+                this.maptipInstance.hide();
+            }
+        },
+        maptipContent() {
+            if (
+                this.maptipContent &&
+                this.maptipContent !== '' &&
+                this.maptipPoint
+            ) {
                 this.maptipInstance.show();
             } else {
                 this.maptipInstance.hide();
@@ -123,10 +136,10 @@ export default defineComponent({
 
             const layers = await Promise.all(
                 newValue
-                    .filter((lc) => !oldValue.includes(lc))
-                    .map((layerConfig) => {
+                    .filter(lc => !oldValue.includes(lc))
+                    .map(layerConfig => {
                         return new Promise<LayerInstance | null>(
-                            async (resolve) => {
+                            async resolve => {
                                 let defLoadProm: Promise<string>;
 
                                 // check if we need to load the layer class
@@ -142,10 +155,9 @@ export default defineComponent({
                                     // if the definition is a custom number, the site host would have had to add the
                                     // definition already. this block should only run for layer types that are bundled
                                     // in the ramp core codebase.
-                                    defLoadProm =
-                                        this.$iApi.geo.layer.addLayerDef(
-                                            layerConfig.layerType
-                                        );
+                                    defLoadProm = this.$iApi.geo.layer.addLayerDef(
+                                        layerConfig.layerType
+                                    );
                                 }
 
                                 // wait for definition to load, or ride the resolve if already loaded

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -71,7 +71,8 @@
                 placement: 'top',
                 hideOnClick: false,
                 theme: 'ramp4',
-                animation: 'scale'
+                animation: 'scale',
+                appendTo: 'parent'
             }"
             :content="$t('map.toggleScaleUnits')"
         >

--- a/packages/ramp-core/src/components/notification-center/caption-button.vue
+++ b/packages/ramp-core/src/components/notification-center/caption-button.vue
@@ -50,7 +50,8 @@
                             v-tippy="{
                                 placement: 'bottom',
                                 theme: 'ramp4',
-                                animation: 'scale'
+                                animation: 'scale',
+                                appendTo: 'parent'
                             }"
                         >
                             <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Aclear_all -->

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -7,7 +7,8 @@
             v-tippy="{
                 placement: 'bottom',
                 theme: 'ramp4',
-                animation: 'scale'
+                animation: 'scale',
+                appendTo: 'parent'
             }"
         >
             <svg

--- a/packages/ramp-core/src/geo/map/maptip.ts
+++ b/packages/ramp-core/src/geo/map/maptip.ts
@@ -28,11 +28,8 @@ export class MaptipAPI extends APIScope {
      */
     async checkAtCoord(screenPoint: ScreenPoint): Promise<void> {
         // Get the graphic object
-        const graphicHit:
-            | GraphicHitResult
-            | undefined = await this.$iApi.geo.map.getGraphicAtCoord(
-            screenPoint
-        );
+        const graphicHit: GraphicHitResult | undefined =
+            await this.$iApi.geo.map.getGraphicAtCoord(screenPoint);
 
         if (!graphicHit) {
             this.lastHit = undefined;
@@ -56,9 +53,8 @@ export class MaptipAPI extends APIScope {
         this.clear();
 
         // Get the layer
-        const layerInstance:
-            | LayerInstance
-            | undefined = this.$iApi.geo.layer.getLayer(graphicHit.layerId);
+        const layerInstance: LayerInstance | undefined =
+            this.$iApi.geo.layer.getLayer(graphicHit.layerId);
         if (!layerInstance) {
             // Something seriously wrong here because esri gave us a non-existent layerID
             console.error(
@@ -97,7 +93,7 @@ export class MaptipAPI extends APIScope {
         icon: string;
     }) {
         this.setContent(
-            `<div class="flex justify-center text-center">${info.icon} ${
+            `<div class="flex items-center">${info.icon} ${
                 info.attributes[
                     info.layer.config.tooltipField ||
                         info.layer.getNameField(info.graphicHit.layerIdx)

--- a/packages/ramp-core/src/store/modules/maptip/maptip-state.ts
+++ b/packages/ramp-core/src/store/modules/maptip/maptip-state.ts
@@ -1,8 +1,7 @@
-import { MaptipProperties } from '@/geo/api';
+import { MaptipProperties, Point } from '@/geo/api';
 
 export class MaptipState {
     maptipInstance: any = undefined;
-    maptipProperties: MaptipProperties | undefined = undefined;
-    defaultContent: string = '';
+    maptipPoint: Point | undefined = undefined;
     content: string = '';
 }

--- a/packages/ramp-core/src/store/modules/maptip/maptip-store.ts
+++ b/packages/ramp-core/src/store/modules/maptip/maptip-store.ts
@@ -3,7 +3,7 @@ import { make } from 'vuex-pathify';
 
 import { MaptipState } from './maptip-state';
 import { RootState } from '@/store';
-import { MaptipProperties } from '@/geo/api';
+import { MaptipProperties, Point } from '@/geo/api';
 
 type MaptipContext = ActionContext<MaptipState, RootState>;
 
@@ -13,14 +13,11 @@ const actions = {
     setMaptipInstance: (context: MaptipContext, maptipInstance: any) => {
         context.commit('SET_MAPTIP_INSTANCE', maptipInstance);
     },
-    setMaptipProperties: (context: MaptipContext, maptip: MaptipProperties) => {
-        context.commit('SET_MAPTIP_PROPERTIES', maptip);
+    setMaptipPoint: (context: MaptipContext, maptipPoint: Point) => {
+        context.commit('SET_MAPTIP_Point', maptipPoint);
     },
     setMaptipContent: (context: MaptipContext, content: string) => {
         context.commit('SET_MAPTIP_CONTENT', content);
-    },
-    setMaptipDefaultContent: (context: MaptipContext, content: string) => {
-        context.commit('SET_MAPTIP_CONTENT_DEFAULT', content);
     }
 };
 
@@ -28,23 +25,20 @@ const mutations = {
     SET_MAPTIP_INSTANCE: (state: MaptipState, value: any) => {
         state.maptipInstance = value;
     },
-    SET_MAPTIP_PROPERTIES: (state: MaptipState, value: MaptipProperties) => {
-        state.maptipProperties = value;
+    SET_MAPTIP_POINT: (state: MaptipState, value: Point) => {
+        state.maptipPoint = value;
     },
     SET_MAPTIP_CONTENT: (state: MaptipState, value: string) => {
-        state.content = value || state.defaultContent;
+        state.content = value;
         state.maptipInstance.setContent(state.content);
-    },
-    SET_MAPTIP_CONTENT_DEFAULT: (state: MaptipState, value: string) => {
-        state.defaultContent = value;
     }
 };
 
 export enum MaptipStore {
     /**
-     * (State) maptipProperties: MaptipProperties
+     * (State) maptipPoint: Point
      */
-    maptipProperties = 'maptip/maptipProperties',
+    maptipPoint = 'maptip/maptipPoint',
     /**
      * (State) maptipInstance: any
      */
@@ -54,17 +48,13 @@ export enum MaptipStore {
      */
     content = 'maptip/content',
     /**
-     * (Action) setMaptipProperties: (maptip: MaptipProperties)
+     * (Action) setMaptipPoint: (maptip: Point)
      */
-    setMaptipProperties = 'maptip/setMaptipProperties!',
+    setMaptipPoint = 'maptip/setMaptipPoint!',
     /**
      * (Action) setMaptipContent: (content: string)
      */
     setMaptipContent = 'maptip/setMaptipContent!',
-    /**
-     * (Action) setMaptipDefaultContent: (content: string)
-     */
-    setMaptipDefaultContent = 'maptip/setMaptipDefaultContent!',
     /**
      * (Action) setMaptipInstance: (tooltipInstance: any)
      */


### PR DESCRIPTION
closes #684 

Default maptips now show icon + tooltip field (or name if theres no tooltip field) like ramp2.
Custom maptips can be shown by replacing the `show_default_maptip` event with a different event that listens for `map/graphichit`

sample of changing maptips;
```js
rInstance.event.off('show_default_maptip');
rInstance.event.on('map/graphichit', (tooltipInfo) => { console.log(tooltipInfo); rInstance.geo.map.maptip.setContent('CUSTOM MAPTIP <br>' + tooltipInfo.attributes.STATION_NAME) });
```

The blue points should now show the following when hovered.
```
CUSTOM MAPTIP
<station name>
```

There is a `generateDefaultMaptip` function that will set the maptip content to the default, so if a user only wants to cusomize one they can check the layer name in their new event and call `generateDefaultMaptip` for every other layer.

Not sure if everything is in the file it should be... the maptip stuff being under geoapi seems wrong but since its now less separated from the ui core maybe its fine.