### PR TITLE
Migrate custom renderers

### DIFF
--- a/packages/ramp-core/public/starter-scripts/custom-renderer.js
+++ b/packages/ramp-core/public/starter-scripts/custom-renderer.js
@@ -1,0 +1,549 @@
+window.rInstance = null;
+document.title = 'Custom Renderer';
+
+console.log('RAMP has loaded.');
+
+let config = {
+    en: {
+        map: {
+            extent: {
+                xmax: -5007771.626060756,
+                xmin: -16632697.354854,
+                ymax: 10015875.184845109,
+                ymin: 5022907.964742964,
+                spatialReference: {
+                    wkid: 102100,
+                    latestWkid: 3857
+                }
+            },
+            caption: {
+                mouseCoords: {
+                    formatter: 'WEB_MERCATOR'
+                },
+                scaleBar: {
+                    imperialScale: true
+                }
+            },
+            lods: RAMP.GEO.defaultLODs(RAMP.GEO.defaultTileSchemas()[1]), // idx 1 = mercator
+            tileSchemas: [
+                {
+                    id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    name: 'Lambert Maps',
+                    extentSetId: 'EXT_NRCAN_Lambert_3978',
+                    lodSetId: 'LOD_NRCAN_Lambert_3978',
+                    thumbnailTileUrls: ['/tile/8/285/268', '/tile/8/285/269'],
+                    hasNorthPole: true
+                },
+                {
+                    id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    name: 'Web Mercator Maps',
+                    extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                    lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                    thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                }
+            ],
+            basemaps: [
+                {
+                    id: 'baseNrCan',
+                    name: 'Canada Base Map - Transportation (CBMT)',
+                    description:
+                        'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                    altText: 'The Canada Base Map - Transportation (CBMT)',
+                    layers: [
+                        {
+                            id: 'CBMT',
+                            layerType: 'esriTile',
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    wkid: 3978
+                },
+                {
+                    id: 'baseSimple',
+                    name: 'Canada Base Map - Simple',
+                    description: 'Canada Base Map - Simple',
+                    altText: 'Canada base map - Simple',
+                    layers: [
+                        {
+                            id: 'SMR',
+                            layerType: 'esriTile',
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    wkid: 3978
+                },
+                {
+                    id: 'baseCBME_CBCE_HS_RO_3978',
+                    name: 'Canada Base Map - Elevation (CBME)',
+                    description:
+                        'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                    altText: 'Canada Base Map - Elevation (CBME)',
+                    layers: [
+                        {
+                            id: 'CBME_CBCE_HS_RO_3978',
+                            layerType: 'esriTile',
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    wkid: 3978
+                },
+                {
+                    id: 'baseCBMT_CBCT_GEOM_3978',
+                    name: 'Canada Base Map - Transportation (CBMT)',
+                    description:
+                        ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                    altText: 'Canada Base Map - Transportation (CBMT)',
+                    layers: [
+                        {
+                            id: 'CBMT_CBCT_GEOM_3978',
+                            layerType: 'esriTile',
+                            url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                    wkid: 3978
+                },
+                {
+                    id: 'baseEsriWorld',
+                    name: 'World Imagery',
+                    description:
+                        'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                    altText: 'World Imagery',
+                    layers: [
+                        {
+                            id: 'World_Imagery',
+                            layerType: 'esriTile',
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    wkid: 102100,
+                    attribution: {
+                        text: {
+                            disabled: true
+                        },
+                        logo: {
+                            disabled: true
+                        }
+                    }
+                },
+                {
+                    id: 'baseEsriPhysical',
+                    name: 'World Physical Map',
+                    description:
+                        'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                    altText: 'World Physical Map',
+                    layers: [
+                        {
+                            id: 'World_Physical_Map',
+                            layerType: 'esriTile',
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    wkid: 102100
+                },
+                {
+                    id: 'baseEsriRelief',
+                    name: 'World Shaded Relief',
+                    description:
+                        'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                    altText: 'World Shaded Relief',
+                    layers: [
+                        {
+                            id: 'World_Shaded_Relief',
+                            layerType: 'esriTile',
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    wkid: 102100
+                },
+                {
+                    id: 'baseEsriStreet',
+                    name: 'World Street Map',
+                    description:
+                        'This worldwide street map presents highway-level data for the world.',
+                    altText: 'ESWorld Street Map',
+                    layers: [
+                        {
+                            id: 'World_Street_Map',
+                            layerType: 'esriTile',
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    wkid: 102100
+                },
+                {
+                    id: 'baseEsriTerrain',
+                    name: 'World Terrain Base',
+                    description:
+                        'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                    altText: 'World Terrain Base',
+                    layers: [
+                        {
+                            id: 'World_Terrain_Base',
+                            layerType: 'esriTile',
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    wkid: 102100
+                },
+                {
+                    id: 'baseEsriTopo',
+                    name: 'World Topographic Map',
+                    description:
+                        'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                    altText: 'World Topographic Map',
+                    layers: [
+                        {
+                            id: 'World_Topo_Map',
+                            layerType: 'esriTile',
+                            url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                        }
+                    ],
+                    tileSchemaId:
+                        'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                    wkid: 102100
+                }
+            ],
+            initialBasemapId: 'baseEsriWorld'
+        },
+        layers: [
+            {
+                id: 'CleanAirSimple',
+                layerType: 'esriFeature',
+                url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/9',
+                customRenderer: {
+                    type: 'simple',
+                    symbol: {
+                        type: 'esriSMS',
+                        style: 'esriSMSCross',
+                        color: [255, 225, 0, 255],
+                        size: 8,
+                        angle: 0,
+                        xoffset: 0,
+                        yoffset: 0,
+                        outline: {
+                            color: [255, 225, 0, 255],
+                            width: 4
+                        }
+                    }
+                }
+            },
+            {
+                id: 'CleanAirUniqueValue',
+                layerType: 'esriFeature',
+                url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/9',
+                customRenderer: {
+                    type: 'uniqueValue',
+                    field1: 'Category',
+                    // defaultSymbol: {},
+                    // all possible values must be covered or use defaultSymbol
+                    uniqueValueInfos: [
+                        {
+                            value: 'Clean Air',
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSDiamond',
+                                color: [225, 152, 234, 255],
+                                size: 12,
+                                angle: 0,
+                                xoffset: 0,
+                                yoffset: 0,
+                                outline: {
+                                    color: [255, 255, 255, 255],
+                                    width: 0.5
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            {
+                id: 'CleanAirClassBreaks',
+                layerType: 'esriFeature',
+                url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/9',
+                customRenderer: {
+                    type: 'classBreaks',
+                    field: 'OBJECTID',
+                    // all possible values must be covered
+                    minValue: 0,
+                    classBreakInfos: [
+                        {
+                            classMaxValue: 100,
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSCircle',
+                                color: [122, 250, 255, 255],
+                                size: 10,
+                                outline: {
+                                    color: [0, 0, 0, 255],
+                                    width: 1
+                                }
+                            },
+                            label: '0 to 100'
+                        },
+                        {
+                            classMaxValue: 300,
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSCircle',
+                                color: [55, 169, 255, 255],
+                                size: 14,
+                                outline: {
+                                    color: [0, 0, 0, 255],
+                                    width: 1
+                                }
+                            },
+                            label: '100 to 300'
+                        },
+                        {
+                            classMaxValue: 1000,
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSCircle',
+                                color: [0, 27, 209, 255],
+                                size: 18,
+                                outline: {
+                                    color: [0, 0, 0, 255],
+                                    width: 1
+                                }
+                            },
+                            label: '300 to 1000'
+                        }
+                    ]
+                }
+            },
+            {
+                id: 'WFSLayerSimple',
+                layerType: 'ogcWfs',
+                url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                customRenderer: {
+                    type: 'simple',
+                    symbol: {
+                        type: 'esriSMS',
+                        style: 'esriSMSTriangle',
+                        color: [61, 255, 166, 255],
+                        size: 8,
+                        angle: 0,
+                        xoffset: 0,
+                        yoffset: 0,
+                        outline: {
+                            color: [255, 255, 255, 255],
+                            width: 0.5
+                        }
+                    }
+                }
+            },
+            {
+                id: 'WFSLayerUniqueValue',
+                layerType: 'ogcWfs',
+                url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                customRenderer: {
+                    type: 'uniqueValue',
+                    field1: 'STATUS_EN',
+                    defaultSymbol: {
+                        type: 'esriSMS',
+                        style: 'esriSMSCircle',
+                        color: [255, 255, 255, 255],
+                        size: 8,
+                        angle: 0,
+                        xoffset: 0,
+                        yoffset: 0,
+                        outline: {
+                            color: [0, 0, 0, 255],
+                            width: 2
+                        }
+                    },
+                    defaultLabel: 'Other',
+                    // all possible values must be covered or use defaultSymbol
+                    uniqueValueInfos: [
+                        {
+                            value: 'Discontinued',
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSDiamond',
+                                color: [142, 0, 0, 255],
+                                size: 10,
+                                angle: 20,
+                                xoffset: 0,
+                                yoffset: 0,
+                                outline: {
+                                    color: [0, 0, 0, 255],
+                                    width: 0.5
+                                }
+                            },
+                            label: 'Discontinued'
+                        },
+                        {
+                            value: 'Active',
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSDiamond',
+                                color: [0, 142, 77, 255],
+                                size: 10,
+                                angle: 65,
+                                xoffset: 0,
+                                yoffset: 0,
+                                outline: {
+                                    color: [255, 255, 255, 255],
+                                    width: 0.5
+                                }
+                            },
+                            label: 'Active'
+                        }
+                    ]
+                }
+            },
+            {
+                id: 'WFSLayerClassBreaks',
+                layerType: 'ogcWfs',
+                url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                customRenderer: {
+                    type: 'classBreaks',
+                    field: 'OBJECTID',
+                    defaultSymbol: {
+                        type: 'esriSMS',
+                        style: 'esriSMSCross',
+                        color: [0, 0, 0, 255],
+                        size: 8,
+                        angle: 45,
+                        xoffset: 0,
+                        yoffset: 0,
+                        outline: {
+                            color: [0, 0, 0, 255],
+                            width: 4
+                        }
+                    },
+                    defaultLabel: 'Other',
+                    // all possible values must be covered
+                    minValue: 0,
+                    classBreakInfos: [
+                        {
+                            classMaxValue: 50,
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSCross',
+                                color: [255, 190, 124, 255],
+                                size: 8,
+                                angle: 45,
+                                xoffset: 0,
+                                yoffset: 0,
+                                outline: {
+                                    color: [255, 190, 124, 255],
+                                    width: 4
+                                }
+                            },
+                            label: '0 to 50'
+                        },
+                        {
+                            classMaxValue: 100,
+                            symbol: {
+                                type: 'esriSMS',
+                                style: 'esriSMSCross',
+                                color: [190, 124, 255, 255],
+                                size: 8,
+                                angle: 45,
+                                xoffset: 0,
+                                yoffset: 0,
+                                outline: {
+                                    color: [190, 124, 255, 255],
+                                    width: 4
+                                }
+                            },
+                            label: '50 to 100'
+                        }
+                    ]
+                }
+            }
+        ],
+        fixtures: {
+            legend: {
+                reorderable: true,
+                root: {
+                    children: [
+                        {
+                            name: 'Feature Layer',
+                            exclusiveVisibility: [
+                                {
+                                    layerId: 'CleanAirSimple',
+                                    name: 'Clean Air - Simple'
+                                },
+                                {
+                                    layerId: 'CleanAirUniqueValue',
+                                    name: 'Clean Air - Unique Value'
+                                },
+                                {
+                                    layerId: 'CleanAirClassBreaks',
+                                    name: 'Clean Air - Class Breaks'
+                                }
+                            ]
+                        },
+                        {
+                            name: '(fake) File Layer',
+                            exclusiveVisibility: [
+                                {
+                                    layerId: 'WFSLayerSimple',
+                                    name: 'WFS Layer - Simple'
+                                },
+                                {
+                                    layerId: 'WFSLayerUniqueValue',
+                                    name: 'WFS Layer - Unique Value'
+                                },
+                                {
+                                    layerId: 'WFSLayerClassBreaks',
+                                    name: 'WFS Layer - Class Breaks'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            appbar: {
+                items: ['legend'],
+                temporaryButtons: ['details', 'grid', 'settings']
+            },
+            mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] }
+        },
+        animate: true
+    }
+};
+
+let options = {
+    loadDefaultFixtures: false,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
+rInstance.fixture.addDefaultFixtures().then(() => {
+    rInstance.panel.open('legend-panel');
+});
+
+// load map if startRequired is true
+rInstance.start();
+
+function animateToggle() {
+    if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
+        rInstance.$vApp.$el.classList.remove('animation-enabled');
+    } else {
+        rInstance.$vApp.$el.classList.add('animation-enabled');
+    }
+    document.getElementById('animate-status').innerText =
+        'Animate: ' + rInstance.animate;
+}

--- a/packages/ramp-core/src/geo/layer/attrib-fc.ts
+++ b/packages/ramp-core/src/geo/layer/attrib-fc.ts
@@ -16,7 +16,6 @@ import {
 import {
     Attributes,
     BaseGeometry,
-    CoreFilter,
     DataFormat,
     Extent,
     FieldDefinition,
@@ -155,18 +154,16 @@ export class AttribFC extends CommonFC {
                     })();
             }
 
-            // TODO add in renderer and legend magic
-            // add renderer and legend
-            const sourceRenderer =
+            // options.customRenderer is a custom renderer from the config already converted to client style
+            const renderer =
                 options && options.customRenderer && options.customRenderer.type
                     ? options.customRenderer
-                    : sData.drawingInfo.renderer;
+                    : EsriRendererFromJson(sData.drawingInfo.renderer);
             this.renderer =
                 this.parentLayer.$iApi.geo.utils.symbology.makeRenderer(
-                    EsriRendererFromJson(sourceRenderer),
+                    renderer,
                     this.fields
                 );
-
             // this array will have a set of promises that resolve when all the legend svg has drawn.
             // for now, will not include that set (promise.all'd) on the layer load blocker;
             // don't want to stop a layer from loading just because an icon won't draw.

--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -5,7 +5,6 @@
 
 import { AttribLayer, FileFC, InstanceAPI } from '@/api/internal';
 import {
-    DefPromise,
     GeometryType,
     IdentifyParameters,
     IdentifyResult,
@@ -17,7 +16,7 @@ import {
     RampLayerConfig,
     TreeNode
 } from '@/geo/api';
-import { EsriFeatureLayer, EsriField } from '@/geo/esri';
+import { EsriFeatureLayer, EsriField, EsriRendererFromJson } from '@/geo/esri';
 import { markRaw } from 'vue';
 
 // util function to manage trickery. file layer can have field names that are bad keys.
@@ -167,27 +166,12 @@ export class FileLayer extends AttribLayer {
             throw new Error('superclass did not create layer tree');
         }
 
-        // attempt to set custom renderer here. if fails, we can attempt on client but prefer it here
-        // as this doesnt care where the layer came from
-        // TODO implement custom renderers
-        // TODO look at final implementation of FeatureLayer, will probably be similar
-        /*
-        if (this.origRampConfig.customRenderer.type) {
-            // all renderers have a type field. if it's missing, no renderer was provided, or its garbage
-            const classMapper = {
-                simple: this._apiRef.symbology.SimpleRenderer,
-                classBreaks: this._apiRef.symbology.ClassBreaksRenderer,
-                uniqueValue: this._apiRef.symbology.UniqueValueRenderer
-            }
-
-            // renderer constructors apparently convert their input json from server style to client style.
-            // we dont want that. use a clone to protect config's property.
-            const cloneRenderer = jsonCloner(this.config.customRenderer);
-            const custRend = classMapper[cloneRenderer.type](cloneRenderer);
-            this._layer.setRenderer(custRend);
-
+        // setting custom renderer here (if one is provided)
+        if (this.esriLayer && this.origRampConfig.customRenderer?.type) {
+            this.esriLayer.renderer = EsriRendererFromJson(
+                this.config.customRenderer
+            );
         }
-        */
 
         // feature has only one layer
         const featIdx: number = 0; // GeoJSON is always 0

--- a/packages/ramp-core/src/geo/utils/symbology.ts
+++ b/packages/ramp-core/src/geo/utils/symbology.ts
@@ -8,7 +8,15 @@ import {
     UniqueValueRenderer
 } from '@/api/internal';
 import { Attributes, LegendSymbology, LineStyle } from '@/geo/api';
-import { EsriRendererFromJson, EsriRequest } from '@/geo/esri';
+import {
+    EsriRenderer,
+    EsriSimpleRenderer,
+    EsriUniqueValueRenderer,
+    EsriClassBreaksRenderer,
+    EsriRendererFromJson,
+    EsriField,
+    EsriRequest
+} from '@/geo/esri';
 import svgjs from 'svg.js';
 import to from 'await-to-js';
 
@@ -62,27 +70,27 @@ export class SymbologyAPI extends APIScope {
     }
 
     makeRenderer(
-        esriRenderer: __esri.Renderer,
-        fields: Array<__esri.Field>,
+        esriRenderer: EsriRenderer,
+        fields: Array<EsriField>,
         falseRenderer: boolean = false
     ): BaseRenderer {
         switch (esriRenderer.type) {
             case this.SIMPLE:
                 return new SimpleRenderer(
-                    <__esri.SimpleRenderer>esriRenderer,
+                    <EsriSimpleRenderer>esriRenderer,
                     fields
                 );
 
             case this.CLASS_BREAKS:
                 return new ClassBreaksRenderer(
-                    <__esri.ClassBreaksRenderer>esriRenderer,
+                    <EsriClassBreaksRenderer>esriRenderer,
                     fields,
                     falseRenderer
                 );
 
             case this.UNIQUE_VALUE:
                 return new UniqueValueRenderer(
-                    <__esri.UniqueValueRenderer>esriRenderer,
+                    <EsriUniqueValueRenderer>esriRenderer,
                     fields,
                     falseRenderer
                 );


### PR DESCRIPTION
For #206 
- File and Feature layer support for custom renderers has been migrated over
- For now, can't test actual file layers (geojson, shape files, csv) because of CORS issues. Using WFS layer instead
- New starter script for custom renderers!
- Custom renderers for MIL need further investigation

[Demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/206-custom-renderer/host/index-e2e.html?script=custom-renderer) - Data points and correct symbols should show up in map/grid/legend/details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/725)
<!-- Reviewable:end -->
