### PR TITLE
Implement layer boundary zoom

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -1,8 +1,8 @@
 <template>
     <div @click.stop @mouseover.stop class="options display-none cursor-auto">
         <dropdown-menu
-            class="relative"
-            position="left-start"
+            class="flex-shrink-0"
+            position="bottom-start"
             :tooltip="$t('legend.entry.options')"
             tooltip-placement="left"
         >
@@ -84,7 +84,25 @@
                 </svg>
                 {{ $t('legend.entry.controls.symbology') }}
             </a>
-            <!-- Remove -->
+            <!-- boundary zoom -->
+            <a
+                href="#"
+                class="flex leading-snug items-center w-auto"
+                :class="{
+                    disabled: !legendItem._controlAvailable(`boundaryZoom`)
+                }"
+                @click="zoomToLayerBoundary"
+            >
+                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                    <path
+                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                    <path d="M0 0h24v24H0V0z" fill="none" />
+                    <path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z" />
+                </svg>
+                {{ $t('legend.entry.controls.boundaryzoom') }}
+            </a>
+            <!-- remove -->
             <a
                 href="#"
                 class="flex leading-snug items-center w-auto"
@@ -100,7 +118,7 @@
                 </svg>
                 {{ $t('legend.entry.controls.remove') }}
             </a>
-            <!-- Reload -->
+            <!-- reload -->
             <a
                 href="#"
                 class="flex leading-snug items-center w-auto"
@@ -175,6 +193,15 @@ export default defineComponent({
                     layer: 'Sample Layer Name',
                     url: 'https://ryan-coulson.com/RAMPMetadataDemo.html'
                 });
+            }
+        },
+
+        /**
+         * Zoom to the boundary of layer
+         */
+        zoomToLayerBoundary() {
+            if (this.legendItem!._controlAvailable(Controls.BoundaryZoom)) {
+                this.legendItem?.layer?.zoomToLayerBoundary();
             }
         },
 

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -20,6 +20,7 @@ legend.entry.controls.metadata,Metadata,1,Métadonnées,1
 legend.entry.controls.settings,Settings,1,Paramètres,1
 legend.entry.controls.datatable,Datatable,1,Tableau de données,1
 legend.entry.controls.symbology,Legend,1,Légende,1
+legend.entry.controls.boundaryzoom,Zoom to Layer Boundary,1,Zoomer à la limite,1
 legend.entry.controls.remove,Remove,1,Retirer,1
 legend.entry.controls.reload,Reload,1,Recharger,1
 legend.alert.symbologyExpanded,Layer legend expanded,1,Légende de la couche élargi,0

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -1,6 +1,5 @@
 import { DefPromise, LayerType, LegendSymbology, TreeNode } from '@/geo/api';
 import { LayerInstance } from '@/api/internal';
