### PR TITLE
Fix grid keyboard navigation

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/accessibility.ts
+++ b/packages/ramp-core/src/fixtures/grid/accessibility.ts
@@ -1,18 +1,12 @@
 import { ColumnApi, GridApi } from 'ag-grid-community';
-import { FocusListManager, generateID } from '@/directives/focus-list';
 
-const FOCUS_LIST_ATTR = 'focus-list';
-const FOCUS_ITEM_ATTR = 'focus-item';
-const GRID_BODY_SELECTOR = '.ag-body-viewport';
 const HEADER_ROW_SELECTOR = '.ag-header-viewport .ag-header-row';
 
-export default class GridAccessibilityManager {
+export class GridAccessibilityManager {
     element: HTMLElement;
-    gridBody: HTMLElement;
     headerRows: HTMLElement[];
     gridApi: GridApi;
     columnApi: ColumnApi;
-    observer: MutationObserver;
 
     mousedown: boolean = false;
 
@@ -27,9 +21,6 @@ export default class GridAccessibilityManager {
         this.element = element;
         this.gridApi = gridApi;
         this.columnApi = columnApi;
-        this.gridBody = this.element.querySelector(
-            GRID_BODY_SELECTOR
-        )! as HTMLElement;
         this.headerRows = Array.prototype.slice.call(
             this.element.querySelectorAll(HEADER_ROW_SELECTOR)
         ) as HTMLElement[];
@@ -41,65 +32,42 @@ export default class GridAccessibilityManager {
             .querySelector('.ag-body-horizontal-scroll-viewport')
             ?.setAttribute('tabindex', '-1');
 
-        this.observer = new MutationObserver(mutations => {
-            const el = mutations[0].target as HTMLElement;
-            this.manageHeaderScrolling(el);
-        });
-
         this.initAccessibilityListeners();
-        this.gridBody.toggleAttribute(FOCUS_LIST_ATTR, true);
-        new FocusListManager(this.gridBody as HTMLElement, '');
     }
 
     /**
      * Set up the listeners for the grid
      */
     private initAccessibilityListeners() {
-        this.gridBody.addEventListener('keydown', event => {
-            this.onKeydown(event);
-        });
-        this.gridBody.addEventListener(
-            'focus',
-            () => {
-                this.onFocus();
-            },
-            false
-        );
-        this.element.addEventListener('mousedown', () => {
-            this.onMousedown();
-        });
-        this.element.addEventListener('mouseup', () => {
-            this.onMouseup();
-        });
-
-        this.headerRows.forEach((row, index) => {
-            // Force rows to not be tabbable
-            // since they are created after everything has rendered the parent focus-lists will not be able to toggle them off before user input
-            row.setAttribute('tabindex', '-1');
-            row.toggleAttribute(FOCUS_LIST_ATTR, true);
-            this.observer.observe(row, {
-                attributeFilter: ['aria-activedescendant']
-            });
-            row.addEventListener('focus', () => {
-                this.manageHeaderScrolling(row);
-            });
-            if (index > 0) {
-                row.addEventListener('keydown', (event: KeyboardEvent) => {
-                    this.shiftTabHandler(event);
-                });
+        const headerCells = Array.prototype.slice.call(
+            this.headerRows[0].querySelectorAll('.ag-header-cell')
+        ) as HTMLElement[];
+        headerCells.forEach((cell, index) => {
+            if (index < 3) {
+                return;
             }
-
-            // set up cells as focus list items, need to manually add ID since we can't use the directive
-            const headerCells = Array.prototype.slice.call(
-                row.querySelectorAll('.ag-header-cell')
+            const buttons = Array.prototype.slice.call(
+                cell.querySelectorAll('button')
             ) as HTMLElement[];
-            headerCells.forEach(cell => {
-                cell.toggleAttribute('focus-item', true);
-                cell.id = generateID();
-                cell.classList.add('default-focus-style');
+
+            cell.addEventListener('keydown', (event: KeyboardEvent) => {
+                this.cellKeydownHandler(event, cell, buttons);
             });
 
-            new FocusListManager(row as HTMLElement, 'horizontal');
+            cell.addEventListener('blur', (event: FocusEvent) => {
+                this.cellBlurHandler(event, cell, buttons);
+            });
+
+            buttons[buttons.length - 1].addEventListener(
+                'keydown',
+                (event: KeyboardEvent) => {
+                    this.cellButtonTabHandler(event, cell, buttons, false);
+                }
+            );
+
+            buttons[0].addEventListener('keydown', (event: KeyboardEvent) => {
+                this.cellButtonTabHandler(event, cell, buttons, true);
+            });
         });
     }
 
@@ -107,133 +75,195 @@ export default class GridAccessibilityManager {
      * Remove all accessibility listeners from the grid
      */
     removeAccessibilityListeners() {
-        this.gridBody.removeEventListener('keydown', event => {
-            this.onKeydown(event);
-        });
-        this.gridBody.removeEventListener(
-            'focus',
-            () => {
-                this.onFocus();
-            },
-            true
-        );
-        this.element.removeEventListener('mousedown', () => {
-            this.onMousedown();
-        });
-        this.element.removeEventListener('mouseup', () => {
-            this.onMouseup();
-        });
-        this.observer.disconnect();
-
-        this.headerRows.forEach(row => {
-            row.removeEventListener('focus', () => {
-                this.manageHeaderScrolling(row);
-            });
-        });
-    }
-
-    /**
-     * Callback for the keydown event.
-     * On tab focuses the first cell if needed. On shift+tab backs out to the last header row.
-     *
-     * @param {KeyboardEvent} event the keyboard event that triggered the callback
-     */
-    private onKeydown(event: KeyboardEvent) {
-        const focusedCell = this.gridApi.getFocusedCell();
-
-        if (event.key === 'Tab' && focusedCell === null) {
-            // if first tab into grid body automatically focus on first cell
-            const firstCol = this.columnApi.getAllDisplayedColumns()[0];
-            this.gridApi.setFocusedCell(0, firstCol);
-        } else if (event.key === 'Tab' && event.shiftKey) {
-            // Get visible headers, there are invisible ones but they aren't under `.ag-header-viewport`
-            const headers = this.element.querySelectorAll(HEADER_ROW_SELECTOR);
-            // Prevent the real shift + tab event from happening after focus leaves the grid
-            event.preventDefault();
-            // Force focus onto the last header
-            (headers[headers.length - 1] as HTMLElement).focus();
-        }
-    }
-
-    /**
-     * Helper function to handle the mousedown event
-     */
-    private onMousedown() {
-        this.mousedown = true;
-    }
-
-    /**
-     * Helper function to handle the mouseup event
-     */
-    private onMouseup() {
-        this.mousedown = false;
-    }
-
-    /**
-     * Callback for the focus event on the grid body.
-     * Manages the grid's focused cell when the grid itself is given focus.
-     */
-    private onFocus() {
-        // Don't want to adjust focused cell if focus was gained via mouseclick
-        if (!this.mousedown) {
-            let firstCol = this.columnApi.getAllDisplayedColumns()[0];
-
-            const focusedCell = this.gridApi.getFocusedCell();
-            if (!this.gridApi.getFocusedCell()) {
-                // focus first cell if nothing was focused
-                this.gridApi.setFocusedCell(0, firstCol);
-                this.gridApi.ensureIndexVisible(0);
-                this.gridApi.ensureColumnVisible(firstCol);
-            } else {
-                if (focusedCell) {
-                    this.gridApi.setFocusedCell(
-                        focusedCell.rowIndex,
-                        focusedCell.column
-                    );
-                }
+        const headerCells = Array.prototype.slice.call(
+            this.headerRows[0].querySelectorAll('.ag-header-cell')
+        ) as HTMLElement[];
+        headerCells.forEach((cell, index) => {
+            if (index < 3) {
+                return;
             }
-        }
-    }
+            const buttons = Array.prototype.slice.call(
+                cell.querySelectorAll('button')
+            ) as HTMLElement[];
 
-    /**
-     * Makes sure the currently selected header cell is always visible
-     * @param row the header row to manage
-     */
-    private manageHeaderScrolling(row: Element) {
-        if (this.mousedown) {
-            return;
-        }
+            cell.removeEventListener('keydown', (event: KeyboardEvent) => {
+                this.cellKeydownHandler(event, cell, buttons);
+            });
 
-        const id = row.getAttribute('aria-activedescendant');
-        if (id) {
-            row.querySelectorAll(`[${FOCUS_ITEM_ATTR}]`).forEach(
-                (cell: Element, index: number) => {
-                    if (cell.id === id) {
-                        this.gridApi.ensureColumnVisible(
-                            this.columnApi.getAllDisplayedColumns()[index]
-                        );
-                    }
+            cell.removeEventListener('blur', (event: FocusEvent) => {
+                this.cellBlurHandler(event, cell, buttons);
+            });
+
+            buttons[buttons.length - 1].removeEventListener(
+                'keydown',
+                (event: KeyboardEvent) => {
+                    this.cellButtonTabHandler(event, cell, buttons, false);
                 }
             );
-        } else {
-            this.gridApi.ensureColumnVisible(
-                this.columnApi.getAllDisplayedColumns()[0]
+
+            buttons[0].removeEventListener(
+                'keydown',
+                (event: KeyboardEvent) => {
+                    this.cellButtonTabHandler(event, cell, buttons, true);
+                }
             );
+        });
+    }
+
+    /**
+     * Makes `enter` allow navigation within the cell
+     *
+     * @param {KeyboardEvent} event The event to handle
+     * @param {HTMLElement} cell The grid header cell
+     * @param {HTMLElement[]} buttons The list of buttons in the cell
+     */
+    private cellKeydownHandler(
+        event: KeyboardEvent,
+        cell: HTMLElement,
+        buttons: HTMLElement[]
+    ) {
+        if (event.key === 'Enter' && event.target === cell) {
+            event.preventDefault();
+            buttons.forEach(item => {
+                item.setAttribute('tabindex', '0');
+            });
+            buttons[0].focus();
         }
     }
 
-    //TODO: Grid wasn't scrolling to column properly when something inside the header was focused, see if we can make that work
     /**
-     * Callback for keydown event on header rows
-     * Moves focus to previous header row on shift + tab (instead of anything inside the row)
+     * Removes ability to tab to inner items when focus leaves the cell (and inner items)
      *
-     * @param event
+     * @param {FocusEvent} event The event to handle
+     * @param {HTMLElement} cell The grid header cell
+     * @param {HTMLElement[]} buttons The list of buttons in the cell
      */
-    private shiftTabHandler(event: KeyboardEvent) {
-        if (event.key === 'Tab' && event.shiftKey) {
-            event.preventDefault();
-            const index = this.headerRows.indexOf(event.target as HTMLElement);
-            this.headerRows[index - 1].focus();
+    private cellBlurHandler(
+        event: FocusEvent,
+        cell: HTMLElement,
+        buttons: HTMLElement[]
+    ) {
+        if (
+            event.target === cell &&
+            !buttons.includes(event.relatedTarget as HTMLElement)
+        ) {
+            buttons.forEach(item => {
+                item.setAttribute('tabindex', '-1');
+            });
         }
     }
+
+    /**
+     * Handles giving focus back to the cell after shift+tabbing on the first inner item or tabbing on the last
+     *
+     * @param event The event to handle
+     * @param cell The grid header cell
+     * @param buttons The list of buttons in the cell
+     * @param shift Whether to handle shift tab or regular tab
+     */
+    private cellButtonTabHandler(
+        event: KeyboardEvent,
+        cell: HTMLElement,
+        buttons: HTMLElement[],
+        shift: boolean
+    ) {
+        if (
+            event.key === 'Tab' &&
+            ((shift && event.shiftKey) || (!shift && !event.shiftKey))
+        ) {
+            event.preventDefault();
+            cell.focus();
+            buttons.forEach(item => {
+                item.setAttribute('tabindex', '-1');
+            });
+        }
+    }
+}
+
+// From https://www.ag-grid.com/vue-data-grid/keyboard-navigation/#tabtonextheader
+interface TabToNextHeaderParams {
+    // True if the Shift key is also down
+    backwards: boolean;
+    // The header that currently has focus
+    previousHeaderPosition: HeaderPosition | null;
+    // The header the grid would normally pick as the next header for this navigation
+    nextHeaderPosition: HeaderPosition | null;
+    // The number of header rows present in the grid
+    headerRowCount: number;
+    api: GridApi;
+    columnApi: ColumnApi;
+}
+
+interface HeaderPosition {
+    // A number from 0 to n, where n is the last header row the grid is rendering
+    headerRowIndex: number;
+    // The grid column or column group
+    column: any;
+}
+
+/**
+ * Change the tab functionality to move up/down between headers and into the grid cells
+ *
+ * @param {TabToNextHeaderParams} params The parameters passed by the ag grid callback, see above
+ * @returns {HeaderPosition} The new header we want the grid to focus
+ */
+export function tabToNextHeaderHandler(
+    params: TabToNextHeaderParams
+): HeaderPosition | null {
+    const column = params.previousHeaderPosition!.column;
+
+    const lastIndex = params.previousHeaderPosition!.headerRowIndex;
+    let headerRowIndex = params.backwards ? lastIndex - 1 : lastIndex + 1;
+
+    if (headerRowIndex === -1) {
+        // null cancels grid handling the keypress, this will move us out of the grid entirely
+        return null;
+    } else if (headerRowIndex === params.headerRowCount) {
+        // headerRowIndex of -1 means move to the first line of cells
+        headerRowIndex = -1;
+    }
+
+    return { headerRowIndex, column };
+}
+
+// From https://www.ag-grid.com/vue-data-grid/keyboard-navigation/#reference-nav-tabToNextCell
+interface TabToNextCellParams {
+    // True if the Shift key is also down
+    backwards: boolean;
+    // True if the current cell is editing
+    // (you may want to skip cells that are not editable, as the grid will enter the next cell in editing mode also if tabbing)
+    editing: boolean;
+    // The cell that currently has focus
+    previousCellPosition: CellPosition;
+    // The cell the grid would normally pick as the next cell for navigation.
+    nextCellPosition: CellPosition | null;
+    api: GridApi;
+    columnApi: ColumnApi;
+}
+
+interface CellPosition {
+    // The grid column
+    column: any;
+    // A positive number from 0 to n, where n is the last row the grid is rendering
+    // or -1 if you want to navigate to the grid header
+    rowIndex: number;
+    // Either 'top', 'bottom' or null (for not pinned)
+    rowPinned?: string | null;
+}
+
+/**
+ * Change the tab to move out of the grid and shift+tab to move back to the last header
+ *
+ * @param {TabToNextHeaderParams} params The parameters passed by the ag grid callback, see above
+ * @returns {CellPosition} The new header we want the grid to focus
+ */
+export function tabToNextCellHandler(
+    params: TabToNextCellParams
+): CellPosition | null {
+    if (params.backwards) {
+        // rowIndex of -1 means go to last header
+        return { column: params.previousCellPosition.column, rowIndex: -1 };
+    }
+    // null cancels grid handling the keypress, this will move us out of the grid entirely
+    return null;
 }

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -14,6 +14,7 @@
                 "
                 role="columnheader"
                 truncate-trigger
+                tabindex="-1"
             >
                 <!-- <div v-truncate="{ externalTrigger: true }"> -->
                 <div>
@@ -60,10 +61,12 @@
                 v-tippy="{ placement: 'top' }"
                 @click="moveLeft()"
                 class="
+                    move-left
                     opacity-60
                     hover:opacity-90
                     disabled:opacity-30 disabled:cursor-default
                 "
+                tabindex="-1"
                 :disabled="!canMoveLeft"
             >
                 <div class="inline-block">
@@ -81,10 +84,12 @@
                 v-tippy="{ placement: 'top' }"
                 @click="moveRight()"
                 class="
+                    move-right
                     opacity-60
                     hover:opacity-90
                     disabled:opacity-30 disabled:cursor-default
                 "
+                tabindex="-1"
                 :disabled="!canMoveRight"
             >
                 <div class="inline-block">
@@ -160,6 +165,18 @@ export default defineComponent({
 
             if (this.canMoveLeft) {
                 this.columnApi.moveColumn(this.params.column, index);
+
+                // Focus the "move left" button on the new column
+                // The same column index keeps this element so we can't just use a ref for the buttons;
+                // e.g. grid is A | B | C and this is B, if B moves left so the grid B | A | C this element is now A
+                (
+                    (this.$el as HTMLElement)
+                        .closest('.ag-header-row')
+                        ?.querySelectorAll('.ag-header-cell')
+                        [index].querySelector('.move-left') as HTMLElement
+                ).focus();
+
+                this.params.gridApi.ensureColumnVisible(allColumns[index]);
             }
         },
 
@@ -174,6 +191,7 @@ export default defineComponent({
 
             if (this.canMoveRight) {
                 this.columnApi.moveColumn(this.params.column, index);
+                this.params.gridApi.ensureColumnVisible(allColumns[index]);
             }
         },
 


### PR DESCRIPTION
closes #693 

How navigation now works:
- Arrow keys can move between grid body and headers (grid default)
- Enter on filter cell moves focus to the filter inputs (grid default)
- Enter on header cell moves focus to the inner buttons (default has enter change sorting with no way to reorder columns)
- Tab and Shift+Tab move between headers and into/out of the grid body (default is moving horizontally)
- Tab on the grid body moves focus out of the grid (default is moving to next row)

DEMO: http://ramp4-app.azureedge.net/demo/users/spencerwahl/grid-keyboard-nav/host/index.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/715)
<!-- Reviewable:end -->
