### PR TITLE
Esri 4.21 lib update

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   ../../packages/ramp-core:
     specifiers:
-      '@arcgis/core': 4.19.3
+      '@arcgis/core': 4.21.2
       '@braid/vue-formulate': ~2.5.2
       '@popperjs/core': ~2.9.2
       '@tailwindcss/forms': ^0.2.1
@@ -93,7 +93,7 @@ importers:
       webpack-dev-server: 3.9.0
       wrapper-webpack-plugin: 2.1.0
     dependencies:
-      '@arcgis/core': 4.19.3
+      '@arcgis/core': 4.21.2
       '@braid/vue-formulate': 2.5.2
       '@popperjs/core': 2.9.2
       '@vueform/toggle': 2.0.0
@@ -126,7 +126,7 @@ importers:
       vue-loader: 16.8.1_webpack@4.41.3
       vue-property-decorator: 10.0.0-rc.3_02f8eea4846df4e4acf82e1a0ada6ce8
       vue-slider-component: 4.0.0-beta.4_02f8eea4846df4e4acf82e1a0ada6ce8
-      vue-tippy: 6.0.0-alpha.32_vue@3.1.5
+      vue-tippy: 6.0.0-alpha.33_vue@3.1.5
       vuex: 4.0.2_vue@3.1.5
       vuex-pathify: 1.4.5_vue@3.1.5+vuex@4.0.2
       webpack: 4.41.3
@@ -240,15 +240,21 @@ importers:
 
 packages:
 
-  /@arcgis/core/4.19.3:
-    resolution: {integrity: sha512-dDNpp8fG09ZkyKlDcJmDaVRQHSRyw7hoOA8WvdmjZ8uRyppmPYrIgbFc/+Dd4RXsZFxClwu0qOzO46+jl24NWg==}
+  /@a11y/focus-trap/1.0.5:
+    resolution: {integrity: sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==}
+    dev: false
+
+  /@arcgis/core/4.21.2:
+    resolution: {integrity: sha512-L3Rc84wOFsMcljrydVKc1jkgYQSO+ru4Kgr7tCsK+YLVGWNeggLRh2XeGNIuXOEklaMxdWIBZ+Kw9424K+JQyw==}
     dependencies:
-      '@esri/arcgis-html-sanitizer': 2.5.0
-      '@esri/calcite-colors': 5.0.0
-      '@popperjs/core': 2.6.0
-      focus-trap: 6.3.0
+      '@esri/arcgis-html-sanitizer': 2.7.0
+      '@esri/calcite-colors': 6.0.1
+      '@esri/calcite-components': 1.0.0-beta.62
+      '@popperjs/core': 2.9.3
+      focus-trap: 6.6.1
+      luxon: 2.0.2
       moment: 2.29.1
-      sortablejs: 1.13.0
+      sortablejs: 1.14.0
     dev: false
 
   /@babel/code-frame/7.12.13:
@@ -1384,15 +1390,27 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@esri/arcgis-html-sanitizer/2.5.0:
-    resolution: {integrity: sha512-axq4dGwm3bjY/iR1DoPxrnJOt2SKXD0Cy1QYihK4yZx25CEDpfdSUBE71oz77BSYFz+KQZvh6A3xxOgLnVEoWA==}
+  /@esri/arcgis-html-sanitizer/2.7.0:
+    resolution: {integrity: sha512-T3D2Gn5n7Wsu3YmsPtw9F2HmxI2McebkYHOAo9D7HF6bHBcca0GpBsDaRgYTmQ68ABOsAIIvbFfBY6aDyyHYbw==}
     dependencies:
       lodash.isplainobject: 4.0.6
-      xss: 1.0.8
+      xss: 1.0.10
     dev: false
 
-  /@esri/calcite-colors/5.0.0:
-    resolution: {integrity: sha512-8+coTzRjHQkk/T7UTvX4bTpseyiL41lKzAfVC11b4C3ORKrIOI+uhJFssBb0rGl7N40Epuzxto/2HY8xs4pLsA==}
+  /@esri/calcite-colors/6.0.1:
+    resolution: {integrity: sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw==}
+    dev: false
+
+  /@esri/calcite-components/1.0.0-beta.62:
+    resolution: {integrity: sha512-GCDIX6TKgjAc3MZ/nKZIheCEH2a1vsM+B1cldczEXgOqGeGP+sOgGuJRV6PzbpoYnvAvklsGpXjgVKNnkacIFw==}
+    dependencies:
+      '@a11y/focus-trap': 1.0.5
+      '@popperjs/core': 2.9.3
+      '@stencil/core': 2.6.0
+      '@types/color': 3.0.2
+      color: 4.0.1
+      lodash-es: 4.17.21
+      sortablejs: 1.14.0
     dev: false
 
   /@fullhuman/postcss-purgecss/3.1.3:
