### PR TITLE
Add `expand`/`collapse` panel control, Grid expanded by default

### DIFF
--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -31,6 +31,7 @@ import PanelScreenV from '@/components/panel-stack/panel-screen.vue';
 import PinV from '@/components/panel-stack/controls/pin.vue';
 import CloseV from '@/components/panel-stack/controls/close.vue';
 import BackV from '@/components/panel-stack/controls/back.vue';
+import ExpandV from '@/components/panel-stack/controls/expand.vue';
 import MinimizeV from '@/components/panel-stack/controls/minimize.vue';
 import PanelOptionsMenuV from '@/components/panel-stack/controls/panel-options-menu.vue';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
@@ -329,6 +330,7 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
     vueElement.component('pin', PinV);
     vueElement.component('close', CloseV);
     vueElement.component('back', BackV);
+    vueElement.component('expand', ExpandV);
     vueElement.component('panel-options-menu', PanelOptionsMenuV);
     vueElement.component('dropdown-menu', DropdownMenuV);
     vueElement.component('minimize', MinimizeV);

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -121,12 +121,20 @@ export class PanelInstance extends APIScope {
     }
 
     /**
-     * The style object to apply to the panel.
+     * The style object applied to the panel.
      *
      * @type {PanelConfigStyle}
-     * @memberof PanelConfig
+     * @memberof PanelInstance
      */
     style: PanelConfigStyle;
