### PR TITLE
Fix popper errors when legend entries are re-created on load

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/checkbox.vue
@@ -3,7 +3,7 @@
         <!-- TODO: see if getting this to use v-model works; children wouldnt update properly on initial try -->
         <input
             :type="isRadio ? 'radio' : 'checkbox'"
-            :checked="checked"
+            :checked="checked && initialChecked"
             @click.stop="toggleVisibility(value)"
             @keyup.enter.stop="toggleVisibility(value)"
             :class="[
@@ -42,6 +42,18 @@ export default defineComponent({
         isRadio: { type: Boolean },
         disabled: { type: Boolean }
     },
+
+    data() {
+        return {
+            initialChecked: this.legendItem.visibility
+        };
+    },
+
+    mounted() {
+        this.legendItem.checkVisibilityRules();
+        this.initialChecked = this.legendItem.visibility === this.checked;
+    },
+
     methods: {
         /**
          * Returns true if non of the child symbols are visible
@@ -113,6 +125,7 @@ export default defineComponent({
                         .join(' OR ')
                 );
             }
+            this.initialChecked = true;
         }
     }
 });

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -187,13 +187,6 @@ export default defineComponent({
         },
 
         /**
-         * Get the visibility of the legend item
-         */
-        getLegendItemVisibility(): Boolean {
-            return this.legendItem.visibility || false;
-        },
-
-        /**
          * Get animation enabled status
          */
         isAnimationEnabled(): Boolean {
@@ -212,8 +205,6 @@ export default defineComponent({
             );
             return;
         }
-
-        this.legendItem.checkVisibilityRules();
 
         Promise.all(
             this._getLegend().map((item: LegendSymbology) => item.drawPromise)

--- a/packages/ramp-core/src/fixtures/legend/components/group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/group.vue
@@ -88,10 +88,6 @@ export default defineComponent({
 
     data() {
         return { LegendTypes: LegendTypes };
-    },
-
-    mounted() {
-        this.legendItem.checkVisibilityRules();
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
@@ -91,10 +91,6 @@ export default defineComponent({
 
     data() {
         return { LegendTypes: LegendTypes };
-    },
-
-    mounted() {
-        this.legendItem.checkVisibilityRules();
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -193,7 +193,7 @@ export class LegendEntry extends LegendItem {
         }
         // if parent is turned off turn layer entry visiblity off
         if (this._parent !== undefined && !this._parent.visibility) {
-            this.toggleVisibility(false, false);
+            this._layer?.setVisibility(false, this._layerUID);
         } else if (this._parent?.type === LegendTypes.Set) {
             // toggle off visibility if entry is part of a visibility set with a set entry already toggled on
             const childVisible = this._parent.children.some(
@@ -201,7 +201,7 @@ export class LegendEntry extends LegendItem {
             );
 
             if (childVisible) {
-                this.toggleVisibility(false, false);
+                this._layer?.setVisibility(false, this._layerUID);
             }
         }
     }
@@ -218,7 +218,9 @@ export class LegendEntry extends LegendItem {
 
     /** Returns visibility of layer. */
     get visibility(): boolean | undefined {
-        return this._layer?.getVisibility(this.layerUID);
+        return this._layer !== undefined
+            ? this._layer?.getVisibility(this._layerUID)
+            : false;
     }
 
     /** Returns BaseLayer associated with legend entry. */
@@ -299,8 +301,8 @@ export class LegendEntry extends LegendItem {
                 return;
             }
             visibility !== undefined
-                ? this._layer?.setVisibility(visibility, this.layerUID)
-                : this._layer?.setVisibility(!this.visibility, this.layerUID);
+                ? this._layer?.setVisibility(visibility, this._layerUID)
+                : this._layer?.setVisibility(!this.visibility, this._layerUID);
 
             // Check if some of the child symbols have their definition visibility on
             const noDefinitionsVisible: boolean = !this._layer
@@ -398,6 +400,9 @@ export class LegendGroup extends LegendItem {
      * Ensures visibility rules are followed if legend group is nested in another group/set on initialization.
      */
     checkVisibilityRules(): void {
+        if (!this._visibility) {
+            return;
+        }
         // if parent is turned off turn layer entry visiblity off
         if (this._parent !== undefined && !this._parent.visibility) {
             this.toggleVisibility(false, false);
@@ -516,7 +521,7 @@ export class LegendGroup extends LegendItem {
                           entry.toggleVisibility(this._visibility, false)
                       )
                     : this._children.forEach(entry =>
-                          entry.toggleVisibility(this.visibility, false)
+                          entry.toggleVisibility(this._visibility, false)
                       );
             } else {
                 // otherewise turn off visibility for all children


### PR DESCRIPTION
Closes #722 

Fixes Popper errors that showed up locally due to the legend entry component getting re-rendered initially from checking for visibility rules. For testing, ensure that visibility set stuff still works and there are no regression bugs. 

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/722-popper-errors/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/727)
<!-- Reviewable:end -->
