### PR TITLE
Add mapnav config upgrader + simplify mapnav state

### DIFF
--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -477,7 +477,7 @@
                     "items": {
                         "type": "string",
                         "enum": [
-                            "geoLocator",
+                            "geolocator",
                             "zoom",
                             "home",
                             "basemap",

--- a/packages/ramp-core/src/api/config-upgrade.ts
+++ b/packages/ramp-core/src/api/config-upgrade.ts
@@ -322,4 +322,30 @@ function servicesUpgrader(r2Services: any, r4c: any): void {
  */
 function uiUpgrader(r2ui: any, r4c: any): void {
     // TODO git r done
+
+    if (r2ui.navBar) {
+        // process nav bar
+        r4c.fixtures.mapnav = {
+            zoomOption: r2ui.navBar.zoom || 'buttons',
+            items: []
+        };
+        const allowedItems: string[] = [
+            'geolocator',
+            'zoom',
+            'home',
+            'basemap',
+            'help',
+            'fullscreen',
+            'geosearch',
+            'legend'
+        ];
+        r2ui.navBar.extra.forEach((item: string) => {
+            const itemLower = item.toLowerCase();
+            if (!allowedItems.includes(itemLower)) {
+                console.warn(`ignored invalid mapnav item: ${item}`);
+            } else {
+                r4c.fixtures.mapnav.items.push(itemLower);
+            }
+        });
+    }
 }

--- a/packages/ramp-core/src/fixtures/mapnav/api/mapnav.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/api/mapnav.ts
@@ -1,10 +1,6 @@
 import { FixtureInstance } from '@/api';
 
-import {
-    MapnavFixtureConfig,
-    MapnavItemInstance,
-    MapnavItemSet
-} from '../store';
+import { MapnavFixtureConfig, MapnavItem, MapnavItemSet } from '../store';
 
 export class MapnavAPI extends FixtureInstance {
     /**
@@ -19,9 +15,9 @@ export class MapnavAPI extends FixtureInstance {
     }
 
     /**
-     * Parses the appbar config JSON snippet from the config file and save resulting objects to the fixture store.
+     * Parses the mapnav config JSON snippet from the config file and save resulting objects to the fixture store.
      *
-     * @param {MapnavFixtureConfig} [appbarConfig]
+     * @param {MapnavFixtureConfig} [mapnavConfig]
      * @returns
      * @memberof MapnavAPI
      */
@@ -30,8 +26,10 @@ export class MapnavAPI extends FixtureInstance {
             return;
         }
 
-        const mapnavItems = mapnavConfig.items.map(
-            (item: any) => new MapnavItemInstance(item)
+        const mapnavItems: MapnavItem[] = mapnavConfig.items.map(
+            (item: string) => ({
+                id: item
+            })
         );
 
         // save mapnav items as a collection to the store

--- a/packages/ramp-core/src/fixtures/mapnav/store/mapnav-state.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/store/mapnav-state.ts
@@ -8,7 +8,7 @@ export class MapnavState {
     items: MapnavItemSet = {};
 
     /**
-     * An ordered list of appbar item ids.
+     * An ordered list of mapnav item ids.
      *
      * @type {string[]}
      * @memberof MapnavState
@@ -16,57 +16,14 @@ export class MapnavState {
     order: string[] = [];
 }
 
-export type MapnavItemSet = { [name: string]: MapnavItemInstance };
-
 export interface MapnavFixtureConfig {
-    items: (string | MapnavItemConfig)[];
+    zoomOption: string;
+    items: string[];
 }
 
-export interface MapnavItemConfig {
-    /**
-     * ID of this Mapnav item.
-     *
-     * @type {string}
-     * @memberof MapnavItemConfig
-     */
+export interface MapnavItem {
     id: string;
-
-    /**
-     * The options for the displayed appbar button.
-     *
-     * @type {object}
-     * @memberof MapnavItemConfig
-     */
-    options?: object;
-}
-
-export class MapnavItemInstance implements MapnavItemConfig {
-    id: string;
-
-    /**
-     * Optional object containing any options to be passed to the appbar component.
-     *
-     * @type {object}
-     * @memberof MapnavItemInstance
-     */
-    options: object;
-
-    /**
-     * An actual id of the appbar Vue component to use when rendering in the template.
-     *
-     * @type {string}
-     * @memberof MapnavItemInstance
-     */
     componentId?: string;
-
-    constructor(value: string | MapnavItemConfig) {
-        const params = {
-            options: {},
-            ...(typeof value === 'string' ? { id: value } : value)
-        };
-        ({ id: this.id, options: this.options } = params);
-
-        // this should work too, but it doesn't;
-        // ({ id: this.id, options: this.options } = { options: {}, ...(typeof value === 'string' ? { id: value} : value) });
-    }
 }
+
+export type MapnavItemSet = { [name: string]: MapnavItem };

--- a/packages/ramp-core/src/fixtures/mapnav/store/mapnav-store.ts
+++ b/packages/ramp-core/src/fixtures/mapnav/store/mapnav-store.ts
@@ -1,7 +1,7 @@
 import { ActionContext, Action, Mutation } from 'vuex';
 import { make } from 'vuex-pathify';
 
-import { MapnavState, MapnavItemInstance } from './mapnav-state';
+import { MapnavState, MapnavItem } from './mapnav-state';
 import { RootState } from '@/store/state';
 
 type MapnavContext = ActionContext<MapnavState, RootState>;
@@ -11,14 +11,14 @@ type StoreMutations = { [key: string]: Mutation<MapnavState> };
 
 const getters = {
     /**
-     * Return a list of appbar items with registered components (ones that can be rendered right now).
+     * Return a list of mapnav items with registered components (ones that can be rendered right now).
      *
      * @param {Mapnav} state
-     * @returns {MapnavItemInstance[]}
+     * @returns {MapnavItem[]}
      */
-    visible(state: MapnavState): MapnavItemInstance[] {
+    visible(state: MapnavState): MapnavItem[] {
         return state.order
-            .map<MapnavItemInstance>(id => state.items[id])
+            .map<MapnavItem>(id => state.items[id])
             .filter(item => item.componentId);
     }
 };


### PR DESCRIPTION
## Closes #618, Closes #619

## Changes in this PR
- [FEAT] Added config upgrader for mapnav config
- [FIX] Renamed `geoLocator` to `geolocator` for naming consistency
- [FIX] Simplified mapnav state properties 
    - Mapnav items list to just a list of strings
    - Converted the `MapnavItemInstance` class into a `MapnavItem` interface

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/878)
<!-- Reviewable:end -->
