### PR TITLE
Remove MIL once all sublayers are deleted

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -199,13 +199,19 @@ export default defineComponent({
                         layerTree.children[0].isLayer
                     )
                 ) {
-                    // cheap hack for MIL with multiple children - set visibility to false and remove legend entry
-                    // TODO get rid of this when/if MIL sublayers can be removed for real
                     this.removeLayerEntry(this.legendItem!.layerUID!);
-                    this.legendItem!.layer!.setVisibility(
-                        false,
-                        this.legendItem!._layerIndex
-                    );
+
+                    // remove MIL if all layer entries have been removed
+                    if (this.legendItem!.parent!.children?.length === 0) {
+                        this.$iApi.geo.map.removeLayer(layerTree.uid);
+                    } else {
+                        // cheap hack for MIL with multiple children - set visibility to false and remove legend entry
+                        // TODO get rid of this when/if MIL sublayers can be removed for real
+                        this.legendItem!.layer!.setVisibility(
+                            false,
+                            this.legendItem!._layerIndex
+                        );
+                    }
                 } else {
                     this.legendItem!.toggleVisibility(false);
                     this.$iApi.geo.map.removeLayer(this.legendItem!.layerUID!);

--- a/packages/ramp-core/src/fixtures/wizard/stepper-item.vue
+++ b/packages/ramp-core/src/fixtures/wizard/stepper-item.vue
@@ -77,8 +77,7 @@ export default defineComponent({
             required: true
         },
         summary: {
-            type: String,
-            required: true
+            type: String
         }
     },
 

--- a/packages/ramp-core/vue.config.js
+++ b/packages/ramp-core/vue.config.js
@@ -28,6 +28,16 @@ module.exports = {
             libraryExport: 'default'
         },
 
+        module: {
+            rules: [
+                {
+                    test: /\.mjs$/,
+                    include: /node_modules/,
+                    type: 'javascript/auto'
+                }
+            ]
+        },
+
         optimization: {
             splitChunks: {
                 // increase the minimum size of the chunk to 300kb


### PR DESCRIPTION
Closes #717

Removes MapImage layer once all its child entries have been removed. Note: I had to add a webpack rule to prevent the build from erroring, not sure if there is a better method for this.

**Testing**: Follow original steps described in issue and ensure none of the issues remain (specifically no more blank network requests and layer removed from store). Tested using this [layer](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Oilsands/MapServer).

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/717-MIL-sublayers-remove/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/721)
<!-- Reviewable:end -->