@@ -1708,12 +1726,12 @@ packages:
       fastq: 1.11.0
     dev: true
 
-  /@popperjs/core/2.6.0:
-    resolution: {integrity: sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==}
-    dev: false
-
   /@popperjs/core/2.9.2:
     resolution: {integrity: sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==}
+    dev: false
+
+  /@popperjs/core/2.9.3:
+    resolution: {integrity: sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ==}
     dev: false
 
   /@samverschueren/stream-to-observable/0.3.1_rxjs@6.6.7:
@@ -1767,6 +1785,12 @@ packages:
   /@soda/get-current-script/1.0.2:
     resolution: {integrity: sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==}
     dev: true
+
+  /@stencil/core/2.6.0:
+    resolution: {integrity: sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==}
+    engines: {node: '>=12.10.0', npm: '>=6.0.0'}
+    hasBin: true
+    dev: false
 
   /@szmarczak/http-timer/1.1.2:
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
@@ -1864,6 +1888,22 @@ packages:
   /@types/clone-deep/4.0.1:
     resolution: {integrity: sha512-bdkCSkyVHsgl3Goe1y16T9k6JuQx7SiDREkq728QjKmTZkGJZuS8R3gGcnGzVuGBP0mssKrzM/GlMOQxtip9cg==}
     dev: true
+
+  /@types/color-convert/2.0.0:
+    resolution: {integrity: sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==}
+    dependencies:
+      '@types/color-name': 1.1.1
+    dev: false
+
+  /@types/color-name/1.1.1:
+    resolution: {integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==}
+    dev: false
+
+  /@types/color/3.0.2:
+    resolution: {integrity: sha512-INiJl6sfNn8iyC5paxVzqiVUEj2boIlFki02uRTAkKwAj++7aAF+ZfEv/XrIeBa0XI/fTZuDHW8rEEcEVnON+Q==}
+    dependencies:
+      '@types/color-convert': 2.0.0
+    dev: false
 
   /@types/connect-history-api-fallback/1.3.4:
     resolution: {integrity: sha512-Kf8v0wljR5GSCOCF/VQWdV3ZhKOVA73drXtY3geMTQgHy9dgqQ0dLrf31M0hcuWkhFzK5sP0kkS3mJzcKVtZbw==}
@@ -4540,12 +4580,26 @@ packages:
       simple-swizzle: 0.2.2
     dev: true
 
+  /color-string/1.6.0:
+    resolution: {integrity: sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==}
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.2
+    dev: false
+
   /color/3.1.3:
     resolution: {integrity: sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==}
     dependencies:
       color-convert: 1.9.3
       color-string: 1.5.5
     dev: true
+
+  /color/4.0.1:
+    resolution: {integrity: sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==}
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.6.0
+    dev: false
 
   /colorette/1.2.2:
     resolution: {integrity: sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==}
@@ -6704,10 +6758,10 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.7
 
-  /focus-trap/6.3.0:
-    resolution: {integrity: sha512-BBzvFfkPg5PqrVVCdQ1YOIVNKGvqG9YNVkiAUQFuDM66N8J9uADhs6mlYKrd30ofDJIzEniBnBKM7GO45iCzKQ==}
+  /focus-trap/6.6.1:
+    resolution: {integrity: sha512-x9BWuAeF5UrfWuYKJ3jYrjcVYSYptS9CqtxH5IH7lPlZrMsaugKeAa0HtoZSBZe5DmeTMx2m0qY464ZMzqarzw==}
     dependencies:
-      tabbable: 5.2.0
+      tabbable: 5.2.1
     dev: false
 
   /follow-redirects/1.14.0:
@@ -7852,7 +7906,6 @@ packages:
 
   /is-arrayish/0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
