### PR TITLE
ESRI Proxy and API Version Boost

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -7,7 +7,7 @@ importers:
 
   ../../packages/ramp-core:
     specifiers:
-      '@arcgis/core': 4.21.2
+      '@arcgis/core': 4.22.0
       '@braid/vue-formulate': ~2.5.2
       '@popperjs/core': ~2.9.2
       '@tailwindcss/forms': ^0.2.1
@@ -95,7 +95,7 @@ importers:
       webpack-dev-server: 3.9.0
       wrapper-webpack-plugin: 2.1.0
     dependencies:
-      '@arcgis/core': 4.21.2
+      '@arcgis/core': 4.22.0
       '@braid/vue-formulate': 2.5.2
       '@popperjs/core': 2.9.2
       '@vueform/toggle': 2.0.0
@@ -248,15 +248,15 @@ packages:
     resolution: {integrity: sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw==}
     dev: false
 
-  /@arcgis/core/4.21.2:
-    resolution: {integrity: sha512-L3Rc84wOFsMcljrydVKc1jkgYQSO+ru4Kgr7tCsK+YLVGWNeggLRh2XeGNIuXOEklaMxdWIBZ+Kw9424K+JQyw==}
+  /@arcgis/core/4.22.0:
+    resolution: {integrity: sha512-5FXgkJ0840PGJEYp83SLw9AT6ad5SXPKB3fBB3zAbja+Cg5n8RPG7FDY9x/BnMVk+sBVAYiBEShOL/SOV8H1Vw==}
     dependencies:
-      '@esri/arcgis-html-sanitizer': 2.7.0
+      '@esri/arcgis-html-sanitizer': 2.9.0
       '@esri/calcite-colors': 6.0.1
-      '@esri/calcite-components': 1.0.0-beta.62
-      '@popperjs/core': 2.9.3
-      focus-trap: 6.6.1
-      luxon: 2.0.2
+      '@esri/calcite-components': 1.0.0-beta.69
+      '@popperjs/core': 2.10.2
+      focus-trap: 6.7.1
+      luxon: 2.1.1
       moment: 2.29.1
       sortablejs: 1.14.0
     dev: false
@@ -1394,8 +1394,8 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@esri/arcgis-html-sanitizer/2.7.0:
-    resolution: {integrity: sha512-T3D2Gn5n7Wsu3YmsPtw9F2HmxI2McebkYHOAo9D7HF6bHBcca0GpBsDaRgYTmQ68ABOsAIIvbFfBY6aDyyHYbw==}
+  /@esri/arcgis-html-sanitizer/2.9.0:
+    resolution: {integrity: sha512-kF5gfE2W16Nu/p4P69bsGmo7CKzKiTHlK3oWOqrDy/ptaMxEDCorHLm9UKULCA478xlOQM6lSnq4o3HYgST5Lw==}
     dependencies:
       lodash.isplainobject: 4.0.6
       xss: 1.0.10
@@ -1405,12 +1405,12 @@ packages:
     resolution: {integrity: sha512-iGUIIpeMCJSTDGw4ZsxLwwxkml0QzOUJTtysjRryGbhSt183NEtwWKS+yQO19utXQz5LbQWjoav6x6CsawElkw==}
     dev: false
 
-  /@esri/calcite-components/1.0.0-beta.62:
-    resolution: {integrity: sha512-GCDIX6TKgjAc3MZ/nKZIheCEH2a1vsM+B1cldczEXgOqGeGP+sOgGuJRV6PzbpoYnvAvklsGpXjgVKNnkacIFw==}
+  /@esri/calcite-components/1.0.0-beta.69:
+    resolution: {integrity: sha512-aBcFqNYI7T1KJyAlUtEGl/VlRJ2SyPszheRpkLG+88GnlI8nN/bMrqxXVpltkViXhx370kotdBoO4xJkWnV5pQ==}
     dependencies:
       '@a11y/focus-trap': 1.0.5
-      '@popperjs/core': 2.9.3
-      '@stencil/core': 2.6.0
+      '@popperjs/core': 2.10.2
+      '@stencil/core': 2.10.0
       '@types/color': 3.0.2
       color: 4.0.1
       lodash-es: 4.17.21
@@ -1730,6 +1730,10 @@ packages:
       fastq: 1.11.0
     dev: true
 
+  /@popperjs/core/2.10.2:
+    resolution: {integrity: sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==}
+    dev: false
+
   /@popperjs/core/2.9.2:
     resolution: {integrity: sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==}
     dev: false
@@ -1790,8 +1794,8 @@ packages:
     resolution: {integrity: sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==}
     dev: true
 
-  /@stencil/core/2.6.0:
-    resolution: {integrity: sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==}
+  /@stencil/core/2.10.0:
+    resolution: {integrity: sha512-15rWMTPQ/sp0lSV82HVCXkIya3QLN+uBl7pqK4JnTrp4HiLrzLmNbWjbvgCs55gw0lULbCIGbRIEsFz+Pe/Q+A==}
     engines: {node: '>=12.10.0', npm: '>=6.0.0'}
     hasBin: true
     dev: false
@@ -6754,8 +6758,8 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.7
 
-  /focus-trap/6.6.1:
-    resolution: {integrity: sha512-x9BWuAeF5UrfWuYKJ3jYrjcVYSYptS9CqtxH5IH7lPlZrMsaugKeAa0HtoZSBZe5DmeTMx2m0qY464ZMzqarzw==}
+  /focus-trap/6.7.1:
+    resolution: {integrity: sha512-a6czHbT9twVpy2RpkWQA9vIgwQgB9Nx1PIxNNUxQT4nugG/3QibwxO+tWTh9i+zSY2SFiX4pnYhTaFaQF/6ZAg==}
     dependencies:
       tabbable: 5.2.1
     dev: false
