### PR TITLE
Add identify toggle

### DIFF
--- a/packages/ramp-core/docs/geo/layers.md
+++ b/packages/ramp-core/docs/geo/layers.md
@@ -40,19 +40,19 @@ Most layers have one single logical component and a basic tree. The structure is
 
 ```json
 {
-    layerIdx: -1,
-    name: "Fancy Layer",
-    children: [
+    "layerIdx": -1,
+    "name": "Fancy Layer",
+    "children": [
         {
-            layerIdx: 4,
-            name: "Fancy Layer",
-            children: [],
-            isLayer: true,
-            uid: "432rubbishasdfsdfad"
+            "layerIdx": 4,
+            "name": "Fancy Layer",
+            "children": [],
+            "isLayer": true,
+            "uid": "432rubbishasdfsdfad"
         }
     ],
-    isLayer: false,
-    uid: "ABCDskipafewYbecauseihavetogo4aP&Z4U"
+    "isLayer": false,
+    "uid": "ABCDskipafewYbecauseihavetogo4aP&Z4U"
 }
 ```
 
@@ -60,41 +60,41 @@ A Map Image Layer composed of multiple sources could have a more structured resu
 
 ```json
 {
-    layerIdx: -1,
-    name: "Restaurants",
-    children: [
+    "layerIdx": -1,
+    "name": "Restaurants",
+    "children": [
         {
-            layerIdx: 4,
-            name: "Fine Dining",
-            children: [],
-            isLayer: true,
-            uid: "432rubbishasdfsdfad"
+            "layerIdx": 4,
+            "name": "Fine Dining",
+            "children": [],
+            "isLayer": true,
+            "uid": "432rubbishasdfsdfad"
         },
         {
-            layerIdx: 6,
-            name: "Fast Food",
-            children: [
+            "layerIdx": 6,
+            "name": "Fast Food",
+            "children": [
                 {
-                    layerIdx: 7,
-                    name: "Burger Joints",
-                    children: [],
-                    isLayer: true,
-                    uid: "765rubbishasdfsdfad"
+                    "layerIdx": 7,
+                    "name": "Burger Joints",
+                    "children": [],
+                    "isLayer": true,
+                    "uid": "765rubbishasdfsdfad"
                 },
                 {
-                    layerIdx: 9,
-                    name: "Pizza Parlours",
-                    children: [],
-                    isLayer: true,
-                    uid: "988rubbishasdfsdfad"
+                    "layerIdx": 9,
+                    "name": "Pizza Parlours",
+                    "children": [],
+                    "isLayer": true,
+                    "uid": "988rubbishasdfsdfad"
                 }
             ],
-            isLayer: false,
-            uid: ""
+            "isLayer": false,
+            "uid": ""
         }
     ],
-    isLayer: false,
-    uid: "ABCDskipafewYbecauseihavetogo4aP&Z4U"
+    "isLayer": false,
+    "uid": "ABCDskipafewYbecauseihavetogo4aP&Z4U"
 }
 ```
 
@@ -102,16 +102,16 @@ A Map Image Layer composed of multiple sources could have a more structured resu
 
 The following formats have support built in the codebase. The ESRI formats assume being hosted on an ArcGIS Server `MapServer`. `FeatureServer` may work but with some functionality missing. The configuration `layerType` is provided in brackets.
 
-- ESRI Feature Layer (`esriFeature`)
-- ESRI Map Image Layer (formerly known as Dynamic Layer) (`esriMapImage`)
-- ESRI Tile Layer (`esriTile`)
-- ESRI Image Service (`esriImagery`)
-- ESRI Graphic Layer (`esriGraphic`)
-- OGC WFS 3.0 (`ogcWfs`)
-- OGC WMS (`ogcWms`)
-- GeoJSON (`fileGeoJson`)
-- CSV File (`fileCsv`)
-- Shapefile (`fileShape`)
+-   ESRI Feature Layer (`esriFeature`)
+-   ESRI Map Image Layer (formerly known as Dynamic Layer) (`esriMapImage`)
+-   ESRI Tile Layer (`esriTile`)
+-   ESRI Image Service (`esriImagery`)
+-   ESRI Graphic Layer (`esriGraphic`)
+-   OGC WFS 3.0 (`ogcWfs`)
+-   OGC WMS (`ogcWms`)
+-   GeoJSON (`fileGeoJson`)
+-   CSV File (`fileCsv`)
+-   Shapefile (`fileShape`)
 
 ## Layer Creation
 