-    dev: true
 
   /is-bigint/1.0.1:
     resolution: {integrity: sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg==}
@@ -9629,6 +9682,10 @@ packages:
       p-locate: 4.1.0
     dev: true
 
+  /lodash-es/4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+    dev: false
+
   /lodash._reinterpolate/3.0.0:
     resolution: {integrity: sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=}
     dev: true
@@ -9800,6 +9857,10 @@ packages:
   /lunr/2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
     dev: true
+
+  /luxon/2.0.2:
+    resolution: {integrity: sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==}
+    dev: false
 
   /magic-string/0.25.7:
     resolution: {integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==}
@@ -12836,7 +12897,6 @@ packages:
     resolution: {integrity: sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=}
     dependencies:
       is-arrayish: 0.3.2
-    dev: true
 
   /sisteransi/0.1.1:
     resolution: {integrity: sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==}
@@ -12973,8 +13033,8 @@ packages:
       is-plain-obj: 1.1.0
     dev: true
 
-  /sortablejs/1.13.0:
-    resolution: {integrity: sha512-RBJirPY0spWCrU5yCmWM1eFs/XgX2J5c6b275/YyxFRgnzPhKl/TDeU2hNR8Dt7ITq66NRPM4UlOt+e5O4CFHg==}
+  /sortablejs/1.14.0:
+    resolution: {integrity: sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==}
     dev: false
 
   /source-list-map/2.0.1:
@@ -13421,8 +13481,8 @@ packages:
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  /tabbable/5.2.0:
-    resolution: {integrity: sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==}
+  /tabbable/5.2.1:
+    resolution: {integrity: sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==}
     dev: false
 
   /table/5.4.6:
@@ -14490,8 +14550,8 @@ packages:
     resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}
     dev: true
 
-  /vue-tippy/6.0.0-alpha.32_vue@3.1.5:
-    resolution: {integrity: sha512-nU8d39ElTuFVp6W0oWfqb6JdQdNEYTSBIBSHX9FZRH/fJTSF2AcqVlwwHyNY1QCLQAbhNRZgf/k11xt8GdMaZg==}
+  /vue-tippy/6.0.0-alpha.33_vue@3.1.5:
+    resolution: {integrity: sha512-AiotSphbFBUYVg4e4DrZeV7JVADyWycxyGXqr9ix6gS8WkJIqLlnsZ5OWvc5M1uivxsKOzZ7FkBZnOBTwKkJgw==}
     peerDependencies:
       vue: ^3.0.0
     dependencies:
@@ -15130,8 +15190,8 @@ packages:
   /xmlchars/2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  /xss/1.0.8:
