### PR TITLE
Fixture doc updates

### DIFF
--- a/packages/ramp-core/docs/api/geometry.md
+++ b/packages/ramp-core/docs/api/geometry.md
@@ -2,6 +2,8 @@
 
 In general, the constructors are very flexible in accepting the varying and mixed geometry formats. The geometry input is parsed recursively, so in almost all cases if it makes sense logically, the constructor will parse it.
 
+This document uses the global `RAMP.GEO` object as the source of geometry constructors. However they are also available on the Ramp Instance API, via the `.geo` object. So `RAMP.GEO.Point()` and `rInstance.geo.Point()` are the same. Use whichever source is most convenient.
+
 ## Spatial Reference
 
 This is fairly in-line with ESRI's format. It supports WKID and WKT, and optional latestWKID parameters.

--- a/packages/ramp-core/docs/api/startup.md
+++ b/packages/ramp-core/docs/api/startup.md
@@ -1,5 +1,7 @@
 # RAMP Instantiation
 
+TODO do we need a note about needing the Vue library script to be added before RAMP script? Are there any other dependencies? Should this type of "page setup" be it's own doc page?
+
 ## Creating An Instance
 
 A page script can create an instance of RAMP with the following call:

--- a/packages/ramp-core/docs/app/details.md
+++ b/packages/ramp-core/docs/app/details.md
@@ -1,5 +1,7 @@
 # Details Fixture
 
+TODO revist after meeting with UI/UX team. Adjust page if we change the design.
+
 The details fixture adds a panel to RAMP that displays in-depth information about any specific data point on the map. It can be opened by performing an identify query either on the map or through the RAMP API.
 
 ## Panels

--- a/packages/ramp-core/docs/app/fixtures.md
+++ b/packages/ramp-core/docs/app/fixtures.md
@@ -2,6 +2,154 @@
 
 This covers various ways to create fixtures.
 
