### PR TITLE
Add type to legend symbology

### DIFF
--- a/packages/ramp-core/src/fixtures/export-v1-legend/index.ts
+++ b/packages/ramp-core/src/fixtures/export-v1-legend/index.ts
@@ -292,7 +292,7 @@ class ExportV1LegendFixture
                 await promisify(fabric.loadSVGFromString)(symbol.svgcode)
             )[0];
 
-            if (symbol.hasOwnProperty('imgHeight')) {
+            if (!symbol.esriStandard) {
                 // WMS legend
                 const fbLabel = new fabric.Textbox(symbol.label, {
                     fontSize: 12,

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -266,6 +266,7 @@ export interface LegendSymbology {
     definitionClause?: string;
     svgcode: string;
     drawPromise: Promise<string | void>;
+    esriStandard: boolean; // indicates if this symbol is ESRI standard symbology or an image
     imgHeight?: string; // height of the original legend graphic (for wms layers)
     imgWidth?: string; // width of the original legend graphic (for wms layers)
     // TODO: Reduce this to one visibility flag (or move visibility state management another place altogether)

--- a/packages/ramp-core/src/geo/layer/ogcWms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/index.ts
@@ -540,6 +540,7 @@ export default class WmsLayer extends CommonLayer {
                 uid: RAMP.GEO.sharedUtils.generateUUID(),
                 label: name,
                 svgcode: '',
+                esriStandard: false, // is an image
                 drawPromise: this.$iApi.geo.utils.symbology
                     .generateWMSSymbology(imageUri)
                     .then((data: any) => {

--- a/packages/ramp-core/src/geo/utils/symbology.ts
+++ b/packages/ramp-core/src/geo/utils/symbology.ts
@@ -850,6 +850,7 @@ export class SymbologyAPI extends APIScope {
                               .map(su => su.definitionClause)
                               .join(' OR ')})`,
                 svgcode: '', // TODO is '' ok? maybe we need white square svg? or some loading icon?
+                esriStandard: true, // is ESRI standard symbology
                 visibility: true,
                 lastVisbility: true,
                 drawPromise: this.symbolToSvg(firstSu.symbol).then(svg => {


### PR DESCRIPTION
## Closes #649

## Changes in this PR
- [FEAT] `LegendSymbology` now has an `esriStandard` boolean property that indicates if it's standard ESRI symbology

## Comments
- I decided to go with the boolean for now and in the future if we support more types we can upgrade this property accordingly

### [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/649/host/index.html)
### [Demo - WMS](http://ramp4-app.azureedge.net/demo/users/sharvenp/649/host/index-e2e.html?script=wms-layer)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/792)
<!-- Reviewable:end -->
