### PR TITLE
Add click tolerance layer property

### DIFF
--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -475,6 +475,7 @@ export interface RampLayerConfig {
     rawData?: any; // used for static data, like geojson string, shapefile guts
     latField?: string; // csv coord field
     longField?: string; // csv coord field
+    tolerance?: number; // click tolerance
 }
 
 export interface RampExtentConfig {

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -30,6 +30,7 @@ export class CommonLayer extends LayerInstance {
     _name: string;
     _scaleSet: ScaleSet;
     _legend: Array<LegendSymbology>;
+    _clickTolerance: number;
     _featureCount: number;
     _fields: Array<FieldDefinition>;
     _geomType: string;
@@ -67,6 +68,8 @@ export class CommonLayer extends LayerInstance {
         this._scaleSet = new ScaleSet();
         this._legend = [];
         this._featureCount = -1;
+        this._clickTolerance =
+            rampConfig.tolerance != undefined ? rampConfig.tolerance : 5; // use default value of 5 if tolerance is undefined
         this._fields = [];
         this._geomType = 'error';
         this._nameField = 'error';
@@ -76,8 +79,7 @@ export class CommonLayer extends LayerInstance {
 
         this.origRampConfig = rampConfig;
         this.id = rampConfig.id || '';
-        // this.uid = this.bestUid(-1);
-        this.uid = this.$iApi.geo.utils.shared.generateUUID(); // TODO[Layer-Refactor]: every sublayer is now independent, so they get their own uid :)
+        this.uid = this.$iApi.geo.utils.shared.generateUUID();
         this.isRemoved = false;
         this.isSublayer = false;
         this.supportsIdentify = false; // default state.
@@ -534,12 +536,43 @@ export class CommonLayer extends LayerInstance {
     }
 
     /**
-     * Set the feature count for thelayer
+     * Set the feature count for this layer
      *
      * @param {Integer} count the new number of features in the layer
      */
     set featureCount(count: number) {
         this._featureCount = count;
+    }
+
+    /**
+     * Get the click tolerance in pixels for this layer
+     *
+     * @returns {number} the click tolerance of this layer
+     */
+    get clickTolerance() {
+        return this._clickTolerance;
+    }
+
+    /**
+     * Set the click tolerance for this layer in pixels
+     *
+     * @param {number} tolerance the new click tolerance
+     */
+    set clickTolerance(tolerance: number) {
+        if (!this.supportsIdentify) {
+            console.warn(
+                "Attempted to set click tolerance on a layer that doesn't support identify"
+            );
+            return;
+        }
+
+        // should not happen, but we never know
+        if (tolerance < 0) {
+            console.error('Attempted to set a negative click tolerance');
+            return;
+        }
+
+        this._clickTolerance = tolerance;
     }
 
     /**

--- a/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
@@ -142,6 +142,34 @@ export class MapImageSublayer extends AttribLayer {
     }
 
     /**
+     * Get the click tolerance in pixels for this sublayer's parent layer
+     *
+     * @returns {number} the click tolerance of the parent layer
+     */
+    get clickTolerance(): number {
+        if (!this.parentLayer?.esriLayer || !this.esriSubLayer) {
+            this.noLayerErr();
+            return 0;
+        }
+
+        return this.parentLayer.clickTolerance;
+    }
+
+    /**
+     * Set the click tolerance for this sublayer's parent layer in pixels
+     *
+     * @param {number} tolerance the new click tolerance
+     */
+    set clickTolerance(tolerance: number) {
+        if (!this.parentLayer?.esriLayer || !this.esriSubLayer) {
+            this.noLayerErr();
+            return;
+        }
+
+        this.parentLayer.clickTolerance = tolerance;
+    }
+
+    /**
      * Applies the current filter settings to the physical map layer.
      *
      * @function applySqlFilter

--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -280,8 +280,6 @@ export class FileLayer extends AttribLayer {
             parentUid: this.uid
         };
 
-        const tolerance = options.tolerance || 0; // this.clickTolerance; // TODO remove the 0 and add the parameter once we implement clickTolerance from config constructor
-
         // run a spatial query
         const qOpts: QueryFeaturesParams = {
             outFields: this.fieldList,

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -551,11 +551,11 @@ export class LayerInstance extends APIScope {
     set scaleSet(scaleSet: ScaleSet) {}
 
     /**
-     * Indicates if the layer/sublayer is not in a visible scale range.
+     * Indicates if the layer is not in a visible scale range.
      *
      * @function isOffscale
      * @param {Integer} [testScale] optional scale to test against. if not provided, current map scale is used.
-     * @returns {Boolean} true if the layer/sublayer is outside of a visible scale range
+     * @returns {Boolean} true if the layer is outside of a visible scale range
      */
     isOffscale(testScale: number | undefined = undefined): boolean {
         return false;
@@ -587,7 +587,7 @@ export class LayerInstance extends APIScope {
     set legend(legend: Array<LegendSymbology>) {}
 
     /**
-     * Returns an array of field definitions about the given sublayer's fields. Raster layers will have empty arrays.
+     * Returns an array of field definitions about the given layer's fields. Raster layers will have empty arrays.
      *
      * @returns {Array} list of field definitions
      */
@@ -603,7 +603,7 @@ export class LayerInstance extends APIScope {
     set fields(fields: Array<FieldDefinition>) {}
 
     /**
-     * Returns the geometry type of the given sublayer.
+     * Returns the geometry type of the given layer.
      *
      * @returns {Array} list of field definitions
      */
@@ -619,7 +619,7 @@ export class LayerInstance extends APIScope {
     set geomType(type: string) {}
 
     /**
-     * Returns the name field of the given sublayer.
+     * Returns the name field of the given layer.
      *
      * @returns {string} name field
      */
@@ -635,7 +635,7 @@ export class LayerInstance extends APIScope {
     set nameField(name: string) {}
 
     /**
-     * Returns the OID field of the given sublayer.
+     * Returns the OID field of the given layer.
      *
      * @returns {string} OID field
      */
@@ -651,9 +651,9 @@ export class LayerInstance extends APIScope {
     set oidField(name: string) {}
 
     /**
-     * Get the feature count for the given sublayer.
+     * Get the feature count for the given layer.
      *
-     * @returns {Integer} number of features in the sublayer
+     * @returns {Integer} number of features in the layer
      */
     get featureCount(): number {
         return -1;
@@ -665,6 +665,22 @@ export class LayerInstance extends APIScope {
      * @param {Integer} count the new number of features in the layer
      */
     set featureCount(count: number) {}
+
+    /**
+     * Get the click tolerance in pixels for this layer
+     *
+     * @returns {number} the click tolerance of this layer
+     */
+    get clickTolerance(): number {
+        return 0;
+    }
+
+    /**
+     * Set the click tolerance for this layer in pixels
+     *
+     * @param {Integer} tolerance the new click tolerance
+     */
+    set clickTolerance(tolerance: number) {}
 
     /**
      * Baseline identify function for layers that do not support identify.

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -754,7 +754,7 @@ export class MapAPI extends CommonMapAPI {
             // This will filter out all MapImageLayers that are not visible, regardless of the visibility of the MapImageFCs (sublayers)
             .filter(layer => layer.supportsIdentify)
             .map(layer => {
-                p.tolerance = layer.config.tolerance || 5;
+                p.tolerance = layer.clickTolerance;
                 return layer.identify(p);
             });
 


### PR DESCRIPTION
#### ~~There is an error with `MapImageSublayer` - fixing it now~~ - Good to go 

## Closes #803 

## Changes in this PR
- [FEAT] Layers now have a `clickTolerance` property
    - Setting `clickTolerance` on layers that do no support identify will throw a warning
    - Setting `clickTolerance` on `MapImageSublayers` will set the tolerance on the parent `MapImageLayer`
- [FIX] Fixed some method docs and comments in `LayerInstance`

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/803/host/index.html)
### Steps to test

1. Try setting the click tolerance on layers using the line below and then identify them - the results should appear based on the new tolerance value
`rInstance.geo.layer.getLayer("WFSLayer").clickTolerance = 100` 
2. Try the same with sublayers - all sublayers under that parent layer should now use the new tolerance when identifying
`rInstance.geo.layer.getLayer("WaterQuantity-1").clickTolerance = 100`
(Running the line above will affect the tolerance of "Carbon monoxide emissions" as well)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/806)
<!-- Reviewable:end -->
