### PR TITLE
Fix opacity bug in settings panel

### DIFF
--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -173,7 +173,7 @@ export default defineComponent({
 
         // Update the layer opacity.
         updateOpacity(val: number) {
-            this.legendItem.setOpacity(this.opacityModel / 100);
+            this.legendItem.setOpacity(val / 100);
             this.opacityModel = val;
         },
 
@@ -190,7 +190,7 @@ export default defineComponent({
                 if (oldUid === this.layer.uid) {
                     // ensure that it's still the same layer
                     this.visibilityModel = this.layer.visibility;
-                    this.opacityModel = this.layer.opacity * 100;
+                    this.opacityModel = Math.round(this.layer.opacity * 100);
                     this.layerName = this.layer.name;
                 }
             });


### PR DESCRIPTION
## Closes #804

## Changes in this PR
- [FIX] The opacity slider in the settings panel should now properly update and display the opacity

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/804/host/index.html)
### Steps to test

1. Change the opacity of a layer
2. Close and re-open the settings panel - the correct opacity value should be displayed with no formatting issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/808)
<!-- Reviewable:end -->
