### PR TITLE
Convert animate flag to boolean + Add about ramp mini-dropdown

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -1,7 +1,5 @@
 window.rInstance = null;
 
-console.log('RAMP has loaded.');
-
 // TODO: Location for version string needs to be finalized
 // document.getElementById('ramp-version').innerText =
 //     'v.' +

--- a/packages/ramp-core/public/starter-scripts/cam.js
+++ b/packages/ramp-core/public/starter-scripts/cam.js
@@ -1,7 +1,5 @@
 window.rInstance = null;
 
-console.log('RAMP has loaded.');
-
 let config = {
     configs: {
         en: {

--- a/packages/ramp-core/public/starter-scripts/custom-renderer.js
+++ b/packages/ramp-core/public/starter-scripts/custom-renderer.js
@@ -1,8 +1,6 @@
 window.rInstance = null;
 document.title = 'Custom Renderer';
 
-console.log('RAMP has loaded.');
-
 let config = {
     configs: {
         en: {

--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -167,7 +167,7 @@ let config = {
                     }
                 },
                 appbar: {
-                    items: ['legend']
+                    items: ['legend', 'layer-reorder']
                 },
                 mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
                 details: {
@@ -182,6 +182,9 @@ let config = {
                     text: 'WMS'
                 }
             }
+        },
+        system: {
+            animate: false
         }
     }
 };
@@ -255,7 +258,8 @@ rInstance.fixture
         'details',
         'wizard',
         'export-v1',
-        'basemap'
+        'basemap',
+        'layer-reorder'
     ])
     .then(() => {
         rInstance.panel.open('legend-panel');

--- a/packages/ramp-core/src/api/instance.ts
+++ b/packages/ramp-core/src/api/instance.ts
@@ -76,6 +76,14 @@ export class InstanceAPI {
         configs?: RampConfigs,
         options?: RampOptions
     ) {
+        console.log(
+            `RAMP v${RAMP.version.major}.${RAMP.version.minor}.${
+                RAMP.version.patch
+            } [${RAMP.version.hash.slice(0, 9)}] (Built on ${new Date(
+                RAMP.version.timestamp
+            ).toLocaleString()})`
+        );
+
         if (options?.startRequired) {
             this.startRequired = true;
         } else {
@@ -131,8 +139,14 @@ export class InstanceAPI {
             );
 
             // disable animations if needed
-            if (!langConfig.system?.animate && this.$element._container) {
-                this.$element._container.classList.remove('animation-enabled');
+            if (
+                !langConfig.system?.animate &&
+                this.$element._container &&
+                this.$element._container.children[0]
+            ) {
+                this.$element._container.children[0].classList.remove(
+                    'animation-enabled'
+                );
             }
 
             // process system configurations
@@ -274,17 +288,17 @@ export class InstanceAPI {
      * The current animation status.
      *
      * @readonly
-     * @type string
+     * @type boolean
      * @memberof InstanceAPI
      */
-    get animate(): string {
-        if (
+    get animate(): boolean {
+        return !!(
             this.$element._container &&
-            this.$element._container.classList.contains('animation-enabled')
-        ) {
-            return 'on';
-        }
-        return 'off';
+            this.$element._container.children[0] &&
+            this.$element._container.children[0].classList.contains(
+                'animation-enabled'
+            )
+        );
     }
 
     /**

--- a/packages/ramp-core/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/packages/ramp-core/src/components/about-ramp/about-ramp-dropdown.vue
@@ -1,0 +1,127 @@
+<template>
+    <dropdown-menu
+        class="pointer-events-auto sm:flex"
+        :aria-label="$t('ramp.about')"
+        :position="position"
+        :tooltip="$t('ramp.about')"
+        :tooltipPlacement="position"
+        v-focus-item
+    >
+        <template #header>
+            <div class="flex hover:text-white">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    class="fill-current w-20 h-20"
+                >
+                    <path
+                        d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+                    />
+                </svg>
+            </div>
+        </template>
+        <template v-slot:default="scope">
+            <div
+                class="
+                    about-ramp-dropdown
+                    pointer-events-auto
+                    bg-white
+                    rounded
+                    w-256
+                    h-50
+                "
+            >
+                <div>
+                    <h4 class="pb-8 border-b border-gray-600 mb-10">
+                        {{ $t('ramp.about') }}
+                    </h4>
+                    <div class="absolute right-5 top-5">
+                        <close @click="scope.close"></close>
+                    </div>
+
+                    <div>
+                        <div>
+                            <span class="font-bold">{{ versionString }} </span>
+                            <span class="text-sm"> [{{ versionHash }}] </span>
+                        </div>
+                        <div>
+                            <span class="text-sm"> {{ buildDate }} </span>
+                        </div>
+                        <div class="mt-5">
+                            <a
+                                class="text-sm underline text-blue-600"
+                                href="https://github.com/ramp4-pcar4/ramp4-pcar4"
+                                target="_blank"
+                            >
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 24 24"
+                                    class="inline-block fill-black w-16 h-16"
+                                >
+                                    <path
+                                        d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+                                    />
+                                </svg>
+                                ramp4-pcar4
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </dropdown-menu>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
+
+export default defineComponent({
+    name: 'AboutRampDropdownV',
+
+    props: {
+        position: {
+            type: String,
+            default: 'top-start'
+        }
+    },
+
+    components: {
+        'dropdown-menu': DropdownMenuV
+    },
+
+    computed: {
+        /**
+         * Get RAMP's version string
+         */
+        versionString(): string {
+            return `${RAMP.version.major}.${RAMP.version.minor}.${RAMP.version.patch}`;
+        },
+
+        /**
+         * Get RAMP build version hash
+         */
+        versionHash(): string {
+            return RAMP.version.hash.slice(0, 9);
+        },
+
+        /**
+         * Get RAMP build date
+         */
+        buildDate(): string {
+            let timestamp = new Date(RAMP.version.timestamp);
+            return `${timestamp.getFullYear()}-${
+                timestamp.getMonth() + 1
+            }-${timestamp.getDate()} ${timestamp.getHours()}:${timestamp.getMinutes()}:${timestamp.getSeconds()}`;
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped>
+.about-ramp-dropdown {
+    &:hover {
+        @apply bg-white #{!important};
+    }
+}
+</style>

--- a/packages/ramp-core/src/components/map/map-caption.vue
+++ b/packages/ramp-core/src/components/map/map-caption.vue
@@ -12,19 +12,30 @@
             left-0
             right-0
             py-2
+            sm:py-6
         "
     >
+        <about-ramp-dropdown
+            class="sm:block display-none ml-8 mr-4"
+            position="top-end"
+        ></about-ramp-dropdown>
+
+        <notifications-caption-button
+            class="sm:block display-none"
+        ></notifications-caption-button>
+
         <span
-            class="relative ml-10 truncate top-1"
+            class="relative truncate top-1 sm:block display-none"
             v-if="!attribution.logo.disabled"
         >
             <a
                 class="pointer-events-auto cursor-pointer"
                 :href="attribution.logo.link"
                 target="_blank"
+                :aria-label="attribution.logo.altText"
             >
                 <img
-                    class="object-contain h-24"
+                    class="object-contain h-26"
                     :src="attribution.logo.value"
                     :alt="attribution.logo.altText"
                 />
@@ -32,15 +43,11 @@
         </span>
 
         <span
-            class="relative ml-10 truncate top-1"
+            class="relative ml-10 truncate top-2 sm:block display-none"
             v-if="!attribution.text.disabled"
         >
             {{ attribution.text.value }}
         </span>
-
-        <notifications-caption-button
-            class="sm:block display-none"
-        ></notifications-caption-button>
 
         <span class="flex-grow w-15"></span>
 
@@ -48,7 +55,15 @@
 
         <span
             v-if="!cursorCoords.disabled"
-            class="flex-shrink-0 relative top-1 pr-14 pl-14"
+            class="
+                flex-shrink-0
+                relative
+                top-2
+                pr-14
+                pl-14
+                text-sm
+                sm:text-base
+            "
         >
             {{ cursorCoords.formattedString }}
         </span>
@@ -60,7 +75,6 @@
                 mx-10
                 px-4
                 pointer-events-auto
-                h-20
                 cursor-pointer
                 border-none
             "
@@ -80,19 +94,20 @@
                 class="
                     border-solid border-2 border-white border-t-0
                     h-5
-                    mr-2
+                    mr-4
                     inline-block
                 "
                 :style="{ width: scale.width }"
             ></span>
-            {{ scale.label }}
+            <span class="relative text-sm sm:text-base">
+                {{ scale.label }}
+            </span>
         </button>
 
         <dropdown-menu
             class="
                 flex-shrink-0
                 pointer-events-auto
-                h-20
                 focus:outline-none
                 px-4
                 mr-4
@@ -102,14 +117,22 @@
             tooltip-placement="top-end"
         >
             <template #header>
-                <span class="text-gray-400 hover:text-white">
+                <span
+                    class="
+                        text-gray-400
+                        hover:text-white
+                        text-sm
+                        sm:text-base
+                        pb-5
+                    "
+                >
                     {{ $t('map.language.short') }}
                 </span>
             </template>
             <a
                 v-for="(item, index) in lang"
                 :key="`${item}-${index}`"
-                class="flex-auto items-center"
+                class="flex-auto items-center text-sm sm:text-base"
                 @click="changeLang(item)"
             >
                 {{ $t('map.language.' + item) }}
@@ -119,12 +142,14 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from 'vue';
+import { defineComponent } from 'vue';
 import { get } from '@/store/pathify-helper';
-import { Attribution, MouseCoords, RampMapConfig, ScaleBar } from '@/geo/api';
+import { RampMapConfig } from '@/geo/api';
 import { MapCaptionStore } from '@/store/modules/map-caption';
 import { ConfigStore } from '@/store/modules/config';
 import NotificationsCaptionButtonV from '@/components/notification-center/caption-button.vue';
+import AboutRampDropdown from '@/components/about-ramp/about-ramp-dropdown.vue';
+
 export default defineComponent({
     data() {
         return {
@@ -135,9 +160,12 @@ export default defineComponent({
             lang: [] as string[]
         };
     },
+
     components: {
-        'notifications-caption-button': NotificationsCaptionButtonV
+        'notifications-caption-button': NotificationsCaptionButtonV,
+        'about-ramp-dropdown': AboutRampDropdown
     },
+
     watch: {
         mapConfig(newConfig: RampMapConfig, oldConfig: RampMapConfig) {
             if (newConfig === oldConfig) {
@@ -146,6 +174,7 @@ export default defineComponent({
             this.$iApi.geo.map.caption.createCaption(this.mapConfig.caption);
         }
     },
+
     updated() {
         this.$nextTick(function () {
             if (this.$iApi.$vApp.$i18n && this.lang.length == 0) {
@@ -153,6 +182,7 @@ export default defineComponent({
             }
         });
     },
+
     methods: {
         changeLang(lang: string) {
             if (this.$iApi.$vApp.$i18n.locale != lang) {

--- a/packages/ramp-core/src/components/notification-center/caption-button.vue
+++ b/packages/ramp-core/src/components/notification-center/caption-button.vue
@@ -1,9 +1,10 @@
 <template>
     <dropdown-menu
         position="top-start"
+        :aria-label="$t('notifications.title')"
         :tooltip="$t('notifications.title')"
         tooltipPlacement="top"
-        class="pointer-events-auto sm:flex mx-16"
+        class="pointer-events-auto sm:flex ml-4 mr-8"
     >
         <template #header>
             <div class="flex items-center hover:text-white">

--- a/packages/ramp-core/src/components/shell.vue
+++ b/packages/ramp-core/src/components/shell.vue
@@ -39,7 +39,7 @@
                     xs:pl-40
                     sm:p-12 sm:pl-80
                     z-10
-                    sm:pb-36
+                    sm:pb-48
                     xs:pb-28
                 "
             ></panel-stack>

--- a/packages/ramp-core/src/fixtures/appbar/appbar.vue
+++ b/packages/ramp-core/src/fixtures/appbar/appbar.vue
@@ -5,14 +5,14 @@
             top-0
             left-0
             bottom-28
-            z-50
             flex flex-col
             items-stretch
             w-40
             pointer-events-auto
             appbar
             bg-black-75
-            sm:w-64
+            z-50
+            sm:w-64 sm:z-0 sm:bottom-38
         "
         v-focus-list
         ref="el"
@@ -40,24 +40,32 @@
         <notifications-appbar-button
             class="appbar-item bottom-48 h-48 sm:display-none"
         ></notifications-appbar-button>
-        <nav-button id="nav"></nav-button>
+
+        <!-- TODO: disabled this button for now, revist this when we need it in the future -->
+        <!-- <nav-button id="nav"></nav-button> -->
+        <about-ramp-dropdown
+            class="absolute bottom-0 h-40 sm:display-none w-full text-center"
+            position="right-start"
+        ></about-ramp-dropdown>
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent } from 'vue';
 import { get } from '@/store/pathify-helper';
 
 import MoreAppbarButtonV from './more-button.vue';
-import NavAppbarButtonV from './nav-button.vue';
+//import NavAppbarButtonV from './nav-button.vue';
 import NotificationsAppbarButtonV from '@/components/notification-center/appbar-button.vue';
+import AboutRampDropdownV from '@/components/about-ramp/about-ramp-dropdown.vue';
 
 export default defineComponent({
     name: 'AppbarV',
     components: {
         'more-button': MoreAppbarButtonV,
-        'nav-button': NavAppbarButtonV,
-        'notifications-appbar-button': NotificationsAppbarButtonV
+        // 'nav-button': NavAppbarButtonV,
+        'notifications-appbar-button': NotificationsAppbarButtonV,
+        'about-ramp-dropdown': AboutRampDropdownV
     },
 
     data() {

--- a/packages/ramp-core/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/packages/ramp-core/src/fixtures/layer-reorder/components/layer-component.vue
@@ -193,8 +193,8 @@ export default defineComponent({
         /**
          * Get animation enabled status
          */
-        isAnimationEnabled(): Boolean {
-            return this.$iApi.animate === 'on';
+        isAnimationEnabled(): boolean {
+            return this.$iApi.animate;
         }
     },
     watch: {

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -196,8 +196,8 @@ export default defineComponent({
         /**
          * Get animation enabled status
          */
-        isAnimationEnabled(): Boolean {
-            return this.$iApi.animate === 'on';
+        isAnimationEnabled(): boolean {
+            return this.$iApi.animate;
         }
     },
 

--- a/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
+++ b/packages/ramp-core/src/fixtures/mapnav/mapnav.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="mapnav absolute right-0 bottom-0 pb-36 pr-12">
+    <div class="mapnav absolute right-0 bottom-0 pb-36 sm:pb-48 pr-12">
         <div class="flex flex-col" v-focus-list>
             <zoom-nav-section
                 class="mapnav-section bg-white-75 hover:bg-white"

--- a/packages/ramp-core/src/lang/lang.csv
+++ b/packages/ramp-core/src/lang/lang.csv
@@ -4,6 +4,7 @@ lang-dir,ltr,1,ltr,1
 lang-en,English,1,French,1
 lang-fr,anglais,1,français,1
 lang-native,English,1,Français,1
+ramp.about,About RAMP,1,Au sujet de la PCAR,0
 keyboardInstructions.title,Keyboard Instructions,1,Instructions clavier,1
 keyboardInstructions.open,Open keyboard instructions,1,Instructions clavier ouvert,1
 keyboardInstructions.app,"Use 'Tab' to navigate between sections of the application.",1,"Utilisez la touche Tab pour vous déplacer entre les sections de l’application.",1


### PR DESCRIPTION
## Closes #902, Closes #881

## Changes in this PR
- [FEAT] Animate instance property is now a boolean
- [FEAT] Added "About RAMP" mini-dropdown to map caption bar that moves to app bar on mobile screens
    - Moved the notification bell next to the octocat icon to make the caption bar look a bit more organized
    - Also increased the height of the caption bar so icons look bigger 
    - Additionally, the caption bar will shrink its height on mobile screens for more screen space (the fonts will also become smaller)
- [FEAT] Added RAMP version info console log 

## Comments
- I noticed that when using the keyboard to navigate, the tippy tooltip doesn't go away when the action is invoked
    - This causes the tooltip to stay on top and cover the ui (especially for the about ramp dropdown)
    - Could explore this in another issue
- The About RAMP appbar button is not actually an appbar button and so it can't be selected using arrow keys when navigating the appbar
    - I don't think this is an issue because I'm not sure if mobile screens are expected to be keyboard accessible, but let me know otherwise
    - If we really want to support an actual appbar button, I suggest we add an "About RAMP" panel just like the notifications panel
---

[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/902/host/index.html)
[Demo WMS](http://ramp4-app.azureedge.net/demo/users/sharvenp/902/host/index-e2e.html?script=wms-layer)
- `ramp-starter.js` has animations turned on, so the layer reorder panel will animate when dragging/dropping
- `wms-layer.js` has animations turned off, so layer reordering will not animate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/914)
<!-- Reviewable:end -->
