### PR TITLE
add centered prop to dropdown menu component

### DIFF
--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -25,9 +25,9 @@
                 py-8
                 bg-white
                 rounded
-                text-center
                 z-10
             "
+            :class="{ 'text-center': centered }"
             ref="dropdown"
         >
             <slot v-bind:close="closeDropdown"></slot>
@@ -49,7 +49,8 @@ export default defineComponent({
         tooltip: { type: String },
         tooltipPlacement: { type: String, default: 'bottom' },
         tooltipTheme: { type: String, default: 'ramp4' },
-        tooltipAnimation: { type: String, default: 'scale' }
+        tooltipAnimation: { type: String, default: 'scale' },
+        centered: { type: Boolean, default: true }
     },
     data() {
         return {

--- a/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
+++ b/packages/ramp-core/src/fixtures/grid/column-dropdown.vue
@@ -4,6 +4,7 @@
         position="bottom-end"
         :tooltip="$t('grid.label.columns')"
         :tooltip-placement="'bottom'"
+        :centered="false"
     >
         <template #header>
             <div class="flex text-black p-8">


### PR DESCRIPTION
Closes #687 

This PR adds a new prop to the dropdown menu component that determines whether the menu options are centered within the container. The default setting for this prop is `true`.

This is the best way I can see fixing #687 without just removing the `text-center` class (since I'm assuming that we want to allow the menu items to be centered? If not, I can just remove the class instead). If anyone has any better recommendations to fix this let me know!


**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-687/host/index-e2e.html?script=grid).

If you open the `carbon monoxide` grid and open the `hide columns` menu, the `carbon monoxide emissions` option will no longer be centered. All other dropdown menus in the app should still have their options centered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/711)
<!-- Reviewable:end -->
