### PR TITLE
Fix details template null field error

### DIFF
--- a/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/esri-default.vue
@@ -57,6 +57,10 @@ export default defineComponent({
          * Make links look like links and work like links
          */
         makeHtmlLink(html: string): string {
+            if (!html) {
+                return html;
+            }
+
             const classes = 'underline text-blue-600 break-all';
             const div = document.createElement('div');
             div.innerHTML = html.trim();


### PR DESCRIPTION
## Closes #757

## Fixes in this PR
- [FIX] Identify results with `null/undefined` fields will no longer cause an error while rendering the details template

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/757/host/index.html)
Steps to test:
1. Load [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/757/host/index.html)
2. Open the Water Quantity grid and search this station name: "Rock Creek below Horse Creek near International Boundary"
3. Open the details for this feature - the panel should open with no errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/759)
<!-- Reviewable:end -->
