### PR TITLE
Add screen reader alerts

### DIFF
--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -663,6 +663,11 @@ export class EventAPI extends APIScope {
                             LegendStore.removeLayerEntry,
                             layer.uid
                         );
+                        this.$iApi.updateAlert(
+                            this.$vApp.$t('legend.alert.layerRemoved', {
+                                name: layer.name
+                            })
+                        );
                     }
                 };
                 this.$iApi.event.on(

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -291,6 +291,27 @@ export class InstanceAPI {
         return this._isFullscreen;
     }
 
+    /**
+     * Updates the screen reader alert. Use this to inform screen reader users of visual changes in the app (pieces of ui appearing/leaving).
+     *
+     * @param alert the alert to make available to screen readers
+     * @memberof InstanceAPI
+     */
+    updateAlert(alert: string): void {
+        const alertContainer = this.$vApp.$el.querySelector(
+            '.screen-reader-alert'
+        ) as HTMLElement;
+
+        if (alertContainer.childNodes.length > 0) {
+            alertContainer.innerHTML = '';
+        }
+        const alertSpan = document.createElement('span');
+        alertSpan.setAttribute('role', 'alert');
+        const alertText = document.createTextNode(alert);
+        alertSpan.appendChild(alertText);
+        alertContainer.insertBefore(alertSpan, null);
+    }
+
     start(): void {
         // delay map loading
         if (!this.started && this.startRequired) {

--- a/packages/ramp-core/src/api/notifications.ts
+++ b/packages/ramp-core/src/api/notifications.ts
@@ -23,7 +23,8 @@ export class NotificationAPI extends APIScope {
             config: {
                 screens: {
                     'notifications-screen': markRaw(NotificationsScreenV)
-                }
+                },
+                alertName: 'notifications.title'
             }
         });
     }

