### PR TITLE
Fix incorrect MIL sublayer symbology

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -297,7 +297,9 @@ export default defineComponent({
          * Wrapper to safely get the legend from layer while avoiding ArcGIS and Vue3 conflict
          */
         _getLegend(): LegendSymbology[] {
-            return toRaw(this.legendItem!.layer!).getLegend();
+            return toRaw(this.legendItem!.layer!).getLegend(
+                this.legendItem.layerUID
+            );
         }
     }
 });


### PR DESCRIPTION
## Closes #682

## Changes in this PR
- [FIX] Expanding sublayer symbology now displays the correct stack

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/682/host/index.html)

### Steps to test:
1. Load Demo
2. Load all 3 sublayers of this layer: https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Oilsands/MapServer
3. Expand the symbology of each sublayer - it should now show the correct symbol

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/698)
<!-- Reviewable:end -->
