### PR TITLE
Fix visibility set rules + updating visibility on layer removal

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -19,7 +19,6 @@ import { RampConfig } from '@/types';
 import { debounce, throttle } from 'throttle-debounce';
 import { MapCaptionStore } from '@/store/modules/map-caption';
 import { LayerStore } from '@/store/modules/layer';
-import { reactive } from 'vue';
 
 export enum GlobalEvents {
     /**

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -62,7 +62,6 @@ import PanelStackV from '@/components/panel-stack/panel-stack.vue';
 import MapCaptionV from '@/components/map/map-caption.vue';
 import NotificationsFloatingButtonV from '@/components/notification-center/floating-button.vue';
 import KeyboardInstructionsModalV from './keyboard-instructions.vue';
-import { Get } from 'vuex-pathify';
 import { get } from '@/store/pathify-helper';
 import { FixtureInstance } from '@/api';
 import { GlobalEvents } from '@/api';

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -1,5 +1,4 @@
 import { FixtureInstance, LayerInstance } from '@/api';
-import { TreeNode } from '@/geo/api';
 import { LegendConfig, LegendStore } from '../store';
 import {
     LegendItem,
@@ -64,25 +63,7 @@ export class LegendAPI extends FixtureInstance {
                     legendGroup = new LegendGroup(lastEntry, lastEntry.parent);
                 }
                 legendEntries.push(legendGroup);
-
-                // NOTE: the below code is if storing nested legend items is necessary, alternative method is to just store top-level legend items and perform traversals, there are pros and cons for each method
-                // if (lastEntry?.children !== undefined && lastEntry.children.length > 0) {
-                //     // push all children in current legend node back onto stack (for legend groups)
-                //     lastEntry?.children.forEach((groupChild: any) => {
-                //         groupChild.parent = legendGroup;
-                //         stack.push(groupChild);
-                //     });
-                // } else {
-                //     // push all children in current legend node back onto stack (for visibility sets)
-                //     lastEntry?.exclusiveVisibility.forEach((setChild: any) => {
-                //         setChild.parent = legendGroup;
-                //         stack.push(setChild);
-                //     });
-                // }
-            } else if (
-                lastEntry.layerId !== undefined &&
-                layers !== undefined
-            ) {
+            } else if (lastEntry.layerId !== undefined) {
                 // create a wrapper legend object for single legend entry
                 const legendEntry = new LegendEntry(
                     lastEntry,
@@ -92,7 +73,6 @@ export class LegendAPI extends FixtureInstance {
             }
         }
 
-        // console.log('all legend entries: ', legendEntries);
         this.$vApp.$store.set(LegendStore.children, legendEntries);
         // TODO: validate legend items?
     }

--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -59,7 +59,6 @@ export default defineComponent({
         toggleVisibility(): void {
             if (this.value instanceof LegendItem) {
                 // Toggle parent symbology checkbox
-
                 this.legendItem.toggleVisibility();
             } else {
                 // Toggle child symbology checkbox

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -171,15 +171,13 @@ export default defineComponent({
         'symbology-stack': LegendSymbologyStackV,
         options: LegendOptionsV
     },
-    // setup(props) {
-    //     const visibility = ref(props.legendItem.visibility);
-    //     return { visibility };
-    // },
+
     data() {
         return {
             symbologyStack: [] as Array<LegendSymbology>
         };
     },
+
     computed: {
         /**
          * Get the type of layer
@@ -202,6 +200,7 @@ export default defineComponent({
             return this.$iApi.animate === 'on';
         }
     },
+
     mounted() {
         this.symbologyStack = [];
 
@@ -214,9 +213,7 @@ export default defineComponent({
             return;
         }
 
-        if (this.legendItem!.parent instanceof LegendGroup) {
-            this.legendItem!.parent.checkVisibility(this.legendItem!);
-        }
+        this.legendItem.checkVisibilityRules();
 
         Promise.all(
             this._getLegend().map((item: LegendSymbology) => item.drawPromise)
@@ -224,6 +221,7 @@ export default defineComponent({
             this.symbologyStack = this._getLegend();
         });
     },
+
     methods: {
         /**
          * Display symbology stack for the layer.

--- a/packages/ramp-core/src/fixtures/legend/components/group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/group.vue
@@ -85,8 +85,13 @@ export default defineComponent({
         LegendComponent: defineAsyncComponent(() => import('./component.vue')),
         checkbox: LegendCheckboxV
     },
+
     data() {
         return { LegendTypes: LegendTypes };
+    },
+
+    mounted() {
+        this.legendItem.checkVisibilityRules();
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -207,6 +207,7 @@ export default defineComponent({
                         this.legendItem!._layerIndex
                     );
                 } else {
+                    this.legendItem!.toggleVisibility(false);
                     this.$iApi.geo.map.removeLayer(this.legendItem!.layerUID!);
                 }
             }

--- a/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
@@ -52,6 +52,7 @@
 
                 <!-- visibility -->
                 <checkbox
+                    :checked="legendItem.visibility"
                     :value="legendItem"
                     :isRadio="
                         legendItem.parent &&
@@ -87,8 +88,13 @@ export default defineComponent({
         LegendComponent: defineAsyncComponent(() => import('./component.vue')),
         checkbox: LegendCheckboxV
     },
+
     data() {
         return { LegendTypes: LegendTypes };
+    },
+
+    mounted() {
+        this.legendItem.checkVisibilityRules();
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -31,6 +31,7 @@ class LegendFixture extends LegendAPI {
 
         // parse legend section of config and store information in legend store
         this._parseConfig(this.config);
+
         this.$vApp.$watch(
             () => this.config,
             (value: any) => this._parseConfig(value)


### PR DESCRIPTION
Closes #588, #686

Modified visibility logic relevant to visibility sets to ensure rules are respected in all cases, particularly on initial app startup. This should be revisited and tested when more complex legend structures such as nested visibility sets config samples are made. Removed some unnecessary code and comments that was redundant in the visibility chain logic. Re-added `:checked` property for visibility set component and added a `toggleVisibility(false)` call to deal with updating group visibility on layer removal.

**Testing**: 
- no longer more than one entry being visible in a set when app loads or any other case
- visibility set checkbox displays 
- deleting a layer entry in a group updates the group visibility if it is the only entry toggled on
- other different visibility set cases of toggling entries/groups on and off

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/588-visibility-set/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/714)
<!-- Reviewable:end -->
