### PR TITLE
Implement number localization

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -267,6 +267,12 @@ export default defineComponent({
                         if (NUM_TYPES.indexOf(fieldInfo.type) > -1) {
                             this.setUpNumberFilter(col, this.config.state);
                             col.filter = 'agNumberColumnFilter';
+                            col.cellRenderer = (cell: any) => {
+                                return this.$iApi.$vApp.$n(
+                                    cell.value,
+                                    'number'
+                                );
+                            };
                         } else if (fieldInfo.type === DATE_TYPE) {
                             this.setUpDateFilter(col, this.config.state);
                             col.filter = 'agDateColumnFilter';
@@ -368,6 +374,14 @@ export default defineComponent({
                         }
                     }
                 )
+            );
+            this.handlers.push(
+                this.$iApi.event.on(GlobalEvents.CONFIG_CHANGE, () => {
+                    // Refresh the grid when the config changes (the language might have changed)
+                    this.gridApi.redrawRows({
+                        force: true
+                    });
+                })
             );
             this.applyLayerFilters();
         },

--- a/packages/ramp-core/src/geo/map/caption.ts
+++ b/packages/ramp-core/src/geo/map/caption.ts
@@ -246,7 +246,7 @@ export class MapCaptionAPI extends APIScope {
 
         this.$iApi.$vApp.$store.set(MapCaptionStore.setScale, {
             width: `${pixels}px`,
-            label: `${distance}${unit}`,
+            label: `${this.$iApi.$vApp.$n(distance, 'number')}${unit}`,
             isImperialScale: isImperialScale
         });
     }
@@ -287,23 +287,6 @@ export class MapCaptionAPI extends APIScope {
         } else {
             // value is a function
             this.pointFormatter = value;
-        }
-    }
-
-    /**
-     * Pad value with leading 0 to make sure there is at least 2 digits if number is below 10.
-     *
-     * @function padZero
-     * @private
-     * @param {Number} val value to pad with 0
-     * @return {String} string with at least 2 characters
-     */
-    padZero(val: number | string): string {
-        if (typeof val === 'number') {
-            return val >= 10 ? `${val}` : `0${val}`;
-        } else {
-            const floatVal = parseFloat(val);
-            return parseFloat(val) >= 10 ? `${floatVal}` : `0${floatVal}`;
         }
     }
 
@@ -349,16 +332,23 @@ export class MapCaptionAPI extends APIScope {
         const mx = Math.floor(Math.abs((lon - dx) * 60));
         const sx = Math.floor((Math.abs(lon) - Math.abs(dx) - mx / 60) * 3600);
 
-        const newY = `${Math.abs(dy)}${degreeSymbol} ${this.padZero(
-            my
-        )}' ${this.padZero(sy)}"`;
-        const newX = `${Math.abs(dx)}${degreeSymbol} ${this.padZero(
-            mx
-        )}' ${this.padZero(sx)}"`;
-
-        return `${newY} ${this.$iApi.$vApp.$t(
+        return `${this.$iApi.$vApp.$n(
+            Math.abs(dy),
+            'number'
+        )}${degreeSymbol} ${this.$iApi.$vApp.$n(my, 'number', {
+            minimumIntegerDigits: 2
+        } as any)}' ${this.$iApi.$vApp.$n(sy, 'number', {
+            minimumIntegerDigits: 2
+        } as any)}" ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (lat > 0 ? 'north' : 'south')
-        )} | ${newX} ${this.$iApi.$vApp.$t(
+        )} | ${this.$iApi.$vApp.$n(
+            Math.abs(dx),
+            'number'
+        )}${degreeSymbol} ${this.$iApi.$vApp.$n(mx, 'number', {
+            minimumIntegerDigits: 2
+        } as any)}' ${this.$iApi.$vApp.$n(sx, 'number', {
+            minimumIntegerDigits: 2
+        } as any)}" ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (0 > lon ? 'west' : 'east')
         )}`;
     }
@@ -381,16 +371,24 @@ export class MapCaptionAPI extends APIScope {
         const degreeSymbol = String.fromCharCode(176);
 
         const dy = Math.floor(Math.abs(lat)) * (lat < 0 ? -1 : 1);
-        const my = Math.abs((lat - dy) * 60).toFixed(2);
-        const newY = `${Math.abs(dy)}${degreeSymbol} ${this.padZero(my)}'`;
+        const my = Math.abs((lat - dy) * 60);
 
         const dx = Math.floor(Math.abs(lon)) * (lon < 0 ? -1 : 1);
