### PR TITLE
Fun updates - Schema, API, Events, Comments

### DIFF
--- a/packages/ramp-core/docs/api/notifications.md
+++ b/packages/ramp-core/docs/api/notifications.md
@@ -12,9 +12,9 @@ As stated above there are three types of notifications; `error`, `warning` and `
 
 ```js
 var rInstance = new RAMP.Instance(domElement, configs);
-rInstance.notifications.show("info", "The map has been created!");
-rInstance.notifications.show("error", "Could not connect to the server for fixture A, try reloading the page");
-rInstance.notifications.show("warning", "Slow response times from the server");
+rInstance.notify.show("info", "The map has been created!");
+rInstance.notify.show("error", "Could not connect to the server for fixture A, try reloading the page");
+rInstance.notify.show("warning", "Slow response times from the server");
 ```
 
 In real cases errors and warnings would probably not be right after the instance creation and would be in a callback or some error handling code.
@@ -26,7 +26,7 @@ In real cases errors and warnings would probably not be right after the instance
 The notifications API also allows the creation of groups
 
 ```js
-let serverErrors = rInstance.notifications.addGroup('server-errors', 'error', 'Some servers seem to be having issues');
+let serverErrors = rInstance.notify.addGroup('server-errors', 'error', 'Some servers seem to be having issues');
 ```
 
 After creating a group you can show messages in them

--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -437,7 +437,7 @@ let config = {
                 text: 'All Your Base are Belong to Us'
             }
         },
-        animate: true
+        system: { animate: true }
     },
     fr: {
         map: {
@@ -860,7 +860,7 @@ let config = {
                 text: 'All Your Base are Belong to Us'
             }
         },
-        animate: true
+        system: { animate: true }
     }
 };
 

--- a/packages/ramp-core/public/starter-scripts/cam.js
+++ b/packages/ramp-core/public/starter-scripts/cam.js
@@ -383,7 +383,7 @@ let config = {
                 }
             }
         },
-        animate: true
+        system: { animate: true }
     },
     fr: {
         map: {
@@ -962,7 +962,7 @@ let config = {
                 }
             }
         },
-        animate: true
+        system: { animate: true }
     }
 };
 

--- a/packages/ramp-core/public/starter-scripts/custom-renderer.js
+++ b/packages/ramp-core/public/starter-scripts/custom-renderer.js
@@ -759,7 +759,7 @@ let config = {
             },
             mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] }
         },
-        animate: true
+        system: { animate: true }
     }
 };
 

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -405,7 +405,7 @@ let config = {
                 text: 'All Your Base are Belong to Us'
             }
         },
-        animate: true
+        system: { animate: true }
     }
 };
 

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1703,27 +1703,6 @@
             "enum": ["4.0"],
             "description": "The schema version used to validate the configuration file. The schema should enumerate the list of versions accepted by this version of the viewer."
         },
-        "ui": {
-            "type": "object",
-            "description": "Configuration for required UI map components.",
-            "properties": {
-                "title": {
-                    "type": "string",
-                    "description": "An optional title to be used in the place of the default viewer title."
-                },
-                "fullscreen": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Indicates if viewer takes up entire viewport."
-                },
-                "restrictNavigation": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Specifies whether or not to restrict user from panning beyond the maximum map extent."
-                }
-            },
-            "unevaluatedProperties": false
-        },
         "fixtures": {
             "type": "object",
             "description": "Optional configuration for required map fixtures. TODO: fixtures may not exist so cannot enforce fixtures in config file",
@@ -1894,6 +1873,11 @@
                 "proxyUrl": {
                     "type": "string",
                     "description": "An optional proxy to be used for dealing with same-origin issues.  URL must either be a relative path on the same server or an absolute path on a server which sets CORS headers."
+                },
+                "animate": {
+                    "type": "boolean",
+                    "description": "Will enable visual animation when using the site, such as control transitions.",
+                    "default": true
                 }
             },
             "required": [],

--- a/packages/ramp-core/src/api/config-upgrade.ts
+++ b/packages/ramp-core/src/api/config-upgrade.ts
@@ -51,8 +51,7 @@ function individualConfigUpgrader(r2c: any): any {
         fixtures: [],
         layers: [],
         map: {},
-        system: {},
-        animate: true
+        system: { animate: true }
     };
 
     // ramp 2 top-level object has

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -198,6 +198,12 @@ export enum GlobalEvents {
     MAP_REFRESH_START = 'map/refreshstart',
 
     /**
+     * Fires when a layer is reordered in the map stack.
+     * Payload: `( { layer: LayerInstance, newIndex: integer })`
+     */
+    MAP_REORDER = 'map/reorder',
+
+    /**
      * Fires when the map view is resized.
      * Payload: `({ height: number, width: number })`
      */
@@ -593,6 +599,7 @@ export class EventAPI extends APIScope {
                 this.on(GlobalEvents.MAP_IDENTIFY, zeHandler, handlerName);
                 break;
             case DefEH.TOGGLE_SETTINGS:
+                // opens or closes the settings panel and hooks it up to the requested layer.
                 zeHandler = (payload: any) => {
                     const settingsFixture: SettingsAPI =
                         this.$iApi.fixture.get('settings');
@@ -600,7 +607,6 @@ export class EventAPI extends APIScope {
                         settingsFixture.toggleSettings(payload);
                     }
                 };
-                // Create a new event: opens the settings panel and hooks it up to the requested layer.
                 this.$iApi.event.on(
                     GlobalEvents.SETTINGS_TOGGLE,
                     zeHandler,
@@ -608,6 +614,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.OPEN_DETAILS:
+                // opens the standard details panel when a show details event happens
                 zeHandler = (payload: any) => {
                     const detailsFixture: DetailsAPI =
                         this.$iApi.fixture.get('details');
@@ -625,6 +632,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.TOGGLE_HELP:
+                // opens or closes the standard help panel when a toggle help event happens
                 zeHandler = (payload?: boolean) => {
                     const helpFixture: HelpAPI = this.$iApi.fixture.get('help');
                     if (helpFixture) {
@@ -638,6 +646,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.TOGGLE_GRID:
+                // opens or closes the standard grid panel when a toggle grid event happens
                 zeHandler = (uid: string, open?: boolean) => {
                     const gridFixture: GridAPI = this.$iApi.fixture.get('grid');
                     if (gridFixture) {
@@ -651,6 +660,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.OPEN_WIZARD:
+                // opens the standard add layer wizard panel when an open wizard event happens
                 zeHandler = () => {
                     const wizardFixture: WizardAPI =
                         this.$iApi.fixture.get('wizard');
@@ -665,6 +675,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.OPEN_LAYER_REORDER:
+                // opens the standard layer reorder panel when an open reorder event happens
                 zeHandler = () => {
                     const reorderFixture: LayerReorderAPI =
                         this.$iApi.fixture.get('layer-reorder');
@@ -679,6 +690,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.UPDATE_LEGEND_LAYER_REGISTER:
+                // when a layer is regestered, have the standard legend update in accordance to the layer
                 zeHandler = (layer: LayerInstance) => {
                     const legendFixture: LegendAPI =
                         this.$iApi.fixture.get('legend');
@@ -693,6 +705,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.UPDATE_LEGEND_WIZARD_ADDED:
+                // when a layer is user-added, have the standard legend create a new stock entry for the layer
                 zeHandler = (layer: LayerInstance) => {
                     const legendFixture: LegendAPI =
                         this.$iApi.fixture.get('legend');
@@ -707,6 +720,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.UPDATE_LEGEND_LAYER_RELOAD:
+                // when a layer is reloaded, have the standard legend update in accordance to the layer
                 zeHandler = (layer: LayerInstance) => {
                     const legendFixture: LegendAPI =
                         this.$iApi.fixture.get('legend');
@@ -721,6 +735,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MAP_KEYDOWN:
+                // processes keyboard interaction from the map view
                 zeHandler = (payload: KeyboardEvent) => {
                     this.$iApi.geo.map.mapKeyDown(payload);
                 };
@@ -731,6 +746,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MAP_KEYUP:
+                // processes keyboard interaction from the map view
                 zeHandler = (payload: KeyboardEvent) => {
                     this.$iApi.geo.map.mapKeyUp(payload);
                 };
@@ -741,6 +757,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MAP_BLUR:
+                // processes loss of focus from the map view
                 zeHandler = (payload: FocusEvent) => {
                     this.$iApi.geo.map.stopKeyPan();
                 };
@@ -751,6 +768,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION:
+                // update any basemap attribution in the map caption when the basemap changes
                 zeHandler = () => {
                     this.$iApi.geo.map.caption.updateAttribution(
                         (
@@ -767,6 +785,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.CONFIG_CHANGE_ATTRIBUTION:
+                // update any basemap attribution in the map caption when the config changes (likely langauge switch)
                 zeHandler = (payload: RampConfig) => {
                     let currentBasemapConfig: RampBasemapConfig | undefined =
                         payload.map.basemaps.find(
@@ -786,6 +805,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MAP_CREATED_ATTRIBUTION:
+                // update any basemap attribution in the map caption when the map is created
                 zeHandler = () => {
                     this.$iApi.geo.map.caption.updateAttribution(
                         (
@@ -802,6 +822,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MAP_SCALECHANGE_SCALEBAR:
+                // update the map scale caption when the map scale changes
                 this.$iApi.event.on(
                     GlobalEvents.MAP_SCALECHANGE,
                     debounce(300, () =>
@@ -811,6 +832,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MOUSE_MOVE_MAPTIP_CHECK:
+                // update any maptip state when the mouse moves over the map
                 zeHandler = (mapMove: MapMove) => {
                     this.$iApi.geo.map.maptip.checkAtCoord({
                         screenX: mapMove.screenX,
@@ -824,6 +846,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.EXTENT_CHANGE_MAPTIP_CHECK:
+                // update any maptip state when the map extent changes
                 zeHandler = () => {
                     if (this.$iApi.geo.map.keysActive) {
                         // The user is using the crosshairs, perform hit-test using center of screens
@@ -844,6 +867,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.SHOW_DEFAULT_MAPTIP:
+                // show a maptip in default format when the mouse goes over a vector feature
                 zeHandler = (tooltipInfo: any) => {
                     this.$iApi.geo.map.maptip.generateDefaultMaptip(
                         tooltipInfo
@@ -856,6 +880,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.MAP_UPDATE_CAPTION_COORDS:
+                // update the mouse co-ordinate caption when the mouse moves over the map
                 this.$iApi.event.on(
                     GlobalEvents.MAP_MOUSEMOVE,
                     throttle(200, (mapMove: MapMove) => {
@@ -888,6 +913,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.LEGEND_REMOVES_LAYER_ENTRY:
+                // when a layer is removed from the map, remove any bound entries from the standard legend
                 zeHandler = (layer: LayerInstance) => {
                     if (this.$iApi.$vApp.$store.hasModule('legend')) {
                         this.$iApi.$vApp.$store.dispatch(
@@ -908,6 +934,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.LEGEND_RELOADS_LAYER_ENTRY:
+                // when a layer starts to reload, reset any entries in the standard legend to a loading state
                 zeHandler = (layer: LayerInstance) => {
                     if (this.$iApi.$vApp.$store.hasModule('legend')) {
                         this.$iApi.$vApp.$store.dispatch(
@@ -923,6 +950,7 @@ export class EventAPI extends APIScope {
                 );
                 break;
             case DefEH.GRID_REMOVES_LAYER_GRID:
+                // when a layer is removed, close the standard grid if open for that layer
                 zeHandler = (layer: LayerInstance) => {
                     // remove cached grid state for layer from grid store
                     this.$vApp.$store.dispatch(

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -55,7 +55,7 @@ export class InstanceAPI {
     readonly panel: PanelAPI;
     readonly event: EventAPI;
     readonly geo: GeoAPI;
-    readonly notifications: NotificationAPI;
+    readonly notify: NotificationAPI;
     readonly startRequired: boolean;
     readonly ui: { maptip: MaptipAPI };
     started: boolean = false;
@@ -94,8 +94,7 @@ export class InstanceAPI {
         this.geo = new GeoAPI(this);
         //TODO before 1.0: does the ui namespace still make sense, should we just leave maptip under geo.map only?
         this.ui = { maptip: this.geo.map.maptip };
-        //TODO before 1.0: is 'notifications' too long of a name? maybe 'log' or 'notify'
-        this.notifications = new NotificationAPI(this);
+        this.notify = new NotificationAPI(this);
 
         // TODO: decide whether to move to src/main.ts:createApp
         // TODO: store a reference to the even bus in the global store [?]
@@ -128,7 +127,7 @@ export class InstanceAPI {
             );
 
             // disable animations if needed
-            if (!langConfig.animate && this.$element._container) {
+            if (!langConfig.system?.animate && this.$element._container) {
                 this.$element._container.classList.remove('animation-enabled');
             }
 

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -124,14 +124,14 @@ export class LegendAPI extends FixtureInstance {
     }
 
     /**
-     * Update an existing legend entry to load the given layer
+     * Update an existing legend entry with data from the given layer
      * Does nothing if the legend entry is not found
      *
-     * @param {LayerInstance} layer the layer to load into the legend entry
+     * @param {LayerInstance} layer the layer to update the legend entry with
      * @memberOf LegendFixture
      */
     updateLegend(layer: LayerInstance) {
-        // helper function to load a layer onto a legend entry
+        // helper function to link a layer into a legend entry
         const updateEntry = (layer: LayerInstance) => {
             const entry: LegendEntry | undefined = this.$vApp.$store.get(
                 LegendStore.getChildById,

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -197,7 +197,7 @@ export class LegendEntry extends LegendItem {
     }
 
     /**
-     * Load the given layer into this entry
+     * Have the entry adapt and update to the given layer as it loads.
      * Is either called in the constructor, or through the legend api
      */
     loadLayer(layer: LayerInstance): void {

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -227,6 +227,14 @@ export class LayerAPI extends APIScope {
         return layer;
     }
 
+    /**
+     * Return all registered layers.
+     * @returns {Array<LayerInstance>} all registered layers
+     */
+    allLayers(): Array<LayerInstance> {
+        return this.$vApp.$store.get<LayerInstance[]>(LayerStore.layers) || [];
+    }
+
     // TODO consider if we need a defaulting scenario. This might tie in with
     //      people wanting to override core layer types; they would omit then provide
     //      the custom layer definition class.

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -436,6 +436,10 @@ export class MapAPI extends CommonMapAPI {
         }
         // sync layer store order with map order
         this.$vApp.$store.set(LayerStore.reorderLayer, { layer, index });
+        this.$iApi.event.emit(GlobalEvents.MAP_REORDER, {
+            layer,
+            newIndex: index
+        });
     }
 
     /**

--- a/packages/ramp-core/src/types.d.ts
+++ b/packages/ramp-core/src/types.d.ts
@@ -76,9 +76,9 @@ export interface RampConfig {
     map: RampMapConfig;
     layers: RampLayerConfig[];
     fixtures: { [key: string]: any };
-    animate: boolean;
     system?: {
         proxyUrl?: string;
+        animate?: boolean;
     };
 }
 


### PR DESCRIPTION
- Removes the `ui` nugget from the config schema
- Adds `animate` option to config schema and relocates it to the `system` nugget (instead of just sitting on the root)
- Changes the `.notification` API nugget to `.notify`
- Adds lovely comments to all the default event handlers
- Adds a `map/reorder` global event
- Adds a new API call `.geo.layer.allLayers()` to get an array of all registered layers

Donethankses #637 , #868
The event and api call were bonus requests from https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/847

[Demo](http://ramp4-app.azureedge.net/demo/users/james-rae/jamesparty/host/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/870)
<!-- Reviewable:end -->