--- a/packages/ramp-core/src/api/panel-instance.ts
+++ b/packages/ramp-core/src/api/panel-instance.ts
@@ -46,6 +46,8 @@ export class PanelInstance extends APIScope {
      */
     private readonly loadedScreens: string[] = [];
 
+    readonly alertName: string;
+
     /**
      * Checks if a given screen component id is already loaded and ready to render.
      *
@@ -176,7 +178,8 @@ export class PanelInstance extends APIScope {
             id: this.id,
             screens: this.screens,
             style: this.style,
-            expanded: this.expanded
+            expanded: this.expanded,
+            alertName: this.alertName
         } = {
             id,
             style: {},

--- a/packages/ramp-core/src/api/panel.ts
+++ b/packages/ramp-core/src/api/panel.ts
@@ -154,6 +154,11 @@ export class PanelAPI extends APIScope {
         this.show(panel, { screen, props });
 
         this.$vApp.$store.set(`panel/${PanelAction.openPanel}!`, { panel });
+        this.$iApi.updateAlert(
+            this.$vApp.$t(`panels.alert.open`, {
+                name: this.$vApp.$t(panel.alertName)
+            })
+        );
         this.$iApi.event.emit(GlobalEvents.PANEL_OPENED, panel);
 
         return panel;
@@ -198,6 +203,11 @@ export class PanelAPI extends APIScope {
         }
 
         this.$vApp.$store.set(`panel/${PanelAction.closePanel}!`, { panel });
+        this.$iApi.updateAlert(
+            this.$vApp.$t(`panels.alert.close`, {
+                name: this.$vApp.$t(panel.alertName)
+            })
+        );
         this.$iApi.event.emit(GlobalEvents.PANEL_CLOSED, panel);
 
         return panel;
@@ -218,6 +228,11 @@ export class PanelAPI extends APIScope {
         }
 
         this.$vApp.$store.set(`panel/${PanelAction.closePanel}!`, { panel });
+        this.$iApi.updateAlert(
+            this.$vApp.$t(`panels.alert.minimize`, {
+                name: this.$vApp.$t(panel.alertName)
+            })
+        );
 
         return panel;
     }

--- a/packages/ramp-core/src/components/panel-stack/panel-stack.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-stack.vue
@@ -20,8 +20,6 @@ import { get, sync } from '@/store/pathify-helper';
 
 import anime from 'animejs';
 
-import { PanelInstance } from '@/api';
-
 import PanelContainerV from './panel-container.vue';
 
 declare class ResizeObserver {

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -12,6 +12,7 @@
                 pointer-events-none
             "
         >
+            <div class="sr-only screen-reader-alert"></div>
             <div class="absolute top-8 w-full flex justify-center">
                 <button
                     class="

--- a/packages/ramp-core/src/fixtures/basemap/index.ts
+++ b/packages/ramp-core/src/fixtures/basemap/index.ts
@@ -25,7 +25,8 @@ class BasemapFixture extends BasemapAPI {
             {
                 id: 'basemap-panel',
                 config: {
-                    screens: { 'basemap-component': markRaw(BasemapScreenV) }
+                    screens: { 'basemap-component': markRaw(BasemapScreenV) },
+                    alertName: 'basemap.title'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -19,7 +19,8 @@ class DetailsFixture extends DetailsAPI {
                     },
                     style: {
                         width: '350px'
-                    }
+                    },
+                    alertName: 'details.title'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/export-v1/index.ts
+++ b/packages/ramp-core/src/fixtures/export-v1/index.ts
@@ -26,7 +26,8 @@ class ExportV1Fixture extends ExportV1API {
                     style: {
                         'flex-grow': '1',
                         'max-width': '800px'
-                    }
+                    },
+                    alertName: 'export-v1.alertName'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/export-v1/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/export-v1/lang/lang.csv
@@ -1,4 +1,5 @@
 key,enValue,enValid,frValue,frValid
 export-v1.appbarButton,Export,1,[fr] Export,0
+export-v1.alertName,Export,1,[fr] Export,0
 export-v1.download,Download image,1,[fr] Download image,1
 export-v1.refresh,Refresh,1,[fr] Refresh,1

--- a/packages/ramp-core/src/fixtures/gazebo/index.ts
+++ b/packages/ramp-core/src/fixtures/gazebo/index.ts
@@ -44,7 +44,8 @@ class GazeboFixture extends FixtureInstance {
                     style: {
                         'flex-grow': '1',
                         'max-width': '500px'
-                    }
+                    },
+                    alertName: 'gz.alert1'
                 }
             },
             { i18n: { messages } }
@@ -100,7 +101,8 @@ class GazeboFixture extends FixtureInstance {
                     style: {
                         'flex-grow': '1',
                         'max-width': '500px'
-                    }
+                    },
+                    alertName: 'gz.alert2'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/gazebo/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/gazebo/lang/lang.csv
@@ -1,3 +1,5 @@
 key,enValue,enValid,frValue,frValid
 gz.hello,"I'm a simple panel. but from a locale file",1,"Bonjour. Je suis un panel.",0
 gz.hello2,"I'm a simple panel.",1,"Bonjour. Je suis un panel.",0
+gz.alert1,Gazebo,1,Gazebo,0
+gz.alert2,Gazebo two,1,Gazebo deux,0

--- a/packages/ramp-core/src/fixtures/geosearch/index.ts
+++ b/packages/ramp-core/src/fixtures/geosearch/index.ts
@@ -21,7 +21,8 @@ class GeosearchFixture extends GeosearchAPI {
                 config: {
                     screens: {
                         'geosearch-component': markRaw(GeosearchScreenV)
-                    }
+                    },
+                    alertName: 'geosearch.title'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/grid/index.ts
+++ b/packages/ramp-core/src/fixtures/grid/index.ts
@@ -18,7 +18,8 @@ class GridFixture extends GridAPI {
                     style: {
                         width: '450px'
                     },
-                    expanded: true
+                    expanded: true,
+                    alertName: 'grid.alertName'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/grid/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/grid/lang/lang.csv
@@ -1,5 +1,6 @@
 key,enValue,enValid,frValue,frValid
 grid.title,Features,1,Éléments,1
+grid.alertName,Grid,1,Grille,0
 grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,0
 grid.layer.loading,The layer is loading...,1,La couche est le chargement...,0
 grid.label.columns,Hide columns,1,Masquer les colonnes,0

--- a/packages/ramp-core/src/fixtures/help/index.ts
+++ b/packages/ramp-core/src/fixtures/help/index.ts
@@ -23,7 +23,8 @@ class HelpFixture extends HelpAPI {
                     style: {
                         'flex-grow': '1',
                         'max-width': '750px'
-                    }
+                    },
+                    alertName: 'help.title'
                 }
             },
             {

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -107,6 +107,11 @@ export class LegendAPI extends FixtureInstance {
             },
             parent
         );
+        if (layer.userAdded) {
+            this.$iApi.updateAlert(
+                this.$vApp.$t('legend.alert.layerAdded', { name: layer.name })
+            );
+        }
         this.$vApp.$store.set(LegendStore.addEntry, entry);
     }
 }

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -219,7 +219,14 @@ export default defineComponent({
          */
         toggleSymbology(): void {
             if (this.legendItem!._controlAvailable(Controls.Symbology)) {
-                this.legendItem!.toggleDisplaySymbology();
+                const expanded = this.legendItem!.toggleDisplaySymbology();
+                this.$iApi.updateAlert(
+                    this.$t(
+                        `legend.alert.symbology${
+                            expanded ? 'Expanded' : 'Collapsed'
+                        }`
+                    )
+                );
             }
         },
 

--- a/packages/ramp-core/src/fixtures/legend/components/group.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/group.vue
@@ -12,7 +12,7 @@
                     default-focus-style
                     hover:bg-gray-200
                 "
-                @click="legendItem.toggleExpanded()"
+                @click="toggleExpand()"
                 v-focus-item="'show-truncate'"
                 :content="
                     $t(
@@ -88,6 +88,18 @@ export default defineComponent({
 
     data() {
         return { LegendTypes: LegendTypes };
+    },
+    methods: {
+        toggleExpand() {
+            this.legendItem.toggleExpanded();
+            this.$iApi.updateAlert(
+                this.$t(
+                    `legend.alert.group${
+                        this.legendItem.expanded ? 'Expanded' : 'Collapsed'
+                    }`
+                )
+            );
+        }
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/visibility-set.vue
@@ -12,7 +12,7 @@
                     default-focus-style
                     hover:bg-gray-200
                 "
-                @click="legendItem.toggleExpanded()"
+                @click="toggleExpand()"
                 v-focus-item="'show-truncate'"
                 :content="
                     $t(
@@ -91,6 +91,18 @@ export default defineComponent({
 
     data() {
         return { LegendTypes: LegendTypes };
+    },
+    methods: {
+        toggleExpand() {
+            this.legendItem.toggleExpanded();
+            this.$iApi.updateAlert(
+                this.$t(
+                    `legend.alert.group${
+                        this.legendItem.expanded ? 'Expanded' : 'Collapsed'
+                    }`
+                )
+            );
+        }
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/legend/index.ts
+++ b/packages/ramp-core/src/fixtures/legend/index.ts
@@ -17,7 +17,8 @@ class LegendFixture extends LegendAPI {
                     },
                     style: {
                         width: '350px'
-                    }
+                    },
+                    alertName: 'legend.title'
                 }
             },
             {

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -22,3 +22,7 @@ legend.entry.controls.datatable,Datatable,1,Tableau de données,1
 legend.entry.controls.symbology,Legend,1,Légende,1
 legend.entry.controls.remove,Remove,1,Retirer,1
 legend.entry.controls.reload,Reload,1,Recharger,1
+legend.alert.symbologyExpanded,Layer legend expanded,1,Légende de la couche élargi,0
+legend.alert.symbologyCollapsed,Layer legend collapsed,1,Légende de la couche de fondre,0
+legend.alert.groupExpanded,Legend group expanded,1,Légende groupe élargi,0
+legend.alert.groupCollapsed,Legend group collapsed,1,Légende de fondre en groupe,0

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -26,3 +26,5 @@ legend.alert.symbologyExpanded,Layer legend expanded,1,Légende de la couche él
 legend.alert.symbologyCollapsed,Layer legend collapsed,1,Légende de la couche de fondre,0
 legend.alert.groupExpanded,Legend group expanded,1,Légende groupe élargi,0
 legend.alert.groupCollapsed,Legend group collapsed,1,Légende de fondre en groupe,0
+legend.alert.layerAdded,{name} layer added to legend,1,{name} couche ajoutée à la légende,1
+legend.alert.layerRemoved,{name} layer removed from legend,1,Couche {name} retiré de la légende,1

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -258,6 +258,7 @@ export class LegendEntry extends LegendItem {
      */
     toggleDisplaySymbology() {
         this._displaySymbology = !this._displaySymbology;
+        return this._displaySymbology;
     }
 
     /**

--- a/packages/ramp-core/src/fixtures/metadata/index.ts
+++ b/packages/ramp-core/src/fixtures/metadata/index.ts
@@ -15,7 +15,8 @@ class MetadataFixture extends MetadataAPI {
                     },
                     style: {
                         width: '350px'
-                    }
+                    },
+                    alertName: 'metadata.title'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/settings/index.ts
+++ b/packages/ramp-core/src/fixtures/settings/index.ts
@@ -16,7 +16,8 @@ class SettingsFixture extends SettingsAPI {
                     },
                     style: {
                         width: '350px'
-                    }
+                    },
+                    alertName: 'settings.title'
                 }
             },
             { i18n: { messages } }

--- a/packages/ramp-core/src/fixtures/wizard/index.ts
+++ b/packages/ramp-core/src/fixtures/wizard/index.ts
@@ -17,7 +17,8 @@ class WizardFixture extends WizardAPI {
                     },
                     style: {
                         width: '350px'
-                    }
+                    },
+                    alertName: 'wizard.title'
                 }
             },
             {

--- a/packages/ramp-core/src/fixtures/wizard/screen.vue
+++ b/packages/ramp-core/src/fixtures/wizard/screen.vue
@@ -511,6 +511,7 @@ export default defineComponent({
 
             const layer = await this.$iApi.geo.layer.createLayer(config);
             await layer.initiate();
+            layer.userAdded = true;
 
             // add layer to map
             this.$iApi.geo.map.addLayer(layer);

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -383,6 +383,7 @@ export class LayerInstance extends APIScope {
     isSublayer: boolean;
     isRemoved: boolean; // used to mark sublayers for removal
     isFile: boolean;
+    userAdded: boolean;
 
     esriLayer: __esri.Layer | undefined;
     esriSubLayer: __esri.Sublayer | undefined; // used only by sublayers
@@ -416,6 +417,7 @@ export class LayerInstance extends APIScope {
         this.isSublayer = false;
         this.isRemoved = false;
         this.isFile = false;
+        this.userAdded = false;
 
         this._sublayers = [];
     }

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -34,3 +34,6 @@ panels.controls.optionsMenu,More,1,Plus,0
 panels.controls.minimize,Minimize,1,Réduire au minimum,0
 panels.controls.expand,Expand,1,Élargir,0
 panels.controls.collapse,Collapse,1,Réduire,0
+panels.alert.open,{name} panel opened,1,Panneau de {name} ouvert,0
+panels.alert.close,{name} panel closed,1,Panneau de {name} fermé,0
+panels.alert.minimize,{name} panel minimized,1,Panneau de {name} minimisé,0

--- a/packages/ramp-core/src/store/modules/panel/panel-state.ts
+++ b/packages/ramp-core/src/store/modules/panel/panel-state.ts
@@ -97,6 +97,14 @@ export interface PanelConfig {
     screens: PanelConfigScreens;
 
     /**
+     * Translation key (or string) to use in panel screen reader alerts.
+     *
+     * @type {string}
+     * @memberof PanelConfig
+     */
+    alertName: string;
+
+    /**
      * The style object to apply to the panel.
      *
      * @type {PanelConfigStyle}


### PR DESCRIPTION
Closes #737

Screen reader alerts on panel open/close/minimize. Alerts on symbology/group expand and collapse.
I based what to alert on off of what we did in ramp2... there might be more to add in the future.

I added to the panel config to supply a translation key for the panel name to use in alerts... if you have ideas for a better way please let me know.

Also if you're wondering why there are no alerts for panels getting pushed off/onto the screen... its a mess to accurately describe whats happening in many cases. It's likely that anything that doesn't involve a big change to how panel stuff is tracked would just overwhelm users with non-useful info.

demo: http://ramp4-app.azureedge.net/demo/users/spencerwahl/screen-reader-alerts/host/index.html
If you have a screenreader/feel like trying to use one then open and close some panels and interact with the legend and see if the screen reader actually responds to alerts.

I use the NVDA screen reader: https://www.nvaccess.org/download/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/765)
<!-- Reviewable:end -->