-import { legend } from '.';
 
 /**
  * Function definitions for legend item wrapper objects.
@@ -223,6 +222,21 @@ export class LegendEntry extends LegendItem {
                 this._layerParentId = layer.isSublayer
                     ? layer.parentLayer!.id
                     : undefined;
+
+                // remove controls if layer doesn't support them
+                let controlsToRemove: Array<string> = [];
+                if (!layer.supportsFeatures) {
+                    controlsToRemove.push(Controls.Datatable);
+                }
+                if (layer.extent === undefined) {
+                    controlsToRemove.push(Controls.BoundaryZoom);
+                }
+                controlsToRemove.forEach(control => {
+                    let idx: number = this._controls.indexOf(control);
+                    if (idx !== -1) {
+                        this._controls.splice(idx, 1);
+                    }
+                });
 
                 this.checkVisibilityRules();
                 if (!layer.visibility) {

--- a/packages/ramp-core/src/geo/layer/attrib-layer.ts
+++ b/packages/ramp-core/src/geo/layer/attrib-layer.ts
@@ -41,7 +41,6 @@ export class AttribLayer extends CommonLayer {
     geomType: GeometryType;
     esriFields: Array<EsriField>;
     fieldList: string; // list of field names, useful for numerous esri api calls
-    extent: Extent | undefined;
     attLoader: AttributeLoaderBase | undefined;
     renderer: BaseRenderer | undefined;
     serviceUrl: string;
@@ -132,7 +131,12 @@ export class AttribLayer extends CommonLayer {
         this.scaleSet.minScale = sData.effectiveMinScale || sData.minScale;
         this.scaleSet.maxScale = sData.effectiveMaxScale || sData.maxScale;
         this.supportsFeatures = false; // saves us from having to keep comparing type to 'Feature Layer' on the client
-        this.extent = sData.extent; // TODO might need to cast/fromJson to a proper esri object
+        this.extent = sData.extent
+            ? this.$iApi.geo.utils.geom._convEsriExtentToRamp(
+                  sData.extent,
+                  this.id + '_extent'
+              )
+            : undefined;
 
         if (sData.type === 'Feature Layer') {
             this.supportsFeatures = true;

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -507,6 +507,21 @@ export class CommonLayer extends LayerInstance {
     }
 
     /**
+     * Cause the map to zoom to this layer's boundary extent
+     *
+     * @returns {Promise} resolves when map has finished zooming
+     */
+    zoomToLayerBoundary(): Promise<void> {
+        if (!this.extent) {
+            throw new Error(
+                `Attempted to zoom to boundary of a layer with no extent (Layer Id: ${this.id})`
+            );
+        }
+        this.mapCheck();
+        return this.$iApi.geo.map.zoomMapTo(this.extent);
+    }
+
+    /**
      * Return the legend of the layer
      *
      * @returns {Array<LegendSymbology>} the legend of the layer

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -126,6 +126,11 @@ class MapImageLayer extends AttribLayer {
         this.isDynamic =
             this.esriLayer.capabilities.exportMap.supportsDynamicLayers;
 
+        this.extent = this.$iApi.geo.utils.geom._convEsriExtentToRamp(
+            this.esriLayer.fullExtent,
+            this.id + '_extent'
+        );
+
         // TODO the whole "configIsComplete" logic in RAMP2 was never invoked by the client.
         //      Don't see the point in re-adding it here.
 

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -388,6 +388,7 @@ export class LayerInstance extends APIScope {
     esriLayer: __esri.Layer | undefined;
     esriSubLayer: __esri.Sublayer | undefined; // used only by sublayers
     esriView: __esri.LayerView | undefined;
+    extent: Extent | undefined; // layer extent
 
     protected _parentLayer: LayerInstance | undefined;
     protected _sublayers: Array<LayerInstance>;
@@ -567,6 +568,15 @@ export class LayerInstance extends APIScope {
      * @returns {Promise} resolves when map has finished zooming
      */
     zoomToVisibleScale(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    /**
+     * Cause the map to zoom to this layer's boundary extent
+     *
+     * @returns {Promise} resolves when map has finished zooming
+     */
+    zoomToLayerBoundary(): Promise<void> {
         return Promise.resolve();
     }
 


### PR DESCRIPTION
## Closes #815

## Changes in this PR
- [FEAT] Can now zoom to a layer's boundary through the legend options dropdown
- [FEAT] Automatically remove legend entry controls if the layer doesn't support them
    - Layers that don't support attributes will have the datatable option greyed out in the legend options
    - Similarly, layers will no extent will have the boundary zoom option greyed out

### Note
- I added the "Zoom to Layer Boundary" translation (Zoomer à la limite) to the legend lang file
- Not sure if this is valid but I got this string from RAMP2 since it also uses "Zoom to Layer Boundary" in the dropdown

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/815/host/index.html)
### Steps to test

1. Zoom to various layer boundaries using the legend dropdown
2. Add this [Feature Layer](https://maps-cartes.ec.gc.ca/arcgis/rest/services/Shellfish_Classification_Mollusques/MapServer/6) (Shellfish Classification)
3. Zoom to this layer's boundary - should zoom in to Nova Scotia
4. Add this [Tile Layer](http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer) (World Physical Map) - the zoom to boundary and datatable options for this layer should be disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/820)
<!-- Reviewable:end -->
