### PR TITLE
Fix settings screen update and duplicate legend options dropdown

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -371,7 +371,7 @@ let config = {
             },
             appbar: {
                 items: ['legend', 'geosearch', 'basemap', 'export-v1'],
-                temporaryButtons: ['details', 'grid']
+                temporaryButtons: ['details', 'grid', 'settings']
             },
             details: {
                 items: [
@@ -725,7 +725,7 @@ let config = {
             },
             appbar: {
                 items: ['legend', 'geosearch', 'basemap', 'export-v1'],
-                temporaryButtons: ['details', 'grid']
+                temporaryButtons: ['details', 'grid', 'settings']
             },
             mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
             'export-v1-title': {

--- a/packages/ramp-core/src/components/controls/dropdown-menu.vue
+++ b/packages/ramp-core/src/components/controls/dropdown-menu.vue
@@ -62,10 +62,7 @@ export default defineComponent({
         window.addEventListener(
             'click',
             event => {
-                if (
-                    event.target instanceof HTMLElement &&
-                    !this.$el.contains(event.target)
-                ) {
+                if (!this.$el.contains(event.target)) {
                     this.open = false;
                 }
             },
@@ -92,13 +89,11 @@ export default defineComponent({
         });
     },
     beforeUnmount() {
+        this.open = false;
         window.removeEventListener(
             'click',
             event => {
-                if (
-                    event.target instanceof HTMLElement &&
-                    !this.$el.contains(event.target)
-                ) {
+                if (!this.$el.contains(event.target)) {
                     this.open = false;
                 }
             },

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -243,31 +243,6 @@ export default defineComponent({
         },
 
         /**
-         * Toggles settings panel to open/close type for the LegendItem.
-         */
-        toggleSettings(): void {
-            if (this.legendItem!._controlAvailable(Controls.Settings)) {
-                this.$iApi.event.emit(
-                    GlobalEvents.SETTINGS_TOGGLE,
-                    this.legendItem!.layerUID
-                );
-            }
-        },
-
-        /**
-         * Toggles metadata panel to open/close for the legendItem!.
-         */
-        toggleMetadata(): void {
-            if (this.legendItem!._controlAvailable(Controls.Metadata)) {
-                this.$iApi.event.emit('metadata/open', {
-                    type: 'html',
-                    layer: 'Sample Layer Name',
-                    url: 'https://ryan-coulson.com/RAMPMetadataDemo.html'
-                });
-            }
-        },
-
-        /**
          * Returns a span containing the resized legend graphic.
          */
         getLegendGraphic(item: any): string | undefined {
@@ -280,13 +255,6 @@ export default defineComponent({
             svg?.setAttribute('height', item.imgHeight);
             svg?.setAttribute('width', item.imgWidth);
             return span.outerHTML;
-        },
-
-        /**
-         * Remove layer from the map
-         */
-        removeLayer(): void {
-            this.$iApi.geo.map.removeLayer(this.legendItem!.layer!);
         },
 
         /**

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -105,7 +105,6 @@ import { PanelInstance } from '@/api';
 import SettingsComponentV from './component.vue';
 import { GlobalEvents, LayerInstance } from '@/api/internal';
 import { LegendEntry } from '../legend/store/legend-defs';
-import { LayerType } from '@/geo/api';
 
 export default defineComponent({
     name: 'SettingsScreenV',
@@ -127,13 +126,15 @@ export default defineComponent({
             handlers: [] as Array<string>
         };
     },
+    watch: {
+        uid(newUid: string, oldUid: string) {
+            if (newUid !== oldUid) {
+                this.loadLayerProperties();
+            }
+        }
+    },
     mounted() {
-        // Listen for a layer load event. Some of these values may change when the layer fully loads.
-        this.layer.isLayerLoaded().then(() => {
-            this.visibilityModel = this.layer.visibility;
-            this.opacityModel = this.layer.opacity * 100;
-            this.layerName = this.layer.name;
-        });
+        this.loadLayerProperties();
 
         this.handlers.push(
             this.$iApi.event.on(
@@ -152,8 +153,7 @@ export default defineComponent({
                 (reloadedLayer: LayerInstance) => {
                     reloadedLayer.isLayerLoaded().then(() => {
                         if (this.uid === reloadedLayer.uid) {
-                            this.visibilityModel = this.layer.visibility;
-                            this.opacityModel = this.layer.opacity * 100;
+                            this.loadLayerProperties();
                         }
                     });
                 }
@@ -181,6 +181,19 @@ export default defineComponent({
         toggleSnapshot() {
             this.snapshotToggle = !this.snapshotToggle;
             // TODO: make necessary changes to layer
+        },
+
+        // load property data from layer
+        loadLayerProperties() {
+            const oldUid = this.layer.uid;
+            this.layer.isLayerLoaded().then(() => {
+                if (oldUid === this.layer.uid) {
+                    // ensure that it's still the same layer
+                    this.visibilityModel = this.layer.visibility;
+                    this.opacityModel = this.layer.opacity * 100;
+                    this.layerName = this.layer.name;
+                }
+            });
         }
     }
 });


### PR DESCRIPTION
## Closes #761 

## Changes in this PR
- [FIX] Existing settings panel will update its screen when the settings of another layer is opened
- [FIX] Mousing over other legend entries will not open its options dropdown if the dropdown is currently open for another entry
- [FIX] Removed unused functions from legend entry component
- [FEAT] The appbar now shows a temporary button for the settings panel (for #760)

### [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/761/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/769)
<!-- Reviewable:end -->
