### PR TITLE
Make identify tolerance configurable

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -292,6 +292,7 @@ let config = {
                     opacity: 0.8,
                     visibility: true
                 },
+                tolerance: 10,
                 customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
             },
             {

--- a/packages/ramp-core/public/starter-scripts/cam.js
+++ b/packages/ramp-core/public/starter-scripts/cam.js
@@ -289,6 +289,7 @@ let config = {
                         }
                     }
                 ],
+                tolerance: 20,
                 state: {
                     opacity: 1,
                     visibility: true

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -642,6 +642,11 @@
                     },
                     "minItems": 1
                 },
+                "tolerance": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"
+                },
                 "extent": {
                     "$ref": "#/$defs/extentWithReferenceNode"
                 },
@@ -791,6 +796,11 @@
                     "default": true,
                     "description": "Allows individual symbols to have visibility toggled on/off."
                 },
+                "tolerance": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"
+                },
                 "extent": {
                     "$ref": "#/$defs/extentWithReferenceNode"
                 },
@@ -887,6 +897,11 @@
                     "type": "string",
                     "description": "The longitude field of the layer (only for CSVs)."
                 },
+                "tolerance": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"
+                },
                 "extent": {
                     "$ref": "#/$defs/extentWithReferenceNode"
                 },
@@ -968,6 +983,11 @@
                     "enum": ["ogcWfs"],
                     "default": "ofcWfs",
                     "description": "Service type shorthand for WFS layers."
+                },
+                "tolerance": {
+                    "type": "number",
+                    "default": 5,
+                    "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"
                 },
                 "extent": {
                     "$ref": "#/$defs/extentWithReferenceNode"
@@ -1802,7 +1822,15 @@
                                     "type": "string",
                                     "description": "ID of the initial mouse point formatter",
                                     "default": "LAT_LONG_DMS",
-                                    "enum": ["LAT_LONG_DMS", "LAT_LONG_DD", "LAT_LONG_DDM", "WEB_MERCATOR", "CANADA_ATLAS_LAMBERT", "UTM", "BASEMAP"]
+                                    "enum": [
+                                        "LAT_LONG_DMS",
+                                        "LAT_LONG_DD",
+                                        "LAT_LONG_DDM",
+                                        "WEB_MERCATOR",
+                                        "CANADA_ATLAS_LAMBERT",
+                                        "UTM",
+                                        "BASEMAP"
+                                    ]
                                 }
                             }
                         },

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -751,6 +751,7 @@ export class MapAPI extends CommonMapAPI {
             // This will filter out all MapImageLayers that are not visible, regardless of the visibility of the MapImageFCs (sublayers)
             .filter(layer => layer.supportsIdentify)
             .map(layer => {
+                p.tolerance = layer.config.tolerance || 5;
                 return layer.identify(p);
             });
 


### PR DESCRIPTION
### Closes #731
Identify tolerance is now configurable and is an option for MIL, Feature, WFS, and File layers. Copied schema stuff from ramp 2 so the default tolerance of 5 is from there.
### [Demo ](https://ramp4-app.azureedge.net/demo/users/elsa-huang/731-configure-identify/host/index-e2e.html?script=cam)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/774)
<!-- Reviewable:end -->
