### PR TITLE
Implement layer reordering fixture

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -87,6 +87,7 @@ importers:
       vue-property-decorator: ^10.0.0-rc.2
       vue-slider-component: next
       vue-tippy: next
+      vuedraggable: next
       vuepress: ~1.8.2
       vuex: ^4.0.0
       vuex-pathify: ~1.4.1
@@ -131,6 +132,7 @@ importers:
       vue-property-decorator: 10.0.0-rc.3_02f8eea4846df4e4acf82e1a0ada6ce8
       vue-slider-component: 4.0.0-beta.4_02f8eea4846df4e4acf82e1a0ada6ce8
       vue-tippy: 6.0.0-alpha.44_vue@3.1.5
+      vuedraggable: 4.1.0_vue@3.1.5
       vuex: 4.0.2_vue@3.1.5
       vuex-pathify: 1.4.5_vue@3.1.5+vuex@4.0.2
       webpack: 4.41.3
@@ -14580,6 +14582,15 @@ packages:
       '@vue/compiler-dom': 3.1.5
       '@vue/runtime-dom': 3.1.5
       '@vue/shared': 3.1.5
+    dev: false
+
+  /vuedraggable/4.1.0_vue@3.1.5:
+    resolution: {integrity: sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==}
+    peerDependencies:
+      vue: ^3.0.1
+    dependencies:
+      sortablejs: 1.14.0
+      vue: 3.1.5
     dev: false
 
   /vuepress-html-webpack-plugin/3.2.0_webpack@4.41.3:

--- a/packages/ramp-core/package.json
+++ b/packages/ramp-core/package.json
@@ -48,6 +48,7 @@
         "vue-property-decorator": "^10.0.0-rc.2",
         "vue-slider-component": "next",
         "vue-tippy": "next",
+        "vuedraggable": "next",
         "tippy.js": "next",
         "vuex": "^4.0.0",
         "vuex-pathify": "~1.4.1",

