### PR TITLE
Add basemap, tile schema, and lod/extent sets config upgrader

### DIFF
--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1467,18 +1467,20 @@
                         "properties": {
                             "id": {
                                 "type": "string",
-                                "default": ""
+                                "description": "Base layer's id"
                             },
                             "layerType": {
                                 "type": "string",
-                                "default": ""
+                                "description": "Base layer's type",
+                                "enum": ["esriMapImage", "esriTile"]
                             },
                             "url": {
                                 "type": "string",
-                                "default": ""
+                                "description": "Base layer's url"
                             },
                             "opacity": {
                                 "type": "number",
+                                "description": "Base layer's opacity",
                                 "default": 1
                             }
                         },

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -509,9 +509,10 @@ export interface RampExtentSetConfig {
 }
 
 export interface RampBasemapLayerConfig {
+    id?: string;
     layerType: string;
     url: string;
-    // TODO figure out if we need extra flag to mark as baselayer or referencelayer
+    opacity?: number;
 }
 
 export interface RampBasemapConfig {
@@ -520,6 +521,7 @@ export interface RampBasemapConfig {
     name?: string;
     description?: string;
     altText?: string;
+    thumbnailUrl?: string;
     attribution?: Attribution;
     layers: Array<RampBasemapLayerConfig>;
 }

--- a/packages/ramp-core/src/geo/map/basemap.ts
+++ b/packages/ramp-core/src/geo/map/basemap.ts
@@ -15,11 +15,13 @@ export class Basemap {
             baseLayers: rampConfig.layers.map(layerConfig => {
                 if (layerConfig.layerType === LayerType.TILE) {
                     return new EsriTileLayer({
-                        url: layerConfig.url
+                        url: layerConfig.url,
+                        opacity: layerConfig.opacity
                     });
                 } else if (layerConfig.layerType === LayerType.MAPIMAGE) {
                     return new EsriMapImageLayer({
-                        url: layerConfig.url
+                        url: layerConfig.url,
+                        opacity: layerConfig.opacity
                     });
                 } else {
                     throw new Error(


### PR DESCRIPTION
## Closes #634, Closes #635

## Changes in this PR
- [FEAT] Added basemap, tile schema, lod/extent sets mapping to R2->R4 config upgrader
    - Also handles case where R2 tile schema config provides a basemap layer to be used for the overview map
    - This basemap layer is properly passed to the overview map fixture config

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/874)
<!-- Reviewable:end -->