-    resolution: {integrity: sha512-3MgPdaXV8rfQ/pNn16Eio6VXYPTkqwa0vc7GkiymmY/DqR1SE/7VPAAVZz1GJsJFrllMYO3RHfEaiUGjab6TNw==}
+  /xss/1.0.10:
+    resolution: {integrity: sha512-qmoqrRksmzqSKvgqzN0055UFWY7OKx1/9JWeRswwEVX9fCG5jcYRxa/A2DHcmZX6VJvjzHRQ2STeeVcQkrmLSw==}
     engines: {node: '>= 0.10.0'}
     hasBin: true
     dependencies:

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -13,7 +13,7 @@
         "host": "http-server . -p 3001"
     },
     "dependencies": {
-        "@arcgis/core": "4.19.3",
+        "@arcgis/core": "4.21.2",
         "@braid/vue-formulate": "~2.5.2",
         "@popperjs/core": "~2.9.2",
         "@vueform/toggle": "2.0.0",

--- a/packages/ramp-core/src/geo/api/graphic/geometry/geometry.ts
+++ b/packages/ramp-core/src/geo/api/graphic/geometry/geometry.ts
@@ -35,7 +35,7 @@ import {
     EsriSimpleMarkerSymbol,
     EsriSpatialReference,
     EsriSymbol,
-    EsriSymbolJsonUtils
+    EsriSymbolFromJson
 } from '@/geo/esri';
 import { PointStyle } from '../../geo-defs';
 
@@ -67,12 +67,12 @@ export class GeometryAPI {
     /**
      * Convert an ESRI map click event object to a generic RAMPish map click event object
      *
-     * @param {MapViewClickEvent | MapViewDoubleClickEvent} esriMapClick an event param from an esri 2D map click or double-click event
+     * @param {ViewClickEvent | ViewDoubleClickEvent} esriMapClick an event param from an esri 2D map click or double-click event
      * @param {String | Number} [id] optional id for the map point geometry on the result
      * @returns {MapClick} a generic bundle of data matching a subset of the incoming esri data
      */
     esriMapClickToRamp(
-        esriMapClick: __esri.MapViewClickEvent | __esri.MapViewDoubleClickEvent,
+        esriMapClick: __esri.ViewClickEvent | __esri.ViewDoubleClickEvent,
         id?: number | string
     ): MapClick {
         return {
@@ -87,10 +87,10 @@ export class GeometryAPI {
     /**
      * Convert an ESRI map click event object to a generic RAMPish map click event object
      *
-     * @param {MapViewPointerMoveEvent} esriMapMove an event param from an esri 2D map click or double-click event
+     * @param {ViewPointerMoveEvent} esriMapMove an event param from an esri 2D map click or double-click event
      * @returns {MapMove} a generic bundle of data matching a subset of the incoming esri data
      */
-    esriMapMouseToRamp(esriMapMove: __esri.MapViewPointerMoveEvent): MapMove {
+    esriMapMouseToRamp(esriMapMove: __esri.ViewPointerMoveEvent): MapMove {
         return {
             screenX: esriMapMove.x,
             screenY: esriMapMove.y,
@@ -829,9 +829,7 @@ export class GeometryAPI {
                     style: 'esriSLSSolid'
                 }
             };
-            symbol = EsriSymbolJsonUtils.fromJSON(
-                options
-            ) as EsriSimpleMarkerSymbol;
+            symbol = EsriSymbolFromJson(options) as EsriSimpleMarkerSymbol;
         }
 
         return symbol;
@@ -852,7 +850,7 @@ export class GeometryAPI {
                 style: 'esriSLSSolid'
             }
         };
-        return EsriSymbolJsonUtils.fromJSON(symbol) as EsriSimpleLineSymbol;
+        return EsriSymbolFromJson(symbol) as EsriSimpleLineSymbol;
     }
 
     _convRampPolygonStyleToEsri(

--- a/packages/ramp-core/src/geo/esri.ts
+++ b/packages/ramp-core/src/geo/esri.ts
@@ -13,7 +13,7 @@ import EsriPoint from '@arcgis/core/geometry/Point';
 import EsriPolygon from '@arcgis/core/geometry/Polygon';
 import EsriPolyline from '@arcgis/core/geometry/Polyline';
 import EsriSpatialReference from '@arcgis/core/geometry/SpatialReference';
-import * as EsriGeometryJsonUtils from '@arcgis/core/geometry/support/jsonUtils';
+import { fromJSON as EsriGeometryFromJson } from '@arcgis/core/geometry/support/jsonUtils';
 import EsriGraphic from '@arcgis/core/Graphic';
 import EsriFeatureLayer from '@arcgis/core/layers/FeatureLayer';
 import EsriGraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
@@ -32,24 +32,24 @@ import EsriRenderer from '@arcgis/core/renderers/Renderer';
 import EsriSimpleRenderer from '@arcgis/core/renderers/SimpleRenderer';
 import EsriUniqueValueRenderer from '@arcgis/core/renderers/UniqueValueRenderer';
 import EsriClassBreakInfo from '@arcgis/core/renderers/support/ClassBreakInfo';
-import * as EsriRendererUtils from '@arcgis/core/renderers/support/jsonUtils';
+import { fromJSON as EsriRendererFromJson } from '@arcgis/core/renderers/support/jsonUtils';
 import EsriUniqueValueInfo from '@arcgis/core/renderers/support/UniqueValueInfo';
 import EsriRequest from '@arcgis/core/request';
+// import EsriIdentify from '@arcgis/core/rest/identify';
+// import EsriPrint from '@arcgis/core/rest/print';
+import { executeForIds as EsriQueryByIds } from '@arcgis/core/rest/query';
+// import EsriIdentifyParameters from '@arcgis/core/rest/support/IdentifyParameters';
+// import EsriPrintParameters from '@arcgis/core/rest/support/PrintParameters';
+// import EsriPrintTemplate from '@arcgis/core/rest/support/PrintTemplate';
+// import EsriProjectParameters from '@arcgis/core/rest/support/ProjectParameters';
+import EsriQuery from '@arcgis/core/rest/support/Query';
 import EsriPictureMarkerSymbol from '@arcgis/core/symbols/PictureMarkerSymbol';
 import EsriSimpleFillSymbol from '@arcgis/core/symbols/SimpleFillSymbol';
 import EsriSimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import EsriSimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
 import EsriSymbol from '@arcgis/core/symbols/Symbol';
-import * as EsriSymbolJsonUtils from '@arcgis/core/symbols/support/jsonUtils';
+import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jsonUtils';
 import EsriGeometryService from '@arcgis/core/tasks/GeometryService';
-import EsriIdentifyTask from '@arcgis/core/tasks/IdentifyTask';
-import EsriPrintTask from '@arcgis/core/tasks/PrintTask';
-import EsriQueryTask from '@arcgis/core/tasks/QueryTask';
-import EsriIdentifyParameters from '@arcgis/core/tasks/support/IdentifyParameters';
-import EsriPrintParameters from '@arcgis/core/tasks/support/PrintParameters';
-import EsriPrintTemplate from '@arcgis/core/tasks/support/PrintTemplate';
-import EsriProjectParameters from '@arcgis/core/tasks/support/ProjectParameters';
-import EsriQuery from '@arcgis/core/tasks/support/Query';
 import EsriFeatureFilter from '@arcgis/core/views/layers/support/FeatureFilter';
 import EsriMapView from '@arcgis/core/views/MapView';
 import EsriBasemapGallery from '@arcgis/core/widgets/BasemapGallery';
@@ -66,12 +66,12 @@ export {
     EsriFeatureFilter,
     EsriFeatureLayer,
     EsriField,
-    EsriGeometryJsonUtils,
+    EsriGeometryFromJson,
     EsriGeometryService,
     EsriGraphic,
     EsriGraphicsLayer,
-    EsriIdentifyParameters,
-    EsriIdentifyTask,
+    // EsriIdentifyParameters,
+    // EsriIdentify,
     EsriImageParameters,
     EsriImageryLayer,
     EsriLOD,
@@ -80,17 +80,17 @@ export {
     EsriMapView,
     EsriMultipoint,
     EsriPictureMarkerSymbol,
-    EsriPrintParameters,
-    EsriPrintTask,
-    EsriPrintTemplate,
-    EsriProjectParameters,
+    // EsriPrintParameters,
+    // EsriPrint,
+    // EsriPrintTemplate,
+    // EsriProjectParameters,
     EsriPoint,
     EsriPolygon,
     EsriPolyline,
     EsriQuery,
-    EsriQueryTask,
+    EsriQueryByIds,
     EsriRenderer,
-    EsriRendererUtils,
+    EsriRendererFromJson,
     EsriRequest,
     EsriScaleBar,
     EsriSimpleFillSymbol,
@@ -100,7 +100,7 @@ export {
     EsriSpatialReference,
     EsriSymbol,
     EsriSublayer,
-    EsriSymbolJsonUtils,
+    EsriSymbolFromJson,
     EsriTileLayer,
     EsriUniqueValueInfo,
     EsriUniqueValueRenderer,

--- a/packages/ramp-core/src/geo/layer/attrib-fc.ts
+++ b/packages/ramp-core/src/geo/layer/attrib-fc.ts
@@ -33,7 +33,7 @@ import {
 import {
     EsriExtent,
     EsriField,
-    EsriRendererUtils,
+    EsriRendererFromJson,
     EsriRequest
 } from '@/geo/esri';
 import deepmerge from 'deepmerge';
@@ -163,7 +163,7 @@ export class AttribFC extends CommonFC {
                     : sData.drawingInfo.renderer;
             this.renderer =
                 this.parentLayer.$iApi.geo.utils.symbology.makeRenderer(
-                    EsriRendererUtils.fromJSON(sourceRenderer),
+                    EsriRendererFromJson(sourceRenderer),
                     this.fields
                 );
 

--- a/packages/ramp-core/src/geo/map/overview-map.ts
+++ b/packages/ramp-core/src/geo/map/overview-map.ts
@@ -119,10 +119,10 @@ export class OverviewMapAPI extends CommonMapAPI {
     /**
      * Moves graphic and zooms main map if extent graphic is dragged
      *
-     * @param {__esri.MapViewDragEvent} esriDrag
+     * @param {__esri.ViewDragEvent} esriDrag
      * @private
      */
-    private async mapDrag(esriDrag: __esri.MapViewDragEvent) {
+    private async mapDrag(esriDrag: __esri.ViewDragEvent) {
         if (esriDrag.action === 'start') {
             // check if drag hits graphic, if so set start extent
             if (await this.cursorHitTest(esriDrag)) {

--- a/packages/ramp-core/src/geo/utils/attribute.ts
+++ b/packages/ramp-core/src/geo/utils/attribute.ts
@@ -10,7 +10,7 @@ import {
     GetGraphicResult,
     GetGraphicServiceDetails
 } from '@/geo/api';
-import { EsriGeometryJsonUtils, EsriRequest } from '@/geo/esri';
+import { EsriGeometryFromJson, EsriRequest } from '@/geo/esri';
 import to from 'await-to-js';
 import { toRaw } from 'vue';
 
@@ -244,9 +244,7 @@ export class AttributeAPI extends APIScope {
                 // server result omits spatial reference
                 feat.geometry.spatialReference =
                     serviceResult.data.spatialReference;
-                const localEsriGeom = EsriGeometryJsonUtils.fromJSON(
-                    feat.geometry
-                );
+                const localEsriGeom = EsriGeometryFromJson(feat.geometry);
                 result.geometry =
                     this.$iApi.geo.utils.geom.geomEsriToRamp(localEsriGeom);
             }

--- a/packages/ramp-core/src/geo/utils/query.ts
+++ b/packages/ramp-core/src/geo/utils/query.ts
@@ -12,7 +12,7 @@ import {
     QueryFeaturesParams,
     SpatialReference
 } from '@/geo/api';
-import { EsriQuery, EsriQueryTask } from '@/geo/esri';
+import { EsriQuery, EsriQueryByIds } from '@/geo/esri';
 
 // this exists here instead of our main definitions file because it uses `FileLayer` type.
 // the layer inherits from APIScope, causing circular references in the public folder
@@ -52,9 +52,7 @@ export class QueryAPI extends APIScope {
             query.spatialRelationship = 'intersects';
         }
 
-        const queryTask = new EsriQueryTask({ url: options.url });
-
-        const oids = await queryTask.executeForIds(query);
+        const oids = await EsriQueryByIds(options.url, query);
         return Array.isArray(oids) ? oids : [];
     }
 

--- a/packages/ramp-core/src/geo/utils/symbology.ts
+++ b/packages/ramp-core/src/geo/utils/symbology.ts
@@ -8,7 +8,7 @@ import {
     UniqueValueRenderer
 } from '@/api/internal';
 import { Attributes, LegendSymbology, LineStyle } from '@/geo/api';
-import { EsriRendererUtils, EsriRequest } from '@/geo/esri';
+import { EsriRendererFromJson, EsriRequest } from '@/geo/esri';
 import svgjs from 'svg.js';
 import to from 'await-to-js';
 
@@ -935,11 +935,7 @@ export class SymbologyAPI extends APIScope {
             };
 
             // ok to pass empty array. this renderer will only be used to generate a legend; no symbol lookups
-            return this.makeRenderer(
-                EsriRendererUtils.fromJSON(renderer),
-                [],
-                true
-            );
+            return this.makeRenderer(EsriRendererFromJson(renderer), [], true);
         } else {
             // TODO does this case ever exist? need to figure out a way to encode this in our official renderer objects
             // renderer = { type: this.NONE };
@@ -987,11 +983,7 @@ export class SymbologyAPI extends APIScope {
             uniqueValueInfos: [].concat(...layerRenders)
         };
 
-        return this.makeRenderer(
-            EsriRendererUtils.fromJSON(fullRenderer),
-            [],
-            true
-        );
+        return this.makeRenderer(EsriRendererFromJson(fullRenderer), [], true);
     }
 
     /**


### PR DESCRIPTION
Donethankses #651 

Updates ESRI JS API from v4.19 to v4.21, skipping the sketchy v4.20 🌳 

[Demo party](http://ramp4-app.azureedge.net/demo/users/james-rae/esri421/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/709)
<!-- Reviewable:end -->
