### PR TITLE
revert prettier arrow parenthesis config, re-lint

### DIFF
--- a/packages/ramp-core/.prettierrc
+++ b/packages/ramp-core/.prettierrc
@@ -1,5 +1,6 @@
 {
     "tabWidth": 4,
     "singleQuote": true,
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "arrowParens": "avoid"
 }

--- a/packages/ramp-core/src/api/common.ts
+++ b/packages/ramp-core/src/api/common.ts
@@ -99,7 +99,7 @@ export function isComponentOptions(value: any): value is ComponentOptions {
     return (
         typeof value === 'object' &&
         !value.functional &&
-        names.some((name) => value[name] !== undefined)
+        names.some(name => value[name] !== undefined)
     );
 }
 

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -166,7 +166,7 @@ export class EventAPI extends APIScope {
         // getting enum values is a mess. this code does it but assumes
         // all event names in global events use the slash format
         this._nameRegister = Object.values(GlobalEvents).filter(
-            (e) => typeof e === 'string' && e.indexOf('/') > -1
+            e => typeof e === 'string' && e.indexOf('/') > -1
         );
     }
 
@@ -179,7 +179,7 @@ export class EventAPI extends APIScope {
      * @private
      */
     private findHandler(handlerName: string): EventHandler | undefined {
-        return this._eventRegister.find((eh) => eh.handlerName === handlerName);
+        return this._eventRegister.find(eh => eh.handlerName === handlerName);
     }
 
     /**
@@ -203,7 +203,7 @@ export class EventAPI extends APIScope {
      */
     registerEventName(names: string | Array<string>): void {
         const arrr = Array.isArray(names) ? names : [names];
-        arrr.forEach((n) => {
+        arrr.forEach(n => {
             // don't add if name is already registered
             if (this._nameRegister.indexOf(n) === -1) {
                 this._nameRegister.push(n);
@@ -328,11 +328,11 @@ export class EventAPI extends APIScope {
         // TODO add a filter if we implement disabled events
 
         if (event === '') {
-            return this._eventRegister.map((eh) => eh.handlerName);
+            return this._eventRegister.map(eh => eh.handlerName);
         }
         return this._eventRegister
-            .filter((eh) => eh.eventName === event)
-            .map((eh) => eh.handlerName);
+            .filter(eh => eh.eventName === event)
+            .map(eh => eh.handlerName);
     }
 
     /**
@@ -381,7 +381,7 @@ export class EventAPI extends APIScope {
         }
 
         // add all the requested default event handlers.
-        return eventHandlerNames.map((hn) => this.defaultHandlerFactory(hn));
+        return eventHandlerNames.map(hn => this.defaultHandlerFactory(hn));
     }
 
     /**
@@ -536,7 +536,7 @@ export class EventAPI extends APIScope {
                     let currentBasemapConfig: RampBasemapConfig | undefined =
                         this.$iApi
                             .getConfig()
-                            .map.basemaps.find((bms) => bms.id === payload);
+                            .map.basemaps.find(bms => bms.id === payload);
 
                     this.$iApi.geo.map.caption.updateAttribution(
                         currentBasemapConfig?.attribution
@@ -552,7 +552,7 @@ export class EventAPI extends APIScope {
                 zeHandler = (payload: RampConfig) => {
                     let currentBasemapConfig: RampBasemapConfig | undefined =
                         payload.map.basemaps.find(
-                            (bms) =>
+                            bms =>
                                 bms.id ===
                                 this.$iApi.geo.map.getCurrentBasemapId()
                         );
@@ -629,7 +629,7 @@ export class EventAPI extends APIScope {
                                     mapMove
                                 )
                             )
-                            .then((fs) => {
+                            .then(fs => {
                                 this.$iApi.$vApp.$store.set(
                                     MapCaptionStore.setCursorCoords,
                                     {

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -135,7 +135,7 @@ export class FixtureAPI extends APIScope {
             ids.push(item.id);
         }
 
-        const fixtures = ids.map((id) => {
+        const fixtures = ids.map(id => {
             const fixture = this.$vApp.$store.get<T>(`fixture/items@${id}`);
             if (!fixture) {
                 return undefined;
@@ -186,7 +186,7 @@ export class FixtureAPI extends APIScope {
         // add all the requested default promises.
         // return the promise-all of all the add fixture promises
         // TODO alterately, don't do a promise.all, and just return the array of promises. not sure which is more useful.
-        return Promise.all(fixtureNames.map((fn) => this.add(fn)));
+        return Promise.all(fixtureNames.map(fn => this.add(fn)));
     }
 }
 

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -91,14 +91,14 @@ export class PanelInstance extends APIScope {
 
             // for async components, wait until they are resolved and patch in panel's i18n messages
             const component = new Promise<Component>((resolve, reject) => {
-                asyncComponent.then((data) => {
+                asyncComponent.then(data => {
                     // wait until the component promise is resolved and mark it as loaded
                     this.loadedScreens.push(id);
 
                     // if data is a `*.vue` file, use its `default` export
                     resolve(isTypeofImportVue(data) ? data.default : data);
                 });
-                asyncComponent.catch((error) => reject(error));
+                asyncComponent.catch(error => reject(error));
             });
 
             payload = defineAsyncComponent({

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -49,13 +49,13 @@ export class PanelAPI extends APIScope {
 
             // merge `messages`, `dateTimeFormats` and  `numberFormats` into the global locale
             // ignore `sharedMessages` prop as it makes no sense to use it here
-            Object.entries(i18n.messages || {}).forEach((value) =>
+            Object.entries(i18n.messages || {}).forEach(value =>
                 (<any>$i18n).mergeLocaleMessage(...value)
             );
-            Object.entries(i18n.dateTimeFormats || {}).forEach((value) =>
+            Object.entries(i18n.dateTimeFormats || {}).forEach(value =>
                 (<any>$i18n).mergeDateTimeFormat(...value)
             );
-            Object.entries(i18n.numberFormats || {}).forEach((value) =>
+            Object.entries(i18n.numberFormats || {}).forEach(value =>
                 (<any>$i18n).mergeNumberFormat(...value)
             );
         }
@@ -70,7 +70,7 @@ export class PanelAPI extends APIScope {
         }, []);
 
         // register all the panels with the store
-        panels.forEach((panel) =>
+        panels.forEach(panel =>
             this.$vApp.$store.set(`panel/${PanelMutation.REGISTER_PANEL}!`, {
                 panel
             })

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -59,7 +59,7 @@ export default defineComponent({
     mounted() {
         window.addEventListener(
             'click',
-            (event) => {
+            event => {
                 if (
                     event.target instanceof HTMLElement &&
                     !this.$el.contains(event.target)
@@ -92,7 +92,7 @@ export default defineComponent({
     beforeUnmount() {
         window.removeEventListener(
             'click',
-            (event) => {
+            event => {
                 if (
                     event.target instanceof HTMLElement &&
                     !this.$el.contains(event.target)

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -123,10 +123,10 @@ export default defineComponent({
 
             const layers = await Promise.all(
                 newValue
-                    .filter((lc) => !oldValue.includes(lc))
-                    .map((layerConfig) => {
+                    .filter(lc => !oldValue.includes(lc))
+                    .map(layerConfig => {
                         return new Promise<LayerInstance | null>(
-                            async (resolve) => {
+                            async resolve => {
                                 // CUSTOM-LAYER
                                 /*
                                 let defLoadProm: Promise<string>;

--- a/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
+++ b/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
@@ -31,7 +31,7 @@ export class AppbarAPI extends FixtureInstance {
         }
 
         const appbarItems = appbarConfig.items.map(
-            (item) => new AppbarItemInstance(item)
+            item => new AppbarItemInstance(item)
         );
 
         // save appbar items as a collection to the store
@@ -47,12 +47,12 @@ export class AppbarAPI extends FixtureInstance {
         // save an ordered list of item ids to use when rendering components
         this.$vApp.$store.set(
             'appbar/order',
-            appbarItems.map((item) => item.id)
+            appbarItems.map(item => item.id)
         );
 
         if (appbarConfig.temporaryButtons) {
             const appbarTempItems = Object.fromEntries(
-                appbarConfig.temporaryButtons.map((item) => {
+                appbarConfig.temporaryButtons.map(item => {
                     if (typeof item === 'string') {
                         return [`${item}-panel`, new AppbarItemInstance(item)];
                     }
@@ -75,9 +75,9 @@ export class AppbarAPI extends FixtureInstance {
      */
     _validateItems() {
         // get the ordered list of items and see if any of them are registered
-        this.$vApp.$store.get<string[]>('appbar/order')!.forEach((id) => {
+        this.$vApp.$store.get<string[]>('appbar/order')!.forEach(id => {
             // appbar check components with the literal id and with a `-appbar-button` suffix;
-            [`${id}-appbar-button`, id].some((v) => {
+            [`${id}-appbar-button`, id].some(v => {
                 if (this.$iApi.fixture.get(v)) {
                     // if an item is registered globally, save the name of the registered component
                     this.$vApp.$store.set(`appbar/items@${id}.componentId`, v);
@@ -89,9 +89,9 @@ export class AppbarAPI extends FixtureInstance {
         const tempButtonDict = this.$vApp.$store.get<any>(
             'appbar/tempButtonDict'
         );
-        Object.keys(tempButtonDict).forEach((key) => {
+        Object.keys(tempButtonDict).forEach(key => {
             const id = tempButtonDict[key].id;
-            [`${id}-appbar-button`, id].some((v) => {
+            [`${id}-appbar-button`, id].some(v => {
                 if (this.$iApi.fixture.get(v)) {
                     // if an item is registered globally, save the name of the registered component
                     this.$vApp.$store.set(

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -15,7 +15,7 @@ class AppbarFixture extends AppbarAPI {
         this.$vApp.$store.registerModule('appbar', appbar());
 
         // merge in translations since this has no panel
-        Object.entries(messages).forEach((value) =>
+        Object.entries(messages).forEach(value =>
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 
@@ -73,7 +73,7 @@ class AppbarFixture extends AppbarAPI {
     removed() {
         this.$vApp.$store.unregisterModule('appbar');
 
-        this.eventHandlers.forEach((eventHandler) =>
+        this.eventHandlers.forEach(eventHandler =>
             this.$iApi.event.off(eventHandler)
         );
     }

--- a/packages/ramp-core/src/fixtures/appbar/more-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/more-button.vue
@@ -77,7 +77,7 @@ export default defineComponent({
     mounted() {
         window.addEventListener(
             'click',
-            (event) => {
+            event => {
                 if (
                     event.target instanceof HTMLElement &&
                     !this.$el.contains(event.target)

--- a/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
+++ b/packages/ramp-core/src/fixtures/appbar/store/appbar-store.ts
@@ -27,8 +27,8 @@ const getters = {
      */
     visible(state: AppbarState): AppbarItemInstance[] {
         return state.order
-            .map<AppbarItemInstance>((id) => state.items[id])
-            .filter((item) => item.componentId);
+            .map<AppbarItemInstance>(id => state.items[id])
+            .filter(item => item.componentId);
     }
 };
 
@@ -37,7 +37,7 @@ const actions = {
         const item = context.state.tempButtonDict[value];
         if (
             item &&
-            !context.state.temporary.find((button) => button.id === item.id)
+            !context.state.temporary.find(button => button.id === item.id)
         ) {
             context.commit(AppbarMutation.ADD_TEMP_BUTTON, item);
         }
@@ -48,7 +48,7 @@ const actions = {
             return;
         }
         const button = context.state.temporary.find(
-            (button) => button.id === item.id
+            button => button.id === item.id
         );
         if (button) {
             context.commit(AppbarMutation.REMOVE_TEMP_BUTTON, button);

--- a/packages/ramp-core/src/fixtures/basemap/api/basemap.ts
+++ b/packages/ramp-core/src/fixtures/basemap/api/basemap.ts
@@ -38,7 +38,7 @@ export class BasemapAPI extends FixtureInstance {
         this.$iApi.$vApp.$store.set(
             BasemapStore.selectedBasemap,
             basemapConfig.basemaps.find(
-                (basemap) => basemap.id === basemapConfig.initialBasemapId
+                basemap => basemap.id === basemapConfig.initialBasemapId
             ) || null
         );
     }

--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -99,7 +99,7 @@ export class DetailsAPI extends FixtureInstance {
             this.$vApp.$store.get<DetailsItemInstance[]>(
                 DetailsStore.templates
             )!
-        ).forEach((item) => {
+        ).forEach(item => {
             if (item.template in this.$vApp.$options.components!) {
                 this.$vApp.$store.set(
                     `${DetailsStore.templates}@${item.id}.componentId`,

--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -145,11 +145,9 @@ export default defineComponent({
                 return;
             }
             const oidField = layer.getOidField(uid);
-            layer
-                .getIcon(this.identifyItem.data[oidField], uid)
-                .then((value) => {
-                    this.icon = value;
-                });
+            layer.getIcon(this.identifyItem.data[oidField], uid).then(value => {
+                this.icon = value;
+            });
         },
 
         zoomToFeature() {
@@ -165,7 +163,7 @@ export default defineComponent({
             }
             const oid = this.identifyItem.data[layer.getOidField(uid)];
             const opts = { getGeom: true };
-            layer.getGraphic(oid, opts, uid).then((g) => {
+            layer.getGraphic(oid, opts, uid).then(g => {
                 if (g.geometry === undefined) {
                     console.error(`Could not find graphic for objectid ${oid}`);
                 } else {

--- a/packages/ramp-core/src/fixtures/details/result-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/result-screen.vue
@@ -108,7 +108,7 @@ export default defineComponent({
             }
 
             const oidField = layer.getOidField(uid);
-            layer.getIcon(data[oidField], uid).then((value) => {
+            layer.getIcon(data[oidField], uid).then(value => {
                 if (this.icon[idx] !== value) {
                     this.icon[idx] = value;
                 }

--- a/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
@@ -32,7 +32,7 @@ export default defineComponent({
             const helper: any = {};
             Object.assign(helper, this.identifyData.data);
             if (helper.Symbol !== undefined) delete helper.Symbol;
-            Object.keys(helper).map((key) => {
+            Object.keys(helper).map(key => {
                 if (typeof helper[key] === 'number') {
                     helper[key] = this.$iApi.$vApp.$n(helper[key], 'number');
                 }

--- a/packages/ramp-core/src/fixtures/export-v1-legend/index.ts
+++ b/packages/ramp-core/src/fixtures/export-v1-legend/index.ts
@@ -56,11 +56,11 @@ class ExportV1LegendFixture
         const layers = this.$vApp.$store
             .get<LayerInstance[]>(LayerStore.layers)!
             .filter(
-                (layer) =>
+                layer =>
                     layer.isValidState() &&
                     layer.getVisibility() &&
                     !this._getLayerTreeIds(layer.getLayerTree()).every(
-                        (id) => !layer.getVisibility(id)
+                        id => !layer.getVisibility(id)
                     )
             );
 
@@ -113,12 +113,12 @@ class ExportV1LegendFixture
                             result.push(chunkTitle);
                         }
 
-                        chunkItems.forEach((item) => {
+                        chunkItems.forEach(item => {
                             item.top = runningHeight;
                             runningHeight += item.height! + ITEM_MARGIN;
                         });
 
-                        return [...result, ...chunkItems].filter((a) => a);
+                        return [...result, ...chunkItems].filter(a => a);
                     }
                 );
 
@@ -215,8 +215,8 @@ class ExportV1LegendFixture
             });
 
             // filter out invisible layer entries
-            const ids = this._getLayerTreeIds(layer.getLayerTree()).filter(
-                (id) => layer.getVisibility(id)
+            const ids = this._getLayerTreeIds(layer.getLayerTree()).filter(id =>
+                layer.getVisibility(id)
             );
 
             const items = await Promise.all(
@@ -242,7 +242,7 @@ class ExportV1LegendFixture
         segmentWidth: number
     ): Promise<SegmentChunk>[] {
         return ids.map<Promise<SegmentChunk>>(async (idx: number | string) => {
-            await Promise.all(layer.getLegend(idx).map((lg) => lg.drawPromise));
+            await Promise.all(layer.getLegend(idx).map(lg => lg.drawPromise));
             const symbologyStack = layer.getLegend(idx);
 
             const title = new fabric.Textbox(layer.getName(idx), {
@@ -274,7 +274,7 @@ class ExportV1LegendFixture
         symbologyStack: LegendSymbology[],
         segmentWidth: number
     ): Promise<fabric.Group>[] {
-        return symbologyStack.map(async (symbol) => {
+        return symbologyStack.map(async symbol => {
             const fbSymbol = (
                 await promisify(fabric.loadSVGFromString)(symbol.svgcode)
             )[0];
@@ -339,7 +339,7 @@ class ExportV1LegendFixture
             [],
             node.isLayer
                 ? [node.layerIdx]
-                : node.children.map((c) => this._getLayerTreeIds(c))
+                : node.children.map(c => this._getLayerTreeIds(c))
         );
     }
 }
@@ -357,8 +357,8 @@ const promisify = <T, A>(
     fn: (args: T, cb: Callback<A>) => void
 ): ((args: T) => Promise<A>) => {
     return (args: T) =>
-        new Promise((resolve) => {
-            fn(args, (callbackArgs) => {
+        new Promise(resolve => {
+            fn(args, callbackArgs => {
                 resolve(callbackArgs);
             });
         });

--- a/packages/ramp-core/src/fixtures/export-v1-map/index.ts
+++ b/packages/ramp-core/src/fixtures/export-v1-map/index.ts
@@ -16,7 +16,7 @@ class ExportV1MapFixture extends FixtureInstance implements ExportV1SubFixture {
         img.src = screenshot.dataUrl;
 
         const esriImage = await new Promise<HTMLImageElement>(
-            (resolve) => (img.onload = () => resolve(img))
+            resolve => (img.onload = () => resolve(img))
         );
 
         return new fabric.Image(esriImage, options);

--- a/packages/ramp-core/src/fixtures/export-v1/api.ts
+++ b/packages/ramp-core/src/fixtures/export-v1/api.ts
@@ -82,7 +82,7 @@ export class ExportV1API extends FixtureInstance {
         });
 
         // clone items for download canvas
-        const fbGroupDownload: fabric.Group = await new Promise((resolve) => {
+        const fbGroupDownload: fabric.Group = await new Promise(resolve => {
             fbGroup!.clone((g: fabric.Group) => {
                 resolve(g);
             });

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -68,12 +68,12 @@ class GazeboFixture extends FixtureInstance {
                          * for the demo purposes, delay resolution of a component by 2 seconds
                          */
                         'p-2-screen-1': () => {
-                            return new Promise<AsyncComponentEh>((resolve) =>
+                            return new Promise<AsyncComponentEh>(resolve =>
                                 setTimeout(
                                     () =>
                                         import(
                                             /* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`
-                                        ).then((data) => {
+                                        ).then(data => {
                                             resolve(data);
                                         }),
                                     2000
@@ -92,7 +92,7 @@ class GazeboFixture extends FixtureInstance {
                          * returning a `VueConstructor` in a promise
                          */
                         'p-2-screen-3': () => {
-                            return new Promise<AsyncComponentEh>((resolve) =>
+                            return new Promise<AsyncComponentEh>(resolve =>
                                 resolve(markRaw(GazeboP2Screen3V))
                             );
                         }

--- a/packages/ramp-core/src/fixtures/geosearch/bottom-filters.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/bottom-filters.vue
@@ -85,7 +85,7 @@ export default defineComponent({
 
         // Called when the checkbox is pressed. Updates the geosearch extent.
         updateMapExtent(visible: boolean): void {
-            this.latLongExtent(this.$iApi.geo.map.getExtent()).then((e) => {
+            this.latLongExtent(this.$iApi.geo.map.getExtent()).then(e => {
                 this.setMapExtent({
                     extent: e,
                     visible: visible

--- a/packages/ramp-core/src/fixtures/geosearch/screen.vue
+++ b/packages/ramp-core/src/fixtures/geosearch/screen.vue
@@ -159,7 +159,7 @@ export default defineComponent({
             // wrap matched search term in results inside span with styling
             const highlightedResult = name.replace(
                 new RegExp(`${this.searchVal.value}`, 'gi'),
-                (match) =>
+                match =>
                     '<span class="font-bold text-blue-600">' + match + '</span>'
             );
             // add comma to new highlighted result if a province/location is provided

--- a/packages/ramp-core/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/geosearch-store.ts
@@ -183,7 +183,7 @@ function filter(visibleOnly: boolean, queryParams: any, data: Array<any>) {
     if (visibleOnly && queryParams.extent) {
         // ensure bbox boundaries are within the current map extent properties
         data = data.filter(
-            (r) =>
+            r =>
                 r.bbox[0] <= queryParams.extent.xmax &&
                 r.bbox[1] <= queryParams.extent.ymax &&
                 r.bbox[2] >= queryParams.extent.xmin &&
@@ -192,13 +192,13 @@ function filter(visibleOnly: boolean, queryParams: any, data: Array<any>) {
     }
     if (queryParams.province && queryParams.province !== '...') {
         data = data.filter(
-            (r) =>
+            r =>
                 r.location.province.name &&
                 r.location.province.name === queryParams.province
         );
     }
     if (queryParams.type && queryParams.type !== '...') {
-        data = data.filter((r) => r.type === queryParams.type);
+        data = data.filter(r => r.type === queryParams.type);
     }
     return data;
 }

--- a/packages/ramp-core/src/fixtures/geosearch/store/provinces.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/provinces.ts
@@ -28,7 +28,7 @@ class Provinces {
     list: defs.GenericObjectType = {};
 
     constructor(language: string) {
-        Object.keys(provs[language]).forEach((provKey) => {
+        Object.keys(provs[language]).forEach(provKey => {
             this.list[provKey] = (<any>provs[language])[provKey];
         });
     }
@@ -43,7 +43,7 @@ class Provinces {
         if (typeof provCodes === 'number') {
             provCodes = [provCodes];
         }
-        provCodes.forEach((n) => {
+        provCodes.forEach(n => {
             genericObj[n] = this.list[n];
         });
         return genericObj;

--- a/packages/ramp-core/src/fixtures/geosearch/store/query.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/query.ts
@@ -19,7 +19,7 @@ export function make(config: defs.MainConfig, query: string): Query {
     } else {
         // name based search
         const q = new Query(config, query);
-        q.onComplete = q.search().then((results) => {
+        q.onComplete = q.search().then(results => {
             q.results = results;
             return q;
         });
@@ -43,7 +43,7 @@ export class Query {
     search(): Promise<defs.NameResultList> {
         return (<Promise<defs.RawNameResult>>(
             this.jsonRequest(this.getUrl())
-        )).then((r) => this.normalizeNameItems(r.items));
+        )).then(r => this.normalizeNameItems(r.items));
     }
 
     private getUrl(
@@ -68,8 +68,8 @@ export class Query {
 
     normalizeNameItems(items: defs.NameResponse[]): defs.NameResultList {
         return items
-            .filter((i) => this.config.types.validTypes[i.concise.code])
-            .map((i) => {
+            .filter(i => this.config.types.validTypes[i.concise.code])
+            .map(i => {
                 return {
                     name: i.name,
                     location: i.location,
@@ -111,7 +111,7 @@ export class Query {
     nameByLatLon(lat: number, lon: number, restrict?: number[]): any {
         return (<Promise<defs.RawNameResult>>(
             this.jsonRequest(this.getUrl(false, restrict, lat, lon))
-        )).then((r) => {
+        )).then(r => {
             return this.normalizeNameItems(r.items);
         });
     }
@@ -125,8 +125,8 @@ export class LatLongQuery extends Query {
         // remove extra spaces and delimiters (the filter). convert string numbers to floaty numbers
         const filteredQuery = query
             .split(/[\s|,|;|]/)
-            .filter((n) => !isNaN(n as any) && n !== '')
-            .map((n) => parseFloat(n));
+            .filter(n => !isNaN(n as any) && n !== '')
+            .map(n => parseFloat(n));
         coords = filteredQuery;
         // TODO: check and convert DMS format if applicable
 
@@ -170,13 +170,13 @@ export class FSAQuery extends Query {
         super(config, query);
 
         this.onComplete = new Promise((resolve, reject) => {
-            this.formatLocationResult().then((fLR) => {
+            this.formatLocationResult().then(fLR => {
                 if (fLR) {
                     this.featureResults = fLR;
                     this.nameByLatLon(
                         fLR.LatLon.lat,
                         fLR.LatLon.lon,
-                        Object.keys(fLR._provinces).map((x) => parseInt(x))
+                        Object.keys(fLR._provinces).map(x => parseInt(x))
                     ).then((r: any) => {
                         this.results = r;
                         resolve(this);
@@ -189,7 +189,7 @@ export class FSAQuery extends Query {
     }
 
     formatLocationResult(): Promise<defs.FSAResult | undefined> {
-        return this.locateByQuery().then((locateResponseList) => {
+        return this.locateByQuery().then(locateResponseList => {
             // query check added since it can be null but will never be in this case (make TS happy)
             if (locateResponseList.length === 1 && this.query) {
                 const provList = this.config.provinces.fsaToProvinces(
@@ -200,7 +200,7 @@ export class FSAQuery extends Query {
                     code: 'FSA',
                     desc: this.config.types.allTypes.FSA,
                     province: Object.keys(provList)
-                        .map((i) => provList[i])
+                        .map(i => provList[i])
                         .join(','),
                     _provinces: provList,
                     LatLon: {
@@ -241,7 +241,7 @@ export class NTSQuery extends Query {
         query = isNaN(parseInt(query[2])) ? '0' + query : query;
         this.unitName = query;
         this.onComplete = new Promise((resolve, reject) => {
-            this.locateByQuery().then((lr) => {
+            this.locateByQuery().then(lr => {
                 // query check added since it can be null but will never be in this case (make TS happy)
                 if (lr.length > 0 && this.query) {
                     const allSheets = this.locateToResult(lr);
@@ -265,7 +265,7 @@ export class NTSQuery extends Query {
     }
 
     locateToResult(lrl: defs.LocateResponseList): defs.NTSResultList {
-        const results = lrl.map((ls) => {
+        const results = lrl.map(ls => {
             const title = ls.title.split(' ');
             return <defs.NTSResult>{
                 nts: title.shift() || '', // 064D or 064D06

--- a/packages/ramp-core/src/fixtures/geosearch/store/types.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/store/types.ts
@@ -10,7 +10,7 @@ class Types {
     filterComplete: boolean = false;
 
     constructor(language: string) {
-        Object.keys(types[language]).forEach((typeKey) => {
+        Object.keys(types[language]).forEach(typeKey => {
             this.allTypes[typeKey] = (<any>types[language])[typeKey];
             this.validTypes[typeKey] = (<any>types[language])[typeKey];
         });

--- a/packages/ramp-core/src/fixtures/geosearch/tests/e2e/test.js
+++ b/packages/ramp-core/src/fixtures/geosearch/tests/e2e/test.js
@@ -1,4 +1,4 @@
-const search = (query) => {
+const search = query => {
     // types into search bar
     cy.get('.rv-geosearch-bar input').clear().type(query);
     // waits for search to update
@@ -12,13 +12,13 @@ const search = (query) => {
 const viewIsAt = (long, lat, delta = 0.1) => {
     // wait for zoom animation to finish
     cy.wait(1000);
-    cy.window().then((window) => {
+    cy.window().then(window => {
         cy.wrap(
             window.rInstance.geo.utils.proj.projectGeometry(
                 4326,
                 window.rInstance.geo.map.getExtent().center()
             )
-        ).should((point) => {
+        ).should(point => {
             expect(point.x).closeTo(long, delta);
             expect(point.y).closeTo(lat, delta);
         });
@@ -111,7 +111,7 @@ describe('Geosearch', () => {
                 .eq(0)
                 .select('British Columbia');
             search('qu');
-            cy.get('.rv-results-list > li').each(($el) => {
+            cy.get('.rv-results-list > li').each($el => {
                 cy.wrap($el).contains('BC');
             });
             cy.get('.rv-geosearch-top-filters select').eq(0).select('...');
@@ -120,7 +120,7 @@ describe('Geosearch', () => {
         it('filters type', () => {
             cy.get('.rv-geosearch-top-filters select').eq(1).select('City');
             search('ba');
-            cy.get('.rv-results-list > li').each(($el) => {
+            cy.get('.rv-results-list > li').each($el => {
                 cy.wrap($el).contains('City');
             });
             cy.get('.rv-geosearch-top-filters select').eq(1).select('...');
@@ -165,18 +165,18 @@ describe('Geosearch', () => {
             // check checkbox
             cy.get('.rv-geosearch-bottom-filters [type="checkbox"]').check();
             search('t');
-            cy.window().then((window) => {
+            cy.window().then(window => {
                 // project extent to lat/long
                 cy.wrap(
                     window.rInstance.geo.utils.proj.projectExtent(
                         4326,
                         window.rInstance.geo.map.getExtent()
                     )
-                ).then((extent) => {
+                ).then(extent => {
                     // check that each result is inside extent
                     window.rInstance.$vApp.$store
                         .get('geosearch/searchResults')
-                        .forEach((result) => {
+                        .forEach(result => {
                             expect(result.position[0]).to.be.lessThan(
                                 extent.xmax
                             );

--- a/packages/ramp-core/src/fixtures/grid/accessibility.ts
+++ b/packages/ramp-core/src/fixtures/grid/accessibility.ts
@@ -41,7 +41,7 @@ export default class GridAccessibilityManager {
             .querySelector('.ag-body-horizontal-scroll-viewport')
             ?.setAttribute('tabindex', '-1');
 
-        this.observer = new MutationObserver((mutations) => {
+        this.observer = new MutationObserver(mutations => {
             const el = mutations[0].target as HTMLElement;
             this.manageHeaderScrolling(el);
         });
@@ -55,7 +55,7 @@ export default class GridAccessibilityManager {
      * Set up the listeners for the grid
      */
     private initAccessibilityListeners() {
-        this.gridBody.addEventListener('keydown', (event) => {
+        this.gridBody.addEventListener('keydown', event => {
             this.onKeydown(event);
         });
         this.gridBody.addEventListener(
@@ -93,7 +93,7 @@ export default class GridAccessibilityManager {
             const headerCells = Array.prototype.slice.call(
                 row.querySelectorAll('.ag-header-cell')
             ) as HTMLElement[];
-            headerCells.forEach((cell) => {
+            headerCells.forEach(cell => {
                 cell.toggleAttribute('focus-item', true);
                 cell.id = generateID();
                 cell.classList.add('default-focus-style');
@@ -107,7 +107,7 @@ export default class GridAccessibilityManager {
      * Remove all accessibility listeners from the grid
      */
     removeAccessibilityListeners() {
-        this.gridBody.removeEventListener('keydown', (event) => {
+        this.gridBody.removeEventListener('keydown', event => {
             this.onKeydown(event);
         });
         this.gridBody.removeEventListener(
@@ -125,7 +125,7 @@ export default class GridAccessibilityManager {
         });
         this.observer.disconnect();
 
-        this.headerRows.forEach((row) => {
+        this.headerRows.forEach(row => {
             row.removeEventListener('focus', () => {
                 this.manageHeaderScrolling(row);
             });

--- a/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
+++ b/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
@@ -27,7 +27,7 @@
         </template>
         <a
             v-for="col in columnDefs.filter(
-                (c) => c.headerName && c.headerName.length > 0
+                c => c.headerName && c.headerName.length > 0
             )"
             :key="col.headerName"
             v-on:click="

--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -316,7 +316,7 @@ export default defineComponent({
 
     beforeUnmount() {
         // Remove all event handlers for this component
-        this.handlers.forEach((handler) => this.$iApi.event.off(handler));
+        this.handlers.forEach(handler => this.$iApi.event.off(handler));
         this.gridAccessibilityManager?.removeAccessibilityListeners();
     },
 
@@ -644,7 +644,7 @@ export default defineComponent({
                         if (layer === undefined) return;
                         const iconContainer = document.createElement('span');
                         const oid = cell.data[this.oidField];
-                        layer.getIcon(oid, this.layerUid).then((i) => {
+                        layer.getIcon(oid, this.layerUid).then(i => {
                             iconContainer.innerHTML = i;
                         });
                         return iconContainer;
@@ -702,7 +702,7 @@ export default defineComponent({
         getFiltersQuery() {
             const filterModel = this.gridApi.getFilterModel();
             let colStrs: any = [];
-            Object.keys(filterModel).forEach((col) => {
+            Object.keys(filterModel).forEach(col => {
                 colStrs.push(this.filterToSql(col, filterModel[col]));
             });
             if (this.quicksearch && this.quicksearch.length > 0) {

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -65,7 +65,7 @@ export default defineComponent({
             if (layer === undefined) return;
             const oid = this.params.data[this.params.oidField];
             const opts = { getGeom: true };
-            layer.getGraphic(oid, opts, this.params.uid).then((g) => {
+            layer.getGraphic(oid, opts, this.params.uid).then(g => {
                 if (g.geometry === undefined) {
                     console.error(`Could not find graphic for objectid ${oid}`);
                 } else {

--- a/packages/ramp-core/src/fixtures/grid/tests/e2e/grid-test.js
+++ b/packages/ramp-core/src/fixtures/grid/tests/e2e/grid-test.js
@@ -1,4 +1,4 @@
-const toggleGrid = (legendName) => {
+const toggleGrid = legendName => {
     // make sure legend entry is not still loading
     cy.contains('.legend-item', legendName)
         .find('.progress-line')
@@ -19,9 +19,9 @@ describe('Grid', () => {
                 .its('rInstance.$vApp.$store')
                 .invoke('get', 'layer/getLayerById', 'CleanAir')
                 .invoke('getAttributes')
-                .then((attributes) => {
+                .then(attributes => {
                     // check each row
-                    cy.get('.ag-center-cols-viewport .ag-row').each(($row) => {
+                    cy.get('.ag-center-cols-viewport .ag-row').each($row => {
                         const idx = parseInt($row.attr('row-id'));
                         for (attrib in attributes.features[idx]) {
                             // compare attribute value from layer with data in grid
@@ -57,7 +57,7 @@ describe('Grid', () => {
 
             cy.window()
                 .its('performance')
-                .then((p) => {
+                .then(p => {
                     // check that second grid loading is faster than first
                     p.measure('no-cache', 'first-opened', 'first-loaded');
                     p.measure('cache', 'second-opened', 'second-loaded');
@@ -79,13 +79,13 @@ describe('Grid', () => {
         it('has aria role attributes', () => {
             toggleGrid('Clean Air');
             cy.get('.ag-root').should('have.attr', 'role', 'grid');
-            cy.get('.customHeaderLabel').each(($el) => {
+            cy.get('.customHeaderLabel').each($el => {
                 expect($el).to.have.attr('role', 'columnheader');
             });
-            cy.get('.ag-row').each(($el) => {
+            cy.get('.ag-row').each($el => {
                 expect($el).to.have.attr('role', 'row');
             });
-            cy.get('.ag-cell-value').each(($el) => {
+            cy.get('.ag-cell-value').each($el => {
                 expect($el).to.have.attr('role', 'gridcell');
             });
             toggleGrid('Clean Air');
@@ -98,28 +98,28 @@ describe('Grid', () => {
             cy.window()
                 .its('rInstance.$vApp.$store')
                 .invoke('get', 'layer/getLayerById', 'CarbonMonoxide')
-                .then((layer) => {
+                .then(layer => {
                     cy.wrap(layer)
                         .invoke('getAttributes')
-                        .then((attributes) => {
+                        .then(attributes => {
                             // check icon of each row
                             cy.get('.ag-center-cols-viewport .ag-row').each(
-                                ($row) => {
+                                $row => {
                                     // get oid from row
                                     const oid = Object.keys(
                                         attributes.oidIndex
                                     ).find(
-                                        (key) =>
+                                        key =>
                                             attributes.oidIndex[key] ===
                                             parseInt($row.attr('row-id'))
                                     );
                                     // get icon from layer and compare with icon in grid
                                     cy.wrap(layer)
                                         .invoke('getIcon', oid)
-                                        .then((icon) => {
+                                        .then(icon => {
                                             cy.wrap($row)
                                                 .find('[col-id=0] svg')
-                                                .then((svg) => {
+                                                .then(svg => {
                                                     expect(
                                                         svg[0].outerHTML
                                                     ).to.equal(icon);
@@ -134,7 +134,7 @@ describe('Grid', () => {
 
         it('opens feature details', () => {
             toggleGrid('Clean Air');
-            cy.get('.ag-center-cols-container .ag-row').each(($row) => {
+            cy.get('.ag-center-cols-container .ag-row').each($row => {
                 // click details button
                 cy.wrap($row).find(`[col-id="1"]`).click();
                 // should open up the details panel
@@ -142,7 +142,7 @@ describe('Grid', () => {
                 // check that details panel contains row data
                 cy.wrap($row)
                     .find('.ag-cell-value')
-                    .each(($cell) => {
+                    .each($cell => {
                         if ($cell.attr('aria-colindex') > 3) {
                             cy.contains(
                                 '[data-cy="details-panel"]',
@@ -157,7 +157,7 @@ describe('Grid', () => {
 
         it('zooms to feature', () => {
             toggleGrid('Clean Air');
-            const zoom = (row) => {
+            const zoom = row => {
                 // click zoom button
                 cy.get(
                     `.ag-center-cols-container [row-id="${row}"] [col-id="2"]`
@@ -165,8 +165,8 @@ describe('Grid', () => {
                 // get oid
                 cy.get(`.ag-center-cols-container [row-id="${row}"]`)
                     .find('[col-id="OBJECTID"]')
-                    .then(($oid) => {
-                        cy.window().then((window) => {
+                    .then($oid => {
+                        cy.window().then(window => {
                             // wait for animation to finish
                             cy.wait(1000);
                             // get location from layer and compare with centre of visible extent
@@ -179,7 +179,7 @@ describe('Grid', () => {
                                 .invoke('getGraphic', $oid.text(), {
                                     getGeom: true
                                 })
-                                .then((g) => {
+                                .then(g => {
                                     const center = window.rInstance.geo.map
                                         .getExtent()
                                         .center();
@@ -208,7 +208,7 @@ describe('Grid', () => {
                 .its('rInstance.$vApp.$store')
                 .invoke('get', 'layer/getLayerById', 'CarbonMonoxide')
                 .invoke('getAttributes')
-                .then((attributes) => {
+                .then(attributes => {
                     // wait for status bar to update with correct value
                     cy.contains('entries shown').children().should('not.exist');
                     cy.contains('entries shown')
@@ -217,7 +217,7 @@ describe('Grid', () => {
 
                     cy.contains('entries shown')
                         .invoke('text')
-                        .then((txt) => {
+                        .then(txt => {
                             const [start, end, total] = txt
                                 .trim()
                                 .split(/\D+/)
@@ -305,11 +305,9 @@ describe('Grid', () => {
             toggleGrid('Clean Air');
             cy.contains('Columns').click();
             // check that dropdown contains all of the column headers
-            cy.get('.ag-header-cell-sortable .customHeaderLabel').each(
-                ($el) => {
-                    cy.contains('.rv-dropdown > a', $el.text()).find('#done'); // should all be checked initially
-                }
-            );
+            cy.get('.ag-header-cell-sortable .customHeaderLabel').each($el => {
+                cy.contains('.rv-dropdown > a', $el.text()).find('#done'); // should all be checked initially
+            });
             // unselect "Description" and "Group"
             cy.contains('.rv-dropdown > a', 'Description').click();
             cy.contains('.rv-dropdown > a', 'Group').click();
@@ -347,7 +345,7 @@ describe('Grid', () => {
             toggleGrid('Clean Air');
             // should sort ascending after clicking column header
             cy.contains('.customHeaderLabel', 'Name').click();
-            cy.get('.ag-center-cols-container .ag-row').then((r) => {
+            cy.get('.ag-center-cols-container .ag-row').then(r => {
                 // sort rows by row-index (how they appear on the screen)
                 let rows = Array.from(r);
                 rows.sort(
@@ -357,7 +355,7 @@ describe('Grid', () => {
                 );
 
                 let prevName;
-                rows.forEach((el) => {
+                rows.forEach(el => {
                     // extract name attribute from row and check they are lexicographically ascending
                     const name = el.children[3].innerText;
                     if (prevName) {
@@ -368,7 +366,7 @@ describe('Grid', () => {
             });
             // clicking again should sort descending
             cy.contains('.customHeaderLabel', 'Name').click();
-            cy.get('.ag-center-cols-container .ag-row').then((r) => {
+            cy.get('.ag-center-cols-container .ag-row').then(r => {
                 // sort rows by row-index (how they appear on the screen)
                 let rows = Array.from(r);
                 rows.sort(
@@ -378,7 +376,7 @@ describe('Grid', () => {
                 );
 
                 let prevName;
-                rows.forEach((el) => {
+                rows.forEach(el => {
                     // extract name attribute from row and check they are lexicographically descending
                     const name = el.children[3].innerText;
                     if (prevName) {
@@ -446,7 +444,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="OBJECTID"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim())).should('gte', 4848);
             });
 
@@ -463,7 +461,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="OBJECTID"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim())).should('lte', 4860);
             });
 
@@ -483,7 +481,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="OBJECTID"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim()))
                     .should('gte', 4848)
                     .and('lte', 4860);
@@ -506,7 +504,7 @@ describe('Grid', () => {
             // eslint-disable-next-line prettier/prettier
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="OBJECTID"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim())).should('eq', 30);
             });
 
@@ -529,7 +527,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="OBJECTID"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim()))
                     .should('gte', 4848)
                     .and('lte', 4860);
@@ -548,7 +546,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="GridColumn1"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap($cell.text().trim()).should('eq', 'Edmonton Site');
             });
 
@@ -565,7 +563,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="GridColumn1"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap($cell.text().trim()).should('contain', 'Toronto');
             });
 
@@ -587,7 +585,7 @@ describe('Grid', () => {
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 // compare lexicographically since dates are yyyy-MM-dd
                 const dateStr = $cell.text().trim();
                 expect(dateStr >= '2003-05-07').to.be.true;
@@ -609,7 +607,7 @@ describe('Grid', () => {
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 // compare lexicographically since dates are yyyy-MM-dd
                 const dateStr = $cell.text().trim();
                 expect(dateStr <= '2004-09-25').to.be.true;
@@ -636,7 +634,7 @@ describe('Grid', () => {
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 // compare lexicographically since dates are yyyy-MM-dd
                 const dateStr = $cell.text().trim();
                 expect(dateStr >= '2003-05-07').to.be.true;
@@ -662,7 +660,7 @@ describe('Grid', () => {
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 // compare lexicographically since dates are yyyy-MM-dd
                 const dateStr = $cell.text().trim();
                 cy.log(dateStr);
@@ -691,7 +689,7 @@ describe('Grid', () => {
             cy.contains('entries shown').contains('filtered from');
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="risc_date"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 // compare lexicographically since dates are yyyy-MM-dd
                 const dateStr = $cell.text().trim();
                 expect(dateStr == '2000-12-05').to.be.true;
@@ -754,7 +752,7 @@ describe('Grid', () => {
                 { force: true }
             );
 
-            cy.get('.ag-center-cols-container .ag-row').each(($row) => {
+            cy.get('.ag-center-cols-container .ag-row').each($row => {
                 cy.wrap($row).contains('[col-id="GridColumn1"]', 'plant', {
                     matchCase: false
                 });
@@ -765,7 +763,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="OBJECTID"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim())).should('gte', 300);
             });
 
@@ -794,7 +792,7 @@ describe('Grid', () => {
                 .tab()
                 .type('toronto');
 
-            cy.get('.ag-center-cols-container .ag-row').each(($row) => {
+            cy.get('.ag-center-cols-container .ag-row').each($row => {
                 cy.wrap($row).contains('[col-id="GridColumn1"]', 'plant', {
                     matchCase: false
                 });
@@ -805,7 +803,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="OBJECTID"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim())).should('gte', 300);
             });
 
@@ -824,7 +822,7 @@ describe('Grid', () => {
             cy.get('[data-cy="grid-panel"] header .rv-global-search').type(
                 'geo'
             );
-            cy.get('.ag-center-cols-container .ag-row').each(($row) => {
+            cy.get('.ag-center-cols-container .ag-row').each($row => {
                 cy.wrap($row).contains('geo', { matchCase: false });
             });
 
@@ -858,7 +856,7 @@ describe('Grid', () => {
                 { force: true }
             );
 
-            cy.get('.ag-center-cols-container .ag-row').each(($row) => {
+            cy.get('.ag-center-cols-container .ag-row').each($row => {
                 cy.wrap($row).contains('[col-id="GridColumn1"]', 'prince', {
                     matchCase: false
                 });
@@ -870,7 +868,7 @@ describe('Grid', () => {
 
             cy.get(
                 '.ag-center-cols-container .ag-cell[col-id="CO_Symbol"]'
-            ).each(($cell) => {
+            ).each($cell => {
                 cy.wrap(parseInt($cell.text().trim())).should('gte', 3);
             });
 

--- a/packages/ramp-core/src/fixtures/help/screen.vue
+++ b/packages/ramp-core/src/fixtures/help/screen.vue
@@ -72,7 +72,7 @@ export default defineComponent({
                     }
                     return `<img src="${href}" alt="${title}">`;
                 };
-                axios.get(`${base}help/${folder}/${newLocale}.md`).then((r) => {
+                axios.get(`${base}help/${folder}/${newLocale}.md`).then(r => {
                     // matches help sections from markdown file where each section begins with one hashbang and a space
                     // followed by the section header, exactly 2 newlines, then up to but not including a double newline
                     // note that the {2,} below is used as the double line deparator since each double new line is actually 6

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -41,7 +41,7 @@ export class LegendAPI extends FixtureInstance {
         let stack: Array<any> = [];
         // initialize stack with all legend elements listed in config
 
-        legendConfig.root.children.forEach((legendItem) =>
+        legendConfig.root.children.forEach(legendItem =>
             stack.push(legendItem)
         );
 

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -189,7 +189,7 @@ export class LegendEntry extends LegendItem {
             this._parent.type === LegendTypes.Set
         ) {
             this._parent.children.some(
-                (entry) => entry.visibility && entry.id !== this._id
+                entry => entry.visibility && entry.id !== this._id
             )
                 ? this._layer?.setVisibility(false, this.layerUID)
                 : null;
@@ -315,7 +315,7 @@ export class LegendEntry extends LegendItem {
 
                 // if its a set turn off the visibility of all other children
                 if (this._parent instanceof LegendSet) {
-                    this._parent.children.forEach((child) => {
+                    this._parent.children.forEach(child => {
                         if (child !== this && child.visibility)
                             child.toggleVisibility(false);
                     });
@@ -441,19 +441,19 @@ export class LegendGroup extends LegendItem {
     checkVisibility(toggledChild: LegendEntry | LegendGroup): void {
         if (this._type === LegendTypes.Group) {
             // if any children entries are toggled on group must be toggled on, else if all children entries are toggled off, group must be toggled off
-            if (this._children.some((entry) => entry.visibility)) {
+            if (this._children.some(entry => entry.visibility)) {
                 this._visibility = true;
                 // save all entries with visibility on
                 this._visibleEntries = this._children.filter(
-                    (entry) => entry.visibility
+                    entry => entry.visibility
                 );
-            } else if (this._children.every((entry) => !entry.visibility)) {
+            } else if (this._children.every(entry => !entry.visibility)) {
                 this._visibility = false;
                 this._visibleEntries = [];
             }
         } else if (toggledChild.visibility) {
             // turn off all child entries except for the last one toggled on, mark that as the last visible entry in the set
-            this.children.forEach((entry) => {
+            this.children.forEach(entry => {
                 if (entry.visibility && entry.id !== toggledChild.id) {
                     entry instanceof LegendEntry
                         ? entry.layer?.setVisibility(false)
@@ -493,15 +493,15 @@ export class LegendGroup extends LegendItem {
             // for legend groups, if group is toggled on turn on visibility for all children that are saved, and all children if none are saved
             if (this._visibility) {
                 this._visibleEntries.length > 0
-                    ? this._visibleEntries.forEach((entry) =>
+                    ? this._visibleEntries.forEach(entry =>
                           entry.toggleVisibility(this._visibility, false)
                       )
-                    : this._children.forEach((entry) =>
+                    : this._children.forEach(entry =>
                           entry.toggleVisibility(this.visibility, false)
                       );
             } else {
                 // otherewise turn off visibility for all children
-                this._children.forEach((entry) =>
+                this._children.forEach(entry =>
                     entry.toggleVisibility(this._visibility, false)
                 );
             }
@@ -515,7 +515,7 @@ export class LegendGroup extends LegendItem {
             } else {
                 // turn off visibility for all child entries and save/update the last legend entry
                 this._lastVisible = this._children.find(
-                    (entry) => entry.visibility
+                    entry => entry.visibility
                 );
                 this._lastVisible?.toggleVisibility(false);
             }
@@ -527,7 +527,7 @@ export class LegendGroup extends LegendItem {
 
             // if its a set turn off the visibility of all other children
             if (this.parent instanceof LegendSet) {
-                this.parent.children.forEach((child) => {
+                this.parent.children.forEach(child => {
                     if (child !== this && child.visibility)
                         child.toggleVisibility(false);
                 });

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -55,28 +55,28 @@ const mutations = {
         state: LegendState,
         { id, entry }: { id: string; entry: LegendEntry | LegendGroup }
     ) => {
-        const index = state.children.findIndex((child) => child.id === id);
+        const index = state.children.findIndex(child => child.id === id);
         state.children[index] = entry;
     },
     REMOVE_LAYER_ENTRY: (state: LegendState, uid: string) => {
         const removeLayerEntry = (children: (LegendEntry | LegendGroup)[]) => {
             // remove entry if uid corresponds to entry or parent layer
             children = children.filter(
-                (entry) =>
+                entry =>
                     entry instanceof LegendGroup ||
                     (entry.layer!.uid !== uid && entry.layerUID !== uid)
             );
 
             // recursively check child legend groups
             children
-                .filter((entry) => entry instanceof LegendGroup)
-                .forEach((group) => {
+                .filter(entry => entry instanceof LegendGroup)
+                .forEach(group => {
                     group.children = removeLayerEntry(group.children);
                 });
 
             // remove groups with no children
             children = children.filter(
-                (item) =>
+                item =>
                     item instanceof LegendEntry || item.children.length !== 0
             );
 
@@ -90,18 +90,18 @@ const mutations = {
             // reload entry (set to placeholder) if uid corresponds to entry or parent layer
             children
                 .filter(
-                    (entry) =>
+                    entry =>
                         entry instanceof LegendEntry &&
                         (entry.layer?.uid === uid || entry.layerUID === uid)
                 )
-                .forEach((entry) => {
+                .forEach(entry => {
                     entry._type = LegendTypes.Placeholder;
                 });
 
             // recursively check child legend groups
             children
-                .filter((entry) => entry instanceof LegendGroup)
-                .forEach((group) => {
+                .filter(entry => entry instanceof LegendGroup)
+                .forEach(group => {
                     group.children = reloadLayerEntry(group.children);
                 });
 
@@ -152,7 +152,7 @@ const actions = {
     /** Replaces default placeholder after layer is loaded */
     updateDefaultEntry: (context: LegendContext, id: string) => {
         const entry: LegendEntry = <LegendEntry>(
-            context.state.children.find((child) => child.id === id)
+            context.state.children.find(child => child.id === id)
         );
         const layer: LayerInstance = entry.layer!;
 
@@ -206,7 +206,7 @@ function checkVisibility(
 ): boolean {
     // traverse tree to check if all legend items have visibility toggled on/off
     if (child.children && child.children.length > 0) {
-        child.children.forEach((ch) => {
+        child.children.forEach(ch => {
             if (!checkVisibility(ch, visible)) {
                 return false;
             }
@@ -234,7 +234,7 @@ function checkVisibility(
 function checkExpanded(child: LegendItem, expanded: boolean): boolean {
     // traverse tree to check if all legend groups are expanded/collapsed
     if (child.children && child.children.length > 0) {
-        child.children.forEach((ch) => {
+        child.children.forEach(ch => {
             if (!checkExpanded(ch, expanded)) {
                 return false;
             }
@@ -273,7 +273,7 @@ function toggle(child: LegendEntry | LegendGroup, options: any) {
     }
     // traverse the tree and make recursive calls
     if (child.children && child.children.length > 0) {
-        child.children.forEach((ch) => {
+        child.children.forEach(ch => {
             // level order traversal
             toggle(ch, options);
         });

--- a/packages/ramp-core/src/fixtures/mapnav/api/mapnav.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/api/mapnav.ts
@@ -61,9 +61,9 @@ export class MapnavAPI extends FixtureInstance {
      */
     _validateItems() {
         // get the ordered list of items and see if any of them are registered
-        this.$vApp.$store.get<string[]>('mapnav/order')!.forEach((id) => {
+        this.$vApp.$store.get<string[]>('mapnav/order')!.forEach(id => {
             // check components with the literal id and with a `-nav-button` suffix;
-            [`${id}-nav-button`, id].some((v) => {
+            [`${id}-nav-button`, id].some(v => {
                 // TODO: fix this if needed
                 // if (v in this.$vApp.$options.components!) {
                 // if an item is registered globally, save the name of the registered component

--- a/packages/ramp-core/src/fixtures/mapnav/index.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/index.ts
@@ -13,7 +13,7 @@ class MapnavFixture extends MapnavAPI {
 
         // since this has no panel we need to merge in translations ourselves
         // TODO?: see if giving fixtures a nicer way to merge translations w/o panel makes sense
-        Object.entries(messages).forEach((value) =>
+        Object.entries(messages).forEach(value =>
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 

--- a/packages/ramp-core/src/fixtures/mapnav/store/mapnav-store.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/store/mapnav-store.ts
@@ -18,8 +18,8 @@ const getters = {
      */
     visible(state: MapnavState): MapnavItemInstance[] {
         return state.order
-            .map<MapnavItemInstance>((id) => state.items[id])
-            .filter((item) => item.componentId);
+            .map<MapnavItemInstance>(id => state.items[id])
+            .filter(item => item.componentId);
     }
 };
 

--- a/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
+++ b/packages/ramp-core/src/fixtures/mapnav/tests/e2e/test.js
@@ -16,7 +16,7 @@ describe('Mapnav', () => {
     });
 
     it('zoom-in button works', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             cy.get('.mapnav .mapnav-section .w-full').eq(0).click();
             cy.wait(1000);
             expect(window.rInstance.geo.map.getZoomLevel()).to.eq(1);
@@ -24,7 +24,7 @@ describe('Mapnav', () => {
     });
 
     it('zoom-out button works', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             cy.get('.mapnav .mapnav-section .w-full').eq(1).click();
             cy.wait(1000);
             expect(window.rInstance.geo.map.getZoomLevel()).to.eq(0);
@@ -32,7 +32,7 @@ describe('Mapnav', () => {
     });
 
     it('home button works', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             cy.get('.mapnav .mapnav-section .w-full').eq(3).click();
             cy.wait(1000);
             cy.wrap(window.rInstance.geo.map.getExtent())

--- a/packages/ramp-core/src/fixtures/metadata/screen.vue
+++ b/packages/ramp-core/src/fixtures/metadata/screen.vue
@@ -90,7 +90,7 @@ export default defineComponent({
             this.loadFromURL(
                 'https://cors-anywhere.herokuapp.com/' + this.payload.url,
                 []
-            ).then((r) => {
+            ).then(r => {
                 this.state.status = 'success';
 
                 // Append the content to the panel.
@@ -101,7 +101,7 @@ export default defineComponent({
         } else if (this.payload.type === 'html') {
             this.requestContent(
                 'https://cors-anywhere.herokuapp.com/' + this.payload.url
-            ).then((r) => {
+            ).then(r => {
                 this.state.status = 'success';
                 this.state.response = (r as MetadataResult).response;
             });
@@ -126,7 +126,7 @@ export default defineComponent({
             );
 
             if (!this.cache[xmlUrl]) {
-                return this.requestContent(xmlUrl).then((xmlData) => {
+                return this.requestContent(xmlUrl).then(xmlData => {
                     this.cache[xmlUrl] = (xmlData as MetadataResult).response;
                     return this.applyXSLT(this.cache[xmlUrl], XSLT, params);
                 });
@@ -159,7 +159,7 @@ export default defineComponent({
                 xsltProc.importStylesheet(xslDoc);
                 // [patched from ECDMP] Add parameters to xsl document (setParameter = Chrome/FF/Others)
                 if (params) {
-                    params.forEach((p) =>
+                    params.forEach(p =>
                         xsltProc.setParameter('', p.key, p.value || '')
                     );
                 }

--- a/packages/ramp-core/src/fixtures/overviewmap/index.ts
+++ b/packages/ramp-core/src/fixtures/overviewmap/index.ts
@@ -9,7 +9,7 @@ class OverviewmapFixture extends OverviewmapAPI {
 
         this.$vApp.$store.registerModule('overviewmap', overviewmap());
 
-        Object.entries(messages).forEach((value) =>
+        Object.entries(messages).forEach(value =>
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 

--- a/packages/ramp-core/src/fixtures/panguard/index.ts
+++ b/packages/ramp-core/src/fixtures/panguard/index.ts
@@ -6,7 +6,7 @@ class PanguardFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
         // Manually add lang entries to i18n
-        Object.entries(messages).forEach((value) =>
+        Object.entries(messages).forEach(value =>
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 

--- a/packages/ramp-core/src/fixtures/panguard/map-panguard.vue
+++ b/packages/ramp-core/src/fixtures/panguard/map-panguard.vue
@@ -25,20 +25,20 @@ export default defineComponent({
         this.$iApi.geo.map.viewPromise.then(() => {
             // TODO: when projection change is implemented check that the below events track any changes to
             // the esriView or update MapAPI to be raising pointer events on the EventAPI, and this will listen to for those events
-            this.$iApi.geo.map.esriView!.on('pointer-down', (e) => {
+            this.$iApi.geo.map.esriView!.on('pointer-down', e => {
                 if (e.pointerType !== 'touch') return;
                 pointers.set(e.pointerId, { x: e.x, y: e.y });
             });
 
             this.$iApi.geo.map.esriView!.on(
                 ['pointer-up', 'pointer-leave'],
-                (e) => {
+                e => {
                     if (e.pointerType !== 'touch') return;
                     pointers.delete(e.pointerId);
                 }
             );
 
-            this.$iApi.geo.map.esriView!.on('pointer-move', (e) => {
+            this.$iApi.geo.map.esriView!.on('pointer-move', e => {
                 const { pointerId, pointerType, x, y } = e;
                 const pointer = pointers.get(pointerId);
 

--- a/packages/ramp-core/src/fixtures/scrollguard/index.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/index.ts
@@ -6,7 +6,7 @@ class ScrollguardFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
         // Manually add lang entries to i18n
-        Object.entries(messages).forEach((value) =>
+        Object.entries(messages).forEach(value =>
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
         );
 

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -178,7 +178,7 @@ export default defineComponent({
     },
     beforeUnmount() {
         // Remove all event handlers for this component
-        this.handlers.forEach((handler) => this.$iApi.event.off(handler));
+        this.handlers.forEach(handler => this.$iApi.event.off(handler));
     },
     methods: {
         // Update the layer visibility.

--- a/packages/ramp-core/src/fixtures/settings/tests/e2e/settings-test.js
+++ b/packages/ramp-core/src/fixtures/settings/tests/e2e/settings-test.js
@@ -10,7 +10,7 @@ describe('Settings', () => {
             .invoke('get', 'layer/getLayerById', 'CleanAir')
             .as('layer');
 
-        cy.get('@layer').then((layer) => {
+        cy.get('@layer').then(layer => {
             // make layer invisible initially
             cy.wrap(layer).invoke('setVisibility', false);
             // open settings panel
@@ -39,7 +39,7 @@ describe('Settings', () => {
         // wait for panel to close
         cy.get('[data-cy="settings-panel"]').should('not.exist');
 
-        cy.get('@layer').then((layer) => {
+        cy.get('@layer').then(layer => {
             // make layer visible and set opacity
             cy.wrap(layer).invoke('setVisibility', true);
             cy.wrap(layer).invoke('setOpacity', 0.43);
@@ -73,7 +73,7 @@ describe('Settings', () => {
             .invoke('get', 'layer/getLayerById', 'CleanAir')
             .as('layer');
 
-        cy.get('@layer').then((layer) => {
+        cy.get('@layer').then(layer => {
             // make layer invisible  and full opacity initially
             cy.wrap(layer).invoke('setVisibility', false);
             cy.wrap(layer).invoke('setOpacity', 1);
@@ -111,7 +111,7 @@ describe('Settings', () => {
             .invoke('get', 'layer/getLayerById', 'CleanAir')
             .as('layer');
 
-        cy.get('@layer').then((layer) => {
+        cy.get('@layer').then(layer => {
             // make layer invisible  and full opacity initially
             cy.wrap(layer).invoke('setVisibility', false);
             cy.wrap(layer).invoke('setOpacity', 1);

--- a/packages/ramp-core/src/fixtures/wizard/form-input.vue
+++ b/packages/ramp-core/src/fixtures/wizard/form-input.vue
@@ -9,7 +9,7 @@
                     name="file"
                     accept=".geojson,.json,.csv,.zip"
                     @input="
-                        (event) => {
+                        event => {
                             $emit('upload', event.target.files[0]);
                             event.target.value = null;
                         }
@@ -60,7 +60,7 @@
                     :value="modelValue"
                     @change="valid ? (urlError = false) : (urlError = true)"
                     @input="
-                        (event) => {
+                        event => {
                             validUrl(event.target.value);
                             $emit('link', event.target.value, valid);
                             urlError = false;
@@ -92,7 +92,7 @@
                         :value="modelValue"
                         v-model="selected"
                         @change="
-                            (event) => {
+                            event => {
                                 $emit('select', selected);
                                 checkMultiSelectError(selected);
                             }

--- a/packages/ramp-core/src/fixtures/wizard/screen.vue
+++ b/packages/ramp-core/src/fixtures/wizard/screen.vue
@@ -435,7 +435,7 @@ export default defineComponent({
                 // );
             };
 
-            reader.onload = (e) => {
+            reader.onload = e => {
                 this.fileData = reader.result as ArrayBuffer;
                 this.url = file.name;
                 this.onUploadContinue(e);

--- a/packages/ramp-core/src/geo/api/geo-common.ts
+++ b/packages/ramp-core/src/geo/api/geo-common.ts
@@ -59,7 +59,7 @@ export class GeoCommonAPI {
 
     defaultLODs(keycode: string): Array<RampLodConfig> {
         const lodGrinder = (a: Array<Array<number>>) => {
-            return a.map((lod) => {
+            return a.map(lod => {
                 return {
                     level: lod[0],
                     resolution: lod[1],

--- a/packages/ramp-core/src/geo/api/graphic/geometry/geometry.ts
+++ b/packages/ramp-core/src/geo/api/graphic/geometry/geometry.ts
@@ -274,7 +274,7 @@ export class GeometryAPI {
         };
 
         Object.keys(rampGraphic.attributes).forEach(
-            (k) => (f.properties[k] = rampGraphic.attributes[k])
+            k => (f.properties[k] = rampGraphic.attributes[k])
         );
 
         return f;
@@ -328,7 +328,7 @@ export class GeometryAPI {
         gConf.geometry = this.geomRampToEsri(rampGraphic.geometry);
 
         Object.keys(rampGraphic.attributes).forEach(
-            (k) => (gConf.attributes[k] = rampGraphic.attributes[k])
+            k => (gConf.attributes[k] = rampGraphic.attributes[k])
         );
 
         if (rampGraphic.style) {
@@ -497,8 +497,8 @@ export class GeometryAPI {
 
         // TODO is there a more efficient way to do this than with pushes? use concats?
         // concat will keep re-copying all known rings with each new polygon encountered, so probably worse
-        rampMultiPolygon.toArray().forEach((poly) => {
-            poly.forEach((ring) => ringMerger.push(ring));
+        rampMultiPolygon.toArray().forEach(poly => {
+            poly.forEach(ring => ringMerger.push(ring));
         });
         return this.polygonFactory(ringMerger, rampMultiPolygon.sr);
     }

--- a/packages/ramp-core/src/geo/api/graphic/geometry/multi-line-string.ts
+++ b/packages/ramp-core/src/geo/api/graphic/geometry/multi-line-string.ts
@@ -62,7 +62,7 @@ export class MultiLineString extends BaseGeometry {
             }
 
             // process each element, as they could be any format of varying quality
-            this.rawArray = geometry.map((l) => MultiPoint.parsePointSet(l));
+            this.rawArray = geometry.map(l => MultiPoint.parsePointSet(l));
         } else {
             throw new Error('invalid lines format for MulitLineString');
         }
@@ -120,6 +120,6 @@ export class MultiLineString extends BaseGeometry {
         a: Array<Array<Array<number>>>
     ): Array<Array<Array<number>>> {
         // speed tests show loops & slice is 3x faster than JSON parse/stringify
-        return a.map((l) => l.map((p) => p.slice()));
+        return a.map(l => l.map(p => p.slice()));
     }
 }

--- a/packages/ramp-core/src/geo/api/graphic/geometry/multi-point.ts
+++ b/packages/ramp-core/src/geo/api/graphic/geometry/multi-point.ts
@@ -110,7 +110,7 @@ export class MultiPoint extends BaseGeometry {
             if (input.length === 0) {
                 throw new Error('no verticies provided');
             }
-            return input.map((v) => Point.parseXY(v));
+            return input.map(v => Point.parseXY(v));
         } else {
             throw new Error('invalid input format for parsePointSet');
         }
@@ -120,6 +120,6 @@ export class MultiPoint extends BaseGeometry {
         a: Array<Array<number>>
     ): Array<Array<number>> {
         // speed tests show loops & slice is 3x faster than JSON parse/stringify
-        return a.map((p) => p.slice());
+        return a.map(p => p.slice());
     }
 }

--- a/packages/ramp-core/src/geo/api/graphic/geometry/multi-polygon.ts
+++ b/packages/ramp-core/src/geo/api/graphic/geometry/multi-polygon.ts
@@ -123,7 +123,7 @@ export class MultiPolygon extends BaseGeometry {
             if (input.length === 0) {
                 throw new Error('no polygons provided');
             }
-            return input.map((p) => Polygon.parsePolygon(p));
+            return input.map(p => Polygon.parsePolygon(p));
         } else {
             throw new Error('invalid input format for parseMultiPolygon');
         }
@@ -135,6 +135,6 @@ export class MultiPolygon extends BaseGeometry {
     ): Array<Array<Array<Array<number>>>> {
         // speed tests show loops & slice is 3x faster than JSON parse/stringify
         // array of polyGons to array of Lines(rings) to array of Points, copy each point
-        return a.map((g) => g.map((l) => l.map((p) => p.slice())));
+        return a.map(g => g.map(l => l.map(p => p.slice())));
     }
 }

--- a/packages/ramp-core/src/geo/api/graphic/geometry/polygon.ts
+++ b/packages/ramp-core/src/geo/api/graphic/geometry/polygon.ts
@@ -60,7 +60,7 @@ export class Polygon extends BaseGeometry {
 
     addLinearRings(linearRings: Array<LinearRing>): void {
         // TODO consider to make this of any of the wacky types and apply the parser
-        linearRings.forEach((lr) => this.rawArray.push(lr.toArray()));
+        linearRings.forEach(lr => this.rawArray.push(lr.toArray()));
     }
 
     // TODO make a .getAt, .updateAt for rings?
@@ -103,13 +103,13 @@ export class Polygon extends BaseGeometry {
             if (input.length === 0) {
                 throw new Error('no rings provided');
             }
-            arrOfLines = input.map((l) => MultiPoint.parsePointSet(l));
+            arrOfLines = input.map(l => MultiPoint.parsePointSet(l));
         } else {
             throw new Error('invalid input format for parsePolygon');
         }
 
         // ensure each line in our collection of lines is closed
-        arrOfLines.forEach((l) => LinearRing.closeRing(l));
+        arrOfLines.forEach(l => LinearRing.closeRing(l));
         return arrOfLines;
     }
 
@@ -117,6 +117,6 @@ export class Polygon extends BaseGeometry {
         a: Array<Array<Array<number>>>
     ): Array<Array<Array<number>>> {
         // speed tests show loops & slice is 3x faster than JSON parse/stringify
-        return a.map((l) => l.map((p) => p.slice()));
+        return a.map(l => l.map(p => p.slice()));
     }
 }

--- a/packages/ramp-core/src/geo/api/graphic/style/style-options.ts
+++ b/packages/ramp-core/src/geo/api/graphic/style/style-options.ts
@@ -52,14 +52,14 @@ export class StyleOptions {
 
         let arr: Array<number>;
         if (Array.isArray(c)) {
-            arr = (<Array<any>>c).map((n) => parseInt(n));
+            arr = (<Array<any>>c).map(n => parseInt(n));
             if (arr.length === 3) {
                 arr.push(255); // no opacity given. make opaque
             }
         } else if (typeof c === 'string') {
             // trim # if its there
             let s: string = c.substr(0, 1) === '#' ? c.substr(1) : c;
-            arr = [0, 2, 4, 6].map((i) => {
+            arr = [0, 2, 4, 6].map(i => {
                 const hex = s.substr(i, 2);
                 return hex.length === 0 ? 255 : parseInt(hex, 16);
             });
@@ -77,6 +77,6 @@ export class StyleOptions {
             return s.length === 1 ? `0${s}` : s;
         };
 
-        return `#${colourArray.map((i) => toHex(i)).join('')}`;
+        return `#${colourArray.map(i => toHex(i)).join('')}`;
     }
 }

--- a/packages/ramp-core/src/geo/api/layer/filter.ts
+++ b/packages/ramp-core/src/geo/api/layer/filter.ts
@@ -29,11 +29,11 @@ export class Filter {
     sqlActiveFilters(exclusions: Array<string> = []): Array<string> {
         const s = this.sql;
         // find filter keys that have content
-        const rawActive = Object.keys(s).filter((k) => s[k]);
+        const rawActive = Object.keys(s).filter(k => s[k]);
         if (exclusions.length === 0) {
             return rawActive;
         } else {
-            return rawActive.filter((k) => exclusions.indexOf(k) === -1);
+            return rawActive.filter(k => exclusions.indexOf(k) === -1);
         }
     }
 
@@ -68,7 +68,7 @@ export class Filter {
             return this.sql[keys[0]];
         } else {
             // wrap each nugget in bracket, connect with AND
-            return keys.map((k) => `(${this.sql[k]})`).join(' AND ');
+            return keys.map(k => `(${this.sql[k]})`).join(' AND ');
         }
     }
 
@@ -181,7 +181,7 @@ export class Filter {
      */
     private cacheActiveKeys(): Array<string> {
         const c = this.cache;
-        return Object.keys(c).filter((k) => c[k]);
+        return Object.keys(c).filter(k => c[k]);
     }
 
     /**
@@ -203,7 +203,7 @@ export class Filter {
     private clearCacheSet(filterName: string): void {
         // the keys are wrapped in $ chars to avoid matching similarly named filter keys.
         // e.g. 'plugin' would also match 'plugin1' in an indexOf call, but '$plugin$' won't match '$plugin1$'
-        this.cacheActiveKeys().forEach((c) => {
+        this.cacheActiveKeys().forEach(c => {
             if (c.indexOf(`$${filterName}$`) > -1) {
                 delete this.cache[c];
             }

--- a/packages/ramp-core/src/geo/api/layer/tree-node.ts
+++ b/packages/ramp-core/src/geo/api/layer/tree-node.ts
@@ -27,7 +27,7 @@ export class TreeNode {
             let hit: TreeNode | undefined;
 
             // using .some will cause the loop to stop when it gets a hit
-            this.children.some((t) => {
+            this.children.some(t => {
                 return (hit = t.findChildByUid(uid));
             });
 
@@ -45,7 +45,7 @@ export class TreeNode {
             let hit: TreeNode | undefined;
 
             // using .some will cause the loop to stop when it gets a hit
-            this.children.some((t) => {
+            this.children.some(t => {
                 return (hit = t.findChildByIdx(idx));
             });
 

--- a/packages/ramp-core/src/geo/api/utils/projection.ts
+++ b/packages/ramp-core/src/geo/api/utils/projection.ts
@@ -389,10 +389,8 @@ export class ProjectionAPI {
         // interpolate each edge by splitting it in half 3 times (since lines are not guaranteed to project to lines we need to consider
         // max / min points in the middle of line segments)
         [0, 1, 2, 3]
-            .map((i) => interpolate(points[i], points[i + 1], 3).slice(1))
-            .forEach(
-                (seg) => (interpolatedPoly = interpolatedPoly.concat(seg))
-            );
+            .map(i => interpolate(points[i], points[i + 1], 3).slice(1))
+            .forEach(seg => (interpolatedPoly = interpolatedPoly.concat(seg)));
 
         const iPoly: Polygon = new Polygon(
             'warpy',
@@ -408,8 +406,8 @@ export class ProjectionAPI {
 
         // take our projected interpolated polygon, strip out the co-ords for X and Y
         const rawWarp = iWarped.toArray().pop() || [];
-        const xvals = rawWarp.map((p) => p[0]);
-        const yvals = rawWarp.map((p_1) => p_1[1]);
+        const xvals = rawWarp.map(p => p[0]);
+        const yvals = rawWarp.map(p_1 => p_1[1]);
 
         // find the bounding corners of our projected interpolated polygon
         const x0 = Math.min.apply(null, xvals);

--- a/packages/ramp-core/src/geo/api/utils/shared-utils.ts
+++ b/packages/ramp-core/src/geo/api/utils/shared-utils.ts
@@ -11,7 +11,7 @@ export class SharedUtilsAPI {
      */
     generateUUID(): string {
         let d = Date.now();
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
             /*
             // TODO: Come up with cheaper solution that doesn't use the crypto API and satifies CodeQL
             const r =
@@ -65,7 +65,7 @@ export class SharedUtilsAPI {
                 // return canvas
                 resolve(canvas);
             });
-            image.addEventListener('error', (error) => reject(error));
+            image.addEventListener('error', error => reject(error));
         });
 
         // set image source to the one generated from the print task
@@ -93,11 +93,11 @@ export class SharedUtilsAPI {
         }
 
         return this.convertImageToCanvas(imageUri)
-            .then((canvas) => {
+            .then(canvas => {
                 // Converting image to dataURL
                 return canvas.toDataURL(imageType);
             })
-            .catch((error) => {
+            .catch(error => {
                 console.error(
                     'Failed to load crossorigin image',
                     imageUri,

--- a/packages/ramp-core/src/geo/layer/attrib-fc.ts
+++ b/packages/ramp-core/src/geo/layer/attrib-fc.ts
@@ -133,7 +133,7 @@ export class AttribFC extends CommonFC {
             this.nameField = sData.displayField;
 
             // find object id field
-            const noFieldDefOid: boolean = this.fields.every((elem) => {
+            const noFieldDefOid: boolean = this.fields.every(elem => {
                 if (elem.type === 'oid') {
                     this.oidField = elem.name;
                     return false; // break the loop
@@ -222,9 +222,7 @@ export class AttribFC extends CommonFC {
         // if exlusive fields, only respect fields in the field info array
         if (configMetadata.exclusiveFields) {
             // ensure object id field is included
-            if (
-                !configMetadata.fieldInfo.find((f) => f.data === this.oidField)
-            ) {
+            if (!configMetadata.fieldInfo.find(f => f.data === this.oidField)) {
                 configMetadata.fieldInfo.push({ data: this.oidField });
             }
 
@@ -238,20 +236,20 @@ export class AttribFC extends CommonFC {
             //      on things like details panes or grids
 
             this.fieldList = configMetadata.fieldInfo
-                .map((f) => f.data)
+                .map(f => f.data)
                 .join(',');
             const tempFI = configMetadata.fieldInfo; // required because typescript is throwing a fit about undefineds inside the .filter
-            this.fields = this.fields.filter((origField) => {
-                return tempFI.find((fInfo) => fInfo.data === origField.name);
+            this.fields = this.fields.filter(origField => {
+                return tempFI.find(fInfo => fInfo.data === origField.name);
             });
         } else {
             this.fieldList = '*';
         }
 
         // if any aliases overrides, apply them
-        configMetadata.fieldInfo.forEach((cf) => {
+        configMetadata.fieldInfo.forEach(cf => {
             if (cf.alias) {
-                const ff = this.fields.find((fff) => fff.name === cf.data);
+                const ff = this.fields.find(fff => fff.name === cf.data);
                 if (ff) {
                     ff.alias = cf.alias;
                 }
@@ -312,7 +310,7 @@ export class AttribFC extends CommonFC {
      */
     getFields(): Array<FieldDefinition> {
         // extra fancy so we dont have to expose the ESRI field class
-        return this.fields.map((f) => {
+        return this.fields.map(f => {
             f = toRaw(f);
             return {
                 name: f.name,
@@ -378,12 +376,12 @@ export class AttribFC extends CommonFC {
         // create columns array consumable by datables. We don't include the alias defined in the config here as
         // the grid handles it seperately.
         const columns = this.fields
-            .filter((field) =>
+            .filter(field =>
                 // assuming there is at least one attribute - empty attribute budnle promises should be rejected, so it never even gets this far
                 // filter out fields where there is no corresponding attribute data
                 attSet.features[0].hasOwnProperty(toRaw(field).name)
             )
-            .map((field) => ({
+            .map(field => ({
                 data: toRaw(field).name, // TODO calling this data is really unintuitive. consider global rename to fieldName, name, attribName, etc.
                 title: toRaw(field).alias || toRaw(field).name
             }));
@@ -392,7 +390,7 @@ export class AttribFC extends CommonFC {
         // TODO figure out if we want to change the system attributes. making a copy for now with deepmerge.
         // if we add rv properties to the feature in the attribute set, we may see those fields showing up in details panes, API outputs, etc.
         // that said, copying means we double the size of attributes in memory.
-        const rows = attSet.features.map((feature) => {
+        const rows = attSet.features.map(feature => {
             const att = deepmerge({}, feature);
             att.rvInteractive = '';
             att.rvSymbol = this.renderer?.getGraphicIcon(feature);
@@ -402,7 +400,7 @@ export class AttribFC extends CommonFC {
         // if a field name resembles a function, the data table will treat it as one.
         // to get around this, we add a function with the same name that returns the value,
         // tricking that silly datagrid.
-        columns.forEach((c) => {
+        columns.forEach(c => {
             if (c.data.substr(-2) === '()') {
                 // have to use function() to get .this to reference the row.
                 // arrow notation will reference the attribFC class.
@@ -412,7 +410,7 @@ export class AttribFC extends CommonFC {
                 };
 
                 const stub = c.data.substr(0, c.data.length - 2); // function without brackets
-                rows.forEach((r) => {
+                rows.forEach(r => {
                     r[stub] = secretFunc;
                 });
             }
@@ -683,7 +681,7 @@ export class AttribFC extends CommonFC {
             getAttribs: true
             // unboundMap: options.map
         };
-        const cacheQueue: Array<Promise<GetGraphicResult>> = oids.map((oid) =>
+        const cacheQueue: Array<Promise<GetGraphicResult>> = oids.map(oid =>
             this.getGraphic(oid, p)
         );
         return Promise.all(cacheQueue);

--- a/packages/ramp-core/src/geo/layer/common-graphic-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-graphic-layer.ts
@@ -59,7 +59,7 @@ export class CommonGraphicLayer extends CommonLayer {
      * @returns {Graphic} the graphic, undefined if no matching id is found.
      */
     getLocalGraphic(graphicId: string): Graphic | undefined {
-        return this._graphics.find((g) => g.id === graphicId);
+        return this._graphics.find(g => g.id === graphicId);
     }
 
     protected notLoadedErr(): void {
@@ -92,8 +92,8 @@ export class CommonGraphicLayer extends CommonLayer {
             gs = [graphics];
         }
 
-        const validGraphics = gs.filter((g) => {
-            const index = this._graphics.findIndex((gg) => gg.id === g.id);
+        const validGraphics = gs.filter(g => {
+            const index = this._graphics.findIndex(gg => gg.id === g.id);
 
             if (index === -1) {
                 this._graphics.push(g);
@@ -107,7 +107,7 @@ export class CommonGraphicLayer extends CommonLayer {
         });
 
         const mapSR = this.$iApi.geo.map.getSR();
-        const projGeomsProms = validGraphics.map((g) =>
+        const projGeomsProms = validGraphics.map(g =>
             this.$iApi.geo.utils.proj.projectGeometry(mapSR, g.geometry)
         );
 
@@ -152,7 +152,7 @@ export class CommonGraphicLayer extends CommonLayer {
             inArr = [graphics];
         }
 
-        const ids = inArr.map((x) => {
+        const ids = inArr.map(x => {
             if (typeof x === 'string') {
                 return x;
             } else {
@@ -161,14 +161,14 @@ export class CommonGraphicLayer extends CommonLayer {
         });
 
         const targets: Array<__esri.Graphic> = [];
-        ids.forEach((id) => {
+        ids.forEach(id => {
             // need to tag the param as `any` because .id is something we manually added
             const target = this.esriLayer?.graphics.find(
                 (g: any) => g.id === id
             );
             if (target) {
                 targets.push(target);
-                const rampIdx = this._graphics.findIndex((g) => g.id === id);
+                const rampIdx = this._graphics.findIndex(g => g.id === id);
                 if (rampIdx) {
                     this._graphics.splice(rampIdx, 1);
                 }

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -232,7 +232,7 @@ export class CommonLayer extends LayerInstance {
         this.fcs = [];
         this.loadPromise = new DefPromise();
         this.viewPromise = new DefPromise();
-        this.watches.forEach((w) => w.remove());
+        this.watches.forEach(w => w.remove());
         this.watches = [];
         this.updateState(LayerState.NEW);
 
@@ -256,7 +256,7 @@ export class CommonLayer extends LayerInstance {
                 // attempt to find esri layer in esri map
                 const tempPosition =
                     this.$iApi.geo.map.esriMap.layers.findIndex(
-                        (l) => l.id === this.id
+                        l => l.id === this.id
                     );
                 if (tempPosition > -1) {
                     mapStackPosition = tempPosition;
@@ -452,7 +452,7 @@ export class CommonLayer extends LayerInstance {
         if (uid === this.uid) {
             return -1;
         } else {
-            const fcIdx: number = this.fcs.findIndex((fc) => fc?.uid === uid);
+            const fcIdx: number = this.fcs.findIndex(fc => fc?.uid === uid);
             if (fcIdx === -1) {
                 // no match
                 throw new Error(

--- a/packages/ramp-core/src/geo/layer/esriFeature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriFeature/index.ts
@@ -211,7 +211,7 @@ class FeatureLayer extends AttribLayer {
         let loadResolve: any;
         const innerResult: IdentifyResult = {
             uid: myFC.uid,
-            loadPromise: new Promise((resolve) => {
+            loadPromise: new Promise(resolve => {
                 loadResolve = resolve;
             }),
             items: []
@@ -246,9 +246,9 @@ class FeatureLayer extends AttribLayer {
 
         qOpts.filterSql = myFC.getCombinedSqlFilter();
 
-        result.done = myFC.queryFeatures(qOpts).then((results) => {
+        result.done = myFC.queryFeatures(qOpts).then(results => {
             // TODO might be a problem overwriting the array if something is watching/binding to the original
-            innerResult.items = results.map((gr) => {
+            innerResult.items = results.map(gr => {
                 return {
                     // TODO decide if we want to handle alias mapping here or not.
                     //      if we do, our "ESRI" format will need to include field metadata.

--- a/packages/ramp-core/src/geo/layer/esriImagery/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriImagery/index.ts
@@ -55,7 +55,7 @@ class ImageryLayer extends CommonLayer {
 
         const legendPromise = this.$iApi.geo.utils.symbology
             .mapServerToLocalLegend(this.origRampConfig.url)
-            .then((legArray) => {
+            .then(legArray => {
                 imgFC.legend = legArray;
             });
 

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -122,7 +122,7 @@ class MapImageLayer extends AttribLayer {
         };
 
         const findSublayer = (targetIndex: number): __esri.Sublayer => {
-            const finder = this.esriLayer?.allSublayers.find((s) => {
+            const finder = this.esriLayer?.allSublayers.find(s => {
                 return s.id === targetIndex;
             });
             if (!finder) {
@@ -303,7 +303,7 @@ class MapImageLayer extends AttribLayer {
         // process the child layers our config is interested in, and all their children.
         (<Array<RampLayerMapImageLayerEntryConfig>>(
             this.origRampConfig.layerEntries
-        )).forEach((le) => {
+        )).forEach(le => {
             if (!le.stateOnly) {
                 // TODO add a check instead of 0 default on the index?
                 const rootSub = findSublayer(le.index || 0);
@@ -360,7 +360,7 @@ class MapImageLayer extends AttribLayer {
         });
 
         // any sublayers not in our tree, we need to turn off.
-        this.esriLayer.allSublayers.forEach((s) => {
+        this.esriLayer.allSublayers.forEach(s => {
             // find sublayers that are not groups, and dont exist in our initilazation array
             if (
                 !s.sublayers &&
@@ -379,7 +379,7 @@ class MapImageLayer extends AttribLayer {
                     f: 'json'
                 }
             });
-            const setTitle = serviceRequest.then((serviceResult) => {
+            const setTitle = serviceRequest.then(serviceResult => {
                 if (serviceResult.data) {
                     this.name = serviceResult.data.mapName || '';
                     // @ts-ignore
@@ -631,11 +631,11 @@ class MapImageLayer extends AttribLayer {
 
         // loop over active FCs. call query on each. prepare a geometry
         result.done = Promise.all(
-            activeFCs.map((fc) => {
+            activeFCs.map(fc => {
                 let loadResolve: any;
                 const innerResult: IdentifyResult = {
                     uid: fc.uid,
-                    loadPromise: new Promise((resolve) => {
+                    loadPromise: new Promise(resolve => {
                         loadResolve = resolve;
                     }),
                     items: []
@@ -654,9 +654,9 @@ class MapImageLayer extends AttribLayer {
                 qOpts.outFields = fc.fieldList;
                 qOpts.filterSql = fc.getCombinedSqlFilter();
 
-                return fc.queryFeatures(qOpts).then((results) => {
+                return fc.queryFeatures(qOpts).then(results => {
                     // TODO might be a problem overwriting the array if something is watching/binding to the original
-                    innerResult.items = results.map((gr) => {
+                    innerResult.items = results.map(gr => {
                         return {
                             // TODO this block is the same as in featurelayer. might want to abstract to a shared function. really depends if we keep the extra params
                             // TODO decide if we want to handle alias mapping here or not.

--- a/packages/ramp-core/src/geo/layer/esriMapImage/map-image-fc.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/map-image-fc.ts
@@ -24,7 +24,7 @@ export class MapImageFC extends AttribFC {
 
         // TODO not found check?
         this.esriSubLayer = markRaw(
-            parent.esriLayer.allSublayers.find((s) => {
+            parent.esriLayer.allSublayers.find(s => {
                 return s.id === layerIdx;
             })
         );

--- a/packages/ramp-core/src/geo/layer/esriTile/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriTile/index.ts
@@ -55,7 +55,7 @@ class TileLayer extends CommonLayer {
 
         const legendPromise = this.$iApi.geo.utils.symbology
             .mapServerToLocalLegend(this.origRampConfig.url)
-            .then((legArray) => {
+            .then(legArray => {
                 tileFC.legend = legArray;
             });
 

--- a/packages/ramp-core/src/geo/layer/file-fc.ts
+++ b/packages/ramp-core/src/geo/layer/file-fc.ts
@@ -160,7 +160,7 @@ export class FileFC extends AttribFC {
         // iterate through the results and strip out the OIDs
         const gjFeats =
             await this.parentLayer.$iApi.geo.utils.query.geoJsonQuery(gjOpt);
-        return gjFeats.map((feat) =>
+        return gjFeats.map(feat =>
             feat.attributes ? feat.attributes[this.oidField] : -1
         );
     }

--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -26,9 +26,9 @@ import { markRaw } from 'vue';
 // This function will return a valid field name for a given field name. First attempts at
 // direct match, then attempts to reverse any bad field renaming logic.
 function fieldValidator(fields: Array<EsriField>, targetName: string): string {
-    if (fields.findIndex((f) => f.name === targetName) === -1) {
+    if (fields.findIndex(f => f.name === targetName) === -1) {
         // no direct match found.
-        const validField = fields.find((f) => f.alias === targetName);
+        const validField = fields.find(f => f.alias === targetName);
         if (validField) {
             return validField.name;
         } else {
@@ -264,7 +264,7 @@ export class FileLayer extends AttribLayer {
         let loadResolve: any;
         const innerResult: IdentifyResult = {
             uid: myFC.uid,
-            loadPromise: new Promise((resolve) => {
+            loadPromise: new Promise(resolve => {
                 loadResolve = resolve;
             }),
             items: []
@@ -304,9 +304,9 @@ export class FileLayer extends AttribLayer {
         // TODO: Test if works after #206 is implemented
         qOpts.filterSql = myFC.getCombinedSqlFilter();
 
-        result.done = myFC.queryFeatures(qOpts).then((results) => {
+        result.done = myFC.queryFeatures(qOpts).then(results => {
             // TODO might be a problem overwriting the array if something is watching/binding to the original
-            innerResult.items = results.map((gr) => {
+            innerResult.items = results.map(gr => {
                 return {
                     // TODO decide if we want to handle alias mapping here or not.
                     //      if we do, our "ESRI" format will need to include field metadata.

--- a/packages/ramp-core/src/geo/layer/file-utils.ts
+++ b/packages/ramp-core/src/geo/layer/file-utils.ts
@@ -100,7 +100,7 @@ function cleanUpFields(
         return name.indexOf(' ') > -1;
     };
 
-    configPackage.fields?.forEach((f) => {
+    configPackage.fields?.forEach(f => {
         if (f.name && badField(f.name)) {
             const oldField: string = f.name;
             let newField: string;
@@ -111,7 +111,7 @@ function cleanUpFields(
             do {
                 newField = oldField.replace(/ /g, underscore);
                 badNewName = configPackage.fields?.find(
-                    (f2) => f2.name === newField
+                    f2 => f2.name === newField
                 );
                 if (badNewName) {
                     // new field already exists. enhance it
@@ -163,7 +163,7 @@ export class FileUtils extends APIScope {
         const fields: Array<string> = dsv
             .dsvFormat(delimiter)
             .parseRows(csvData)[0];
-        return fields.map((field) => {
+        return fields.map(field => {
             return { name: field, type: 'string' };
         });
     }
@@ -251,7 +251,7 @@ export class FileUtils extends APIScope {
         if (options) {
             if (options.latfield) {
                 const latField = configPackage.fields.find(
-                    (field) => field.name === options.latfield
+                    field => field.name === options.latfield
                 );
                 if (latField) {
                     latField.type = 'double';
@@ -259,7 +259,7 @@ export class FileUtils extends APIScope {
             }
             if (options.lonfield) {
                 const longField = configPackage.fields.find(
-                    (field) => field.name === options.lonfield
+                    field => field.name === options.lonfield
                 );
                 if (longField) {
                     longField.type = 'double';
@@ -304,7 +304,7 @@ export class FileUtils extends APIScope {
 
             // TEMPORARY hunt any complex datatypes and replace with a string
             // TODO figure out how to actually handle arrays or objects as attribute values
-            Object.keys(gr.attributes).forEach((attName) => {
+            Object.keys(gr.attributes).forEach(attName => {
                 if (
                     Array.isArray(gr.attributes[attName]) ||
                     typeof gr.attributes[attName] === 'object'

--- a/packages/ramp-core/src/geo/layer/ogc-utils.ts
+++ b/packages/ramp-core/src/geo/layer/ogc-utils.ts
@@ -115,7 +115,7 @@ export class OgcUtils extends APIScope {
                 // suggest porting this block to geoApi.
                 // for now, easier to modify as early as possible in the transformation
 
-                wfsData.features.forEach((f) => {
+                wfsData.features.forEach(f => {
                     const p = f.geometry.coordinates;
                     f.properties.rvInternalCoordX = p[0];
                     f.properties.rvInternalCoordY = p[1];
@@ -173,11 +173,11 @@ export class OgcUtils extends APIScope {
             }
             return EsriRequest(url, {
                 responseType: 'xml'
-            }).then((result) => result.data);
+            }).then(result => result.data);
         };
 
         // this promise attempts two tries at get capabilities
-        const gcPromise: Promise<any> = new Promise((resolve) => {
+        const gcPromise: Promise<any> = new Promise(resolve => {
             getCapabilities()
                 .then((data: any) => resolve(data)) // if successful, pass straight back
                 .catch(() => {

--- a/packages/ramp-core/src/geo/layer/ogcWms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/index.ts
@@ -55,7 +55,7 @@ export default class WmsLayer extends CommonLayer {
         const lEntries = <Array<RampLayerWmsLayerEntryConfig>>(
             rampLayerConfig.layerEntries
         );
-        this.sublayerNames = lEntries.map((le) => le.id || 'error_no_wms_id');
+        this.sublayerNames = lEntries.map(le => le.id || 'error_no_wms_id');
 
         // reminder: unlike MapImageLayer, we do not allow tweaking visibility
         //           of sublayers at runtime.
@@ -65,7 +65,7 @@ export default class WmsLayer extends CommonLayer {
 
         // NOTE: Currently, we do not disallow using style names in the config that do not exist on the service (for defining custom legend graphics),
         // but because both GetMap and GetLegendGraphic use the currentStyle property, the GetMap request would fail. See #630.
-        const styles = lEntries.map((e) => e.currentStyle).join();
+        const styles = lEntries.map(e => e.currentStyle).join();
 
         // This sets the style for the GetMap request.
         // NOTE: This does NOT set the style for GetLegendGraphic requests. See #603.
@@ -128,7 +128,7 @@ export default class WmsLayer extends CommonLayer {
             sublayers: __esri.Collection<EsriWMSSublayer>
         ): boolean => {
             let anySlVis = false;
-            sublayers.forEach((sl) => {
+            sublayers.forEach(sl => {
                 const visible = this.sublayerNames.indexOf(sl.name) > -1;
                 if (visible) {
                     // if this sublayer is visible, then all of its sublayers should remain visible as well
@@ -212,7 +212,7 @@ export default class WmsLayer extends CommonLayer {
         let loadResolve: any;
         const innerResult: IdentifyResult = {
             uid: myFC.uid,
-            loadPromise: new Promise((resolve) => {
+            loadPromise: new Promise(resolve => {
                 loadResolve = resolve;
             }),
             items: []
@@ -228,7 +228,7 @@ export default class WmsLayer extends CommonLayer {
             this.sublayerNames,
             <Point>options.geometry,
             this.mimeType
-        ).then((response) => {
+        ).then(response => {
             // check if a result is returned by the service. If not, do not add to the array of data
             // TODO verify we want empty .items array
             // TODO is is possible to have more than one item as a result? check how this works
@@ -405,7 +405,7 @@ export default class WmsLayer extends CommonLayer {
         // apply any custom parameters (ignore styles for the moment)
         const clp = esriLayer.customLayerParameters;
         if (clp) {
-            Object.keys(clp).forEach((key) => {
+            Object.keys(clp).forEach(key => {
                 if (key.toLowerCase() !== 'styles') {
                     // @ts-ignore
                     settings[key] = clp[key];
@@ -414,7 +414,7 @@ export default class WmsLayer extends CommonLayer {
         }
 
         // @ts-ignore
-        Object.keys(settings).forEach((key) => (req[key] = settings[key]));
+        Object.keys(settings).forEach(key => (req[key] = settings[key]));
 
         return EsriRequest(esriLayer.url.split('?')[0], {
             query: req,
@@ -470,7 +470,7 @@ export default class WmsLayer extends CommonLayer {
         });
 
         // get any legendUrls that were defined in the config
-        const legendURLs = layerList.map((l) =>
+        const legendURLs = layerList.map(l =>
             l.styleLegends && l.currentStyle
                 ? l.styleLegends.find((style: any) => {
                       return style.name === l.currentStyle;

--- a/packages/ramp-core/src/geo/map/basemap.ts
+++ b/packages/ramp-core/src/geo/map/basemap.ts
@@ -14,7 +14,7 @@ export class Basemap {
 
         this.innerBasemap = new EsriBasemap({
             // TODO split by type if we have to populate referenceLayers
-            baseLayers: rampConfig.layers.map((layerConfig) => {
+            baseLayers: rampConfig.layers.map(layerConfig => {
                 if (layerConfig.layerType === LayerType.TILE) {
                     return new EsriTileLayer({
                         url: layerConfig.url

--- a/packages/ramp-core/src/geo/map/caption.ts
+++ b/packages/ramp-core/src/geo/map/caption.ts
@@ -166,7 +166,7 @@ export class MapCaptionAPI extends APIScope {
                     .toArray();
 
             // Join all the copyright strings and update the attribution
-            Promise.all(baseLayerLoadPromises).then((baseLayers) => {
+            Promise.all(baseLayerLoadPromises).then(baseLayers => {
                 copyrightText = baseLayers
                     .filter((bl: any) => bl?.copyright)
                     .map((bl: any) => bl.copyright)

--- a/packages/ramp-core/src/geo/map/common-map.ts
+++ b/packages/ramp-core/src/geo/map/common-map.ts
@@ -29,7 +29,7 @@ export class CommonMapAPI extends APIScope {
     createMap(config: RampMapConfig, targetDiv: string | HTMLDivElement): void {
         // TODO if .esriMap exists, do we want to do any cleanup on it? E.g. remove event handlers?
         this._basemapStore = config.basemaps.map(
-            (bmConfig) => new Basemap(bmConfig)
+            bmConfig => new Basemap(bmConfig)
         );
         const esriConfig: __esri.MapProperties = {};
         if (config.initialBasemapId) {
@@ -42,7 +42,7 @@ export class CommonMapAPI extends APIScope {
 
     protected findBasemap(id: string): Basemap {
         const bm: Basemap | undefined = this._basemapStore.find(
-            (bms) => bms.id === id
+            bms => bms.id === id
         );
         if (bm) {
             return bm;

--- a/packages/ramp-core/src/geo/map/overview-map.ts
+++ b/packages/ramp-core/src/geo/map/overview-map.ts
@@ -79,28 +79,28 @@ export class OverviewMapAPI extends CommonMapAPI {
         };
         this.esriView.graphics.add(new EsriGraphic(graphic));
 
-        this.esriView.on('mouse-wheel', (esriMouseWheel) => {
+        this.esriView.on('mouse-wheel', esriMouseWheel => {
             esriMouseWheel.stopPropagation();
         });
 
-        this.esriView.on('double-click', (esriDoubleClick) => {
+        this.esriView.on('double-click', esriDoubleClick => {
             esriDoubleClick.stopPropagation();
         });
 
-        this.esriView.on('key-down', (esriKeyDown) => {
+        this.esriView.on('key-down', esriKeyDown => {
             esriKeyDown.stopPropagation();
         });
 
-        this.esriView.on('key-up', (esriKeyUp) => {
+        this.esriView.on('key-up', esriKeyUp => {
             esriKeyUp.stopPropagation();
         });
 
-        this.esriView.on('drag', (esriDrag) => {
+        this.esriView.on('drag', esriDrag => {
             esriDrag.stopPropagation();
             this.mapDrag(esriDrag);
         });
 
-        this.esriView.container.addEventListener('touchmove', (e) => {
+        this.esriView.container.addEventListener('touchmove', e => {
             // need this for panning and zooming to work on mobile devices / touchscreens
             // touchmove stops the drag event (what the MapView reacts to) from firing properly
             e.preventDefault();

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -136,14 +136,14 @@ export class MapAPI extends CommonMapAPI {
             this.$iApi.event.emit(GlobalEvents.MAP_SCALECHANGE, newval);
         });
 
-        this.esriView.on('resize', (esriResize) => {
+        this.esriView.on('resize', esriResize => {
             this.$iApi.event.emit(GlobalEvents.MAP_RESIZE, {
                 height: esriResize.height,
                 width: esriResize.width
             });
         });
 
-        this.esriView.on('click', (esriClick) => {
+        this.esriView.on('click', esriClick => {
             this.$iApi.event.emit(
                 GlobalEvents.MAP_CLICK,
                 this.$iApi.geo.utils.geom.esriMapClickToRamp(
@@ -153,7 +153,7 @@ export class MapAPI extends CommonMapAPI {
             );
         });
 
-        this.esriView.on('double-click', (esriClick) => {
+        this.esriView.on('double-click', esriClick => {
             this.$iApi.event.emit(
                 GlobalEvents.MAP_DOUBLECLICK,
                 this.$iApi.geo.utils.geom.esriMapClickToRamp(
@@ -163,7 +163,7 @@ export class MapAPI extends CommonMapAPI {
             );
         });
 
-        this.esriView.on('pointer-move', (esriMouseMove) => {
+        this.esriView.on('pointer-move', esriMouseMove => {
             // TODO debounce here? the map event fires pretty much every change in pixel value.
             this.$iApi.event.emit(
                 GlobalEvents.MAP_MOUSEMOVE,
@@ -171,7 +171,7 @@ export class MapAPI extends CommonMapAPI {
             );
         });
 
-        this.esriView.on('pointer-down', (esriMouseDown) => {
+        this.esriView.on('pointer-down', esriMouseDown => {
             // .native is a DOM pointer event
             this.$iApi.event.emit(
                 GlobalEvents.MAP_MOUSEDOWN,
@@ -179,24 +179,24 @@ export class MapAPI extends CommonMapAPI {
             );
         });
 
-        this.esriView.on('key-down', (esriKeyDown) => {
+        this.esriView.on('key-down', esriKeyDown => {
             // .native is a DOM keyboard event
             this.$iApi.event.emit(GlobalEvents.MAP_KEYDOWN, esriKeyDown.native);
             esriKeyDown.stopPropagation();
         });
 
-        this.esriView.on('key-up', (esriKeyUp) => {
+        this.esriView.on('key-up', esriKeyUp => {
             // .native is a DOM keyboard event
             this.$iApi.event.emit(GlobalEvents.MAP_KEYUP, esriKeyUp.native);
             esriKeyUp.stopPropagation();
         });
 
-        this.esriView.on('blur', (esriBlur) => {
+        this.esriView.on('blur', esriBlur => {
             // .native is a DOM keyboard event
             this.$iApi.event.emit(GlobalEvents.MAP_BLUR, esriBlur.native);
         });
 
-        this.esriView.container.addEventListener('touchmove', (e) => {
+        this.esriView.container.addEventListener('touchmove', e => {
             // need this for panning and zooming to work on mobile devices / touchscreens
             // touchmove stops the drag event (what the MapView reacts to) from firing properly
             e.preventDefault();
@@ -275,15 +275,13 @@ export class MapAPI extends CommonMapAPI {
             const notLoaded: number = layers
                 .slice(0, index + 1)
                 .filter(
-                    (layer) =>
-                        !this.esriMap!.layers.find((l) => l.id === layer.id)
+                    layer => !this.esriMap!.layers.find(l => l.id === layer.id)
                 ).length;
             // calculate corresponding map layer index
             const esriLayerIndex: number = this.esriMap.layers.indexOf(
                 this.esriMap.layers
                     .filter(
-                        (esrilayer) =>
-                            !!layers.find((l) => l.id === esrilayer.id) // ignore layers not in store (e.g. pole marker)
+                        esrilayer => !!layers.find(l => l.id === esrilayer.id) // ignore layers not in store (e.g. pole marker)
                     )
                     .slice(0, index + 1 - notLoaded) // adjust for layers not on map
                     .pop()
@@ -478,7 +476,7 @@ export class MapAPI extends CommonMapAPI {
 
         // scan for appropriate LOD that will make scale set visible, or pick last LOD if no boundary was found
         const scaleLod =
-            modLods.find((currentLod) =>
+            modLods.find(currentLod =>
                 offStatus.zoomIn
                     ? currentLod.scale < scaleSet.minScale
                     : currentLod.scale > scaleSet.maxScale
@@ -711,8 +709,8 @@ export class MapAPI extends CommonMapAPI {
         // Perform an identify request on each layer. Does not perform the request on layers that do not have an identify function (layers that do not support identify).
         const identifyInstances: IdentifyResultSet[] = layers
             // This will filter out all MapImageLayers that are not visible, regardless of the visibility of the MapImageFCs (sublayers)
-            .filter((layer) => layer.supportsIdentify)
-            .map((layer) => {
+            .filter(layer => layer.supportsIdentify)
+            .map(layer => {
                 return layer.identify(p);
             });
 
@@ -778,9 +776,9 @@ export class MapAPI extends CommonMapAPI {
         let esriGraphic: EsriGraphic | undefined;
         let hitLayer: LayerInstance | undefined;
 
-        layers.some((layer) => {
+        layers.some(layer => {
             // breaks in the first match hit, preserving the layer order
-            const matchedResult: any = response.results.find((result) => {
+            const matchedResult: any = response.results.find(result => {
                 return result.graphic.layer.id === layer.id;
             });
             if (matchedResult) {
@@ -832,7 +830,7 @@ export class MapAPI extends CommonMapAPI {
         ) {
             this._activeKeys.push(payload.key);
             // don't pan in middle of zoom animation
-            if (!this._activeKeys.some((k) => zoomKeys.includes(k))) {
+            if (!this._activeKeys.some(k => zoomKeys.includes(k))) {
                 this.keyPan();
             }
         } else if (
@@ -862,7 +860,7 @@ export class MapAPI extends CommonMapAPI {
         ) {
             this._activeKeys.splice(this._activeKeys.indexOf(payload.key), 1);
             // don't pan in middle of zoom animation
-            if (!this._activeKeys.some((k) => zoomKeys.includes(k))) {
+            if (!this._activeKeys.some(k => zoomKeys.includes(k))) {
                 this.keyPan();
             }
         }
@@ -886,7 +884,7 @@ export class MapAPI extends CommonMapAPI {
      */
     get keysActive(): boolean {
         return (
-            this._activeKeys.filter((k) => !['Control', 'Shift'].includes(k))
+            this._activeKeys.filter(k => !['Control', 'Shift'].includes(k))
                 .length !== 0
         );
     }

--- a/packages/ramp-core/src/geo/tests/e2e/shared-utils-test.js
+++ b/packages/ramp-core/src/geo/tests/e2e/shared-utils-test.js
@@ -10,7 +10,7 @@ describe('GeoAPI SharedUtils', () => {
     });
 
     it('parseUrlIndex works', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             expect(
                 sharedUtils.parseUrlIndex(
@@ -25,7 +25,7 @@ describe('GeoAPI SharedUtils', () => {
     });
 
     it('parseUrlIndex works with trailing slash', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             expect(
                 sharedUtils.parseUrlIndex(
@@ -40,7 +40,7 @@ describe('GeoAPI SharedUtils', () => {
     });
 
     it('parseUrlIndex no sublayer', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             // Expect the default result
             expect(
@@ -56,7 +56,7 @@ describe('GeoAPI SharedUtils', () => {
     });
 
     it('generateUUID uuid is valid format', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             var i;
             // Test 10 uuids
@@ -72,7 +72,7 @@ describe('GeoAPI SharedUtils', () => {
     });
 
     it('generateUUID no uuid collisions', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             var uuids = [];
             var i;
@@ -82,7 +82,7 @@ describe('GeoAPI SharedUtils', () => {
             for (i = 0; i < 10000; i++) {
                 uuids.push(sharedUtils.generateUUID());
             }
-            let findDuplicates = (arr) =>
+            let findDuplicates = arr =>
                 arr.filter((item, index) => arr.indexOf(item) != index);
             let duplicates = findDuplicates(uuids);
             expect(duplicates).to.be.empty;
@@ -90,12 +90,12 @@ describe('GeoAPI SharedUtils', () => {
     });
 
     it('convertImageToCanvas works with data url', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             const url =
                 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAz5JREFUSInF1luIVVUYwPHfMHIWtSvL4jAHDM0mjkJgD9E8lAn6oPSQmWQTZihEFvbSRSySnqKgF6NezIJAwnroJkRSDxZ0PWIQ2O3UiZgy9zCiBrWzNXI6Payt6Vx0Jo71wYLN2mt//+++1wz/scz434EDAwOdSqXSFeWjo6MajUbPpMBardZpNBpdgZ2qM8/zk9CTwHq93mk2m12FQZ7n+vv7O61Wq+c0YLVaNV1gQJzCuVqtptVqOQ04HenHTYGL8A3ejlMDTxtYx9VYHRjI6MWv5f5nkS9wpBvAOrYEFmf0SOvFgq+wEfdmbMiSl1sKdp3B47MCZ+HBwKKM3QU55uL5mJ4XBPYXHMUy3IPvJG//FfD2EtYoeDmm3PVhMPBG5IXSmwLtwJqMNTgaGToT8Px228bAcbxWxuPxwIqMP6X9xwLv4N3I4sDTgfckQyJGcKhgZcZS3B/5ZDJg7O31cWRtYHNIeVqe8UPB76jiuZiUXoZXIzXcEngosC3yVuRL3IjVGQ/glzgJMLTbjuHZyKrAXbgQM3FACt0NIbXEH8jwQbk/uwzpESmveyOXYknGdTjUbo8HztA2GLgcb0YOBCrYHFM4NwQO4tHIz9K59YFHAs+M8SJiL1ZIxhyeyMOit2J7ZHlgXUgHz8PCwLXKyoupiC7A19gRWYibAz+OaYW5Jfgo/poIOHN01NrA/shWCboMg9ghebk+sAffRxYFloYE3RZTSE/IEunbw0Uy8uLe3vHA3yoV+yJ3B/ZhZ0yj6/qMh9Eq2BT/6a9dkVV4IrA98gpWBu7DvIxjBU+V5xdN5OFxfIifykq9M6RQdKQRtlP6eBbml3mZF7gEt5X5vhWzMz4qUru8bryMa/wWnoxcgyvxLdZl3IFKSDlbKPVmX5aisABXSLndVvBSTBU70XibcNJENMoVIqNYiU1ZaomDRQJ+XvB+ZH5IUdgX+XQS0BmBY+FbYyrzqyTL90aGT3m/e6r/pqkATyjdgz3TUHxWYJ7nQghi7ILWUySEIM/z8cBWq9UzZ86czvDwcNegIQR9fX1O3GdOA8LQ0FBPvV7vVKvVrgBHRkY0m83Jr4nQbDZ7zsXtbVLguZa/AdMNKbe5EEnGAAAAAElFTkSuQmCC';
             cy.wrap(null).then(() => {
-                return sharedUtils.convertImageToCanvas(url).then((canvas) => {
+                return sharedUtils.convertImageToCanvas(url).then(canvas => {
                     expect(canvas.width).to.eq(28);
                     expect(canvas.height).to.eq(28);
                 });
@@ -104,12 +104,12 @@ describe('GeoAPI SharedUtils', () => {
     });
 
     it('convertImageToCanvas works with reqular url', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             const url =
                 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/BadDates/MapServer/0/images/eed7a82bfccb37a9c63f3dd221c02906';
             cy.wrap(null).then(() => {
-                return sharedUtils.convertImageToCanvas(url).then((canvas) => {
+                return sharedUtils.convertImageToCanvas(url).then(canvas => {
                     expect(canvas.width).to.eq(54);
                     expect(canvas.height).to.eq(54);
                 });
@@ -125,12 +125,12 @@ describe('GeoAPI SharedUtils', () => {
     }
 
     it('convertImagetoDataURL works with data url', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             const url =
                 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAAMCAYAAAC9QufkAAAAAXNSR0IB2cksfwAAAAlwSFlzAAAOxAAADsQBlSsOGwAAAUJJREFUKJFjYcADIgwZFq84z1DFwMDwGJs8Cy6NpmrcdtUuAjb6Yk/bKncyxJKimSlKlaFEXZxNgUlfmmnz458Wx669OUGUZl89htRIU04rBgYGBlUxNrkw5Q+Vx64x+BOjmT9MiztCiIdXGCYQaixmuf/u/aiN1xiW4dWcZMhdGWAgZoksJsrDIBqgzR2/8drXtQwMDD9xaVaLNON0YmdhYEc3NMhQwGrnHYa8Fee/dmPVXOAgUmOnwmuKxSsMnGxsPBEGDF4rzjMsZGBgeIWiWZGBwSvVjN2UkRGbVghw1xSzTjF8VTrn/NdSZM2sSZ7cmapibBq4tTIwMDMxsCZac1pvfyWg+/Tp08ssDAwMDBbcDEW6kpx2F598xqeXgYGBgYGNhcHSRvhp78qnDG4sDAwMDCe+MnQGzHvTSVAnGgAAdRJMqBlhLeEAAAAASUVORK5CYII=';
             cy.wrap(null).then(() => {
-                return resolveDataURL(sharedUtils, url).then((dUrl) => {
+                return resolveDataURL(sharedUtils, url).then(dUrl => {
                     expect(dUrl).to.eq(url);
                 });
             });
@@ -159,18 +159,18 @@ describe('GeoAPI SharedUtils', () => {
     // TODO: Add more tests for SharedUtils through adding layers through the wizard
 
     it('formatLatLongDMSString undefined point', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             const xyformat = sharedUtils
                 .formatLatLongDMSString(undefined)
-                .then((xyformat) => {
+                .then(xyformat => {
                     expect(xyformat).to.deep.equal({ lat: '', lon: '' });
                 });
         });
     });
 
     it('formatLatLongDMSString invalid map point latitude coordinate', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             sharedUtils.formatLatLongDMSString(undefined);
             const point = new Point(
@@ -179,14 +179,14 @@ describe('GeoAPI SharedUtils', () => {
                 undefined,
                 true
             );
-            sharedUtils.formatLatLongDMSString(point).then((xyformat) => {
+            sharedUtils.formatLatLongDMSString(point).then(xyformat => {
                 expect(xyformat).to.deep.equal({ lat: '', lon: '' });
             });
         });
     });
 
     it('formatLatLongDMSString invalid map point longitude coordinate', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             sharedUtils.formatLatLongDMSString(undefined);
             const point = new Point(
@@ -195,14 +195,14 @@ describe('GeoAPI SharedUtils', () => {
                 undefined,
                 true
             );
-            sharedUtils.formatLatLongDMSString(point).then((xyformat) => {
+            sharedUtils.formatLatLongDMSString(point).then(xyformat => {
                 expect(xyformat).to.deep.equal({ lat: '', lon: '' });
             });
         });
     });
 
     it('formatLatLongDMSString valid map point', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             const sharedUtils = window.rInstance.geo.utils.shared;
             sharedUtils.formatLatLongDMSString(undefined);
             const point = new Point(
@@ -211,7 +211,7 @@ describe('GeoAPI SharedUtils', () => {
                 new SpatialReference(102100),
                 true
             );
-            sharedUtils.formatLatLongDMSString(point).then((xyformat) => {
+            sharedUtils.formatLatLongDMSString(point).then(xyformat => {
                 expect(xyformat).to.deep.equal({
                     lat: '81° 00\' 00"',
                     lon: '100° 00\' 00"'

--- a/packages/ramp-core/src/geo/utils/attribute.ts
+++ b/packages/ramp-core/src/geo/utils/attribute.ts
@@ -137,7 +137,7 @@ export class AttributeAPI extends APIScope {
 
         // hoist the attributes from the .attributes property
         const attSet: AttributeSet = {
-            features: serverResult.map((aa) => aa.attributes),
+            features: serverResult.map(aa => aa.attributes),
             oidIndex: {}
         };
 

--- a/packages/ramp-core/src/geo/utils/renderer.ts
+++ b/packages/ramp-core/src/geo/utils/renderer.ts
@@ -88,7 +88,7 @@ export class BaseRenderer {
         }
 
         // attempt to find our field, and a data type for it.
-        const f = fields.find((ff) => ff.name === fieldName);
+        const f = fields.find(ff => ff.name === fieldName);
         if (f && f.type && f.type !== 'string') {
             // we found a field, with a type on it, but it's not a string. remove the delimiters
             delim = '';
@@ -107,14 +107,14 @@ export class BaseRenderer {
             // testing an undefined/unused field. return original value.
             return fieldName;
         }
-        let myField = fields.find((f) => f.name === fieldName);
+        let myField = fields.find(f => f.name === fieldName);
         if (myField) {
             // field is valid. donethanks.
             return fieldName;
         } else {
             // do case-insensitive search
             const lowName: string = fieldName.toLowerCase();
-            myField = fields.find((f) => f.name.toLowerCase() === lowName);
+            myField = fields.find(f => f.name.toLowerCase() === lowName);
             if (myField) {
                 // use the field definition casing
                 return myField.name;
@@ -137,7 +137,7 @@ export class BaseRenderer {
         }
 
         const elseClauseGuts = this.symbolUnits
-            .map((pl) => pl.definitionClause)
+            .map(pl => pl.definitionClause)
             .join(' OR ');
 
         return `(NOT (${elseClauseGuts}))`;
@@ -205,7 +205,7 @@ export class UniqueValueRenderer extends BaseRenderer {
             esriRenderer.field2,
             esriRenderer.field3
         ] // extract field names
-            .filter((fn) => fn) // remove any undefined names
+            .filter(fn => fn) // remove any undefined names
             .map((fn: string) => this.cleanFieldName(fn, layerFields)); // correct any mismatched case of field names
 
         const fieldDelims: Array<string> = this.keyFields.map((fn: string) =>

--- a/packages/ramp-core/src/geo/utils/symbology.ts
+++ b/packages/ramp-core/src/geo/utils/symbology.ts
@@ -435,7 +435,7 @@ export class SymbologyAPI extends APIScope {
 
                 // patter fill: horizonal line in a 5x5 px square
                 return draw
-                    .pattern(cellSize, cellSize, (add) =>
+                    .pattern(cellSize, cellSize, add =>
                         add.line(0, cellSize / 2, cellSize, cellSize / 2)
                     )
                     .stroke(symbolStroke);
@@ -449,7 +449,7 @@ export class SymbologyAPI extends APIScope {
 
                 // patter fill: vertical line in a 5x5 px square
                 return draw
-                    .pattern(cellSize, cellSize, (add) =>
+                    .pattern(cellSize, cellSize, add =>
                         add.line(cellSize / 2, 0, cellSize / 2, cellSize)
                     )
                     .stroke(symbolStroke);
@@ -462,7 +462,7 @@ export class SymbologyAPI extends APIScope {
                 const cellSize = 5;
 
                 // patter fill: forward diagonal line in a 5x5 px square; two more diagonal lines offset to cover the corners when the main line is cut off
-                return draw.pattern(cellSize, cellSize, (add) => {
+                return draw.pattern(cellSize, cellSize, add => {
                     add.line(0, 0, cellSize, cellSize).stroke(symbolStroke);
                     add.line(0, 0, cellSize, cellSize)
                         .move(0, cellSize)
@@ -480,7 +480,7 @@ export class SymbologyAPI extends APIScope {
                 const cellSize = 5;
 
                 // patter fill: backward diagonal line in a 5x5 px square; two more diagonal lines offset to cover the corners when the main line is cut off
-                return draw.pattern(cellSize, cellSize, (add) => {
+                return draw.pattern(cellSize, cellSize, add => {
                     add.line(cellSize, 0, 0, cellSize).stroke(symbolStroke);
                     add.line(cellSize, 0, 0, cellSize)
                         .move(cellSize / 2, cellSize / 2)
@@ -495,7 +495,7 @@ export class SymbologyAPI extends APIScope {
                 const cellSize = 5;
 
                 // patter fill: horizonal and vertical lines in a 5x5 px square
-                return draw.pattern(cellSize, cellSize, (add) => {
+                return draw.pattern(cellSize, cellSize, add => {
                     add.line(cellSize / 2, 0, cellSize / 2, cellSize).stroke(
                         symbolStroke
                     );
@@ -512,7 +512,7 @@ export class SymbologyAPI extends APIScope {
                 const cellSize = 7;
 
                 // patter fill: crossing diagonal lines in a 7x7 px square
-                return draw.pattern(cellSize, cellSize, (add) => {
+                return draw.pattern(cellSize, cellSize, add => {
                     add.line(0, 0, cellSize, cellSize).stroke(symbolStroke);
                     add.line(cellSize, 0, 0, cellSize).stroke(symbolStroke);
                 });
@@ -640,7 +640,7 @@ export class SymbologyAPI extends APIScope {
                         const symbolFill = draw.pattern(
                             imageWidth,
                             imageHeight,
-                            (add) =>
+                            add =>
                                 // there was a 4th argument 'true' here before, but maximum 3 are accepted. may need to look into this
                                 add.image(imageUri, imageWidth, imageHeight)
                         );
@@ -805,7 +805,7 @@ export class SymbologyAPI extends APIScope {
             // we don't need to do any key collation.
             // this renderer was created from a server legend, so just do a 1-to-1
             // recreation.
-            finalSymbols = allRendererSUs.map((rsu) => [rsu]);
+            finalSymbols = allRendererSUs.map(rsu => [rsu]);
         } else {
             // collate the symbol units by the label. this collapses complex definitions into a nice looking legend.
             // e.g. a renderer has SU for 'type=X' and 'type=Y', both with label 'Fun Stuff'. This merges the logic into
@@ -814,7 +814,7 @@ export class SymbologyAPI extends APIScope {
             // using Map will preserve the order things were encountered
             const legendCollater = new Map<string, Array<BaseSymbolUnit>>();
 
-            allRendererSUs.forEach((su) => {
+            allRendererSUs.forEach(su => {
                 const lblArray = legendCollater.get(su.label);
                 if (lblArray) {
                     // not the first time we hit this label. add to the list
@@ -826,11 +826,11 @@ export class SymbologyAPI extends APIScope {
 
             // iterate through the unique keys in the collater. process each legend item
             finalSymbols = [];
-            legendCollater.forEach((lblArray) => finalSymbols.push(lblArray));
+            legendCollater.forEach(lblArray => finalSymbols.push(lblArray));
         }
 
         // iterate through the final symbol array. process each legend item
-        return finalSymbols.map((suSet) => {
+        return finalSymbols.map(suSet => {
             const firstSu: BaseSymbolUnit = suSet[0];
             const legendSym: LegendSymbology = {
                 uid: this.$iApi.geo.utils.shared.generateUUID(),
@@ -839,17 +839,17 @@ export class SymbologyAPI extends APIScope {
                     suSet.length === 1
                         ? firstSu.definitionClause
                         : `(${suSet
-                              .map((su) => su.definitionClause)
+                              .map(su => su.definitionClause)
                               .join(' OR ')})`,
                 svgcode: '', // TODO is '' ok? maybe we need white square svg? or some loading icon?
                 visibility: true,
                 lastVisbility: true,
-                drawPromise: this.symbolToSvg(firstSu.symbol).then((svg) => {
+                drawPromise: this.symbolToSvg(firstSu.symbol).then(svg => {
                     // update the legend symbol object
                     legendSym.svgcode = svg;
 
                     // update the renderer symbol units
-                    suSet.forEach((su) => {
+                    suSet.forEach(su => {
                         su.svgCode = svg;
                     });
                 })

--- a/packages/ramp-core/src/store/modules/layer/layer-store.ts
+++ b/packages/ramp-core/src/store/modules/layer/layer-store.ts
@@ -58,7 +58,7 @@ const actions = {
         if (!Array.isArray(layerConfigs)) {
             return;
         }
-        layerConfigs.forEach((lc) => {
+        layerConfigs.forEach(lc => {
             context.commit('ADD_LAYER_CONFIG', lc);
         });
     },
@@ -77,7 +77,7 @@ const actions = {
             return;
         }
 
-        layers.forEach((l) => {
+        layers.forEach(l => {
             context.commit('ADD_LAYER', l);
         });
 
@@ -142,18 +142,16 @@ const mutations = {
     },
     REMOVE_LAYER: (state: LayerState, value: LayerInstance) => {
         // copy to new array so watchers will have a reference to the old value
-        const filteredLayers = state.layers.filter((layer) => {
+        const filteredLayers = state.layers.filter(layer => {
             return layer.id !== value.id || layer.uid !== value.uid;
         });
         state.layers = filteredLayers;
     },
     REMOVE_LAYER_CONFIG: (state: LayerState, layerId: string) => {
         // copy to new array so watchers will have a reference to the old value
-        const filteredLayerConfigs = state.layerConfigs.filter(
-            (layerConfig) => {
-                return layerConfig.id !== layerId;
-            }
-        );
+        const filteredLayerConfigs = state.layerConfigs.filter(layerConfig => {
+            return layerConfig.id !== layerId;
+        });
         state.layerConfigs = filteredLayerConfigs;
     }
 };

--- a/packages/ramp-core/src/store/modules/notification/notification-store.ts
+++ b/packages/ramp-core/src/store/modules/notification/notification-store.ts
@@ -77,7 +77,7 @@ const actions: StoreActions = {
         }
     },
     [NotificationAction.clearAll](context: NotificationContext) {
-        Object.values(context.state.groups).forEach((group) =>
+        Object.values(context.state.groups).forEach(group =>
             context.commit(NotificationMutation.REMOVE_GROUP, group)
         );
 

--- a/packages/ramp-core/src/store/pathify-helper.js
+++ b/packages/ramp-core/src/store/pathify-helper.js
@@ -24,5 +24,5 @@ export function sync(path) {
 }
 
 export function call(path) {
-    return (payload) => computed(store.dispatch(path, payload));
+    return payload => computed(store.dispatch(path, payload));
 }

--- a/packages/ramp-core/tailwind.config.js
+++ b/packages/ramp-core/tailwind.config.js
@@ -184,8 +184,8 @@ module.exports = {
                 const newRules = [];
 
                 // `container` is itself a clone; thanks Tailwind :/
-                container.walkRules((rule) => {
-                    shellSizes.forEach((shellSize) => {
+                container.walkRules(rule => {
+                    shellSizes.forEach(shellSize => {
                         const newRule = rule.clone(); // clone a rule so not to modify the original clone
 
                         // prefix shell size selector to the rule; slice the dot from the rule selector

--- a/packages/ramp-core/tests/e2e/specs/test.js
+++ b/packages/ramp-core/tests/e2e/specs/test.js
@@ -7,14 +7,14 @@ describe('RAMP', () => {
     });
 
     it('has global and instance APIs', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             expect(window.RAMP);
             expect(window.rInstance);
         });
     });
 
     it('loads fixtures', () => {
-        cy.window().then((window) => {
+        cy.window().then(window => {
             expect(window.rInstance.fixture.get('appbar'));
         });
     });

--- a/packages/ramp-core/vue.config.js
+++ b/packages/ramp-core/vue.config.js
@@ -38,12 +38,12 @@ module.exports = {
             minimize: false // to build an unminified production build, uncomment the following
         }
     },
-    chainWebpack: (config) => {
+    chainWebpack: config => {
         config.module
             .rule('vue')
             .use('vue-loader')
             .loader('vue-loader')
-            .tap((options) => {
+            .tap(options => {
                 return {
                     ...options
                 };
@@ -83,33 +83,33 @@ module.exports = {
         ]);
 
         // DEV-specific configuration
-        config.when(process.env.VUE_APP_BUILD_TARGET !== 'lib', (config) => {
+        config.when(process.env.VUE_APP_BUILD_TARGET !== 'lib', config => {
             // modify the default injection point from 'body' to 'head', so it's easier to orchestrate the loading order; only when `serve`ing or `test`ing
             config
                 .plugin('html-index')
-                .tap((args) => [{ ...args[0], inject: 'head' }]);
+                .tap(args => [{ ...args[0], inject: 'head' }]);
             config
                 .plugin('html-test')
-                .tap((args) => [{ ...args[0], inject: 'head' }]);
+                .tap(args => [{ ...args[0], inject: 'head' }]);
             config
                 .plugin('html-wet')
-                .tap((args) => [{ ...args[0], inject: 'head' }]);
+                .tap(args => [{ ...args[0], inject: 'head' }]);
         });
 
         // PROD-specific configuration
-        config.when(process.env.NODE_ENV === 'production', (config) => {
+        config.when(process.env.NODE_ENV === 'production', config => {
             // copy `ramp-starter.js` to `dist` folder when building prod build
             config
                 .plugin('webpack-copy-plugin')
-                .tap((args) => [
+                .tap(args => [
                     [...args[0], { from: 'public/alternate.js', to: '' }]
                 ]);
             config
                 .plugin('webpack-copy-plugin')
-                .tap((args) => [
+                .tap(args => [
                     [...args[0], { from: 'public/ramp-starter.js', to: '' }]
                 ]);
-            config.plugin('webpack-copy-plugin').tap((args) => [
+            config.plugin('webpack-copy-plugin').tap(args => [
                 [
                     ...args[0],
                     {
@@ -120,7 +120,7 @@ module.exports = {
             ]);
             config
                 .plugin('webpack-copy-plugin')
-                .tap((args) => [
+                .tap(args => [
                     [...args[0], { from: 'public/help', to: 'help' }]
                 ]);
         });


### PR DESCRIPTION
Closes #701 

Reverts the prettier v2.0 changes to single-variable arrow functions.

Not really any steps for testing, nothing *should* have broken because of this unless the linting went horribly wrong somehow. Nothing stands out to me after a quick scan of all the changes.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-arrow-parens/host/index.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/702)
<!-- Reviewable:end -->
