### PR TITLE
Implement basemap switching for same tile schema

### DIFF
--- a/packages/ramp-core/src/fixtures/basemap/item.vue
+++ b/packages/ramp-core/src/fixtures/basemap/item.vue
@@ -109,9 +109,21 @@ export default defineComponent({
     },
     data() {
         return {
-            selectedBasemap: get(BasemapStore.selectedBasemap),
-            selectBasemap: call(BasemapStore.selectBasemap)
+            selectedBasemap: get(BasemapStore.selectedBasemap)
         };
+    },
+    methods: {
+        selectBasemap(basemap: any) {
+            if (this.selectedBasemap.tileSchemaId !== basemap.tileSchemaId) {
+                console.warn(
+                    'Basemap switching between two different tile schemas has not been implemented yet.'
+                );
+                return;
+            }
+
+            this.$iApi.geo.map.setBasemap(basemap.id);
+            this.$iApi.$vApp.$store.set(BasemapStore.setBasemap, basemap);
+        }
     }
 });
 </script>

--- a/packages/ramp-core/src/fixtures/basemap/screen.vue
+++ b/packages/ramp-core/src/fixtures/basemap/screen.vue
@@ -28,7 +28,6 @@
                         <h3 class="font-bold text-xl" v-truncate>
                             {{ tileSchema.name }}
                         </h3>
-                        <!-- TODO: check if current basemap matches projection, if not need "Map Refresh required" warning here -->
                     </div>
 
                     <div

--- a/packages/ramp-core/src/fixtures/basemap/store/basemap-store.ts
+++ b/packages/ramp-core/src/fixtures/basemap/store/basemap-store.ts
@@ -15,7 +15,7 @@ const actions = {
      *
      * @function setSelectedBasemap
      */
-    selectBasemap: function (
+    setBasemap: function (
         context: BasemapContext,
         basemap: RampBasemapConfig | undefined
     ): void {
@@ -47,9 +47,9 @@ export enum BasemapStore {
      */
     selectedBasemap = 'basemap/selectedBasemap',
     /**
-     * (Action) selectBasemap: (basemap: RampBasemapConfig)
+     * (Action) setBasemap: (basemap: RampBasemapConfig)
      */
-    selectBasemap = 'basemap/selectBasemap'
+    setBasemap = 'basemap/setBasemap!'
 }
 
 export function basemap() {


### PR DESCRIPTION
## Closes #802 

## Changes in this PR
- [FEAT] The basemap panel can now be used to switch to other basemaps within the same tile schema

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/802/host/index.html)
### Steps to test

1. Open the basemap panel
2. Select another Mercator basemap - the map should update along with the map attribution
3. Select a Lambert basemap - should throw a console warning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/805)
<!-- Reviewable:end -->
