### PR TITLE
fix blank div on delayed map start

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -65,11 +65,11 @@ let config = {
                         {
                             id: 'CBMT',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -81,11 +81,11 @@ let config = {
                         {
                             id: 'SMR',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -98,11 +98,11 @@ let config = {
                         {
                             id: 'CBME_CBCE_HS_RO_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -115,11 +115,11 @@ let config = {
                         {
                             id: 'CBMT_CBCT_GEOM_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -132,11 +132,11 @@ let config = {
                         {
                             id: 'World_Imagery',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100,
                     attribution: {
                         text: {
@@ -157,11 +157,11 @@ let config = {
                         {
                             id: 'World_Physical_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -174,11 +174,11 @@ let config = {
                         {
                             id: 'World_Shaded_Relief',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -191,11 +191,11 @@ let config = {
                         {
                             id: 'World_Street_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -208,11 +208,11 @@ let config = {
                         {
                             id: 'World_Terrain_Base',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -225,11 +225,11 @@ let config = {
                         {
                             id: 'World_Topo_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 }
             ],
@@ -289,8 +289,7 @@ let config = {
             {
                 id: 'WFSLayer',
                 layerType: 'ogcWfs',
-                url:
-                    'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
                 state: {
                     visibility: true
                 },
@@ -420,11 +419,11 @@ let config = {
                         {
                             id: 'CBMT',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -436,11 +435,11 @@ let config = {
                         {
                             id: 'SMR',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -453,11 +452,11 @@ let config = {
                         {
                             id: 'CBME_CBCE_HS_RO_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -470,11 +469,11 @@ let config = {
                         {
                             id: 'CBMT_CBCT_GEOM_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -487,11 +486,11 @@ let config = {
                         {
                             id: 'World_Imagery',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100,
                     attribution: {
                         text: {
@@ -512,11 +511,11 @@ let config = {
                         {
                             id: 'World_Physical_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -529,11 +528,11 @@ let config = {
                         {
                             id: 'World_Shaded_Relief',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -546,11 +545,11 @@ let config = {
                         {
                             id: 'World_Street_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -563,11 +562,11 @@ let config = {
                         {
                             id: 'World_Terrain_Base',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -580,11 +579,11 @@ let config = {
                         {
                             id: 'World_Topo_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 }
             ],
@@ -644,8 +643,7 @@ let config = {
             {
                 id: 'WFSLayer',
                 layerType: 'ogcWfs',
-                url:
-                    'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
                 state: {
                     visibility: true
                 },
@@ -728,7 +726,7 @@ let config = {
 let options = {
     loadDefaultFixtures: false,
     loadDefaultEvents: true,
-    startRequired: false
+    startRequired: true
 };
 
 rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
@@ -767,5 +765,6 @@ function animateToggle() {
     } else {
         rInstance.$vApp.$el.classList.add('animation-enabled');
     }
-    document.getElementById('animate-status').innerText = 'Animate: ' + rInstance.animate;
+    document.getElementById('animate-status').innerText =
+        'Animate: ' + rInstance.animate;
 }

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -44,6 +44,14 @@ export default defineComponent({
         // temporarily print out loaded layers to console for grid testing purposes.
         console.log(this.layers, this.mapConfig);
     },
+    mounted() {
+        // Set config watcher up here to be able to call it immediately on mount
+        // regularly `immediate` makes it get called during `created`
+        this.$watch('mapConfig', this.onMapConfigChange, { immediate: true });
+        this.$watch('layerConfigs', this.onLayerConfigArrayChange, {
+            immediate: true
+        });
+    },
 
     watch: {
         maptipProperties() {
@@ -65,39 +73,6 @@ export default defineComponent({
             } else {
                 this.maptipInstance.hide();
             }
-        },
-
-        layerConfigs(newValue: RampLayerConfig[], oldValue: RampLayerConfig[]) {
-            this.onLayerConfigArrayChange(newValue, oldValue);
-        },
-
-        mapConfig(newValue: RampMapConfig, oldValue: RampMapConfig) {
-            console.log('new map config change: ', newValue, this.mapConfig);
-            if (newValue === oldValue) {
-                return;
-            }
-
-            const mapViewElement: Element | null = this.$el;
-
-            this.$iApi.geo.map.createMap(
-                newValue,
-                mapViewElement as HTMLDivElement
-            );
-            this.map = this.$iApi.geo.map;
-            this.$iApi.event.emit(GlobalEvents.MAP_CREATED, this.$iApi.geo.map);
-
-            // Hide hovertip on map creation
-            //@ts-ignore
-            mapViewElement._tippy.hide(0);
-            this.$iApi.$vApp.$store.set(
-                MaptipStore.setMaptipInstance,
-                //@ts-ignore
-                mapViewElement._tippy
-            );
-
-            // TODO see if we still need this. map config should trigger the array watcher due to the store.
-            //      possibly layer config is processed before map config is done creating map?
-            this.onLayerConfigArrayChange(this.layerConfigs.value, []);
         }
     },
 
@@ -123,7 +98,7 @@ export default defineComponent({
 
             const layers = await Promise.all(
                 newValue
-                    .filter((lc) => !oldValue.includes(lc))
+                    .filter((lc) => !oldValue || !oldValue.includes(lc))
                     .map((layerConfig) => {
                         return new Promise<LayerInstance | null>(
                             async (resolve) => {
@@ -194,8 +169,40 @@ export default defineComponent({
             layers
                 .filter(Boolean)
                 .forEach((layer: LayerInstance | null, index: number) => {
-                    this.$iApi.geo.map.reorder(layer!, oldValue.length + index);
+                    this.$iApi.geo.map.reorder(
+                        layer!,
+                        oldValue ? oldValue.length + index : index
+                    );
                 });
+        },
+        onMapConfigChange(newValue: RampMapConfig, oldValue: RampMapConfig) {
+            console.log('new map config change: ', newValue, this.mapConfig);
+
+            if (newValue === oldValue) {
+                return;
+            }
+
+            const mapViewElement: Element | null = this.$el;
+
+            this.$iApi.geo.map.createMap(
+                newValue,
+                mapViewElement as HTMLDivElement
+            );
+            this.map = this.$iApi.geo.map;
+            this.$iApi.event.emit(GlobalEvents.MAP_CREATED, this.$iApi.geo.map);
+
+            // Hide hovertip on map creation
+            //@ts-ignore
+            mapViewElement._tippy.hide(0);
+            this.$iApi.$vApp.$store.set(
+                MaptipStore.setMaptipInstance,
+                //@ts-ignore
+                mapViewElement._tippy
+            );
+
+            // TODO see if we still need this. map config should trigger the array watcher due to the store.
+            //      possibly layer config is processed before map config is done creating map?
+            this.onLayerConfigArrayChange(this.layerConfigs.value, []);
         }
     }
 });


### PR DESCRIPTION
closes #672 

Map config + layer config watcher was missing the initial update of the config if the map start was delayed. Watcher is now set up and called right away in `mounted`.

Don't bother reviewing `ramp-starter.js`, the only actual change is `startRequired: true` that will get reverted before pulling. Everything else is `prettier` linting.

DEMO:
delayed: http://ramp4-app.azureedge.net/demo/users/spencerwahl/blank-delay/host/index.html
normal: http://ramp4-app.azureedge.net/demo/users/spencerwahl/blank-delay/host/index-e2e.html?script=wms-layer