### PR TITLE
fix legend panel opening twice if opened before adding default fixtures

### DIFF
--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -134,6 +134,9 @@ export class PanelAPI extends APIScope {
         // if panel is hidden off screen minimize it first so it is able to reopen
         if (panel.isOpen && !panel.isVisible) {
             panel.minimize();
+        } else if (panel.isOpen) {
+            // if panel is already open and is not hidden, don't do anything
+            return panel;
         }
 
         // Panel opening requires a screen, check if last opened or default makes more sense


### PR DESCRIPTION
Closes #716 

The legend fixture should no longer be opened twice if you manually open it before default fixtures are added.

**Testing this PR**
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-716/host/index.html).

Steps to test:
1. Open the demo link.
2. Click the legend button in the app bar before it opens automatically.
3. A second legend should no longer open after default fixtures are all added.

If the legend button is not clicked, the legend should still open automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/724)
<!-- Reviewable:end -->
