### PR TITLE
Remove caching from rush host

### DIFF
--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -10,7 +10,7 @@
         "lint": "vue-cli-service lint",
         "docs:build": "typedoc && vuepress build docs",
         "docs:dev": "typedoc && vuepress dev docs",
-        "host": "http-server . -p 3001"
+        "host": "http-server . -p 3001 -c-1"
     },
     "dependencies": {
         "@arcgis/core": "4.21.2",


### PR DESCRIPTION
## Closes #394 

## Changes in this PR
- [FIX] `rush host` no longer caches the build

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/756)
<!-- Reviewable:end -->
