### PR TITLE
Add metadata config option to layers

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -262,6 +262,10 @@ let config = {
                     opacity: 1,
                     visibility: true
                 },
+                metadata: {
+                    url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/README.md',
+                    name: 'Read Me!'
+                },
                 customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
             },
             {
@@ -301,7 +305,10 @@ let config = {
                 state: {
                     visibility: true
                 },
-                customRenderer: {}
+                customRenderer: {},
+                metadata: {
+                    url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/README.md'
+                }
             }
             /*
             {
@@ -346,7 +353,17 @@ let config = {
                                         {
                                             layerId: 'WaterQuantity',
                                             name: 'Water Quantity in Nested Group',
-                                            entryIndex: 1
+                                            entryIndex: 1,
+                                            controls: [
+                                                'metadata',
+                                                'boundaryZoom',
+                                                'refresh',
+                                                'reload',
+                                                'remove',
+                                                'datatable',
+                                                'settings',
+                                                'symbology'
+                                            ]
                                         },
                                         {
                                             layerId: 'WaterQuantity',
@@ -364,7 +381,17 @@ let config = {
                         },
                         {
                             layerId: 'WFSLayer',
-                            name: 'WFSLayer'
+                            name: 'WFSLayer',
+                            controls: [
+                                'metadata',
+                                'boundaryZoom',
+                                'refresh',
+                                'reload',
+                                'remove',
+                                'datatable',
+                                'settings',
+                                'symbology'
+                            ]
                         }
                     ]
                 }

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -778,7 +778,7 @@ rInstance.fixture.addDefaultFixtures().then(() => {
     rInstance.event.emit('metadata/open', {
         type: 'html',
         layer: 'Sample Layer Name',
-        url: 'https://ryan-coulson.com/RAMPMetadataDemo.html'
+        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/README.md'
     });
 });
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -186,12 +186,21 @@ export default defineComponent({
          * Toggles metadata panel to open/close for the LegendItem.
          */
         toggleMetadata() {
-            if (this.legendItem!._controlAvailable(Controls.Metadata)) {
+            const metaConfig =
+                this.legendItem?.layer?.config.metadata ||
+                this.legendItem?.layer?.parentLayer?.config?.metadata ||
+                {};
+
+            const name = metaConfig?.name || this.legendItem?.layer?.name || '';
+            if (
+                this.legendItem!._controlAvailable(Controls.Metadata) &&
+                metaConfig.url
+            ) {
                 // TODO: toggle metadata panel through API/store call
                 this.$iApi.event.emit('metadata/open', {
                     type: 'html',
-                    layer: 'Sample Layer Name',
-                    url: 'https://ryan-coulson.com/RAMPMetadataDemo.html'
+                    layer: name,
+                    url: metaConfig.url
                 });
             }
         },

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -32,7 +32,6 @@ export class LegendItem {
                 : [
                       Controls.Visibility,
                       Controls.BoundaryZoom,
-                      Controls.Metadata,
                       Controls.Refresh,
                       Controls.Reload,
                       Controls.Remove,

--- a/packages/ramp-core/src/fixtures/metadata/screen.vue
+++ b/packages/ramp-core/src/fixtures/metadata/screen.vue
@@ -33,7 +33,7 @@
                         payload.type === 'html' && state.status == 'success'
                     "
                     v-html="state.response"
-                    class="flex flex-col justify-center"
+                    class="flex flex-col justify-center max-w-full"
                 ></div>
 
                 <!-- Error Screen -->
@@ -86,11 +86,7 @@ export default defineComponent({
 
     mounted() {
         if (this.payload.type === 'xml') {
-            // This site prevents CORS errors. Helpful for testing purposes.
-            this.loadFromURL(
-                'https://cors-anywhere.herokuapp.com/' + this.payload.url,
-                []
-            ).then(r => {
+            this.loadFromURL(this.payload.url, []).then(r => {
                 this.state.status = 'success';
 
                 // Append the content to the panel.
@@ -99,11 +95,9 @@ export default defineComponent({
                 }
             });
         } else if (this.payload.type === 'html') {
-            this.requestContent(
-                'https://cors-anywhere.herokuapp.com/' + this.payload.url
-            ).then(r => {
+            this.requestContent(this.payload.url).then(r => {
                 this.state.status = 'success';
-                this.state.response = (r as MetadataResult).response;
+                this.state.response = r.response;
             });
         }
     },
@@ -127,7 +121,7 @@ export default defineComponent({
 
             if (!this.cache[xmlUrl]) {
                 return this.requestContent(xmlUrl).then(xmlData => {
-                    this.cache[xmlUrl] = (xmlData as MetadataResult).response;
+                    this.cache[xmlUrl] = xmlData.response;
                     return this.applyXSLT(this.cache[xmlUrl], XSLT, params);
                 });
             } else {
@@ -188,7 +182,7 @@ export default defineComponent({
         /**
          * Sends a GET request to the provided URL. Returns a promise containing information received from the webpage.
          * */
-        requestContent(url: string) {
+        requestContent(url: string): Promise<MetadataResult> {
             return new Promise((resolve, reject) => {
                 const xobj = new XMLHttpRequest();
                 xobj.open('GET', url, true);

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -491,6 +491,7 @@ export interface RampLayerConfig {
     latField?: string; // csv coord field
     longField?: string; // csv coord field
     tolerance?: number; // click tolerance
+    metadata?: { url: string; name?: string };
 }
 
 export interface RampExtentConfig {


### PR DESCRIPTION
Not sure if we want to add this option for `MapImageSublayer` as well. Sublayers only have `layerType` in their configs so that would need to be tweaked.

[Demo](https://ramp4-app.azureedge.net/demo/users/milespetrov/822-parameterize-meta/host/index.html) (WFSLayer and first Water Quantity sublayer have metadata enabled)

Closes #822

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/845)
<!-- Reviewable:end -->