@@ -254,17 +254,16 @@ myLayer.isRemoved; // false
 myLayer.supportsIdentify; // true
 ```
 
-The `.identify()` method will execute an identify request on the layer. Identify is not directly called on logical sublayers. RAMP's sublayer filter can be overridden using the below options parameter object.
+The `.runIdentify()` method will execute an identify request on the layer. Identify is not directly called on logical sublayers. RAMP's sublayer filter can be overridden using the below options parameter object.
 
 Options parameter object:
 
-```js
+```json
 {
     geometry,       // The geometry to identify against. A RAMP API Geometry. Intersecting features will be returned.
     returnGeometry, // An optional boolean to indicate the geometry of the result features should also be downloaded. Defaults to `false`
     sublayerIds,    // An optional array of sublayer uids (string) or server indicies (number) that indicate which sublayers to include in the request.
-    tolerance;      // An optional integer number to buffer the geometry. Is generally only useful if the geometry is a point.
-                    // The number represents pixels to buffer by (so 5 would be a 10x10 pixel square around the point at the current map scale level).
+    tolerance;      // An optional integer number to buffer the geometry. Is generally only useful if the geometry is a point. The number represents pixels to buffer by (so 5 would be a 10x10 pixel square around the point at the current map scale level).
 }
 ```
 
@@ -295,7 +294,7 @@ Example call
 
 ```js
 var opts = { geometry: myPoint, tolerance: 3 };
-var result = myLayer.identify(opts);
+var result = myLayer.runIdentify(opts);
 await result.done;
 result.results.forEach(r => processResults(r));
 ```
@@ -340,7 +339,7 @@ Remove any attributes that had been loaded. The end result of this request is th
 myLayer.destroyAttributes();
 ```
 
-Request the attributes in a tabular format with column metadata, suitable for grid or table consumption. This will use any pre-loaded attribute set, and if none exist, will execute the `getAttributes` request. 
+Request the attributes in a tabular format with column metadata, suitable for grid or table consumption. This will use any pre-loaded attribute set, and if none exist, will execute the `getAttributes` request.
 TODO flush out the return value
 
 ```js
