### PR TITLE
Allow legend symbology to be expanded by default

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -138,7 +138,7 @@ export class LegendEntry extends LegendItem {
         super(legendEntry);
 
         this._isLoaded = false;
-        this._displaySymbology = false;
+        this._displaySymbology = legendEntry.symbologyExpanded || false;
 
         this._loadPromise = new Promise((resolve, _) => {
             this._type =
@@ -156,8 +156,6 @@ export class LegendEntry extends LegendItem {
 
             this._isLoaded =
                 this._layer !== undefined ? this._layer.isValidState : true;
-
-            this._displaySymbology = false;
 
             // check if a layer has been bound to this entry and is done loading. If not, set the type to "placeholder".
             if (this._layer === undefined || !this._isLoaded) {


### PR DESCRIPTION
## Closes #732

## Changes in this PR
- [FEAT] The `symbologyExpanded` config flag is now used by legend entries to expand/collapse the symbology during initialization

## [Demo CAM](http://ramp4-app.azureedge.net/demo/users/sharvenp/732/host/index-e2e.html?script=cam)
The symbology stack for `Keyword search` should now be expanded by default.

_Note:_ The `Keyword search` legend entry will be in a placeholder state forever until the legend is closed/re-opened. This is a race condition and I've fixed this issue in PR #754 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/751)
<!-- Reviewable:end -->