+
+    /**
+     * Whether the panel expands to fill empty space.
+     *
+     * @type {boolean}
+     * @memberof PanelInstance
+     */
+    expanded: boolean;
 
     /**
      * Returns the width of the panel in pixels or undefined if not set.
@@ -167,10 +175,12 @@ export class PanelInstance extends APIScope {
         ({
             id: this.id,
             screens: this.screens,
-            style: this.style
+            style: this.style,
+            expanded: this.expanded
         } = {
             id,
             style: {},
+            expanded: false,
             ...config
         });
 
@@ -383,6 +393,20 @@ export class PanelInstance extends APIScope {
      */
     setStyles(style: object, replace: boolean = false): this {
         this.$iApi.panel.setStyle(this, style, replace);
+
+        return this;
+    }
+
+    /**
+     * Expands/collapses/toggles the expand state of the panel. Panels set to expand fill empty space.
+     * This is a proxy to `InstanceAPI.panel.expand(...)`.
+     *
+     * @param {boolean} expand Optional. Whether the panel should expand. Toggles if no value is given.
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    expand(expand?: boolean): this {
+        this.$iApi.panel.expand(this, expand);
 
         return this;
     }

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -369,6 +369,28 @@ export class PanelAPI extends APIScope {
 
         return panel;
     }
+
+    /**
+     * Expands/collapses the expand state of the panel. Toggles whether the panel expands if no expand value is given.
+     *
+     * @param {(string | PanelInstance)} value
+     * @param {boolean} expand Optional. Whether the panel should expand, toggles the value if not set
+     * @returns {(PanelInstance | null)}
+     * @memberof PanelAPI
+     */
+    expand(
+        value: string | PanelInstance,
+        expand?: boolean
+    ): PanelInstance | null {
+        const panel = this.get(value);
+
+        this.$vApp.$store.set(
+            `panel/items@${panel.id}.expanded`,
+            expand !== undefined ? expand! : !panel.expanded
+        );
+
+        return panel;
+    }
 }
 
 /**

--- a/packages/ramp-core/src/components/panel-stack/controls/back.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/back.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="relative" tabindex="-1">
         <button
-            class="text-gray-500 hover:text-black p-8"
+            class="text-gray-500 hover:text-black focus:text-black p-8"
             :class="{ 'text-gray-700': active }"
             :content="$t('panels.controls.back')"
             v-tippy="{

--- a/packages/ramp-core/src/components/panel-stack/controls/close.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/close.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="relative" tabindex="-1">
         <button
-            class="text-gray-500 hover:text-black p-8"
+            class="text-gray-500 hover:text-black focus:text-black p-8"
             :class="{ 'text-gray-700': active }"
             :content="$t('panels.controls.close')"
             v-tippy="{

--- a/packages/ramp-core/src/components/panel-stack/controls/expand.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/expand.vue
@@ -1,0 +1,58 @@
+<template>
+    <div class="w-32 h-32">
+        <button
+            class="
+                text-gray-500
+                hover:text-black
+                focus:text-black
+                w-full
+                h-full
+                flex
+                justify-center
+                items-center
+            "
+            :content="$t(`panels.controls.${active ? 'collapse' : 'expand'}`)"
+            v-tippy="{ placement: 'bottom', hideOnClick: false }"
+        >
+            <!-- EXPAND https://fonts.google.com/icons?selected=Material%20Icons%3Aexpand%3A -->
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="h-24 w-24 fill-current transform rotate-90"
+                v-if="!active"
+            >
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path
+                    d="M4 20h16v2H4zM4 2h16v2H4zm9 7h3l-4-4-4 4h3v6H8l4 4 4-4h-3z"
+                />
+            </svg>
+
+            <!-- Collapse/shrink/compress/etc. https://fonts.google.com/icons?selected=Material%20Icons%3Acompress%3A -->
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                class="h-24 w-24 fill-current transform rotate-90"
+                v-else
+            >
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path d="M0 0h24v24H0V0z" fill="none" />
+                <path
+                    d="M8 19h3v3h2v-3h3l-4-4-4 4zm8-15h-3V1h-2v3H8l4 4 4-4zM4 9v2h16V9H4z"
+                />
+                <path d="M4 12h16v2H4z" />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'ExpandV',
+    props: {
+        active: Boolean
+    }
+});
+</script>

--- a/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/minimize.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="relative" tabindex="-1">
         <button
-            class="text-gray-500 hover:text-black p-6"
+            class="text-gray-500 hover:text-black focus:text-black p-6"
             :class="{ 'text-gray-700': active }"
             :content="$t('panels.controls.minimize')"
             v-tippy="{

--- a/packages/ramp-core/src/components/panel-stack/controls/pin.vue
+++ b/packages/ramp-core/src/components/panel-stack/controls/pin.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="relative" tabindex="-1">
         <button
-            class="text-gray-500 hover:text-black p-8"
+            class="text-gray-500 hover:text-black focus:text-black p-8"
             :class="{ 'text-gray-700': active }"
             :content="
                 $t(

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -10,6 +10,7 @@
             pointer-events-auto
             min-w-0
         "
+        :class="panel.expanded ? 'flex-grow max-w-full' : ''"
         :style="panel.style"
         :data-cy="panel.id"
     >

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -16,9 +16,9 @@ class GridFixture extends GridAPI {
                         'grid-screen': markRaw(GridScreenV)
                     },
                     style: {
-                        'flex-grow': '1',
-                        'max-width': '900px'
-                    }
+                        width: '450px'
+                    },
+                    expanded: true
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/grid/screen.vue
+++ b/packages/ramp-core/src/fixtures/grid/screen.vue
@@ -4,8 +4,9 @@
             >{{ $t('grid.title') }}: {{ head || $t('grid.layer.loading') }}
         </template>
         <template #controls>
-            <pin @click="panel.pin()" :active="panel.isPinned" />
             <minimize @click="panel.minimize()" />
+            <pin @click="panel.pin()" :active="panel.isPinned" />
+            <expand @click="panel.expand()" :active="panel.expanded" />
             <close @click="panel.close()" />
         </template>
         <template #content>

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -32,3 +32,5 @@ panels.controls.unpin,Unpin,1,Détacher,0
 panels.controls.back,Back,1,Retourner,0
 panels.controls.optionsMenu,More,1,Plus,0
 panels.controls.minimize,Minimize,1,Réduire au minimum,0
+panels.controls.expand,Expand,1,Élargir,0
+panels.controls.collapse,Collapse,1,Réduire,0

--- a/packages/ramp-core/src/store/modules/panel/panel-state.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-state.ts
@@ -103,4 +103,12 @@ export interface PanelConfig {
      * @memberof PanelConfig
      */
     style?: PanelConfigStyle;
+
+    /**
+     * Whether the panel should start expanded. Expanded panels fill empty space.
+     *
+     * @type {boolean}
+     * @memberof PanelConfig
+     */
+    expanded?: boolean;
 }


### PR DESCRIPTION
#733 

Data grid now fills the available width of the app (whatever is left by other panels). Added an expand/collapse control that toggles the panel between expanding to fill width and staying at its base width.

Demo: http://ramp4-app.azureedge.net/demo/users/spencerwahl/data-grid-expand/host/index.html

- Open data grid: it should cover the rest of the map.
- Click `Collapse`: it should shrink down to `450px` width, showing the map
- Click `Expand`: it should go back to covering the map

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/743)
<!-- Reviewable:end -->
