### PR TITLE
Make renderer search throw soft error on no match

### DIFF
--- a/packages/ramp-core/src/geo/utils/renderer.ts
+++ b/packages/ramp-core/src/geo/utils/renderer.ts
@@ -57,9 +57,13 @@ export class BaseRenderer {
             return targetSU;
         } else if (this.defaultUnit) {
             return this.defaultUnit;
-        } else {
-            throw new Error('getGraphicIcon could not find match');
         }
+
+        // could not find match, return default symbol with blank image
+        console.error(`renderer search could not find match for ${sParams}`);
+        let defaultSymbol: BaseSymbolUnit = new BaseSymbolUnit(this);
+        defaultSymbol.svgCode = '';
+        return defaultSymbol;
     }
 
     getGraphicIcon(attributes: any): string {


### PR DESCRIPTION
## Closes #750 

## Changes in this PR
- [FIX] `searchRenderer` no longer bricks the grid and throws a `console.error` + returns a blank icon when it doesn't find a match

## Comments
- It seems the [layer](https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/TC_Assessments_EN/MapServer/0)   that was initially causing this issue is broken (valid features doesn't appear on the map and zoom to feature throws an error)
- Since we no longer throw a hard error, the console is spammed with error messages when opening the grid 
    - While this isn't ideal, the layer is broken and so adding code to throttle the console errors for this specific case might not be worth since it's a rare occurrence

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/750/host/index.html)
### Steps to test

1. Add this [feature layer](https://maps-cartes.services.geo.ca/server_serveur/rest/services/NRCan/TC_Assessments_EN/MapServer/0)
2. Open its grid - the console should show renderer search errors (there will be many errors which is expected), but the grid should still work

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/784)
<!-- Reviewable:end -->