-        const mx = Math.abs((lon - dx) * 60).toFixed(2);
-        const newX = `${Math.abs(dx)}${degreeSymbol} ${this.padZero(mx)}'`;
+        const mx = Math.abs((lon - dx) * 60);
 
-        return `${newY} ${this.$iApi.$vApp.$t(
+        return `${this.$iApi.$vApp.$n(
+            Math.abs(dy),
+            'number'
+        )}${degreeSymbol} ${this.$iApi.$vApp.$n(my, 'number', {
+            minimumIntegerDigits: 2
+        } as any)} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (lat > 0 ? 'north' : 'south')
-        )} | ${newX} ${this.$iApi.$vApp.$t(
+        )} | ${this.$iApi.$vApp.$n(
+            Math.abs(dx),
+            'number'
+        )}${degreeSymbol} ${this.$iApi.$vApp.$n(mx, 'number', {
+            minimumIntegerDigits: 2
+        } as any)} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (0 > lon ? 'west' : 'east')
         )}`;
     }
@@ -412,12 +410,18 @@ export class MapCaptionAPI extends APIScope {
 
         const degreeSymbol = String.fromCharCode(176);
 
-        const dy = Math.abs(lat).toFixed(3);
-        const dx = Math.abs(lon).toFixed(3);
+        const dy = Math.abs(lat);
+        const dx = Math.abs(lon);
 
-        return `${dy}${degreeSymbol} ${this.$iApi.$vApp.$t(
+        return `${this.$iApi.$vApp.$n(
+            dy,
+            'number'
+        )}${degreeSymbol} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (lat > 0 ? 'north' : 'south')
-        )} | ${dx}${degreeSymbol} ${this.$iApi.$vApp.$t(
+        )} | ${this.$iApi.$vApp.$n(
+            dx,
+            'number'
+        )}${degreeSymbol} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (0 > lon ? 'west' : 'east')
         )}`;
     }
@@ -434,11 +438,15 @@ export class MapCaptionAPI extends APIScope {
         const projectedPoint: any =
             await this.$iApi.geo.utils.proj.projectGeometry(3857, p);
 
-        return `${Math.abs(
-            Math.floor(projectedPoint.x)
+        return `${this.$iApi.$vApp.$n(
+            Math.abs(Math.floor(projectedPoint.x)),
+            'number'
         )} m ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (0 > projectedPoint.x ? 'west' : 'east')
-        )} | ${Math.abs(Math.floor(projectedPoint.y))} m ${this.$iApi.$vApp.$t(
+        )} | ${this.$iApi.$vApp.$n(
+            Math.abs(Math.floor(projectedPoint.y)),
+            'number'
+        )} m ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (projectedPoint.y > 0 ? 'north' : 'south')
         )}`;
     }
@@ -455,11 +463,15 @@ export class MapCaptionAPI extends APIScope {
         const projectedPoint: any =
             await this.$iApi.geo.utils.proj.projectGeometry(3978, p);
 
-        return `${Math.abs(
-            Math.floor(projectedPoint.x)
+        return `${this.$iApi.$vApp.$n(
+            Math.abs(Math.floor(projectedPoint.x)),
+            'number'
         )} m ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (0 > projectedPoint.x ? 'west' : 'east')
-        )} | ${Math.abs(Math.floor(projectedPoint.y))} m ${this.$iApi.$vApp.$t(
+        )} | ${this.$iApi.$vApp.$n(
+            Math.abs(Math.floor(projectedPoint.y)),
+            'number'
+        )} m ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (projectedPoint.y > 0 ? 'north' : 'south')
         )}`;
     }
@@ -479,7 +491,7 @@ export class MapCaptionAPI extends APIScope {
         const lon = this.wrapValue(latLongPoint.x, -180, 180);
 
         // find the utm zone (each zone is 6 degrees longitude apart)
-        const zone = this.padZero(Math.ceil((lon + 180) / 6));
+        const zone = Math.ceil((lon + 180) / 6);
 
         // project the point using the zone's utm projection
         const projectedPoint: any =
@@ -488,13 +500,19 @@ export class MapCaptionAPI extends APIScope {
                 p
             );
 
-        return `${zone} ${this.$iApi.$vApp.$t(
+        return `${this.$iApi.$vApp.$n(zone, 'number', {
+            minimumIntegerDigits: 2
+        } as any)} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (lat > 0 ? 'north' : 'south')
-        )} ${Math.floor(projectedPoint.x)} m${this.$iApi.$vApp.$t(
+        )} ${this.$iApi.$vApp.$n(
+            Math.floor(projectedPoint.x),
+            'number'
+        )} m${this.$iApi.$vApp.$t(
             'map.coordinates.east'
-        )} | ${Math.abs(Math.floor(projectedPoint.y))} m${this.$iApi.$vApp.$t(
-            'map.coordinates.north'
-        )}`;
+        )} | ${this.$iApi.$vApp.$n(
+            Math.abs(Math.floor(projectedPoint.y)),
+            'number'
+        )} m${this.$iApi.$vApp.$t('map.coordinates.north')}`;
     }
 
     /**
@@ -512,6 +530,10 @@ export class MapCaptionAPI extends APIScope {
                 p
             );
 
-        return `${projectedPoint.x} | ${projectedPoint.y}`;
+        return `${this.$iApi.$vApp.$n(projectedPoint.x, 'number', {
+            maximumFractionDigits: 6
+        } as any)} | ${this.$iApi.$vApp.$n(projectedPoint.y, 'number', {
+            maximumFractionDigits: 6
+        } as any)}`;
     }
 }

--- a/packages/ramp-core/src/lang/index.ts
+++ b/packages/ramp-core/src/lang/index.ts
@@ -16,10 +16,30 @@ export type I18nComponentOptions = {
 
 const lang = 'en';
 
+// default number localization
+// settings can be overidden when the $n is called
+const numberFormats = {
+    en: {
+        number: {
+            style: 'decimal',
+            useGrouping: false,
+            maximumFractionDigits: 2
+        }
+    },
+    fr: {
+        number: {
+            style: 'decimal',
+            useGrouping: false,
+            maximumFractionDigits: 2
+        }
+    }
+};
+
 export const i18n = createI18n({
     // get the language of the page from the root `html` node
     locale: document.documentElement!.getAttribute('lang') || lang,
     fallbackLocale: lang,
     globalInjection: true,
-    messages: messages
+    messages: messages,
+    numberFormats
 });


### PR DESCRIPTION
## Related issue: #668 

## Changes in this PR
- [FEAT] Configured number localization for RAMP and set up default format (`'number'`)
- [FEAT] Caption bar point formatted string and scalebar now use localization
- [FEAT] Numeric grid values use localization

## Further work/comments/questions
- **Comment:**
    - The localization default formatting can be overridden whenever `$vApp.$n` is called
    - For example, if we want to format a number with grouping and maximum 2 decimal places we do:
    ```ts
    let value = 1000.119;
    let str = window.rInstance.$vApp.$n(value, 'number', {maximumFractionDigits:2, useGrouping: true}  );  
    // Note: You have to add "as any" after the formatting options if this is done in typescript --- ☝
    console.log(str); 
    // 1,000.12 (for en)
    // 1 000,12 (for fr)
    ```
    - The list formatting options can be found [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat)
- **Question:**
    - Do we need to support custom number formats for different columns in the grid? 
        - For example, a column needs to use grouping for its values (maybe it represents a quantity), but other columns do not need to (like the year column)

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/668/host/index.html)

### Steps to test:
1. Load Demo
2. Set the point formatter to `LAT_LONG_DD`:
```ts
window.rInstance.geo.map.caption.setPointFormatter("LAT_LONG_DD")
```
3. Mouse over the map - the point values should use "." as the decimal point (English)
4. Change the language and mouse over the map - the point should now use "," as the decimal point (French)
5. Open the grid for "Water quantity" and scroll to the lat/long column - the values should be formatted in French
6. Change the language to English - the grid should change the format 