### PR TITLE
Minor cleanups

### DIFF
--- a/packages/ramp-core/docs/app/defaults.md
+++ b/packages/ramp-core/docs/app/defaults.md
@@ -121,6 +121,8 @@ TODO add stuff as we make events that core fixtures raise
 | DETAILS_OPEN<br>'details/open'       | _identifyItem_: IdentifyItem object<br>_uid_: layer uid | A feature's details was requested                              |
 | GRID_TOGGLE<br>'grid/toggle'         | _uid_: layer uid<br>_open_: boolean (optional)          | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |
+| METADATA_OPEN<br>'metadata/open'     | { type: string, layerName: string, url: string }        | A metadata view was requested                                  |
+| REORDER_OPEN<br>'reorder/open'       | none                                                    | The reorder panel was requested                                |
 | SETTINGS_TOGGLE<br>'settings/toggle' | layer uid                                               | Settings panel toggle was requested for a layer                |
 | WIZARD_OPEN<br>'wizard/open'         | none                                                    | A request was made to add a layer                              |
 

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -777,7 +777,7 @@ rInstance.fixture.addDefaultFixtures().then(() => {
     // Emits an event to open the metadata panel. Usually, this is be done by any fixture that wants the metadata panel to open.
     rInstance.event.emit('metadata/open', {
         type: 'html',
-        layer: 'Sample Layer Name',
+        layerName: 'Sample Layer Name',
         url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/README.md'
     });
 });

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -203,6 +203,12 @@ export enum GlobalEvents {
     MAP_START = 'map/start',
 
     /**
+     * Fires when a request is issued to open the Metadata panel
+     * Payload: `({ type: string, layerName: string, url: string })`
+     */
+    METADATA_OPEN = 'metadata/open',
+
+    /**
      * Fires when a panel is closed.
      * Payload: `(panel: PanelInstance)`
      */

--- a/packages/ramp-core/src/fixtures/help/screen.vue
+++ b/packages/ramp-core/src/fixtures/help/screen.vue
@@ -26,8 +26,6 @@ import { get } from '@/store/pathify-helper';
 import { PanelInstance } from '@/api';
 import { HelpStore } from './store';
 import HelpSectionV from './section.vue';
-
-// TODO check if we actually need this library. Does vue have its own internal web request library?
 import axios from 'axios';
 import { marked } from 'marked';
 

--- a/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/legend-options.vue
@@ -197,9 +197,9 @@ export default defineComponent({
                 metaConfig.url
             ) {
                 // TODO: toggle metadata panel through API/store call
-                this.$iApi.event.emit('metadata/open', {
+                this.$iApi.event.emit(GlobalEvents.METADATA_OPEN, {
                     type: 'html',
-                    layer: name,
+                    layerName: name,
                     url: metaConfig.url
                 });
             }

--- a/packages/ramp-core/src/fixtures/metadata/definitions.ts
+++ b/packages/ramp-core/src/fixtures/metadata/definitions.ts
@@ -1,6 +1,6 @@
 export interface MetadataPayload {
     type: string; // 'xml' or 'html'
-    layer: string;
+    layerName: string;
     url: string;
 }
 

--- a/packages/ramp-core/src/fixtures/metadata/index.ts
+++ b/packages/ramp-core/src/fixtures/metadata/index.ts
@@ -2,7 +2,7 @@ import { markRaw } from 'vue';
 import { MetadataAPI } from './api/metadata';
 import MetadataAppbarButtonV from './appbar-button.vue';
 import MetadataScreenV from './screen.vue';
-
+import { GlobalEvents } from '@/api';
 import messages from './lang/lang.csv';
 
 class MetadataFixture extends MetadataAPI {
@@ -31,7 +31,7 @@ class MetadataFixture extends MetadataAPI {
         this.$iApi.component('metadata-appbar-button', MetadataAppbarButtonV);
 
         this.$iApi.event.on(
-            'metadata/open',
+            GlobalEvents.METADATA_OPEN,
             handler,
             'metadata_opened_handler'
         );

--- a/packages/ramp-core/src/fixtures/metadata/screen.vue
+++ b/packages/ramp-core/src/fixtures/metadata/screen.vue
@@ -1,7 +1,7 @@
 <template>
     <panel-screen>
         <template #header>
-            {{ $t('metadata.title') }}: {{ payload.layer }}
+            {{ $t('metadata.title') }}: {{ payload.layerName }}
         </template>
 
         <template #controls>

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -415,6 +415,10 @@ export interface MouseCoords {
     formattedString?: string;
 }
 
+export interface UrlQueryMap {
+    [name: string]: string;
+}
+
 // ----------------------- CLIENT CONFIG INTERFACES -----------------------------------
 
 // TODO migrate these to /geo/api/geo-common ? if we need config interfaces before creating an instance,

--- a/packages/ramp-core/src/geo/api/utils/shared-utils.ts
+++ b/packages/ramp-core/src/geo/api/utils/shared-utils.ts
@@ -1,4 +1,4 @@
-import { ArcGisServerUrl } from '@/geo/api';
+import { ArcGisServerUrl, UrlQueryMap } from '@/geo/api';
 import deepmerge from 'deepmerge';
 
 export class SharedUtilsAPI {
@@ -144,8 +144,6 @@ export class SharedUtilsAPI {
     }
 }
 
-type QueryMap = { [name: string]: string };
-
 /**
  * This is a helper class to handle getting and setting query parameters on a url easy.
  *
@@ -155,7 +153,7 @@ export class UrlWrapper {
     _url: string;
     _base: string;
     _query: string;
-    _queryMap: QueryMap = {};
+    _queryMap: UrlQueryMap = {};
 
     constructor(url: string) {
         this._url = url;
@@ -165,7 +163,7 @@ export class UrlWrapper {
         // convert the query part into a mapped object
         this._queryMap = this._query
             .split('&')
-            .reduce((map: QueryMap, parameter: string) => {
+            .reduce((map: UrlQueryMap, parameter: string) => {
                 const [key, value] = parameter.split('=');
                 map[key] = value;
                 return map;
@@ -180,7 +178,7 @@ export class UrlWrapper {
         return this._base;
     }
 
-    get queryMap(): QueryMap {
+    get queryMap(): UrlQueryMap {
         return this._queryMap;
     }
 
@@ -197,12 +195,12 @@ export class UrlWrapper {
      * - resulting url: http://example?demohell=false&acid=cat
      *
      *
-     * @param {QueryMap} queryMapUpdate an object of values to be added or replaced on the query of the url; if any values are undefined, their corresponding keys will be removed from the query.
+     * @param {UrlQueryMap} queryMapUpdate an object of values to be added or replaced on the query of the url; if any values are undefined, their corresponding keys will be removed from the query.
      * @returns {string} updated url
      * @memberof UrlWrapper
      */
-    updateQuery(queryMapUpdate: QueryMap): string {
-        const requestQueryMap: QueryMap = <QueryMap>(
+    updateQuery(queryMapUpdate: UrlQueryMap): string {
+        const requestQueryMap: UrlQueryMap = <UrlQueryMap>(
             deepmerge.all([{}, this.queryMap, queryMapUpdate])
         );
         const requestUrl = `${this.base}${Object.entries(requestQueryMap)

--- a/packages/ramp-core/src/geo/layer/ogc-utils.ts
+++ b/packages/ramp-core/src/geo/layer/ogc-utils.ts
@@ -1,9 +1,7 @@
 import { APIScope } from '@/api/internal';
-import { UrlWrapper } from '@/geo/api';
+import { UrlQueryMap, UrlWrapper } from '@/geo/api';
 import yxList from './reversedAxis.json';
 import { EsriRequest } from '@/geo/esri';
-
-// TODO check if we actually need this library. Does vue have its own internal web request library?
 import axios from 'axios';
 import to from 'await-to-js';
 import { parse } from 'fast-xml-parser';
@@ -12,8 +10,6 @@ type WFSResponse = {
     data: { numberMatched: number; features: any[] };
 };
 type WFSData = { type: string; features: any[] };
-
-type QueryMap = { [name: string]: string };
 
 export class OgcUtils extends APIScope {
     // TODO update logic in this function to get changes done in https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3858
@@ -43,7 +39,7 @@ export class OgcUtils extends APIScope {
         },
         xyInAttribs: boolean = false
     ): Promise<any> {
-        let newQueryMap: QueryMap = {
+        let newQueryMap: UrlQueryMap = {
             startindex: startindex.toString(),
             limit: limit.toString()
         };


### PR DESCRIPTION
Small cleanup of things I had noticed

- double declaration of `QueryMap` type, changed to interface, made name more clear with `UrlQueryMap`
- proper constant for metadata event
- changed `layer` prop on metadata event to `layerName`, since that's what it actually is
- missing event documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/849)
<!-- Reviewable:end -->
