### PR TITLE
Make legend header buttons configurable

### DIFF
--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -202,6 +202,15 @@
             "type": "object",
             "description": "Provides configuration to the legend fixture.",
             "properties": {
+                "headerControls": {
+                    "$ref": "legendHeaderControls",
+                    "default": [
+                        "wizard",
+                        "layerReorder",
+                        "groupToggle",
+                        "visibilityToggle"
+                    ]
+                },
                 "isOpen": {
                     "type": "boolean",
                     "default": false,
@@ -277,6 +286,20 @@
             },
             "required": ["name", "children"],
             "unevaluatedProperties": false
+        },
+        "legendHeaderControls": {
+            "type": "array",
+            "description": "All possible controls to show in the legend header.",
+            "items": {
+                "type": "string",
+                "enum": [
+                    "wizard",
+                    "layerReorder",
+                    "groupToggle",
+                    "visibilityToggle"
+                ]
+            },
+            "uniqueItems": true
         },
         "legendGroupControls": {
             "type": "array",

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -64,6 +64,23 @@ export class LegendAPI extends FixtureInstance {
         }
 
         this.$vApp.$store.set(LegendStore.children, legendEntries);
+
+        let controls: Array<string> = [];
+        if (!legendConfig.headerControls) {
+            // use the default controls
+            controls = [
+                'wizard',
+                'layerReorder',
+                'groupToggle',
+                'visibilityToggle'
+            ];
+        } else {
+            legendConfig.headerControls.forEach(control => {
+                controls.push(control);
+            });
+        }
+        this.$vApp.$store.set(LegendStore.headerControls, controls);
+
         // TODO: validate legend items?
     }
 

--- a/packages/ramp-core/src/fixtures/legend/header.vue
+++ b/packages/ramp-core/src/fixtures/legend/header.vue
@@ -4,7 +4,7 @@
         <button
             @click="openWizard"
             class="relative mr-auto text-gray-500 hover:text-black p-8 mb-3"
-            v-show="getWizardExists()"
+            v-show="getWizardExists() && isControlAvailable('wizard')"
             :content="$t('legend.header.addlayer')"
             v-tippy="{ placement: 'right' }"
         >
@@ -16,7 +16,9 @@
         <button
             @click="openLayerReorder"
             class="relative mr-auto text-gray-500 hover:text-black p-8 mb-3"
-            v-show="getLayerReorderExists()"
+            v-show="
+                getLayerReorderExists() && isControlAvailable('layerReorder')
+            "
             :content="$t('legend.header.reorderlayers')"
             v-tippy="{ placement: 'right' }"
         >
@@ -37,6 +39,7 @@
             position="left-start"
             :tooltip="$t('legend.header.groups')"
             tooltip-placement="left"
+            v-show="isControlAvailable('groupToggle')"
         >
             <template #header>
                 <div class="p-8">
@@ -71,6 +74,7 @@
             position="left-start"
             :tooltip="$t('legend.header.visible')"
             tooltip-placement="left"
+            v-show="isControlAvailable('visibilityToggle')"
         >
             <template #header>
                 <div class="flex p-8">
@@ -139,6 +143,12 @@ export default defineComponent({
             } catch (e) {
                 return false;
             }
+        },
+        isControlAvailable(control: string): boolean {
+            const hc: Array<string> | undefined = this.$store.get(
+                LegendStore.headerControls
+            );
+            return hc!.includes(control);
         }
     }
 });

--- a/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-state.ts
@@ -3,10 +3,12 @@ import { LegendEntry, LegendGroup } from './legend-defs';
 export class LegendState {
     legendConfig: LegendConfig | undefined = undefined;
     children: Array<LegendEntry | LegendGroup> = [];
+    headerControls: Array<string> = [];
 }
 
 export interface LegendConfig {
     isOpen: boolean;
     reorderable: boolean;
     root: { name: string; children: Array<any> };
+    headerControls: Array<string>;
 }

--- a/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-store.ts
@@ -236,6 +236,10 @@ export enum LegendStore {
      */
     children = 'legend/children',
     /**
+     * (State) headerContros: Array<string>
+     */
+    headerControls = 'legend/headerControls',
+    /**
      * (Getter) getChildById: (id: string) => LegendItem | undefined
      */
     getChildById = 'legend/getChildById',


### PR DESCRIPTION
For #840. 

Legend header buttons are now configurable. By default, the legend will include all 4 buttons (`wizard`, `layerReorder`, `groupToggle`, `visibilityToggle`). Config can override this to show only the buttons included in the `headerControls` field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/844)
<!-- Reviewable:end -->