@@ -401,4 +400,3 @@ myLayer.applySqlFilter();
 // ignore the grid filters
 myLayer.applySqlFilter(['grid']);
 ```
-

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -555,7 +555,7 @@ export class EventAPI extends APIScope {
                 // when map clicks, run the identify action
                 zeHandler = (clickParam: MapClick) => {
                     if (clickParam.button === 0) {
-                        this.$iApi.geo.map.identify(clickParam);
+                        this.$iApi.geo.map.runIdentify(clickParam);
                     }
                 };
                 this.on(GlobalEvents.MAP_CLICK, zeHandler, handlerName);

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -347,6 +347,15 @@ export class LegendEntry extends LegendItem {
             this._layer.opacity = opacity;
         }
     }
+
+    /**
+     * Toggle the layer's identify
+     */
+    toggleIdentify(identify: boolean): void {
+        if (this._layer) {
+            this._layer.identify = identify;
+        }
+    }
 }
 
 /**

--- a/packages/ramp-core/src/fixtures/settings/screen.vue
+++ b/packages/ramp-core/src/fixtures/settings/screen.vue
@@ -69,9 +69,8 @@
                     :name="$t('settings.label.identify')"
                     icon="location"
                     :config="{
-                        onChange: () => {},
-                        value: false,
-                        disabled: true
+                        onChange: updateIdentify,
+                        value: identifyModel
                     }"
                 ></settings-component>
 
@@ -122,6 +121,7 @@ export default defineComponent({
             layerName: '',
             visibilityModel: this.layer.visibility,
             opacityModel: this.layer.opacity * 100,
+            identifyModel: this.layer.identify,
             snapshotToggle: false,
             handlers: [] as Array<string>
         };
@@ -177,6 +177,12 @@ export default defineComponent({
             this.opacityModel = val;
         },
 
+        // Update the layer's toggle identify.
+        updateIdentify(val: any) {
+            this.legendItem.toggleIdentify(val);
+            this.identifyModel = val;
+        },
+
         // Toggle snapshot mode for the layer.
         toggleSnapshot() {
             this.snapshotToggle = !this.snapshotToggle;
@@ -191,6 +197,7 @@ export default defineComponent({
                     // ensure that it's still the same layer
                     this.visibilityModel = this.layer.visibility;
                     this.opacityModel = Math.round(this.layer.opacity * 100);
+                    this.identifyModel = this.layer.identify;
                     this.layerName = this.layer.name;
                 }
             });

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -429,6 +429,7 @@ export interface RampSpatialReference {
 export interface RampLayerStateConfig {
     visibility?: boolean;
     opacity?: number;
+    identify?: boolean;
 }
 
 export interface RampLayerFieldInfoConfig {

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -353,6 +353,10 @@ export class CommonLayer extends LayerInstance {
             this.name = this.esriLayer?.title || '';
         }
 
+        this.identify = !(this.config.state.identify == undefined)
+            ? this.config.state.identify
+            : this.supportsIdentify;
+
         // make the root of the tree
         // TODO consider initializing the layer tree object in the constructor, then editing it here.
         //      would mean we can get rid of the undefined type on the property
@@ -807,7 +811,7 @@ export class CommonLayer extends LayerInstance {
      * @param options not used, present for nice signature of overrided function
      * @returns {IdentifyResultSet} an empty result set
      */
-    identify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): IdentifyResultSet {
         // returns an empty set.
         // serves as a fallback incase someone tries to identify on a non-identifiyable layer
         // (callers can use this.supportsIdentify to check for that)

--- a/packages/ramp-core/src/geo/layer/esriFeature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriFeature/index.ts
@@ -180,16 +180,16 @@ class FeatureLayer extends AttribLayer {
 
     // ----------- LAYER ACTIONS -----------
 
-    identify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): IdentifyResultSet {
         // early kickout check. not loaded/error; not visible; not queryable; off scale
         if (
             !this.isValidState ||
             !this.visibility ||
-            // !this.isQueryable() || // TODO implement when we have this flag created
+            !this.identify ||
             this.scaleSet.isOffScale(this.$iApi.geo.map.getScale()).offScale
         ) {
             // return empty result.
-            return super.identify(options);
+            return super.runIdentify(options);
         }
 
         let loadResolve: any;

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -284,7 +284,10 @@ class MapImageLayer extends AttribLayer {
                 // below will run only during first load
                 if (!this._sublayers[sid]) {
                     this._sublayers[sid] = new MapImageSublayer(
-                        { layerType: LayerType.SUBLAYER },
+                        {
+                            layerType: LayerType.SUBLAYER,
+                            state: subConfigs[sid].state
+                        },
                         this.$iApi,
                         this,
                         sid
@@ -456,7 +459,7 @@ class MapImageLayer extends AttribLayer {
 
     // ----------- LAYER ACTIONS -----------
 
-    identify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): IdentifyResultSet {
         // NOTE: we are looping over queryFeatures on each sublayer instead of running an identify on the entire layer.
         //       reasons:
         //         the queries allow us to only return OIDs. identify always pulls all the features.
@@ -468,7 +471,7 @@ class MapImageLayer extends AttribLayer {
         // early kickout check. not loaded/error
         if (!this.isValidState || !this.visibility) {
             // return empty result.
-            return super.identify(options);
+            return super.runIdentify(options);
         }
 
         const map = this.$iApi.geo.map;
@@ -498,16 +501,16 @@ class MapImageLayer extends AttribLayer {
                       return (
                           sublayer.visibility &&
                           sublayer.supportsFeatures &&
+                          sublayer.identify &&
                           !sublayer.scaleSet.isOffScale(map.getScale()).offScale
                       );
-                      // && sublayer.getQuery() // TODO add in identify check once implemented
                   }
               );
 
         // early kickout check. all sublayers are one of: not visible; not identifiable; off scale; a raster layer
         if (activeSublayers.length === 0 || !this.visibility) {
             // return empty result.
-            return super.identify(options);
+            return super.runIdentify(options);
         }
 
         const result: IdentifyResultSet = {

--- a/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
@@ -1,5 +1,11 @@
 import { AttribLayer, InstanceAPI } from '@/api/internal';
-import { DataFormat, LayerType, RampLayerConfig, TreeNode } from '@/geo/api';
+import {
+    DataFormat,
+    LayerType,
+    RampLayerConfig,
+    RampLayerStateConfig,
+    TreeNode
+} from '@/geo/api';
 import MapImageLayer from './index';
 import { markRaw } from 'vue';
 
@@ -7,7 +13,7 @@ export class MapImageSublayer extends AttribLayer {
     tooltipField: string;
 
     constructor(
-        config: { layerType: string },
+        config: { layerType: string; state?: RampLayerStateConfig },
         $iApi: InstanceAPI,
         parent: MapImageLayer,
         layerIdx: number = 0
@@ -61,6 +67,11 @@ export class MapImageSublayer extends AttribLayer {
         if (!this.layerTree) {
             this.layerTree = new TreeNode(this.layerIdx, this.uid, this.name);
         }
+
+        this.identify = !(this.config.state.identify == undefined)
+            ? this.config.state.identify
+            : this.supportsIdentify;
+
         return [];
     }
 

--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -246,7 +246,7 @@ export class FileLayer extends AttribLayer {
 
     // ----------- LAYER ACTIONS -----------
 
-    identify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): IdentifyResultSet {
         // TODO this function is pretty much identical to FeatureLayer, now that we are using query for everything.
         //      the queryFeatures on the sublayer will automatically go to the correct server/file instance due to the
         //      overridden functions.
@@ -259,11 +259,11 @@ export class FileLayer extends AttribLayer {
         if (
             !this.isValidState ||
             !this.visibility ||
-            // !this.isQueryable() || // TODO implement when we have this flag created
+            !this.identify ||
             this.scaleSet.isOffScale(map.getScale()).offScale
         ) {
             // return empty result.
-            return super.identify(options);
+            return super.runIdentify(options);
         }
 
         let loadResolve: any;

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -385,6 +385,7 @@ export class LayerInstance extends APIScope {
     isFile: boolean;
     isCosmetic: boolean;
     userAdded: boolean;
+    identify: boolean;
 
     esriLayer: __esri.Layer | undefined;
     esriSubLayer: __esri.Sublayer | undefined; // used only by sublayers
@@ -421,7 +422,7 @@ export class LayerInstance extends APIScope {
         this.isFile = false;
         this.isCosmetic = config.cosmetic || false;
         this.userAdded = false;
-
+        this.identify = false; // will be updated later based on config/supportsIdentify value
         this._sublayers = [];
     }
 
@@ -701,7 +702,7 @@ export class LayerInstance extends APIScope {
      * @param options not used, present for nice signature of overrided function
      * @returns {IdentifyResultSet} an empty result set
      */
-    identify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): IdentifyResultSet {
         return {
             results: [],
             done: Promise.resolve(),

--- a/packages/ramp-core/src/geo/layer/ogcWms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/index.ts
@@ -173,7 +173,7 @@ export default class WmsLayer extends CommonLayer {
      * @param {Object} options     additional arguemets, see above.
      * @returns {Object} an object with identify results array and identify promise resolving when identify is complete; if an empty object is returned, it will be skipped
      */
-    identify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): IdentifyResultSet {
         // TODO add full documentation for options parameter
 
         if (options.geometry.type !== GeometryType.POINT) {
@@ -200,12 +200,12 @@ export default class WmsLayer extends CommonLayer {
         if (
             !this.isValidState ||
             !this.visibility ||
-            // !this.isQueryable() || // TODO implement when we have this flag created
+            !this.identify ||
             // !infoMap[this.config.featureInfoMimeType] || // TODO implement once config is defined
             this.scaleSet.isOffScale(map.getScale()).offScale
         ) {
             // return empty result.
-            return super.identify(options);
+            return super.runIdentify(options);
         }
 
         // TODO prolly need to flush out the config interfaces for this badboy

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -759,7 +759,7 @@ export class MapAPI extends CommonMapAPI {
      * @returns MapIdentifyResult
      */
 
-    identify(targetPoint: MapClick | Point): MapIdentifyResult {
+    runIdentify(targetPoint: MapClick | Point): MapIdentifyResult {
         let layers: LayerInstance[] | undefined = this.$vApp.$store.get(
             LayerStore.layers
         );
@@ -794,7 +794,7 @@ export class MapAPI extends CommonMapAPI {
             .filter(layer => layer.supportsIdentify)
             .map(layer => {
                 p.tolerance = layer.clickTolerance;
-                return layer.identify(p);
+                return layer.runIdentify(p);
             });
 
         // Merge all results received by the identify into one array.
@@ -911,7 +911,7 @@ export class MapAPI extends CommonMapAPI {
             this._activeKeys.push(payload.key);
             this.keyZoom(payload);
         } else if (payload.key === 'Enter') {
-            this.identify(this.getExtent().center());
+            this.runIdentify(this.getExtent().center());
         }
     }
 


### PR DESCRIPTION
### Closes #835.
- Rename `identify()` function to ` runIdentify()` and add boolean `identify` property to `LayerInstance`
- Allow `identify` property to be set through the config
- Make the identify action check the `identify` property
- Allow settings panel to update the `identify` property

### [Demo](http://ramp4-app.azureedge.net/demo/users/elsa-huang/835-identify-toggle/host/index.html)
