### PR TITLE
Disable clicking on legend entry if it does not support grid

### DIFF
--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -2,20 +2,28 @@
     <div class="legend-item" :key="legendItem.visibility">
         <div class="relative">
             <div
-                class="
+                :class="`
                     default-focus-style
                     p-5
                     flex
                     items-center
                     hover:bg-gray-200
-                    cursor-pointer
+                    ${
+                        legendItem._controlAvailable('datatable')
+                            ? 'cursor-pointer'
+                            : 'cursor-default'
+                    }
                     h-44
-                "
+                `"
                 @click="toggleGrid"
                 v-focus-item="'show-truncate'"
                 @mouseover.stop="$event.currentTarget._tippy.show()"
                 @mouseout.self="$event.currentTarget._tippy.hide()"
-                :content="$t('legend.entry.data')"
+                :content="
+                    legendItem._controlAvailable('datatable')
+                        ? $t('legend.entry.data')
+                        : ''
+                "
                 v-tippy="{
                     placement: 'top-start',
                     trigger: 'manual focus',


### PR DESCRIPTION
## Closes #801

## Changes in this PR
- [FIX] Legend entries tied to layers that do no support the data grid will no longer be shown as clickable and the "Show more data" tooltip will not appear

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/801/host/index.html)
### Steps to test

1. Load this [Tile Layer](http://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer)
2. Mouse over the legend entry - the mouse pointer should be the default (i.e. not the hand) and the "Show more data" tooltip should not appear