### PR TITLE
Panel keyboard navigation update

### DIFF
--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -15,7 +15,7 @@ import { ConfigStore } from '@/store/modules/config';
 
 //@ts-ignore
 import VueTippy from 'vue-tippy';
-import { FocusList, FocusItem } from '@/directives/focus-list';
+import { FocusList, FocusItem, FocusContainer } from '@/directives/focus-list';
 import { Truncate } from '@/directives/truncate/truncate';
 
 import {
@@ -346,6 +346,7 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
         })
         .use(mixin);
 
+    vueElement.directive('focus-container', FocusContainer);
     vueElement.directive('focus-list', FocusList);
     vueElement.directive('focus-item', FocusItem);
     vueElement.directive('truncate', Truncate);

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -3,7 +3,6 @@
         name="esriMap"
         class="h-full"
         v-tippy="{
-            flip: false,
             allowHTML: true,
             zIndex: 5,
             theme: 'ramp4',

--- a/packages/ramp-core/src/components/panel-stack/panel-container.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-container.vue
@@ -22,7 +22,7 @@
                 :is="panel.route.screen"
                 v-bind="panel.route.props"
                 :panel="panel"
-                v-focus-list
+                v-focus-container
             ></component>
         </transition>
     </div>

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -1,5 +1,17 @@
 <template>
-    <div class="h-full flex flex-col items-stretch">
+    <div
+        class="h-full flex flex-col items-stretch"
+        :content="$t('panels.access')"
+        v-tippy="{
+            trigger: 'focus',
+            appendTo: 'parent',
+            popperOptions: {
+                modifiers: [
+                    { name: 'preventOverflow', options: { altAxis: true } }
+                ]
+            }
+        }"
+    >
         <header
             v-if="header"
             class="

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -9,8 +9,8 @@
                 px-8
                 h-48
                 default-focus-style
+                overflow-y-hidden
             "
-            v-focus-item="'show-truncate'"
         >
             <back
                 v-if="$iApi.screenSize === 'xs'"
@@ -26,7 +26,6 @@
         <div
             v-if="content"
             class="p-8 flex-grow default-focus-style overflow-y-auto"
-            v-focus-item
         >
             <slot name="content"></slot>
         </div>

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -20,9 +20,9 @@
                 border-b border-solid border-gray-600
                 px-8
                 h-48
-                default-focus-style
                 overflow-y-hidden
             "
+            tabindex="-1"
         >
             <back
                 v-if="$iApi.screenSize === 'xs'"
@@ -35,10 +35,7 @@
             <slot name="controls"></slot>
         </header>
 
-        <div
-            v-if="content"
-            class="p-8 flex-grow default-focus-style overflow-y-auto"
-        >
+        <div v-if="content" class="p-8 flex-grow overflow-y-auto">
             <slot name="content"></slot>
         </div>
 

--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -20,7 +20,7 @@
                 border-b border-solid border-gray-600
                 px-8
                 h-48
-                overflow-y-hidden
+                overflow-hidden
             "
             tabindex="-1"
         >

