### PR TITLE
Page no longer refreshes after pressing ENTER in wizard

### DIFF
--- a/packages/ramp-core/src/fixtures/wizard/screen.vue
+++ b/packages/ramp-core/src/fixtures/wizard/screen.vue
@@ -435,10 +435,10 @@ export default defineComponent({
                 // );
             };
 
-            reader.onload = () => {
+            reader.onload = (e) => {
                 this.fileData = reader.result as ArrayBuffer;
                 this.url = file.name;
-                this.onUploadContinue();
+                this.onUploadContinue(e);
             };
 
             // this was used by vue-formulate previously
@@ -449,7 +449,10 @@ export default defineComponent({
             reader.readAsArrayBuffer(file);
         },
 
-        onUploadContinue() {
+        onUploadContinue(event: any) {
+            // Prevent the page from refreshing when pressing ENTER to submit the URL.
+            event?.preventDefault();
+
             if (this.fileData) {
                 setTimeout(() => {
                     // reset upload file


### PR DESCRIPTION
Fixes #699

When using the wizard, entering a URL and then pressing enter should no longer cause the page to refresh. It should instead act as it did prior to the Vue3 migration, where it continues to the next step as expected.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-699/host/index.html).

To test this PR, follow the steps listed in #699 and ensure that the issue no longer exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/700)
<!-- Reviewable:end -->
