### PR TITLE
fix build - pin `vue-loader`

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
       vue: 3.1.5
       vue-class-component: ^8.0.0-rc.1
       vue-i18n: ^9.1.7
-      vue-loader: next
+      vue-loader: 16.8.3
       vue-property-decorator: ^10.0.0-rc.2
       vue-slider-component: next
       vue-tippy: next
@@ -130,7 +130,7 @@ importers:
       vue-loader: 16.8.3_webpack@4.41.3
       vue-property-decorator: 10.0.0-rc.3_02f8eea4846df4e4acf82e1a0ada6ce8
       vue-slider-component: 4.0.0-beta.4_02f8eea4846df4e4acf82e1a0ada6ce8
-      vue-tippy: 6.0.0-alpha.36_vue@3.1.5
+      vue-tippy: 6.0.0-alpha.37_vue@3.1.5
       vuex: 4.0.2_vue@3.1.5
       vuex-pathify: 1.4.5_vue@3.1.5+vuex@4.0.2
       webpack: 4.41.3
@@ -14562,8 +14562,8 @@ packages:
     resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}
     dev: true
 
-  /vue-tippy/6.0.0-alpha.36_vue@3.1.5:
-    resolution: {integrity: sha512-C4Ox97eIYCBlYJlHzguu96JPW8gk7nST0lnMG4WQ8i2SKTgifiToJJ5qdX81TxpYj1iSHyQb7pVdvJzxcR8MfA==}
+  /vue-tippy/6.0.0-alpha.37_vue@3.1.5:
+    resolution: {integrity: sha512-CDw8lCzNv5KxTJ22z787GsE8sFM2k04zD7UBZ/NvjMhlcgV2Kg6NDSoFbgcRdVm3xSuMbEq4ttG3+ao/TpdutQ==}
     peerDependencies:
       vue: ^3.0.0
     dependencies:

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -42,7 +42,7 @@
         "throttle-debounce": "~3.0.1",
         "tiny-emitter": "^2.1.0",
         "vue": "3.1.5",
-        "vue-loader": "next",
+        "vue-loader": "16.8.3",
         "vue-class-component": "^8.0.0-rc.1",
         "vue-i18n": "^9.1.7",
         "vue-property-decorator": "^10.0.0-rc.2",

--- a/packages/ramp-core/src/shims-vue.d.ts
+++ b/packages/ramp-core/src/shims-vue.d.ts
@@ -50,3 +50,8 @@ declare class ResizeObserver {
     unobserve(target: Element): void;
     disconnect(): void;
 }
+
+declare module 'vue-tippy' {
+    export var directive: any;
+    export var install: any;
+}


### PR DESCRIPTION
`vue-loader` was updated over the weekend to `17.0.0` which came with breaking changes. We were pulling the version from the branch `next` which made us pick up the breaking changes. I have pinned `vue-loader` to `16.8.3`.


demo: https://ramp4-app.azureedge.net/demo/users/spencerwahl/build-fix/host/index.html
Should be fine since this is how the build was last week but click around as a sanity check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/766)
<!-- Reviewable:end -->
