### PR TITLE
Layer tree refactor

### DIFF
--- a/packages/ramp-core/docs/geo/layers.md
+++ b/packages/ramp-core/docs/geo/layers.md
@@ -36,27 +36,21 @@ The **UID** is a string identifier assigned to every `Layer` that is unique acro
 
 Every `Layer` object has a method `.getLayerTree()`. This returns a heirarchical object that describes the logical layout of the layer.
 
-Most layers have one single logical component and a basic tree. The structure is a bit redundant, but keeps things aligned and predictable.
+Most layers have one single logical component and a basic tree.
 
 ```json
 {
-    "layerIdx": -1,
+    "layerIdx": 0,
     "name": "Fancy Layer",
-    "children": [
-        {
-            "layerIdx": 4,
-            "name": "Fancy Layer",
-            "children": [],
-            "isLayer": true,
-            "uid": "432rubbishasdfsdfad"
-        }
-    ],
-    "isLayer": false,
+    "children": [],
+    "isLayer": true,
     "uid": "ABCDskipafewYbecauseihavetogo4aP&Z4U"
 }
 ```
 
-A Map Image Layer composed of multiple sources could have a more structured result. The tree is the easiest way to inspect the structure. Note that subfolder structures do not have a uid; they exist to organize the heirarchy but have no related `Layer` object.
+A Map Image Layer composed of multiple sources could have a more structured result with Map Image Sublayers. The tree is the easiest way to inspect the structure.
+
+Note that subfolder structures do not have a uid; they exist to organize the heirarchy but have no related `Layer` object.
 
 ```json
 {

--- a/packages/ramp-core/src/geo/api/layer/tree-node.ts
+++ b/packages/ramp-core/src/geo/api/layer/tree-node.ts
@@ -2,7 +2,7 @@ export class TreeNode {
     layerIdx: number;
     name: string;
     children: Array<TreeNode>;
-    isLayer: boolean; // false for groups. effectively a shortcut for `children.length === 0`
+    isLayer: boolean; // TODO: decide on the purpose of this flag post-layer-refactor?
     uid: string;
 
     constructor(

--- a/packages/ramp-core/src/geo/layer/esriFeature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriFeature/index.ts
@@ -71,10 +71,6 @@ class FeatureLayer extends AttribLayer {
     onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
-        if (!this.layerTree) {
-            throw new Error('superclass did not create layer tree');
-        }
-
         // setting custom renderer here (if one is provided)
         const hasCustRed =
             this.esriLayer && this.origRampConfig.customRenderer?.type;
@@ -89,19 +85,13 @@ class FeatureLayer extends AttribLayer {
         // const layerUrl: string = (<esri.FeatureLayer>this._innerLayer).url;
         const layerUrl: string = (<any>this.esriLayer).parsedUrl.path;
         const urlData = this.$iApi.geo.utils.shared.parseUrlIndex(layerUrl);
-        const featIdx: number = urlData.index || 0; // we're going to have an index. feature layer wont load without one.
+        const featIdx: number = urlData.index || 0;
 
         // feature has only one layer
-        // const featFC = new FeatureFC(this, featIdx);
-        // this.fcs[featIdx] = featFC;
         this.serviceUrl = layerUrl;
-        this.layerTree.children.push(
-            new TreeNode(featIdx, this.uid, this.name)
-        ); // TODO verify name is populated at this point
-        // featFC.name = this.name; // feature layer is flat, so the sublayer and layer share their name
 
-        // TODO see if we need to re-synch the parent name
-        // this.layerTree.name = this.name;
+        this.layerTree.name = this.name;
+        this.layerTree.layerIdx = featIdx;
 
         // update asynch data
         const pLD: Promise<void> = this.loadLayerMetadata(

--- a/packages/ramp-core/src/geo/layer/esriGraphic/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriGraphic/index.ts
@@ -46,22 +46,10 @@ class GraphicLayer extends CommonGraphicLayer {
     onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
-        if (!this.layerTree) {
-            throw new Error('superclass did not create layer tree');
-        }
-
         // TODO if we ever have a way to "configure" initial graphics in the layer config,
         //      would probably want to create them here.
 
-        // feature has only one layer
-        // const normieFC = new CommonFC(this, 0);
-        // this.fcs[0] = normieFC;
-
-        this.layerTree.children.push(new TreeNode(0, this.uid, this.name)); // TODO verify name is populated at this point
-        // normieFC.name = this.name; // feature layer is flat, so the sublayer and layer share their name
-
-        // TODO see if we need to re-synch the parent name
-        // this.layerTree.name = this.name;
+        this.layerTree.name = this.name;
 
         return loadPromises;
     }

--- a/packages/ramp-core/src/geo/layer/esriImagery/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriImagery/index.ts
@@ -45,13 +45,7 @@ class ImageryLayer extends CommonLayer {
     onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
-        // const imgFC = new CommonFC(this, 0);
-        // this.fcs[0] = imgFC;
-
-        this.layerTree?.children.push(new TreeNode(0, this.uid, this.name));
-
-        // TODO see if we need to re-synch the parent name
-        // this.layerTree.name = this.name;
+        this.layerTree.name = this.name;
 
         const legendPromise = this.$iApi.geo.utils.symbology
             .mapServerToLocalLegend(this.origRampConfig.url)

--- a/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/index.ts
@@ -42,6 +42,11 @@ class MapImageLayer extends AttribLayer {
         this.supportsSublayers = true;
         this.layerType = LayerType.MAPIMAGE;
         this.isDynamic = false; // will get updated after layer load.
+
+        // mark the root node of this layer as not layer
+        // TODO: revisit this once we decide on what `isLayer` should be
+        this.layerTree.isLayer = false;
+        this.layerTree.layerIdx = -1;
     }
 
     async initiate(): Promise<void> {
@@ -111,6 +116,8 @@ class MapImageLayer extends AttribLayer {
             this.noLayerErr();
             return loadPromises;
         }
+
+        this.layerTree.name = this.name;
 
         // a trick. this promise wont resolve until all the loading things have finished.
         // then we revert the layer visibility back to what the config wanted.

--- a/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
+++ b/packages/ramp-core/src/geo/layer/esriMapImage/map-image-sublayer.ts
@@ -63,10 +63,8 @@ export class MapImageSublayer extends AttribLayer {
      * Load actions for a MapImage sublayer
      */
     onLoadActions(): Array<Promise<void>> {
-        // create a leaf node for this sublayer
-        if (!this.layerTree) {
-            this.layerTree = new TreeNode(this.layerIdx, this.uid, this.name);
-        }
+        this.layerTree.name = this.name;
+        this.layerTree.layerIdx = this.layerIdx;
 
         this.identify = !(this.config.state.identify == undefined)
             ? this.config.state.identify

--- a/packages/ramp-core/src/geo/layer/esriTile/index.ts
+++ b/packages/ramp-core/src/geo/layer/esriTile/index.ts
@@ -45,13 +45,7 @@ class TileLayer extends CommonLayer {
     onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
-        // const tileFC = new CommonFC(this, 0);
-        // this.fcs[0] = tileFC;
-
-        this.layerTree?.children.push(new TreeNode(0, this.uid, this.name));
-
-        // TODO see if we need to re-synch the parent name
-        // this.layerTree.name = this.name;
+        this.layerTree.name = this.name;
 
         const legendPromise = this.$iApi.geo.utils.symbology
             .mapServerToLocalLegend(this.origRampConfig.url)

--- a/packages/ramp-core/src/geo/layer/file-layer.ts
+++ b/packages/ramp-core/src/geo/layer/file-layer.ts
@@ -182,10 +182,6 @@ export class FileLayer extends AttribLayer {
     onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
-        if (!this.layerTree) {
-            throw new Error('superclass did not create layer tree');
-        }
-
         // setting custom renderer here (if one is provided)
         if (this.esriLayer && this.origRampConfig.customRenderer?.type) {
             this.esriLayer.renderer = EsriRendererFromJson(
@@ -193,14 +189,7 @@ export class FileLayer extends AttribLayer {
             );
         }
 
-        // feature has only one layer
-        const featIdx: number = 0; // GeoJSON is always 0
-        // const fFC = new FileFC(this, featIdx);
-        // fFC.name = this.name; // geojson layer is flat, so the sublayer and layer share their name. we do this here and not in extractMetaData because .name is private
-        // this.fcs[featIdx] = fFC;
-        this.layerTree.children.push(
-            new TreeNode(featIdx, this.uid, this.name)
-        );
+        this.layerTree.name = this.name;
 
         // TODO implement symbology load
         // const pLS = aFC.loadSymbology();

--- a/packages/ramp-core/src/geo/layer/ogcWms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogcWms/index.ts
@@ -114,16 +114,7 @@ export default class WmsLayer extends CommonLayer {
     onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
-        if (!this.layerTree) {
-            throw new Error('superclass did not create layer tree');
-        }
-
-        // const wmsFC = new WmsFC(this, 0);
-        // this.fcs[0] = wmsFC;
-
-        this.layerTree.children.push(new TreeNode(0, this.uid, this.name));
-        // TODO see if we need to re-synch the parent name
-        // this.layerTree.name = this.name;
+        this.layerTree.name = this.name;
 
         // Set visibility of sublayers based on presence in the config
         const crawlSublayers = (

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -827,15 +827,13 @@ export class MapAPI extends CommonMapAPI {
             return matchedResult !== undefined;
         });
         if (esriGraphic && hitLayer) {
-            if (hitLayer.getLayerTree().children.length > 1) {
-                console.warn(
-                    'Found layer with more than one child during hitTest'
-                );
+            if (hitLayer.sublayers.length > 1) {
+                console.warn('Found layer with sublayers during hitTest');
             }
             return {
                 oid: esriGraphic.getObjectId(),
                 layerId: esriGraphic.layer.id,
-                layerIdx: hitLayer.getLayerTree().children[0].layerIdx
+                layerIdx: hitLayer.getLayerTree().layerIdx
             };
         }
     }


### PR DESCRIPTION
## Closes #851

## Changes in this PR
- [FIX] All non-MapImageLayers will only have one root node in its layer tree. Reloading the layer should not affect this node.
- [FIX] Layer names are defaulted to the layer id if config name and server name is not provided
- [FIX] North pole layer will no longer throw an error because its `state.identify` is not defined
- [FIX] Removed unused `reloadTree` property in `CommonLayer`

## Further work
- Discuss the purpose of the `isLayer` flag in `TreeNode` post-layer-refactor

### [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/851/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/853)
<!-- Reviewable:end -->
