### PR TITLE
Remove ramp2 protective error for file layer identify

### DIFF
--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -289,10 +289,6 @@ export class FileLayer extends AttribLayer {
             includeGeometry: false
         };
 
-        // TODO in RAMP2, it was found that doing a point identify against a polygon layer
-        //      needed a buffer when running against local feature layers (file based, WFS, etc)
-        //      this never made much sense, re-test against ESRI 4.x api
-
         if (
             this.geomType !== GeometryType.POLYGON &&
             options.geometry.type === GeometryType.POINT
@@ -306,7 +302,6 @@ export class FileLayer extends AttribLayer {
             qOpts.filterGeometry = options.geometry;
         }
 
-        // TODO: Test if works after #206 is implemented
         qOpts.filterSql = this.getCombinedSqlFilter();
 
         result.done = this.queryFeatures(qOpts).then(results => {

--- a/packages/ramp-core/src/geo/utils/query.ts
+++ b/packages/ramp-core/src/geo/utils/query.ts
@@ -134,12 +134,6 @@ export class QueryAPI extends APIScope {
         // TODO consider casting sourceSR to our API SR class?
         let finalGeom: __esri.Geometry;
 
-        if (isFileLayer && geometry.type !== GeometryType.EXTENT) {
-            // TODO verify this is still the case with new layerview queries.
-            throw new Error(
-                'Cannot use geometries other than Extents in queries against non-ArcGIS Server based layers'
-            );
-        }
         if (!isFileLayer && geometry.type === GeometryType.EXTENT) {
             // first check for case of very large extent in Lambert against a LatLong layer.
             // in this case, we tend to get better results keeping things in an Extent form


### PR DESCRIPTION
### Closes #748 
Turns out ESRI 4 is good with Point clicks on file layers. Removing the protective error is safe 👍 
### [Demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/748-file-layer-identify/host/index.html)
- Add `happy.json` (geojson layer) via the wizard and do an identify. There should be no errors and the identify should work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/772)
<!-- Reviewable:end -->