--- a/packages/ramp-core/src/directives/focus-list/focus-container.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-container.ts
@@ -9,7 +9,7 @@ enum KEYS {
 const CONTAINER_ATTR = 'focus-container';
 const LIST_ATTR = 'focus-list';
 const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
-const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
 
 let managers: FocusContainerManager[] = [];
 

--- a/packages/ramp-core/src/directives/focus-list/focus-container.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-container.ts
@@ -1,0 +1,180 @@
+import { Directive, DirectiveBinding } from 'vue';
+
+enum KEYS {
+    Enter = 'Enter',
+    Space = ' ',
+    Tab = 'Tab'
+}
+
+const CONTAINER_ATTR = 'focus-container';
+const LIST_ATTR = 'focus-list';
+const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
+
+let managers: FocusContainerManager[] = [];
+
+/**
+ * The FocusContainer Directive
+ *
+ * To use; add `v-focus-container` to the element.
+ * It will only allow tab access to inner elements when `enter` or `space` are pressed on the container.
+ */
+export const FocusContainer: Directive = {
+    mounted(el: HTMLElement, binding: DirectiveBinding) {
+        managers.push(new FocusContainerManager(el, binding.value));
+    },
+    beforeUnmount(el: HTMLElement) {
+        // filter removes the FocusContainerManager at the same time
+        managers = managers.filter((manager: FocusContainerManager) => {
+            if (manager.element === el) {
+                manager.removeEventListeners();
+                return false;
+            }
+            return true;
+        });
+    }
+};
+
+/**
+ * The FocusContainerManager Class
+ *
+ * Manages the event listeners and callbacks for `FocusContainer`s
+ */
+class FocusContainerManager {
+    element: HTMLElement;
+
+    /**
+     * Creates an instance of FocusContainerManager
+     *
+     * @param element The HTMLElement the directive was placed on
+     * @param options The options provided to the directive
+     */
+    constructor(element: HTMLElement, options: any) {
+        this.element = element;
+        this.element.toggleAttribute(CONTAINER_ATTR, true);
+        this.element.tabIndex = 0;
+        this.disableTabbing();
+
+        const focusManager = this;
+        this.element.addEventListener(
+            'keypress',
+            function (event: KeyboardEvent) {
+                focusManager.onKeypress(event);
+            }
+        );
+        this.element.addEventListener('click', function () {
+            focusManager.onClick();
+        });
+        this.element.addEventListener('focusout', function (event: FocusEvent) {
+            focusManager.onFocusOut(event);
+        });
+        this.element.addEventListener('focus', function (event: FocusEvent) {
+            focusManager.onFocus();
+        });
+    }
+
+    /**
+     * Removes all of the event listeners on the container element.
+     */
+    removeEventListeners() {
+        const focusManager = this;
+        this.element.removeEventListener(
+            'keypress',
+            function (event: KeyboardEvent) {
+                focusManager.onKeypress(event);
+            }
+        );
+        this.element.removeEventListener('click', function () {
+            focusManager.onClick();
+        });
+        this.element.removeEventListener(
+            'focusout',
+            function (event: FocusEvent) {
+                focusManager.onFocusOut(event);
+            }
+        );
+        this.element.removeEventListener('focus', function (event: FocusEvent) {
+            focusManager.onFocus();
+        });
+    }
+
+    /**
+     * Callback for the `keypress` event on the container element
+     *
+     * @param event The keyboard event
+     */
+    onKeypress(event: KeyboardEvent) {
+        if (event.target !== this.element) {
+            return;
+        }
+        if (event.key === KEYS.Enter || event.key === KEYS.Space) {
+            this.enableTabbing();
+            const first_tabbable_item = this.element.querySelector(
+                TABBABLE_TAGS
+            ) as HTMLElement;
+            first_tabbable_item.focus();
+        }
+    }
+
+    /**
+     * Callback for the `click` event on the container element
+     */
+    onClick() {
+        this.enableTabbing();
+    }
+
+    /**
+     * Callback for the `focusout` event on the container element
+     *
+     * @param event The focus event
+     */
+    onFocusOut(event: FocusEvent) {
+        if (!this.element.contains(event.relatedTarget as HTMLElement)) {
+            this.disableTabbing();
+        }
+    }
+
+    /**
+     * Callback for the `focus` event on the container element
+     */
+    onFocus() {
+        this.disableTabbing();
+    }
+
+    /**
+     * Sets tabindex to -1 for EVERY element under the container element
+     */
+    disableTabbing() {
+        const tab_list = Array.prototype.filter.call(
+            this.element.querySelectorAll(TABBABLE_TAGS),
+            el => {
+                return true;
+            }
+        ) as HTMLElement[];
+
+        tab_list.forEach((el: HTMLElement) => {
+            el.tabIndex = -1;
+        });
+    }
+
+    /**
+     * Sets tabindex to 0 for every VISIBLE element not under a different focus container or list
+     */
+    enableTabbing() {
+        Array.prototype.map.call(
+            this.element.querySelectorAll(TABBABLE_TAGS),
+            el => {
+                // !!el.offsetParent means it is visible
+                if (
+                    (el.closest(FOCUS_ATTRS) === this.element ||
+                        (el.closest(FOCUS_ATTRS) === el &&
+                            el.parentElement!.closest(FOCUS_ATTRS) ===
+                                this.element)) &&
+                    !!el.offsetParent
+                ) {
+                    el.tabIndex = 0;
+                }
+            }
+        );
+    }
+}

--- a/packages/ramp-core/src/directives/focus-list/focus-list.ts
+++ b/packages/ramp-core/src/directives/focus-list/focus-list.ts
@@ -17,6 +17,8 @@ enum KEYS {
 
 const LIST_ATTR = 'focus-list';
 const ITEM_ATTR = 'focus-item';
+const CONTAINER_ATTR = 'focus-container';
+const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
 const TRUNCATE_ATTR = 'truncate-text';
 const SHOW_TRUNCATE = 'show-truncate';
 const FOCUSED_CLASS = 'focused';
@@ -73,9 +75,9 @@ function syncTabIndex(element: HTMLElement) {
     tabbable.forEach((el: Element) => {
         // make sure its not part of a sub-list
         if (
-            el.closest(`[${LIST_ATTR}]`) === element ||
-            (el.closest(`[${LIST_ATTR}]`) === el &&
-                el.parentElement!.closest(`[${LIST_ATTR}]`) === element)
+            el.closest(FOCUS_ATTRS) === element ||
+            (el.closest(FOCUS_ATTRS) === el &&
+                el.parentElement!.closest(FOCUS_ATTRS) === element)
         ) {
             // if this element is under a `focused` element in this class list then we dont want to set tabindex to -1
             // this checks if an ancestor with the class `focused` comes before an ancestor that is a `focus-list`
@@ -154,10 +156,9 @@ export class FocusListManager {
             // always set tabindex to -1 if wanted (if focus moves away from an item you want sublists to all be untabbable as well)
             if (
                 value === -1 ||
-                el.closest(`[${LIST_ATTR}]`) === this.element ||
-                (el.closest(`[${LIST_ATTR}]`) === el &&
-                    el.parentElement!.closest(`[${LIST_ATTR}]`) ===
-                        this.element) ||
+                el.closest(FOCUS_ATTRS) === this.element ||
+                (el.closest(FOCUS_ATTRS) === el &&
+                    el.parentElement!.closest(FOCUS_ATTRS) === this.element) ||
                 el
                     .closest(`[${LIST_ATTR}],.${FOCUSED_CLASS}`)!
                     .classList.contains(FOCUSED_CLASS)
@@ -421,16 +422,16 @@ export class FocusListManager {
 
         this.isClicked = false;
 
-        // if the element already has the attribute, or the highlighted element is the list there is nothing to do
         if (
-            this.element.hasAttribute('aria-activedescendant') ||
-            this.highlightedItem === this.element
+            !(
+                this.element.hasAttribute('aria-activedescendant') ||
+                this.highlightedItem === this.element
+            )
         ) {
-            return;
+            this.setAriaActiveDescendant(this.highlightedItem);
         }
-        // otherwise set the active descendant
-        this.setAriaActiveDescendant(this.highlightedItem);
-        this.setTabIndex(0, this.highlightedItem);
+
+        syncTabIndex(this.element);
     }
 
     /**

--- a/packages/ramp-core/src/directives/focus-list/index.ts
+++ b/packages/ramp-core/src/directives/focus-list/index.ts
@@ -1,2 +1,3 @@
 export * from './focus-list';
 export * from './focus-item';
+export * from './focus-container';

--- a/packages/ramp-core/src/directives/truncate/truncate.ts
+++ b/packages/ramp-core/src/directives/truncate/truncate.ts
@@ -41,7 +41,6 @@ export const Truncate: Directive = {
             placement: 'bottom-start',
             //flip: false, // can't find a replacement for Vue3
             //boundary: 'window',
-            //multiple: true,
             triggerTarget: triggerElement
         });
 

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -19,8 +19,7 @@
                 v-tippy="{
                     placement: 'top-start',
                     trigger: 'manual focus',
-                    aria: 'describedby',
-                    multiple: true
+                    aria: 'describedby'
                 }"
                 truncate-trigger
                 :aria-label="legendItem.name"

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -26,6 +26,7 @@ notifications.controls.dismiss,Dismiss,1,Rejeter,1
 notifications.controls.expand,Expand,1,Développer,1
 notifications.controls.collapse,Collapse,1,Réduire,1
 notifications.controls.clearAll,Clear All,1,Effacer tout,1
+panels.access,Access the panel,1,Accéder au panneau,0
 panels.controls.close,Close,1,Fermer,1
 panels.controls.pin,Pin,1,Épingler,1
 panels.controls.unpin,Unpin,1,Désépingler,1


### PR DESCRIPTION
Closes #738, #767

Added the `FocusContainer` directive and added it to panels.

`FocusContainer` keeps any sub-elements from being tabbed to until `enter` or `space` are pressed on the container. When focus moves out of the container or back to the root of the container tab access is removed again. On click tabbing is enabled.

One difference from the issue is that tabbing past the last element will move focus in the normal way rather than back to the container. There were a lot of edge cases with the last elements and in the middle of trying to fix all of that I realized it probably makes more sense to not force the focus to somewhere it wouldn't go normally.

### **If you have better ideas for the directive name or the panel tooltip please comment them**

demo: http://ramp4-app.azureedge.net/demo/users/spencerwahl/panel-keyboard-nav/host/index.html
Try to interact with panels through keyboard and mouse and see if anything is inaccessible or functions strangely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/787)
<!-- Reviewable:end -->
