### PR TITLE
Call fixture initialized method when map created

### DIFF
--- a/packages/ramp-core/src/api/fixture.ts
+++ b/packages/ramp-core/src/api/fixture.ts
@@ -28,6 +28,26 @@ type IFixtureInstance = new (id: string, iApi: InstanceAPI) => FixtureInstance;
 
 export class FixtureAPI extends APIScope {
     /**
+     * Creates an instance of FixtureAPI.
+     *
+     * @param {InstanceAPI} iApi
+     * @memberof FixtureAPI
+     */
+    constructor(iApi: InstanceAPI) {
+        super(iApi);
+
+        // when the map is created call the initialized method (if defined) for each fixture
+        const onMapCreated = () => {
+            const fixtures =
+                this.$vApp.$store.get<FixtureBaseSet>(`fixture/items`)!;
+            Object.keys(fixtures).forEach(fId => {
+                fixtures[fId].initialized?.();
+            });
+        };
+        this.$iApi.event.on(GlobalEvents.MAP_CREATED, onMapCreated);
+    }
+
+    /**
      * Loads a (built-in) fixture or adds supplied fixture into the R4MP Vue instance.
      *
      * @param {string} id
@@ -75,6 +95,9 @@ export class FixtureAPI extends APIScope {
         });
 
         this.$iApi.event.emit(GlobalEvents.FIXTURE_ADDED, fixture);
+
+        // call the fixture initialized method if it's late to the party
+        if (this.$iApi.geo.map.created) fixture.initialized?.();
 
         return fixture;
     }

--- a/packages/ramp-core/src/fixtures/appbar/index.ts
+++ b/packages/ramp-core/src/fixtures/appbar/index.ts
@@ -8,6 +8,11 @@ import messages from './lang/lang.csv';
 
 class AppbarFixture extends AppbarAPI {
     eventHandlers: string[] = [];
+
+    initialized() {
+        console.log(`[fixture] ${this.id} initialized`);
+    }
+
     async added() {
         console.log(`[fixture] ${this.id} added`);
 

--- a/packages/ramp-core/src/geo/map/common-map.ts
+++ b/packages/ramp-core/src/geo/map/common-map.ts
@@ -15,7 +15,7 @@ import { RampMapConfig } from '@/geo/api';
 // Do not add any event emits or listeners that would be tied to a specific map
 export class CommonMapAPI extends APIScope {
     esriMap: EsriMap | undefined;
-
+    created = false;
     _basemapStore: Array<Basemap>;
 
     protected constructor(iApi: InstanceAPI) {

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -201,6 +201,8 @@ export class MapAPI extends CommonMapAPI {
 
         this._viewPromise.resolveMe();
 
+        this.created = true;
+
         // emit basemap changed event
         this.$iApi.event.emit(
             GlobalEvents.MAP_BASEMAPCHANGE,


### PR DESCRIPTION
I'm not sure how to test this PR with a fixture added to the page after everything's loaded. Let me know if there's a good place to add another initialized `console.log` sanity check. 

[Demo](https://ramp4-app.azureedge.net/demo/users/milespetrov/809-fixture-initialized/host/index.html)

Closes #809

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/838)
<!-- Reviewable:end -->
