### PR TITLE
Set default number localizer to use max 20 fractional digits

### DIFF
--- a/packages/ramp-core/docs/configuration/config-language.md
+++ b/packages/ramp-core/docs/configuration/config-language.md
@@ -1,6 +1,7 @@
 # Configuration Language Switching
 
 The main configuration file in RAMP to use is determined by the current language of the app. Each language is restricted to being linked to a single config and is in the format of key-value pairings where the key is the language code with its associated formatted config object as the value.
+
 ```
 registeredConfigs = {
     en: enConfig,
@@ -28,6 +29,7 @@ new RAMP.Instance(document.getElementById('app'), { en: enConfig })
 If the user chooses to pass a single config like above, RAMP will take that config and populate it for all available app languages in `i18n.messages`.
 
 For example, if `i18n.messages` contains **en**, **fr** and **es**, then the registered configs by the end of the instance constructor will look like this:
+
 ```
 registeredConfigs = {
     'en': enConfig,
@@ -46,6 +48,7 @@ new RAMP.Instance(document.getElementById('app'), {
 ```
 
 If the user chooses to pass in more than one config file, each user specified language will be linked to its unique config, while any remaining languages in `i18n.messages` will default to the first config passed in the parameter. The registered configs will look like this at the end of the instance constructor:
+
 ```
 registeredConfigs = {
     'en': enConfig,
@@ -70,20 +73,24 @@ The default config for number localization can be found in the `numberFormats` o
 The localization options use the built-in Internalization API and the documentation for it can be found [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat).
 
 Example usage of number formatting:
+
 ```ts
 let value = 1000.119;
 let str = window.rInstance.$vApp.$n(value, 'number');
 console.log(str);
-// 1000.12 (for en)
-// 1000,12 (for fr)
+// 1000.119 (for en)
+// 1000,119(for fr)
 ```
 
 Localization options can also be passed in when the formatting function is called:
 
 ```ts
 let value = 1000.119;
-let str = window.rInstance.$vApp.$n(value, 'number', { maximumFractionDigits: 3, useGrouping: true } as any);
+let str = window.rInstance.$vApp.$n(value, 'number', {
+    maximumFractionDigits: 1,
+    useGrouping: true
+} as any);
 console.log(str);
-// 1,000.119 (for en)
-// 1 000,119 (for fr)
+// 1,000.1 (for en)
+// 1 000,1 (for fr)
 ```

--- a/packages/ramp-core/public/starter-scripts/lambert.js
+++ b/packages/ramp-core/public/starter-scripts/lambert.js
@@ -30,11 +30,11 @@ let config = {
         },
         fixtures: {}
     }
-}
+};
 
 let options = {
     loadDefaultFixtures: false,
-    loadDefaultEvents: false
+    loadDefaultEvents: true
 };
 
 rInstance = new RAMP.Instance(document.getElementById('app'), config, options);

--- a/packages/ramp-core/src/geo/map/caption.ts
+++ b/packages/ramp-core/src/geo/map/caption.ts
@@ -380,14 +380,18 @@ export class MapCaptionAPI extends APIScope {
             Math.abs(dy),
             'number'
         )}${degreeSymbol} ${this.$iApi.$vApp.$n(my, 'number', {
-            minimumIntegerDigits: 2
+            minimumIntegerDigits: 2,
+            minimumFractionDigits: 5,
+            maximumFractionDigits: 5
         } as any)} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (lat > 0 ? 'north' : 'south')
         )} | ${this.$iApi.$vApp.$n(
             Math.abs(dx),
             'number'
         )}${degreeSymbol} ${this.$iApi.$vApp.$n(mx, 'number', {
-            minimumIntegerDigits: 2
+            minimumIntegerDigits: 2,
+            minimumFractionDigits: 5,
+            maximumFractionDigits: 5
         } as any)} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (0 > lon ? 'west' : 'east')
         )}`;
@@ -413,15 +417,17 @@ export class MapCaptionAPI extends APIScope {
         const dy = Math.abs(lat);
         const dx = Math.abs(lon);
 
-        return `${this.$iApi.$vApp.$n(
-            dy,
-            'number'
-        )}${degreeSymbol} ${this.$iApi.$vApp.$t(
+        return `${this.$iApi.$vApp.$n(dy, 'number', {
+            minimumIntegerDigits: 2,
+            minimumFractionDigits: 5,
+            maximumFractionDigits: 5
+        } as any)}${degreeSymbol} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (lat > 0 ? 'north' : 'south')
-        )} | ${this.$iApi.$vApp.$n(
-            dx,
-            'number'
-        )}${degreeSymbol} ${this.$iApi.$vApp.$t(
+        )} | ${this.$iApi.$vApp.$n(dx, 'number', {
+            minimumIntegerDigits: 2,
+            minimumFractionDigits: 5,
+            maximumFractionDigits: 5
+        } as any)}${degreeSymbol} ${this.$iApi.$vApp.$t(
             'map.coordinates.' + (0 > lon ? 'west' : 'east')
         )}`;
     }
@@ -530,10 +536,9 @@ export class MapCaptionAPI extends APIScope {
                 p
             );
 
-        return `${this.$iApi.$vApp.$n(projectedPoint.x, 'number', {
-            maximumFractionDigits: 6
-        } as any)} | ${this.$iApi.$vApp.$n(projectedPoint.y, 'number', {
-            maximumFractionDigits: 6
-        } as any)}`;
+        return `${this.$iApi.$vApp.$n(
+            projectedPoint.x,
+            'number'
+        )} | ${this.$iApi.$vApp.$n(projectedPoint.y, 'number')}`;
     }
 }

--- a/packages/ramp-core/src/lang/index.ts
+++ b/packages/ramp-core/src/lang/index.ts
@@ -23,14 +23,14 @@ const numberFormats = {
         number: {
             style: 'decimal',
             useGrouping: false,
-            maximumFractionDigits: 2
+            maximumFractionDigits: 20
         }
     },
     fr: {
         number: {
             style: 'decimal',
             useGrouping: false,
-            maximumFractionDigits: 2
+            maximumFractionDigits: 20
         }
     }
 };


### PR DESCRIPTION
## Closes #739

## Changes in this PR
- [FIX] Set the `maximumFractionDigits` value for number localization to 20
- [FIX] Update point coordinate formatter in the map caption bar to use max 3 fractional digits (unless the `"BASEMAP"` formatter is used - this will be formatted with max 20 fractional digits)

### [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/739/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/744)
<!-- Reviewable:end -->
