### PR TITLE
Move export button to appbar

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -65,11 +65,11 @@ let config = {
                         {
                             id: 'CBMT',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -81,11 +81,11 @@ let config = {
                         {
                             id: 'SMR',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -98,11 +98,11 @@ let config = {
                         {
                             id: 'CBME_CBCE_HS_RO_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -115,11 +115,11 @@ let config = {
                         {
                             id: 'CBMT_CBCT_GEOM_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -132,11 +132,11 @@ let config = {
                         {
                             id: 'World_Imagery',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100,
                     attribution: {
                         text: {
@@ -157,11 +157,11 @@ let config = {
                         {
                             id: 'World_Physical_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -174,11 +174,11 @@ let config = {
                         {
                             id: 'World_Shaded_Relief',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -191,11 +191,11 @@ let config = {
                         {
                             id: 'World_Street_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -208,11 +208,11 @@ let config = {
                         {
                             id: 'World_Terrain_Base',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -225,11 +225,11 @@ let config = {
                         {
                             id: 'World_Topo_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 }
             ],
@@ -289,8 +289,7 @@ let config = {
             {
                 id: 'WFSLayer',
                 layerType: 'ogcWfs',
-                url:
-                    'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
                 state: {
                     visibility: true
                 },
@@ -358,7 +357,7 @@ let config = {
                 }
             },
             appbar: {
-                items: ['legend', 'geosearch', 'basemap'],
+                items: ['legend', 'geosearch', 'basemap', 'export-v1'],
                 temporaryButtons: ['details', 'grid']
             },
             details: {
@@ -420,11 +419,11 @@ let config = {
                         {
                             id: 'CBMT',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -436,11 +435,11 @@ let config = {
                         {
                             id: 'SMR',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -453,11 +452,11 @@ let config = {
                         {
                             id: 'CBME_CBCE_HS_RO_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -470,11 +469,11 @@ let config = {
                         {
                             id: 'CBMT_CBCT_GEOM_3978',
                             layerType: 'esriTile',
-                            url:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
                     wkid: 3978
                 },
                 {
@@ -487,11 +486,11 @@ let config = {
                         {
                             id: 'World_Imagery',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100,
                     attribution: {
                         text: {
@@ -512,11 +511,11 @@ let config = {
                         {
                             id: 'World_Physical_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -529,11 +528,11 @@ let config = {
                         {
                             id: 'World_Shaded_Relief',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -546,11 +545,11 @@ let config = {
                         {
                             id: 'World_Street_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -563,11 +562,11 @@ let config = {
                         {
                             id: 'World_Terrain_Base',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 },
                 {
@@ -580,11 +579,11 @@ let config = {
                         {
                             id: 'World_Topo_Map',
                             layerType: 'esriTile',
-                            url:
-                                'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
                         }
                     ],
-                    tileSchemaId: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
                     wkid: 102100
                 }
             ],
@@ -644,8 +643,7 @@ let config = {
             {
                 id: 'WFSLayer',
                 layerType: 'ogcWfs',
-                url:
-                    'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
                 state: {
                     visibility: true
                 },
@@ -713,7 +711,7 @@ let config = {
                 }
             },
             appbar: {
-                items: ['legend', 'geosearch', 'basemap'],
+                items: ['legend', 'geosearch', 'basemap', 'export-v1'],
                 temporaryButtons: ['details', 'grid']
             },
             mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
@@ -767,5 +765,6 @@ function animateToggle() {
     } else {
         rInstance.$vApp.$el.classList.add('animation-enabled');
     }
-    document.getElementById('animate-status').innerText = 'Animate: ' + rInstance.animate;
+    document.getElementById('animate-status').innerText =
+        'Animate: ' + rInstance.animate;
 }

--- a/packages/ramp-core/src/fixtures/appbar/nav-button.vue
+++ b/packages/ramp-core/src/fixtures/appbar/nav-button.vue
@@ -30,25 +30,15 @@
                 </svg>
             </div>
         </template>
+        <!-- TODO: Revisit this when designing the gear icon menu -->
         <a
             href="#"
             class="w-160 inline-flex"
-            @click="exportToggle"
-            :content="$t('navigation.export-v1')"
+            @click="doAThing"
+            content="PLACEHOLDER"
             v-tippy="{ placement: 'right' }"
         >
-            <!-- https://fonts.google.com/icons?selected=Material+Icons:layers&icon.query=export -->
-            <svg
-                class="w-24 h-24 flex-auto"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-            >
-                <path d="M0 0h24v24H0z" fill="none" />
-                <path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z" />
-            </svg>
-            <span class="flex-auto ml-8">
-                {{ $t('map.export') }}
-            </span>
+            <span class="flex-auto ml-8 text-gray-500"> PLACEHOLDER </span>
         </a>
     </dropdown-menu>
 </template>
@@ -59,8 +49,9 @@ import { defineComponent } from 'vue';
 export default defineComponent({
     name: 'NavAppbarButtonV',
     methods: {
-        exportToggle() {
-            this.$iApi.panel.toggle('export-v1-panel');
+        // TODO: Revisit this when designing the gear icon menu
+        doAThing() {
+            console.log('PLACEHOLDER BUTTON CLICKED');
         }
     }
 });


### PR DESCRIPTION
## Closes #673

## Changes in this PR
- Move export button to appbar
- Replace export button in `nav-button` menu with a placeholder

## Further work/comments/questions
- **Comment:**
    - Note that most of the changes are prettier formats on `ramp-starter.js`
        - I ran `rush lint:check` after the formatting and it seems to be okay with the new format
        - I also cross checked this with @RyanCoulsonCA and it seems that this is the format defined by RAMP's `prettierrc`

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/673-fix/host/index.html)
### Steps to test
Nothing to test. Since the export button is no longer a part of the `nav-button` menu, this bug does not occur anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/708)
<!-- Reviewable:end -->
