### PR TITLE
Fix date picker input being cut off in some situations

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
@@ -170,8 +170,14 @@ export default interface GridCustomDateFilter {
 .rv-input {
     @apply m-0 py-1;
 }
+</style>
+<style lang="scss">
 .rv-input[type='date']::-webkit-inner-spin-button {
     -webkit-appearance: none;
     display: none;
+}
+
+.rv-input[type='date']::-webkit-calendar-picker-indicator {
+    margin: 0;
 }
 </style>


### PR DESCRIPTION
Closes #463 

I removed the margin on the little calendar symbol in chrome as it was able to cover the end of the date input. I was only able to get the date cut off before that by setting my font to Very Large in chrome and changing my date format to the one James had the issue with.

[Demo](http://ramp4-app.azureedge.net/demo/users/spencerwahl/date-picker-overflow/host/index.html)

Layer with date fields:
https://maps-cartes.ec.gc.ca/arcgis/rest/services/Shellfish_Classification_Mollusques/MapServer/6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/710)
<!-- Reviewable:end -->
