### PR TITLE
Make interactive details panel elements keyboard accessible

### DIFF
--- a/packages/ramp-core/src/fixtures/details/layers-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/layers-screen.vue
@@ -16,8 +16,9 @@
                     })
                 }}
             </div>
-            <div
+            <button
                 class="
+                    w-full
                     px-20
                     py-10
                     text-md
@@ -36,7 +37,7 @@
                 <!-- Display the count if item exists, else display the loading spinner -->
                 <div v-if="item" class="px-5">{{ item.items.length }}</div>
                 <div v-else class="animate-spin spinner h-20 w-20 px-5"></div>
-            </div>
+            </button>
         </template>
     </panel-screen>
 </template>

--- a/packages/ramp-core/src/fixtures/details/result-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/result-screen.vue
@@ -8,8 +8,9 @@
         </template>
         <template #content>
             <div v-if="identifyResult.items.length > 0">
-                <div
+                <button
                     class="
+                        w-full
                         flex
                         px-10
                         py-10
@@ -34,7 +35,7 @@
                             'Identify Result ' + (idx + 1)
                         }}
                     </span>
-                </div>
+                </button>
             </div>
             <div v-else>{{ $t('details.results.empty') }}</div>
         </template>


### PR DESCRIPTION
Changes a `div` element to a `button` element on screens 1 and 2 of the details panel. Width needs to be set at 100% to maintain the current layout. The special class `w-100` did not work so I manually set the rule.

Closes #795

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/832)
<!-- Reviewable:end -->