@@ -9866,8 +9870,9 @@ packages:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
     dev: true
 
-  /luxon/2.0.2:
-    resolution: {integrity: sha512-ZRioYLCgRHrtTORaZX1mx+jtxKtKuI5ZDvHNAmqpUzGqSrR+tL4FVLn/CUGMA3h0+AKD1MAxGI5GnCqR5txNqg==}
+  /luxon/2.1.1:
+    resolution: {integrity: sha512-6VQVNw7+kQu3hL1ZH5GyOhnk8uZm21xS7XJ/6vDZaFNcb62dpFDKcH8TI5NkoZOdMRxr7af7aYGrJlE/Wv0i1w==}
+    engines: {node: '>=12'}
     dev: false
 
   /magic-string/0.25.7:

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -13,7 +13,7 @@
         "host": "http-server . -p 3001 -c-1"
     },
     "dependencies": {
-        "@arcgis/core": "4.21.2",
+        "@arcgis/core": "4.22.0",
         "@braid/vue-formulate": "~2.5.2",
         "@popperjs/core": "~2.9.2",
         "@vueform/toggle": "2.0.0",

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1827,6 +1827,18 @@
             },
             "required": ["tileSchemas", "baseMaps"],
             "unevaluatedProperties": false
+        },
+        "system": {
+            "type": "object",
+            "description": "Configuration of ramp system properties.",
+            "properties": {
+                "proxyUrl": {
+                    "type": "string",
+                    "description": "An optional proxy to be used for dealing with same-origin issues.  URL must either be a relative path on the same server or an absolute path on a server which sets CORS headers."
+                }
+            },
+            "required": [],
+            "unevaluatedProperties": false
         }
     },
     "required": ["version"]

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -118,12 +118,16 @@ export class InstanceAPI {
                 });
             }
 
+            const langConfig = configs[this.$vApp.$i18n.locale];
+
             // disable animations if needed
-            if (
-                !configs[this.$vApp.$i18n.locale].animate &&
-                this.$element._container
-            ) {
+            if (!langConfig.animate && this.$element._container) {
                 this.$element._container.classList.remove('animation-enabled');
+            }
+
+            // process system configurations
+            if (langConfig.system?.proxyUrl) {
+                this.geo.proxy = langConfig.system.proxyUrl;
             }
         }
 

--- a/packages/ramp-core/src/geo/esri.ts
+++ b/packages/ramp-core/src/geo/esri.ts
@@ -7,6 +7,7 @@
 // sorted by library path
 import EsriBasemap from '@arcgis/core/Basemap';
 import EsriColour from '@arcgis/core/Color';
+import EsriConfig from '@arcgis/core/config';
 import EsriExtent from '@arcgis/core/geometry/Extent';
 import EsriMultipoint from '@arcgis/core/geometry/Multipoint';
 import EsriPoint from '@arcgis/core/geometry/Point';
@@ -62,6 +63,7 @@ export {
     EsriClassBreakInfo,
     EsriClassBreaksRenderer,
     EsriColour,
+    EsriConfig,
     EsriExtent,
     EsriFeatureFilter,
     EsriFeatureLayer,

--- a/packages/ramp-core/src/geo/geo.ts
+++ b/packages/ramp-core/src/geo/geo.ts
@@ -10,7 +10,6 @@ import {
 
 import {
     Extent,
-    GeometryAPI,
     Graphic,
     LinearRing,
     LineString,
@@ -24,6 +23,8 @@ import {
     PolygonStyleOptions,
     SpatialReference
 } from '@/geo/api';
+
+import { EsriConfig } from '@/geo/esri';
 
 export class GeoAPI extends APIScope {
     map: MapAPI;
@@ -70,5 +71,21 @@ export class GeoAPI extends APIScope {
         this.map = new MapAPI(iApi);
         this.utils = new UtilsAPI(iApi);
         this.layer = new LayerAPI(iApi);
+    }
+
+    /**
+     * Set a proxy service to allow consumption of cross-domain non-CORS resources.
+     *
+     * @param {string} proxyUrl Url to proxy or empty string to clear. Must be relative url on host domain, or full url to CORS supported server
+     */
+    set proxy(proxyUrl: string) {
+        EsriConfig.request.proxyUrl = proxyUrl;
+    }
+
+    /**
+     * Read the current proxy setting, returns url string, empty string if no proxy
+     */
+    get proxy(): string {
+        return EsriConfig.request.proxyUrl || '';
     }
 }

--- a/packages/ramp-core/src/types.d.ts
+++ b/packages/ramp-core/src/types.d.ts
@@ -77,6 +77,9 @@ export interface RampConfig {
     layers: RampLayerConfig[];
     fixtures: { [key: string]: any };
     animate: boolean;
+    system?: {
+        proxyUrl?: string;
+    };
 }
 
 /**


### PR DESCRIPTION
This somewhat implements #728 

The code is there, have not been able to find an map server lacking CORS to test against. Will do that when we stumble across one. Am PRing as I've rebased this a billion times.

Sample useage:

```
rInstance.geo.proxy = 'https://maps.canada.ca/wmsproxy/ws/wmsproxy/executeFromProxy';
```

Note that the AXIOS calls are not using this proxy; I have a new discussion in draft to address all that fun.

The ESRI JS API has also been updated. There is a console warning, it appears to be ESRI's fault. It looks like they did a patch to their web assets and did not update their NPM build to match. Our site does not appear to be affected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/768)
<!-- Reviewable:end -->