+TODO this entire doc should be re-verified by the Vue3 squad to ensure things are still accurate.
+TODO also a Vue person should read over the parts talking about Vue to make sure they make sense, and there is enough information provided that a person familiar with Vue would find it useful.
+TODO the outcome of https://github.com/ramp4-pcar4/ramp4-pcar4/issues/692 might impact this doc some.
+
+## Interface
+
+The fixture interface has four methods, all optional. They take no parameters and return no value. If a custom fixture implements them, the RAMP instance will run them at the appropriate time.
+
+- `added()` is run when the fixture has been added to the RAMP instance
+- `initialized()` is run when the fixture is `added` and the instance Map has finished initializing
+- `terminated()` is run immediately before the fixture is removed from the RAMP instance
+- `removed()` is run when after fixture is removed from the RAMP instance
+
+## Creation
+
+### Internal
+
+This approach involves forking the R4MP code-base, adding new fixtures, and re-building the project. While this can be rather intensive, the result means the new fixtures are now a part of the R4MP library you are hosting and can be used like other provided fixtures.
+
+Fixture code should be placed in a directory within `packages/ramp-core/src/fixtures`. The directory name should be the fixture name. The existing source code can be used as a guide or template to begin a fixture, if desired.
+
+The remaining creation examples deal with fixtures that are defined outside of the R4MP source, and are more appropriate for a site that is just using the compiled R4MP library (and not wanting to fork & rebuild).
+
+### Headless
+
+For a non-visual (i.e. no need for Vue UI rendering) fixture, a class that respect the fixture interface can be loaded.
+
+```js
+class HeadlessFixture {
+    initialized() {
+        // do stuff
+        this.$iApi.geo.map.zoomToLevel(8);
+    }
+}
+
+rInstance.fixture.add('headless', HeadlessFixture);
+```
+
+Note the `.add()` method will upgrade the class prototype so it has the standard fixture stuff, like the `.$iApi` property in the example.
+
+### Plain Javascript
+
+This type of fixture is written in plain JS, and requires no compilation step since it doesn't use Vue components or Vue templates or imports any other third-party code. Vue templates in this type of fixture are written as render functions, hence already compiled in the format Vue runtime can understand.
+
+This is the most simple and fast way to create fixtures as no build step is required. It is also the most compact way to create fixtures as no external code (like Vue component decorators or other helper functions) is included in the fixture bundle.
+
+A sample of this type of fixture can be found [here](https://github.com/ramp4-pcar4/ramp4-pcar4/blob/master/packages/ramp-sample-fixtures/src/diligord/diligord-fixture.js).
+
+### Typescript, Vue Decorators
+
+This type of fixture is written in Typescript and contains a `.vue` single-file component in which code is written with the help of Vue decorators (`Component` and `Prop`). Since this fixture contains a Vue template, a build step is necessary to compile HTML template to the render function Vue runtime understands, as well as converting the Typescript to Javascript.
+
+This is the most comfortable way to create fixtures since it's possible to use nice things like decorators and other syntactic sugar, RAMP type definitions, and intellisense.
+
+The resulting bundle includes more of external code as Vue decorators will be incorporated into the end file.
+
+A sample of this type of fixture can be found [here](https://github.com/ramp4-pcar4/ramp4-pcar4/tree/master/packages/ramp-sample-fixtures/src/iklob).
+
+TODO is there a link to some good Vue doc site for people not familiar with Vue Templates, Decorators, and Runtime? Could add it just to be a bit more helpful
+
+> **Note:**
+>
+> Since these fixture uses `Vue` class directly and `Vue` runtime is not bundled in, the fixture expects `Vue` to be available on the global scope. So, it must be loaded after `Vue` runtime is loaded, but before `RAMP` is loaded, to ensure `RAMP` has not been instantiated yet.
+>
+> ```html
+> <!-- load Vue since RAMP doesn't bundle it -->
+> <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+>
+> <!-- load fixtures that require Vue -->
+> <script src="../dist/sample-fixtures/iklob-fixture.js"></script>
+>
+> <!-- load RAMP after loading Vue -->
+> <script src="../dist/RAMP.umd.js"></script>
+> ```
+
+TODO verify part of the above. In particular, why must the script load before the RAMP script. This "note" may have been written before `RAMP.Instance()` was a thing. Is it because the sample fixture dumps itself on `window.hostFixtures`? If so it seems we just need to time the code in the starter script to ensure the fixture exists before adding it to the instantiation.
+
+### Typescript, No Vue Decorators
+
+This type of fixture is written in Typescript and contains a `.vue` single-file component. The code of the component, however, is written in plain Typescript, without use of Vue decorators. This fixture also requires a build step.  
+
+The resulting bundle includes a small amount of external code needed to normalize Vue components, plus a UMD wrapper around it.
+
+Compared to the Vue Decorator technique, this approach offers a smaller package size and avoids having to care about library loading order while still providing the convenience of Typescript and Vue templates. The lack of decorators will likely be the deciding factor.
+
+A sample of this type of fixture can be found [here](https://github.com/ramp4-pcar4/ramp4-pcar4/tree/master/packages/ramp-sample-fixtures/src/mouruge).
+
+## Loading External Fixtures
+
+### The Preferred Way
+
+The preferred way of loading fixtures involves adding the fixture class to the global scope (`window.hostedFixtures` or any other suitable place) and then letting the host page add it to a specific RAMP instance.
+
+```js
+// my-fixture.js
+window.hostFixtures = window.hostFixtures || {};
+window.hostFixtures['myfixture'] = MyFixture;
+```
+
+```html
+// index.html
+<!-- load fixture -->
+<script src="../path/my-fixture.js"></script>
+
+<!-- load Vue and RAMP -->
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+<script src="../dist/RAMP.umd.js"></script>
+
+<script>
+    const rInstance = new RAMP.Instance(...);
+    rInstance.fixture.add('myfixture', window.hostFixtures.myfixture);
+</script>
+```
+
+TODO verify the Vue path in the above sample is Vue 3 (might be Vue 2)
+
+### The Other (Rare) Way
+
+Sometimes, the preferred way doesn't work. Specifically, it won't work when it's not possible to load a fixture that relies on global `Vue` before `RAMP` is loaded, and therefore it's not guaranteed that `RAMP` won't be instantiated earlier (before the fixture can add itself to the global scope).
+
+The following method is more cumbersome since it requires watching a global variable. In such cases, the host page can save the RAMP instance to a global variable and let the fixture add itself to it after the instance is instantiated. This will look something like this:
+
+```ts
+// my-fixture.js
+const handle = setInterval(() => {
+    if (!rInstance) {
+        return;
+    }
+    // wait for `rInstance` to be defined and add `myfixture` to it
+    rInstance.fixture.add('myfixture', MyFixture);
+    clearInterval(handle);
+}, 1000);
+```
+
+```html
+// index.html
+<!-- load RAMP + Vue -->
+<script src="ramp+vue"></script>
+
+<!-- load fixtures that require Vue -->
+<script src="../path/my-fixture.js"></script>
+
+<script>
+    var rInstance;
+    rInstance = new RAMP.Instance(document.getElementById('app'), ...);
+</script>
+```
+
 ## Lazy-Loading
 
 It's possible to lazy-load fixture code for screen panels. This will split code for individual panel screens into separate file and will be loaded on demand. Otherwise, all fixture code is loaded right away and it defeats parts of the idea to make R4MP as flexible as possible. See `gazebo` fixture for examples.

--- a/packages/ramp-core/docs/app/panels.md
+++ b/packages/ramp-core/docs/app/panels.md
@@ -6,6 +6,8 @@ Write other stuff.
 
 ## Localization
 
+TODO why is localization documentation in `panels.md`? I feel half of this file should exist in `config-language.md` and the rest should be massaged as as guide for how to use panels.
+
 ### Core
 
 [Vue-i18n](https://kazupon.github.io/vue-i18n/) is used to localize the application and the core messages are injected into the RAMP instance when it's first created. All messages are stored in a CSV file of the following format:

--- a/packages/ramp-core/src/geo/layer/class-structure.md
+++ b/packages/ramp-core/src/geo/layer/class-structure.md
@@ -1,30 +1,29 @@
 # Guide for devs on how layer classes hang together
 
+LayerInstance: RAMP's internal "base class" for layers. Any code dealing with generic layers should use this class.
 
-LayerBase (Interface): every layer must implement this. A custom layer outside of RAMP would use this as its guide.
+~ ~ CommonLayer: The generic class for layers that are implemented inside RAMP core.
 
-LayerInstance: RAMP's internal "base class" for layers. Implements `LayerBase`. Any code dealing with generic layers should use this class. A custom outside layer (that does not have access to RAMP internals) will get converted to this baseclass via `LayerInstance.updateBaseToInstance()`
+~ ~ ~ TileLayer: Handles ArcGIS Server Tile layers.
 
-- - CommonLayer: The generic class for layers that are implemented inside RAMP core.
+~ ~ ~ ImageryLayer: Handles ArcGIS Server Imagery layers.
 
-- - - TileLayer: Handles ArcGIS Server Tile layers.
+~ ~ ~ WMSLayer: Handles WMS layers.
 
-- - - ImageryLayer: Handles ArcGIS Server Imagery layers.
+~ ~ ~ AttributeLayer: The generic class for layers that deal with attributes / features.
 
-- - - WMSLayer: Handles WMS layers.
+~ ~ ~ ~ FeatureLayer: Handles ArcGIS Server Feature layers.
 
-- - - AttributeLayer: The generic class for layers that deal with attributes / features.
+~ ~ ~ ~ MapImageLayer: Handles ArcGIS Server Map Image layers (formerly Dynamic layers).
 
-- - - - FeatureLayer: Handles ArcGIS Server Feature layers.
+~ ~ ~ ~ MapImageSublayer: Handles sublayers of ArcGIS Server Map Image layers. These are instantiated by MapImageLayers.
 
-- - - - MapImageLayer: Handles ArcGIS Server Map Image layers (formerly Dynamic layers).
+~ ~ ~ ~ FileLayer: The generic class for layers that front-load all their feature data (no server refreshes).
 
-- - - - FileLayer: The generic class for layers that front-load all their feature data (no server refreshes).
+~ ~ ~ ~ ~ CsvLayer: Handles layers populated by a CSV file.
 
-- - - - - CsvLayer: Handles layers populated by a CSV file.
+~ ~ ~ ~ ~ GeoJsonLayer: Handles layers populated by a GeoJson object.
 
-- - - - - GeoJsonLayer: Handles layers populated by a GeoJson object.
+~ ~ ~ ~ ~ WfsLayer: Handles layers populated by a WFS service.
 
-- - - - - WfsLayer: Handles layers populated by a WFS service.
-
-- - - - - ShapefileLayer: Handles layers populated by a zipped shapefile.
+~ ~ ~ ~ ~ ShapefileLayer: Handles layers populated by a zipped shapefile.


### PR DESCRIPTION
Ported Fixture setup notes from samples package to main doc folder.

Ported Headless fixture concept from random old discussion into docs.

Created fixture interface and internal setup sections.

Added some random TODOs to other doc files.