--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -238,7 +238,6 @@ let config = {
         layers: [
             {
                 id: 'WaterQuantity',
-                name: 'Water quantity parent + CO2',
                 layerType: 'esriMapImage',
                 url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
                 layerEntries: [
@@ -371,7 +370,13 @@ let config = {
                 }
             },
             appbar: {
-                items: ['legend', 'geosearch', 'basemap', 'export-v1'],
+                items: [
+                    'legend',
+                    'geosearch',
+                    'basemap',
+                    'export-v1',
+                    'layer-reorder'
+                ],
                 temporaryButtons: ['details', 'grid', 'settings']
             },
             details: {
@@ -402,6 +407,14 @@ let config = {
                 spatialReference: {
                     wkid: 102100,
                     latestWkid: 3857
+                }
+            },
+            caption: {
+                mouseCoords: {
+                    formatter: 'WEB_MERCATOR'
+                },
+                scaleBar: {
+                    imperialScale: true
                 }
             },
             lods: RAMP.GEO.defaultLODs(RAMP.GEO.defaultTileSchemas()[1]), // idx 1 = mercator
@@ -606,7 +619,6 @@ let config = {
         layers: [
             {
                 id: 'WaterQuantity',
-                name: 'Water quantity parent',
                 layerType: 'esriMapImage',
                 url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
                 layerEntries: [
@@ -615,6 +627,14 @@ let config = {
                         name: 'Water quantity child',
                         state: {
                             opacity: 1,
+                            visibility: true
+                        }
+                    },
+                    {
+                        index: 9,
+                        name: 'Carbon monoxide emissions by facility',
+                        state: {
+                            opacity: 0.5,
                             visibility: true
                         }
                     }
@@ -652,6 +672,7 @@ let config = {
                     opacity: 0.8,
                     visibility: true
                 },
+                tolerance: 10,
                 customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
             },
             {
@@ -697,8 +718,7 @@ let config = {
                             name: 'Visibility Set',
                             exclusiveVisibility: [
                                 {
-                                    layerId: 'CleanAir',
-                                    name: 'Clean Air in Set'
+                                    layerId: 'CleanAir'
                                 },
                                 {
                                     name: 'Group in Set',
@@ -707,6 +727,11 @@ let config = {
                                             layerId: 'WaterQuantity',
                                             name: 'Water Quantity in Nested Group',
                                             entryIndex: 1
+                                        },
+                                        {
+                                            layerId: 'WaterQuantity',
+                                            name: 'CO2 in Nested Group',
+                                            entryIndex: 9
                                         },
                                         {
                                             layerId: 'WaterQuality',
@@ -725,8 +750,25 @@ let config = {
                 }
             },
             appbar: {
-                items: ['legend', 'geosearch', 'basemap', 'export-v1'],
+                items: [
+                    'legend',
+                    'geosearch',
+                    'basemap',
+                    'export-v1',
+                    'layer-reorder'
+                ],
                 temporaryButtons: ['details', 'grid', 'settings']
+            },
+            details: {
+                items: [
+                    {
+                        id: 'WaterQuantity'
+                    },
+                    {
+                        id: 'WFSLayer',
+                        template: 'WFSLayer-Custom'
+                    }
+                ]
             },
             mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
             'export-v1-title': {

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -575,6 +575,11 @@
                 },
                 "state": {
                     "$ref": "#/$defs/initialLayerSettings"
+                },
+                "cosmetic": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indicates if this layer is a cosmetic supporting layer which will not be considered for general user interaction."
                 }
             },
             "required": ["id", "layerType", "url"],

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -6,6 +6,7 @@ import { HelpAPI } from '@/fixtures/help/api/help';
 import { GridAPI } from '@/fixtures/grid/api/grid';
 import { WizardAPI } from '@/fixtures/wizard/api/wizard';
 import { LegendAPI } from '@/fixtures/legend/api/legend';
+import { LayerReorderAPI } from '@/fixtures/layer-reorder/api/layer-reorder';
 import { LegendStore } from '@/fixtures/legend/store';
 import { LegendGroup } from '@/fixtures/legend/store/legend-defs';
 import { GridStore, GridAction } from '@/fixtures/grid/store';
@@ -214,6 +215,12 @@ export enum GlobalEvents {
     PANEL_OPENED = 'panel/opened',
 
     /**
+     * Fires when a request is issued to open the Layer Reorder panel.
+     * Payload: none
+     */
+    REORDER_OPEN = 'reorder/open',
+
+    /**
      * Fires when a request is issued to toggle (show if hidden, hide if showing) layer settings.
      * Payload: `(uid: string)`
      */
@@ -250,6 +257,7 @@ enum DefEH {
     TOGGLE_HELP = 'toggles_help_panel',
     TOGGLE_GRID = 'toggles_grid_panel',
     OPEN_WIZARD = 'opens_wizard_panel',
+    OPEN_LAYER_REORDER = 'opens_layer_reorder_panel',
     UPDATE_LEGEND_LAYER_REGISTER = 'updates_legend_layer_register',
     UPDATE_LEGEND_WIZARD_ADDED = 'updates_legend_wizard_added',
     UPDATE_LEGEND_LAYER_RELOAD = 'updates_legend_layer_reload',
@@ -511,6 +519,7 @@ export class EventAPI extends APIScope {
                 DefEH.TOGGLE_HELP,
                 DefEH.TOGGLE_GRID,
                 DefEH.OPEN_WIZARD,
+                DefEH.OPEN_LAYER_REORDER,
                 DefEH.UPDATE_LEGEND_LAYER_REGISTER,
                 DefEH.UPDATE_LEGEND_WIZARD_ADDED,
                 DefEH.UPDATE_LEGEND_LAYER_RELOAD,
@@ -630,6 +639,20 @@ export class EventAPI extends APIScope {
                 };
                 this.$iApi.event.on(
                     GlobalEvents.WIZARD_OPEN,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.OPEN_LAYER_REORDER:
+                zeHandler = () => {
+                    const reorderFixture: LayerReorderAPI =
+                        this.$iApi.fixture.get('layer-reorder');
+                    if (reorderFixture) {
+                        reorderFixture.openLayerReorder();
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.REORDER_OPEN,
                     zeHandler,
                     handlerName
                 );

--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -171,6 +171,7 @@ export class FixtureAPI extends APIScope {
                 'geosearch',
                 'grid',
                 'help',
+                'layer-reorder',
                 'legend',
                 'mapnav',
                 'metadata',

--- a/packages/ramp-core/src/components/map/esri-map.vue
+++ b/packages/ramp-core/src/components/map/esri-map.vue
@@ -167,14 +167,6 @@ export default defineComponent({
                                     this.map.addLayer(layer!);
                                 }
 
-                                // add layers to layer store
-                                // TODO need to revisit https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/328
-                                //      as we may be causing lots of problems putting these objects in vuex store.
-                                this.$iApi.$vApp.$store.set(
-                                    LayerStore.addLayers,
-                                    [layer]
-                                );
-
                                 resolve(layer!);
                             }
                         );

--- a/packages/ramp-core/src/fixtures/layer-reorder/api/layer-reorder.ts
+++ b/packages/ramp-core/src/fixtures/layer-reorder/api/layer-reorder.ts
@@ -1,0 +1,15 @@
+import { FixtureInstance } from '@/api';
+
+export class LayerReorderAPI extends FixtureInstance {
+    /**
+     * Opens the layer reorder fixture panel
+     *
+     * @memberof LayerReorderAPI
+     */
+    openLayerReorder(): void {
+        const panel = this.$iApi.panel.get('layer-reorder-panel');
+        if (!panel.isOpen) {
+            this.$iApi.panel.open('layer-reorder-panel');
+        }
+    }
+}

--- a/packages/ramp-core/src/fixtures/layer-reorder/appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/layer-reorder/appbar-button.vue
@@ -1,0 +1,37 @@
+<template>
+    <appbar-button
+        :onClickFunction="onClick"
+        :tooltip="$t('layerreorder.title')"
+    >
+        <!--https://fonts.google.com/icons?selected=Material+Icons:low_priority -->
+        <svg
+            class="fill-current w-24 h-24 ml-8 sm:ml-20 flip"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+        >
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path
+                d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z"
+            />
+        </svg>
+    </appbar-button>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'LayerReorderAppbarButtonV',
+    methods: {
+        onClick() {
+            this.$iApi.panel.toggle('layer-reorder-panel');
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped>
+.flip {
+    transform: scale(1, -1);
+}
+</style>

--- a/packages/ramp-core/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/packages/ramp-core/src/fixtures/layer-reorder/components/layer-component.vue
@@ -1,0 +1,450 @@
+<template>
+    <div>
+        <div v-if="layersModel.length === 0" class="flex-1 ms-10" v-truncate>
+            <span>{{ $t('layerreorder.nolayers') }}</span>
+        </div>
+        <draggable
+            v-else
+            class="p-3"
+            v-model="layersModel"
+            item-key="uid"
+            :animation="isAnimationEnabled ? 200 : 0"
+            @change="onMoveLayerDragEnd"
+            @start="onMoveLayerDragStart"
+        >
+            <template #item="{ element }">
+                <div
+                    v-if="element.isLoaded"
+                    :class="`
+                        mt-4
+                        relative
+                        ${element.isExpanded ? 'bg-gray-200' : ''}
+                        border-2
+                        border-gray-300
+                        default-focus-style
+                    `"
+                    v-tippy="{
+                        placement: 'top-start',
+                        aria: 'describedby'
+                    }"
+                    :aria-label="element.name"
+                    :content="element.name"
+                    v-focus-container
+                >
+                    <div
+                        class="
+                            flex
+                            items-center
+                            p-5
+                            ms-5
+                            h-44
+                            cursor-pointer
+                            hover:bg-gray-200
+                        "
+                    >
+                        <!-- dropdown toggle  -->
+                        <button
+                            v-if="element.supportsSublayers"
+                            @click="toggleExpand(element)"
+                            class="text-gray-500 hover:text-black p-5"
+                            :content="
+                                $t(
+                                    `layerreorder.${
+                                        !element.isExpanded
+                                            ? 'expand'
+                                            : 'collapse'
+                                    }`
+                                )
+                            "
+                            v-focus-item
+                            v-tippy="{
+                                placement: 'right',
+                                aria: 'describedby'
+                            }"
+                            :aria-label="
+                                $t(
+                                    `layerreorder.${
+                                        !element.isExpanded
+                                            ? 'expand'
+                                            : 'collapse'
+                                    }`
+                                )
+                            "
+                        >
+                            <svg
+                                v-if="element.isExpanded"
+                                class="fill-current w-20 h-20 mx-4"
+                                viewBox="0 0 24 24"
+                            >
+                                <path d="M0 0h24v24H0z" fill="none" />
+                                <path d="M19 13H5v-2h14v2z" />
+                            </svg>
+                            <svg
+                                v-else
+                                class="fill-current w-20 h-20 mx-4"
+                                viewBox="0 0 24 24"
+                            >
+                                <path
+                                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                                ></path>
+                            </svg>
+                        </button>
+
+                        <!-- name -->
+                        <div class="flex-1 mx-10" v-truncate>
+                            <span>{{ element.name }} </span>
+                        </div>
+
+                        <!-- controls -->
+                        <reorder-button
+                            :disabled="_isBoundary(element.orderIdx + 1)"
+                            direction="up"
+                            class="px-7"
+                            @click="onMoveLayerButton(element, 1)"
+                        />
+                        <reorder-button
+                            :disabled="_isBoundary(element.orderIdx - 1)"
+                            direction="down"
+                            class="px-7"
+                            @click="onMoveLayerButton(element, -1)"
+                        />
+                    </div>
+
+                    <!-- display children of the parent layer -->
+                    <div
+                        class="
+                            items-center
+                            bg-gray-200
+                            p-5
+                            pl-30
+                            default-focus-style
+                            cursor-pointer
+                        "
+                        v-if="
+                            element.isExpanded && element.sublayers.length > 0
+                        "
+                        v-focus-list
+                    >
+                        <div
+                            v-for="sublayer in element.sublayers"
+                            :key="sublayer.id"
+                            class="m-15 default-focus-style"
+                            v-truncate
+                            v-tippy="{
+                                placement: 'bottom-start',
+                                aria: 'describedby'
+                            }"
+                            :content="sublayer.name"
+                            :aria-label="sublayer.name"
+                            v-focus-container
+                        >
+                            {{ sublayer.name }}
+                        </div>
+                    </div>
+                </div>
+                <!-- else show loading spinner -->
+                <div
+                    v-else
+                    class="flex items-center p-5 mx-8 h-44 default-focus-style"
+                    :content="$t('layerreorder.loading')"
+                    v-tippy="{
+                        placement: 'top-start',
+                        aria: 'describedby'
+                    }"
+                    :aria-label="$t('layerreorder.loading')"
+                    v-focus-container
+                    truncate-trigger
+                >
+                    <div class="animate-spin spinner h-20 w-20 px-5"></div>
+                    <div class="flex-1 mx-10">
+                        <span>{{ $t('layerreorder.loading') }} </span>
+                    </div>
+                </div>
+            </template>
+        </draggable>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, toRaw } from 'vue';
+import { get } from '@/store/pathify-helper';
+import { LayerStore } from '@/store/modules/layer';
+import { GlobalEvents, LayerInstance } from '@/api';
+import { LayerModel } from '../definitions';
+import LayerReorderButtonV from './reorder-button.vue';
+import draggable from 'vuedraggable';
+
+export default defineComponent({
+    name: 'LayerReorderComponentV',
+    components: {
+        draggable,
+        'reorder-button': LayerReorderButtonV
+    },
+    data() {
+        return {
+            layers: get(LayerStore.layers),
+            layersModel: [] as Array<LayerModel>,
+            oldOrder: [] as Array<number>, // keeps track of layer order when dragging starts
+            minIdx: -Infinity, // lowest allowed index
+            maxIdx: Infinity // highest allowed index
+        };
+    },
+    computed: {
+        /**
+         * Get animation enabled status
+         */
+        isAnimationEnabled(): Boolean {
+            return this.$iApi.animate === 'on';
+        }
+    },
+    watch: {
+        layers() {
+            // want to reload layers in case layers were added/removed, or existing layers have changed
+            this.loadLayers();
+        }
+    },
+    mounted() {
+        this.loadLayers();
+
+        // watch for layer remove events (this is mainly used to react to sublayer removals)
+        this.$iApi.event.on(
+            GlobalEvents.LAYER_REMOVE,
+            () => {
+                this.loadLayers();
+            },
+            'layer-reorder-remove'
+        );
+    },
+    beforeUnmount() {
+        // unmount handler
+        this.$iApi.event.off('layer-reorder-remove');
+    },
+    methods: {
+        /**
+         * Convert the layers from the store into a simple LayerModel interface that draggable can use
+         * Additionally set up layer load promise listeners to automatically update model when the layer loads
+         */
+        loadLayers(): void {
+            // remember which layers were expanded
+            let layerExpandedState: { [id: string]: boolean } = {};
+            this.layersModel.forEach((layer: LayerModel) => {
+                layerExpandedState[layer.id] = layer.isExpanded;
+            });
+
+            // reset models
+            this.layersModel = [];
+
+            this.layersModel = [...toRaw(this.layers)]
+                .filter((layer: LayerInstance) => !layer.isCosmetic) // filter out cosmetic layers
+                .reverse() // needs to be reverse because map-stack is in reverse order of layer list
+                .map((layer: LayerInstance) => {
+                    // get the true index of this layer in the layers list
+                    const trueIdx: number = this.layers.indexOf(layer);
+                    // map layer instance to simpler layer model object
+                    let model: LayerModel = {
+                        id: layer.id,
+                        uid: layer.uid,
+                        name: '',
+                        orderIdx: trueIdx,
+                        isExpanded: layerExpandedState[layer.id] || false,
+                        isLoaded: false,
+                        supportsSublayers: layer.supportsSublayers,
+                        sublayers: []
+                    };
+                    return model;
+                });
+
+            // add load promise listeners to update models
+            this.layers.forEach((layer: LayerInstance) => {
+                layer.isLayerLoaded().then(() => {
+                    this.loadLayerData(layer);
+                });
+            });
+
+            // calculate the min and max boundary indices
+            // algorithm explanation:
+            //      loop through the list of layers from both directions and store the index of the first cosmetic layer hit
+            //      if we only see cosmetic layers after that index, then the index will not change and hence we found the boundary
+            //      if we see a non-cosmetic layer, then we reset the index because that was not the boundary
+            this.layers.forEach((layer: LayerInstance, idx: number) => {
+                // check if we hit a cosmetic layer and if we did, keep track of the index
+                if (this.maxIdx === Infinity && layer.isCosmetic) {
+                    this.maxIdx = idx;
+                }
+                if (
+                    this.minIdx === -Infinity &&
+                    this.layers[this._reverseIndex(idx)].isCosmetic
+                ) {
+                    this.minIdx = this._reverseIndex(idx);
+                }
+
+                // check if it's a non-cosmetic layer, and if it is, reset the boundaries
+                if (!layer.isCosmetic) {
+                    this.maxIdx = Infinity;
+                }
+                if (!this.layers[this._reverseIndex(idx)].isCosmetic) {
+                    this.minIdx = -Infinity;
+                }
+            });
+        },
+
+        /**
+         * Update the layer model associated with this layer
+         * @param {LayerInstance} layer the layer that has loaded
+         */
+        loadLayerData(layer: LayerInstance): void {
+            let model: LayerModel | undefined = this.layersModel.find(
+                (layerModel: LayerModel) => layerModel.id === layer.id
+            );
+
+            if (!model) {
+                return;
+            }
+
+            // load data from layer
+            model.name = layer.name;
+            model.sublayers = layer.sublayers
+                .filter(
+                    (sublayer: LayerInstance) =>
+                        sublayer !== undefined && !sublayer.isRemoved
+                )
+                .map((sublayer: LayerInstance) => {
+                    return {
+                        id: sublayer.id,
+                        name: sublayer.name
+                    };
+                });
+            model.isLoaded = true;
+        },
+
+        /**
+         * Toggle expand on a layer model
+         * @param {LayerModel} layerModel the layer model to update
+         */
+        toggleExpand(layerModel: LayerModel): void {
+            if (!layerModel.supportsSublayers) {
+                return;
+            }
+            layerModel.isExpanded = !layerModel.isExpanded;
+            this.$iApi.updateAlert(
+                this.$t(
+                    layerModel.isExpanded
+                        ? 'layerreorder.expanded'
+                        : 'layerreorder.collapsed',
+                    {
+                        name: layerModel.name
+                    }
+                )
+            );
+        },
+
+        /**
+         * User started moving the layer, keep track of the old order
+         */
+        onMoveLayerDragStart(): void {
+            this.oldOrder = this.layersModel.map(
+                (layerModel: LayerModel) => layerModel.orderIdx
+            );
+        },
+
+        /**
+         * Move a layer's order index
+         * Called by draggable after the user stops dragging the layer
+         * @param {CustomEvent} evt draggable event that contains the data on the moved object
+         */
+        onMoveLayerDragEnd(evt: any): void {
+            if (!evt.moved) {
+                // not a move event, ignore the change
+                return;
+            }
+
+            const layerModel: LayerModel = evt.moved.element;
+            const oldRelativeIdx: number = evt.moved.oldIndex;
+            const newRelativeIdx: number = evt.moved.newIndex;
+
+            if (oldRelativeIdx === newRelativeIdx) {
+                // the layer was not moved
+                return;
+            }
+
+            const layer: LayerInstance = this.layers.find(
+                (l: LayerInstance) => l.uid === layerModel.uid
+            );
+
+            // apply changes
+            const newIdx: number = this.oldOrder[newRelativeIdx];
+            this.$iApi.geo.map.reorder(layer, newIdx, true);
+
+            this.$iApi.updateAlert(
+                this.$t('layerreorder.layermoved', {
+                    name: layerModel.name,
+                    index: newIdx
+                })
+            );
+        },
+
+        /**
+         * Increment/Decrement a layer's order index
+         * Called by the reorder buttons
+         * @param {LayerModel} layerModel layer that is being moved
+         * @param {number} direction direction to move the layer (+1 is up and -1 is down)
+         */
+        onMoveLayerButton(layerModel: LayerModel, direction: number): void {
+            let layer: LayerInstance = this.layers.find(
+                (l: LayerInstance) => l.uid === layerModel.uid
+            );
+
+            const currRelativeIdx: number =
+                this.layersModel.indexOf(layerModel);
+
+            // just in case
+            if (layer === undefined || currRelativeIdx === -1) {
+                return;
+            }
+
+            // calculate new layer order index
+            const newRelativeIdx: number = currRelativeIdx - direction;
+            const newIdx: number = this.layersModel[newRelativeIdx].orderIdx;
+
+            // apply changes
+            this.$iApi.geo.map.reorder(layer, newIdx, true);
+
+            this.$iApi.updateAlert(
+                this.$t('layerreorder.layermoved', {
+                    name: layerModel.name,
+                    index: newIdx
+                })
+            );
+        },
+
+        /** ==================================== Helpers ==================================== **/
+
+        /**
+         * Helper function - reverse a given index relative to the layer stack
+         * @returns {number} the reversed index
+         */
+        _reverseIndex(idx: number): number {
+            return this.layers.length - 1 - idx;
+        },
+
+        /**
+         * Checks if the given index is at the boundary of the layers list
+         * Also accounts for cosmetic layers in the boundary
+         *
+         * @param {number} idx the index to be checked
+         * @returns {boolean} returns true if the index is at the boundary
+         */
+        _isBoundary(idx: number): boolean {
+            if (idx < 0 || idx > this.layers.length - 1) {
+                return true;
+            }
+            if (idx >= this.maxIdx || idx <= this.minIdx) {
+                return true;
+            }
+            return false;
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/layer-reorder/components/reorder-button.vue
+++ b/packages/ramp-core/src/fixtures/layer-reorder/components/reorder-button.vue
@@ -1,0 +1,54 @@
+<template>
+    <button
+        v-if="!disabled"
+        :class="`pb-10 text-gray-500 hover:text-black p-8 ${
+            direction === 'up' ? 'rotate-180' : ''
+        }`"
+        :content="$t(`layerreorder.move.${direction}`)"
+        v-tippy="{
+            placement: 'top-start',
+            aria: 'describedby'
+        }"
+        v-focus-item
+        :aria-label="$t(`layerreorder.move.${direction}`)"
+    >
+        <svg class="fill-current w-20 h-20" viewBox="0 0 23 21">
+            <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" />
+        </svg>
+    </button>
+    <button
+        v-else
+        :class="`pb-10 text-gray-300 p-8 ${
+            direction === 'up' ? 'rotate-180' : ''
+        }`"
+        :disabled="disabled"
+        :aria-label="$t(`layerreorder.move.${direction}`)"
+    >
+        <svg class="fill-current w-20 h-20" viewBox="0 0 23 21">
+            <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" />
+        </svg>
+    </button>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'LayerReorderButtonV',
+    props: {
+        disabled: {
+            type: Boolean
+        },
+        direction: {
+            type: String,
+            required: true
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped>
+.rotate-180 {
+    transform: rotate(-180deg);
+}
+</style>

--- a/packages/ramp-core/src/fixtures/layer-reorder/definitions.ts
+++ b/packages/ramp-core/src/fixtures/layer-reorder/definitions.ts
@@ -1,0 +1,17 @@
+// a simple abstract model of a layer used by the layer reorder fixture
+export interface LayerModel {
+    id: string;
+    uid: string;
+    name: string;
+    orderIdx: number;
+    isExpanded: boolean;
+    isLoaded: boolean;
+    supportsSublayers: boolean;
+    sublayers: Array<SublayerModel>;
+}
+
+// a simple abstract model of a sublayer used by the layer reorder fixture
+export interface SublayerModel {
+    id: string;
+    name: string;
+}

--- a/packages/ramp-core/src/fixtures/layer-reorder/index.ts
+++ b/packages/ramp-core/src/fixtures/layer-reorder/index.ts
@@ -1,0 +1,39 @@
+import { markRaw } from 'vue';
+import LayerReorderScreenV from './screen.vue';
+import LayerReorderAppbarButtonV from './appbar-button.vue';
+import messages from './lang/lang.csv';
+import { LayerReorderAPI } from './api/layer-reorder';
+
+class LayerReorderFixture extends LayerReorderAPI {
+    added() {
+        console.log(`[fixture] ${this.id} added`);
+
+        this.$iApi.component(
+            'layer-reorder-appbar-button',
+            LayerReorderAppbarButtonV
+        );
+
+        this.$iApi.panel.register(
+            {
+                'layer-reorder-panel': {
+                    screens: {
+                        'layer-reorder-screen': markRaw(LayerReorderScreenV)
+                    },
+                    style: {
+                        width: '350px'
+                    },
+                    alertName: 'layerreorder.title'
+                }
+            },
+            {
+                i18n: { messages }
+            }
+        );
+    }
+
+    removed() {
+        console.log(`[fixture] ${this.id} removed`);
+    }
+}
+
+export default LayerReorderFixture;

--- a/packages/ramp-core/src/fixtures/layer-reorder/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/layer-reorder/lang/lang.csv
@@ -1,0 +1,11 @@
+key,enValue,enValid,frValue,frValid
+layerreorder.title,Reorder Layers,1,Reorder Layers,0
+layerreorder.nolayers,No Layers,1,No Layers,0
+layerreorder.loading,Loading,1,Loading,0
+layerreorder.expand,Expand Sublayers,1,Expand Sublayers,0
+layerreorder.expanded,{name} sublayers expanded,1,{name} sublayers expanded,0
+layerreorder.collapse,Collapse Sublayers,1,Collapse Sublayers,0
+layerreorder.collapsed,{name} sublayers collapsed,1,{name} sublayers collapsed,0
+layerreorder.move.up,Move up,1,Move up,0
+layerreorder.move.down,Move down,1,Move down,0
+layerreorder.layermoved,{name} moved to index {index},1,{name} moved to index {index},0

--- a/packages/ramp-core/src/fixtures/layer-reorder/screen.vue
+++ b/packages/ramp-core/src/fixtures/layer-reorder/screen.vue
@@ -1,0 +1,42 @@
+<template>
+    <panel-screen>
+        <template #header>
+            {{ $t('layerreorder.title') }}
+        </template>
+
+        <template #controls>
+            <pin @click="panel.pin()" :active="isPinned()"></pin>
+            <close @click="panel.close()"></close>
+        </template>
+
+        <template #content>
+            <layer-reorder-component />
+        </template>
+    </panel-screen>
+</template>
+
+<script lang="ts">
+import { defineComponent, PropType } from 'vue';
+import { PanelInstance } from '@/api';
+import LayerReorderComponentV from './components/layer-component.vue';
+
+export default defineComponent({
+    name: 'LayerReorderScreenV',
+    components: {
+        'layer-reorder-component': LayerReorderComponentV
+    },
+    props: {
+        panel: {
+            type: Object as PropType<PanelInstance>,
+            required: true
+        }
+    },
+    methods: {
+        isPinned(): boolean {
+            return this.panel.isPinned;
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/legend/header.vue
+++ b/packages/ramp-core/src/fixtures/legend/header.vue
@@ -3,13 +3,31 @@
         <!-- open import wizard -->
         <button
             @click="openWizard"
-            class="relative mr-auto text-gray-500 hover:text-black p-8"
-            v-show="getWizardExists"
+            class="relative mr-auto text-gray-500 hover:text-black p-8 mb-3"
+            v-show="getWizardExists()"
             :content="$t('legend.header.addlayer')"
             v-tippy="{ placement: 'right' }"
         >
             <svg class="fill-current w-18 h-18 mx-8" viewBox="0 0 23 21">
                 <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path>
+            </svg>
+        </button>
+        <!-- open layer reorder -->
+        <button
+            @click="openLayerReorder"
+            class="relative mr-auto text-gray-500 hover:text-black p-8 mb-3"
+            v-show="getLayerReorderExists()"
+            :content="$t('legend.header.reorderlayers')"
+            v-tippy="{ placement: 'right' }"
+        >
+            <svg
+                class="fill-current w-18 h-18 mx-8 mt-4 flip"
+                viewBox="0 0 23 21"
+            >
+                <path d="M0 0h24v24H0z" fill="none" />
+                <path
+                    d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z"
+                />
             </svg>
         </button>
         <span class="flex-1"></span>
@@ -111,9 +129,23 @@ export default defineComponent({
             } catch (e) {
                 return false;
             }
+        },
+        openLayerReorder() {
+            this.$iApi.event.emit(GlobalEvents.REORDER_OPEN);
+        },
+        getLayerReorderExists(): boolean {
+            try {
+                return !!this.$iApi.fixture.get('layer-reorder');
+            } catch (e) {
+                return false;
+            }
         }
     }
 });
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.flip {
+    transform: scale(1, -1);
+}
+</style>

--- a/packages/ramp-core/src/fixtures/legend/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/legend/lang/lang.csv
@@ -1,6 +1,7 @@
 key,enValue,enValid,frValue,frValid
 legend.title,Legend,1,Légende,1
 legend.header.addlayer,Add Layer,1,Ajouter une couche,1
+legend.header.reorderlayers,Reorder Layers,1,Reorder Layers,0
 legend.header.groups,Toggle Groups,1,Basculer les Groupes,1
 legend.header.groups.expand,Expand All,1,Élargir les groupes,1
 legend.header.groups.collapse,Collapse All,1,Réduire les groupes,1

--- a/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
+++ b/packages/ramp-core/src/fixtures/northarrow/northarrow.vue
@@ -141,7 +141,8 @@ export default defineComponent({
                         const poleLayer =
                             await this.$iApi.geo.layer.createLayer({
                                 layerId: 'PoleMarker',
-                                layerType: 'esriGraphic'
+                                layerType: 'esriGraphic',
+                                cosmetic: true // mark this layer as a cosmetic layer
                             });
                         await poleLayer.initiate();
 

--- a/packages/ramp-core/src/fixtures/wizard/screen.vue
+++ b/packages/ramp-core/src/fixtures/wizard/screen.vue
@@ -518,7 +518,6 @@ export default defineComponent({
 
             // add layer to map
             this.$iApi.geo.map.addLayer(layer);
-            this.$iApi.$vApp.$store.set(LayerStore.addLayers, [layer]);
 
             this.goNext = false;
             this.goToStep(WizardStep.UPLOAD);

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -383,6 +383,7 @@ export class LayerInstance extends APIScope {
     isSublayer: boolean;
     isRemoved: boolean; // used to mark sublayers for removal
     isFile: boolean;
+    isCosmetic: boolean;
     userAdded: boolean;
 
     esriLayer: __esri.Layer | undefined;
@@ -418,6 +419,7 @@ export class LayerInstance extends APIScope {
         this.isSublayer = false;
         this.isRemoved = false;
         this.isFile = false;
+        this.isCosmetic = config.cosmetic || false;
         this.userAdded = false;
 
         this._sublayers = [];

--- a/packages/ramp-core/src/store/modules/layer/layer-store.ts
+++ b/packages/ramp-core/src/store/modules/layer/layer-store.ts
@@ -159,6 +159,8 @@ const mutations = {
     ) => {
         state.layers.splice(state.layers.indexOf(layer), 1);
         state.layers.splice(index, 0, layer);
+        // copy to new array to trigger reactivity
+        state.layers = [...state.layers];
     },
     REMOVE_LAYER: (state: LayerState, value: LayerInstance) => {
         // copy to new array so watchers will have a reference to the old value


### PR DESCRIPTION
## Closes #823

## Changes in this PR
- [FEAT] Added layer reorder fixture panel
    - Added with `rInstance.fixture.add('layer-reorder');` 
    - Also added buttons to appbar and legend (only visible if fixture is added)
- [FEAT] Added optional `index` param to `addLayer` that allows layers to be inserted at a specific map-stack index
- [FEAT] Layers now have a `isCosmetic` property that indicates if they are cosmetic 
    - Used by support layers like North Pole
    - These layers will be excluded from the legend and layer reorder fixtures 

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/823/host/index.html)
### Steps to test

1. Open reorder panel with appbar/legend button and play around with the order - the map should update the layer stack
2. Add/remove layers - the layers in the panel should update (should also work with sublayer removals)
3. Check accessibility (tabbing and screen reader)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/833)
<!-- Reviewable:end -->
