### PR TITLE
Fix symbology loading in details fixture

### DIFF
--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -92,6 +92,14 @@ export default defineComponent({
             icon: '' as String
         };
     },
+    watch: {
+        payload(newPayload: any) {
+            let idx: number = newPayload.length === 1 ? 0 : this.resultIndex!;
+            newPayload[idx].loadPromise.then(() => {
+                this.fetchIcon();
+            });
+        }
+    },
     computed: {
         /**
          * Returns the information for a single identify result, given the layer and item offsets.
@@ -135,6 +143,10 @@ export default defineComponent({
     },
     methods: {
         fetchIcon() {
+            if (!this.identifyItem) {
+                return;
+            }
+
             const layerInfo = this.payload[this.resultIndex!];
             const uid = layerInfo.uid;
             const layer: LayerInstance | undefined = this.getLayerByUid(uid);

--- a/packages/ramp-core/src/main.ts
+++ b/packages/ramp-core/src/main.ts
@@ -5,8 +5,8 @@
 // so we need to expose RAMP API on the window manually
 import api from '@/api';
 //@ts-ignore
-// import Vue from 'vue/dist/vue.esm-bundler.js';
-import Vue from 'vue/dist/vue.global.js';
+import Vue from 'vue/dist/vue.esm-bundler.js';
+// import Vue from 'vue/dist/vue.global.js';
 import '@/styles/main.css';
 
 // assign RAMP api to global variable


### PR DESCRIPTION
## Closes #680

## Changes in this PR
- [FIX] Details fixture will now update the displayed symbology correctly when opened via the grid


## Further work/comments/questions
- **Comment:**
    - Note that while trying to replicate this bug locally, I kept running into this error:
   
    ```
    Component provided template option but runtime compilation is not supported in this build of Vue. Configure your bundler to alias "vue" to "vue/dist/vue.esm-bundler.js".
    ``` 
    - Due to this, I reverted the `Vue` import from `vue/dist/vue.global.js` to `vue/dist/vue.esm-bundler.js`
    - We were initially importing from `vue/dist/vue.global.js` in an attempt to get the custom fixtures to load locally, however it didn't work so reverting this change shouldn't really affect anything

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/680/host/index.html)
### Steps to test:

1. Load Demo
2. Open the grid of a layer and then open the details panel
3. Close the grid
4. Repeat step 2. for another layer - the symbology in the details panel should update

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/707)
<!-- Reviewable:end -->
