### PR TITLE
Make details hyperlinks distinguishable from normal text

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -55,6 +55,8 @@ importers:
       fast-xml-parser: ~3.19.0
       file-saver: ~2.0.5
       http-server: ^0.12.0
+      linkify-html: ~3.0.4
+      linkifyjs: ~3.0.4
       marked: ^1.2.2
       postcss: ^7.0.35
       prettier: ^2.2.0
@@ -107,6 +109,8 @@ importers:
       fabric: 4.4.0
       fast-xml-parser: 3.19.0
       file-saver: 2.0.5
+      linkify-html: 3.0.4_linkifyjs@3.0.4
+      linkifyjs: 3.0.4
       marked: 1.2.9
       proj4: 2.6.0
       ramp-locale-loader: link:../ramp-locale-loader
@@ -123,10 +127,10 @@ importers:
       vue: 3.1.5
       vue-class-component: 8.0.0-rc.1_vue@3.1.5
       vue-i18n: 9.1.7_vue@3.1.5
-      vue-loader: 16.8.1_webpack@4.41.3
+      vue-loader: 16.8.3_webpack@4.41.3
       vue-property-decorator: 10.0.0-rc.3_02f8eea4846df4e4acf82e1a0ada6ce8
       vue-slider-component: 4.0.0-beta.4_02f8eea4846df4e4acf82e1a0ada6ce8
-      vue-tippy: 6.0.0-alpha.34_vue@3.1.5
+      vue-tippy: 6.0.0-alpha.36_vue@3.1.5
       vuex: 4.0.2_vue@3.1.5
       vuex-pathify: 1.4.5_vue@3.1.5+vuex@4.0.2
       webpack: 4.41.3
@@ -2594,7 +2598,7 @@ packages:
       webpack-dev-server: 3.11.2_777e958c1436af419002454c0780d0b4
       webpack-merge: 4.2.2
     optionalDependencies:
-      vue-loader-v16: /vue-loader/16.8.1_webpack@4.41.3
+      vue-loader-v16: /vue-loader/16.8.3_webpack@4.41.3
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9511,11 +9515,23 @@ packages:
     resolution: {integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=}
     dev: true
 
+  /linkify-html/3.0.4_linkifyjs@3.0.4:
+    resolution: {integrity: sha512-pQrMEkEaKfbVj/eCUyi+5lgmRwaCt1MOuzHexyCOZp40iLGEH6j/6kMqg2WLCGKYET70SvFGOoSe5aAnDsoJoQ==}
+    peerDependencies:
+      linkifyjs: ^3.0.0
+    dependencies:
+      linkifyjs: 3.0.4
+    dev: false
+
   /linkify-it/2.2.0:
     resolution: {integrity: sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==}
     dependencies:
       uc.micro: 1.0.6
     dev: true
+
+  /linkifyjs/3.0.4:
+    resolution: {integrity: sha512-JWw1HHMx54g8mEsG7JwI8I/xh7qeJbF6L9u1dQOYW91RdRqDYpnTn1UaNXYkmLD967Vk0xGuyHzuRnkSApby3w==}
+    dev: false
 
   /listr-silent-renderer/1.1.1:
     resolution: {integrity: sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=}
@@ -14471,8 +14487,8 @@ packages:
       loader-utils: 2.0.0
     dev: true
 
-  /vue-loader/16.8.1_webpack@4.41.3:
-    resolution: {integrity: sha512-V53TJbHmzjBhCG5OYI2JWy/aYDspz4oVHKxS43Iy212GjGIG1T3EsB3+GWXFm/1z5VwjdjLmdZUFYM70y77vtQ==}
+  /vue-loader/16.8.3_webpack@4.41.3:
+    resolution: {integrity: sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==}
     peerDependencies:
       webpack: ^4.1.0 || ^5.0.0-0
     dependencies:
@@ -14546,8 +14562,8 @@ packages:
     resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}
     dev: true
 
-  /vue-tippy/6.0.0-alpha.34_vue@3.1.5:
-    resolution: {integrity: sha512-gotH7V2bObe6JayL+XgQL6BkkYACMPSUMGafNTUK5vNrQlbEcIRcKnP6Imy0XcTnP2AOeb+LzxPg+0nnC1qkyw==}
+  /vue-tippy/6.0.0-alpha.36_vue@3.1.5:
+    resolution: {integrity: sha512-C4Ox97eIYCBlYJlHzguu96JPW8gk7nST0lnMG4WQ8i2SKTgifiToJJ5qdX81TxpYj1iSHyQb7pVdvJzxcR8MfA==}
     peerDependencies:
       vue: ^3.0.0
     dependencies:

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -27,6 +27,8 @@
         "fabric": "^4.3.1",
         "fast-xml-parser": "~3.19.0",
         "file-saver": "~2.0.5",
+        "linkify-html": "~3.0.4",
+        "linkifyjs": "~3.0.4",
         "marked": "^1.2.2",
         "proj4": "2.6.0",
         "ramp-locale-loader": "workspace:*",

--- a/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
@@ -7,15 +7,15 @@
         >
             <span class="inline font-bold">{{ val.alias }}</span>
             <span class="flex-auto"></span>
-            <span class="inline" v-html="val.value"></span>
+            <span class="inline" v-html="makeHtmlLink(val.value)"></span>
         </div>
     </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
-
 import { FieldDefinition, IdentifyItem } from '@/geo/api';
+import linkifyHtml from 'linkify-html';
 
 export default defineComponent({
     name: 'ESRIDefaultV',
@@ -52,6 +52,27 @@ export default defineComponent({
                 };
             });
             return helper;
+        },
+        /**
+         * Make links look like links and work like links
+         */
+        makeHtmlLink(html: string): string {
+            const classes = 'underline text-blue-600 break-all';
+            const div = document.createElement('div');
+            div.innerHTML = html.trim();
+
+            // check if the html string is just an <a> tag
+            if (div.firstElementChild?.tagName == 'A') {
+                div.firstElementChild.className = classes;
+                return div.innerHTML;
+            } else {
+                // otherwise, look for any valid links
+                const options = {
+                    className: classes,
+                    target: '_blank'
+                };
+                return linkifyHtml(html, options);
+            }
         }
     }
 });


### PR DESCRIPTION
For #736.
- Hyperlinks in details panel should be blue + underlined and open the page in a new tab
- Uses `linkify` suggested by Spencer [here](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/735#issuecomment-983805185)

[Demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/736-details-hyperlink/host/index-e2e.html?script=cam)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/747)
<!-- Reviewable:end -->
