### PR TITLE
Add auto hyperlinking to grid + sublayer fixes

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -206,6 +206,7 @@ import ZoomButtonRendererV from './templates/zoom-button-renderer.vue';
 import { CoreFilter } from '@/geo/api';
 
 import { debounce } from 'throttle-debounce';
+import linkifyHtml from 'linkify-html';
 
 // these should match up with the `type` value returned by the attribute promise.
 const NUM_TYPES: string[] = ['oid', 'double', 'single', 'integer'];
@@ -403,6 +404,23 @@ export default defineComponent({
                             } else {
                                 this.setUpTextFilter(col, this.config.state);
                             }
+
+                            col.cellRenderer = (cell: any) => {
+                                // if value is falsey, return it
+                                if (!cell.value) {
+                                    return cell.value;
+                                }
+
+                                // test if the value already contains an anchor tag
+                                // if it does, just return the value
+                                if (/<a[^>]*>[^<]+<\/a>/g.test(cell.value)) {
+                                    return cell.value;
+                                }
+
+                                return linkifyHtml(cell.value, {
+                                    target: '_blank'
+                                });
+                            };
 
                             col.filter = 'agTextColumnFilter';
                         }
@@ -1153,6 +1171,13 @@ interface ColumnDefinition {
 ::v-deep .ag-root .rv-input::placeholder {
     font-size: 12px;
 }
+
+/* Need this for hyperlinked text in the grid */
+::v-deep a {
+    color: rgba(37, 99, 235, 1);
+    text-decoration: underline;
+}
+
 .shadow-clip {
     box-shadow: 0px 0px 15px 1px rgb(0 0 0 / 75%);
     clip-path: inset(0px 0px -50px 0px);

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -67,6 +67,7 @@ export class LegendAPI extends FixtureInstance {
                 // create a wrapper legend object for single legend entry
                 // if the entry is a sublayer, override the entry id to the sublayers id
                 if (lastEntry.entryIndex !== undefined) {
+                    lastEntry.layerParentId = lastEntry.layerId;
                     lastEntry.layerId = `${lastEntry.layerId}-${lastEntry.entryIndex}`;
                 }
                 const legendEntry = new LegendEntry(

--- a/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/placeholder.vue
@@ -70,13 +70,22 @@ export default defineComponent({
             if (newLayers === undefined) {
                 return;
             }
-            let layer: LayerInstance | undefined = this.$iApi.$vApp.$store.get(
-                LayerStore.getLayerById,
-                this.legendItem.id
-            );
 
-            if (layer !== undefined) {
-                layer?.isLayerLoaded().then(() => {
+            let mainLayer: LayerInstance | undefined =
+                this.$iApi.$vApp.$store.get(
+                    LayerStore.getLayerById,
+                    this.legendItem.layerParentId || this.legendItem.id
+                );
+
+            if (mainLayer !== undefined) {
+                mainLayer?.isLayerLoaded().then(() => {
+                    // re-fetch the layer using the legend item id
+                    let layer: LayerInstance | undefined =
+                        this.$iApi.$vApp.$store.get(
+                            LayerStore.getLayerById,
+                            this.legendItem.id
+                        );
+
                     this.legendItem.setEntry(layer!);
                     if (this.legendItem.isDefault) {
                         this.$store.set(

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -121,6 +121,7 @@ export class LegendItem {
  */
 export class LegendEntry extends LegendItem {
     _layer: LayerInstance | undefined;
+    _layerParentId: string | undefined;
     _layerUID: string | undefined;
     _layerIndex: number | undefined;
     _layerTree: TreeNode | undefined;
@@ -136,6 +137,8 @@ export class LegendEntry extends LegendItem {
      */
     constructor(legendEntry: any, parent: LegendGroup | undefined = undefined) {
         super(legendEntry);
+
+        this._layerParentId = legendEntry.layerParentId;
 
         this._isLoaded = false;
         this._displaySymbology = false;
@@ -211,6 +214,11 @@ export class LegendEntry extends LegendItem {
     /** Returns the UID of the layer */
     get layerUID(): string | undefined {
         return this._layerUID || this._layer?.uid;
+    }
+
+    /** Returns the parent layer id for this layer. Only defined for sublayers */
+    get layerParentId(): string | undefined {
+        return this._layerParentId;
     }
 
     /** Returns the entry index of the layer */
@@ -348,7 +356,11 @@ export class LegendEntry extends LegendItem {
      */
     setEntry(layer: LayerInstance) {
         this._layer = layer;
-        this._type = LegendTypes.Entry;
+        this._layer.isLayerLoaded().then(() => {
+            this._layerTree = this._layer?.getLayerTree();
+            this._layerUID = this._layer?.uid;
+            this._type = LegendTypes.Entry;
+        });
     }
 }
 
@@ -406,6 +418,7 @@ export class LegendGroup extends LegendItem {
                 } else {
                     // if the entry is a sublayer, set the entry id to the sublayers id
                     if (entry.entryIndex !== undefined) {
+                        entry.layerParentId = entry.layerId;
                         entry.layerId = `${entry.layerId}-${entry.entryIndex}`;
                     }
                     this._children.push(new LegendEntry(entry, this));

--- a/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
@@ -1,5 +1,5 @@
 import { AttribLayer, InstanceAPI } from '@/api/internal';
-import { DataFormat, LayerType, RampLayerConfig } from '@/geo/api';
+import { DataFormat, LayerType, RampLayerConfig, TreeNode } from '@/geo/api';
 import MapImageLayer from './index';
 import { markRaw } from 'vue';
 
@@ -57,6 +57,10 @@ export class MapImageSublayer extends AttribLayer {
      * Load actions for a MapImage sublayer
      */
     onLoadActions(): Array<Promise<void>> {
+        // create a leaf node for this sublayer
+        if (!this.layerTree) {
+            this.layerTree = new TreeNode(this.layerIdx, this.uid, this.name);
+        }
         return [];
     }
 


### PR DESCRIPTION
## Closes #735 

## Changes in this PR
- [FEAT] Text fields in the data grid that contains links will be automatically hyperlinked
- [FIX] Fix sublayer legend entry race condition that causes the entry to be in a placeholder state until the legend is re-opened
- [FIX] Sublayers now return a valid `TreeNode` object when `getLayerTree()` is called

### [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/735/host/index-e2e.html?script=cam)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/754)
<!-- Reviewable:end -->
