### PR TITLE
Implement new identify UI

### DIFF
--- a/packages/ramp-core/docs/app/appbar.md
+++ b/packages/ramp-core/docs/app/appbar.md
@@ -1,3 +1,5 @@
+TODO: revisit this once the appbar has been enhanced (#817)
+
 # Appbar
 
 The Appbar is used as a starting point for functionality in the app. Its main use is buttons that open and close/minimize panels for fixtures but it can do whatever you want a component to do (assuming it fits in the appbar properly).
@@ -36,12 +38,12 @@ There is also the ability to configure temporary appbar buttons, these buttons a
 {
     "temporaryButtons": [
         "legend",
-        { "panelId": "details-panel", "appbarItem": "details" }
+        { "panelId": "settings-panel", "appbarItem": "settings" }
     ]
 }
 ```
 
-The first item in the array above (`legend`) will link `legend-panel` to `legend-appbar-button`. The second item links `details-panel` (panel-id) to the appbar-item described like it would in `items` in this case `details` or `details-appbar-button`.
+The first item in the array above (`legend`) will link `legend-panel` to `legend-appbar-button`. The second item links `settings-panel` (panel-id) to the appbar-item described like it would in `items` in this case `settings` or `settings-appbar-button`.
 
 Using what we've learned, the whole config for an appbar could be:
 

--- a/packages/ramp-core/docs/app/defaults.md
+++ b/packages/ramp-core/docs/app/defaults.md
@@ -120,7 +120,7 @@ TODO add stuff as we make events that core fixtures raise
 
 | Event Name                           | Payload                                                 | Event Announces                                                |
 | ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------- |
-| DETAILS_OPEN<br>'details/open'       | _identifyItem_: IdentifyItem object<br>_uid_: layer uid | A feature's details was requested                              |
+| DETAILS_OPEN<br>'details/open'       | { data: any, uid: string }                              | A feature's details was requested                              |
 | GRID_TOGGLE<br>'grid/toggle'         | _uid_: layer uid<br>_open_: boolean (optional)          | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |
 | METADATA_OPEN<br>'metadata/open'     | { type: string, layerName: string, url: string }        | A metadata view was requested                                  |

--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -441,7 +441,13 @@ let config = {
                         'export-v1',
                         'layer-reorder'
                     ],
-                    temporaryButtons: ['details', 'grid', 'settings']
+
+                    temporaryButtons: [
+                        'details-layers',
+                        'details-items',
+                        'grid',
+                        'settings'
+                    ]
                 },
                 details: {
                     items: [

--- a/packages/ramp-core/public/starter-scripts/cam.js
+++ b/packages/ramp-core/public/starter-scripts/cam.js
@@ -331,7 +331,11 @@ let config = {
                 },
                 appbar: {
                     items: ['legend', 'geosearch', 'export-v1'],
-                    temporaryButtons: ['details', 'grid']
+                    temporaryButtons: [
+                        'details-layers',
+                        'details-items',
+                        'grid'
+                    ]
                 },
                 mapnav: { items: ['fullscreen', 'geoLocator', 'home', 'help'] },
                 'export-v1-title': {
@@ -910,7 +914,11 @@ let config = {
                 },
                 appbar: {
                     items: ['legend', 'geosearch', 'export-v1'],
-                    temporaryButtons: ['details', 'grid']
+                    temporaryButtons: [
+                        'details-layers',
+                        'details-items',
+                        'grid'
+                    ]
                 },
                 mapnav: { items: ['fullscreen', 'geoLocator', 'home', 'help'] },
                 'export-v1-title': {

--- a/packages/ramp-core/public/starter-scripts/cesi.js
+++ b/packages/ramp-core/public/starter-scripts/cesi.js
@@ -627,7 +627,11 @@ let config = {
                 },
                 appbar: {
                     items: ['legend', 'geosearch', 'basemap', 'export-v1'],
-                    temporaryButtons: ['details', 'grid']
+                    temporaryButtons: [
+                        'details-layers',
+                        'details-items',
+                        'grid'
+                    ]
                 },
                 mapnav: { items: ['fullscreen', 'geoLocator', 'home', 'help'] },
                 'export-v1-title': {

--- a/packages/ramp-core/public/starter-scripts/custom-renderer.js
+++ b/packages/ramp-core/public/starter-scripts/custom-renderer.js
@@ -761,7 +761,12 @@ let config = {
                 },
                 appbar: {
                     items: ['legend'],
-                    temporaryButtons: ['details', 'grid', 'settings']
+                    temporaryButtons: [
+                        'details-layers',
+                        'details-items',
+                        'grid',
+                        'settings'
+                    ]
                 },
                 mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] }
             },

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -390,7 +390,8 @@ let config = {
                         'export-v1'
                     ],
                     temporaryButtons: [
-                        { panelId: 'details-panel', appbarItem: 'details' },
+                        'details-layers',
+                        'details-items',
                         'metadata',
                         'settings',
                         'grid'

--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -167,7 +167,8 @@ let config = {
                     }
                 },
                 appbar: {
-                    items: ['legend', 'layer-reorder']
+                    items: ['legend', 'layer-reorder'],
+                    temporaryButtons: ['details-layers', 'details-items']
                 },
                 mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
                 details: {
@@ -254,8 +255,8 @@ rInstance.fixture
         'mapnav',
         'legend',
         'appbar',
-        'grid',
         'details',
+        'grid',
         'wizard',
         'export-v1',
         'basemap',

--- a/packages/ramp-core/src/api/event.ts
+++ b/packages/ramp-core/src/api/event.ts
@@ -615,14 +615,11 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.OPEN_DETAILS:
                 // opens the standard details panel when a show details event happens
-                zeHandler = (payload: any) => {
+                zeHandler = (payload: { data: any; uid: string }) => {
                     const detailsFixture: DetailsAPI =
                         this.$iApi.fixture.get('details');
                     if (detailsFixture) {
-                        detailsFixture.openFeature(
-                            payload.identifyItem,
-                            payload.uid
-                        );
+                        detailsFixture.openFeature(payload);
                     }
                 };
                 this.$iApi.event.on(

--- a/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
+++ b/packages/ramp-core/src/fixtures/appbar/api/appbar.ts
@@ -91,15 +91,25 @@ export class AppbarAPI extends FixtureInstance {
         );
         Object.keys(tempButtonDict).forEach(key => {
             const id = tempButtonDict[key].id;
-            [`${id}-appbar-button`, id].some(v => {
-                if (this.$iApi.fixture.get(v)) {
-                    // if an item is registered globally, save the name of the registered component
-                    this.$vApp.$store.set(
-                        `appbar/tempButtonDict@${key}.componentId`,
-                        v
-                    );
-                }
-            });
+            if (
+                ![`${id}-appbar-button`, id].some(v => {
+                    let found: boolean = !!this.$iApi.fixture.get(v);
+                    if (found) {
+                        // if an item is registered globally, save the name of the registered component
+                        this.$vApp.$store.set(
+                            `appbar/tempButtonDict@${key}.componentId`,
+                            v
+                        );
+                    }
+                    return found;
+                })
+            ) {
+                // if we could not find the fixture component id, we register this id
+                this.$vApp.$store.set(
+                    `appbar/tempButtonDict@${key}.componentId`,
+                    id
+                );
+            }
         });
     }
 }

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -1,6 +1,7 @@
 import { DetailsAPI } from './api/details';
 import { details, DetailsConfig } from './store';
-import DetailsAppbarButtonV from './appbar-button.vue';
+import DetailsLayersAppbarButtonV from './layers-appbar-button.vue';
+import DetailsItemsAppbarButtonV from './items-appbar-button.vue';
 import DetailsLayerScreenV from './layers-screen.vue';
 import DetailsResultScreenV from './result-screen.vue';
 import DetailsItemScreenV from './item-screen.vue';
@@ -11,16 +12,24 @@ class DetailsFixture extends DetailsAPI {
     async added() {
         this.$iApi.panel.register(
             {
-                'details-panel': {
+                'details-layers-panel': {
                     screens: {
-                        'details-screen-layers': markRaw(DetailsLayerScreenV),
-                        'details-screen-result': markRaw(DetailsResultScreenV),
-                        'details-screen-item': markRaw(DetailsItemScreenV)
+                        'layers-screen': markRaw(DetailsLayerScreenV)
                     },
                     style: {
                         width: '350px'
                     },
-                    alertName: 'details.title'
+                    alertName: 'details.layers.title'
+                },
+                'details-items-panel': {
+                    screens: {
+                        'results-screen': markRaw(DetailsResultScreenV),
+                        'item-screen': markRaw(DetailsItemScreenV)
+                    },
+                    style: {
+                        width: '350px'
+                    },
+                    alertName: 'details.items.title'
                 }
             },
             { i18n: { messages } }
@@ -28,7 +37,15 @@ class DetailsFixture extends DetailsAPI {
 
         this.$vApp.$store.registerModule('details', details());
 
-        this.$iApi.component('details-appbar-button', DetailsAppbarButtonV);
+        // register a button for each panel
+        this.$iApi.component(
+            'details-layers-appbar-button',
+            DetailsLayersAppbarButtonV
+        );
+        this.$iApi.component(
+            'details-items-appbar-button',
+            DetailsItemsAppbarButtonV
+        );
 
         // Parse the details portion of the configuration file and save any custom
         // template bindings in the details store.

--- a/packages/ramp-core/src/fixtures/details/items-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/details/items-appbar-button.vue
@@ -1,6 +1,9 @@
 <template>
-    <appbar-button :onClickFunction="onClick" :tooltip="$t('details.title')">
-        <!-- https://fonts.google.com/icons?selected=Material+Icons:place -->
+    <appbar-button
+        :onClickFunction="onClick"
+        :tooltip="$t('details.items.title')"
+    >
+        <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Aarticle%3A -->
         <svg
             class="fill-current w-24 h-24 ml-8 sm:ml-20"
             xmlns="http://www.w3.org/2000/svg"
@@ -8,7 +11,7 @@
         >
             <path d="M0 0h24v24H0z" fill="none" />
             <path
-                d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+                d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z"
             />
         </svg>
     </appbar-button>
@@ -17,10 +20,10 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-    name: 'DetailsAppbarButtonV',
+    name: 'DetailsItemsAppbarButtonV',
     methods: {
         onClick() {
-            this.$iApi.panel.toggleMinimize('details-panel');
+            this.$iApi.panel.toggleMinimize('details-items-panel');
         }
     }
 });

--- a/packages/ramp-core/src/fixtures/details/lang/lang.csv
+++ b/packages/ramp-core/src/fixtures/details/lang/lang.csv
@@ -1,6 +1,15 @@
 key,enValue,enValid,frValue,frValid
-details.title,Details,1,Détails,1
+details.layers.title,Identified Layers,1,Couches Identifiés,0
 details.layers.found,Found {numResults} results in {numLayers} layers,1,{numResults} résultats trouvés dans {numLayers} couches,1
 details.layers.loading,The layer is loading...,1,La couche est en cours de chargement...,1
-details.results.empty,No results found for the selected layer.,1,Aucun résultat trouvé pour la couche sélectionnée.,1
+details.layers.results.empty,No results found for the selected layer.,1,Aucun résultat trouvé pour la couche sélectionnée.,1
+details.result.default.name,Identify Item {0},1,Déterminer le point {0},0
+details.items.title,Details,1,Détails,1
+details.item.see.list,See List,1,Voir la liste,0
 details.item.zoom,Zoom to feature,1,Zoom à l'élément,1
+details.item.previous.item,Previous item,1,Point précédent,0
+details.item.next.item,Next item,1,Prochain article,0
+details.item.count,{0} of {1},1,{0} de {1},0
+details.item.alert.zoom,Zoomed into feature,1,Zoomed into feature,0
+details.item.alert.show.item,Showing result {itemName},1,Showing result {itemName},0
+details.item.alert.show.list,Showing all results for {layerName},1,Showing all results for {layerName},0

--- a/packages/ramp-core/src/fixtures/details/layers-appbar-button.vue
+++ b/packages/ramp-core/src/fixtures/details/layers-appbar-button.vue
@@ -1,0 +1,32 @@
+<template>
+    <appbar-button
+        :onClickFunction="onClick"
+        :tooltip="$t('details.layers.title')"
+    >
+        <!-- https://fonts.google.com/icons?selected=Material+Icons:place -->
+        <svg
+            class="fill-current w-24 h-24 ml-8 sm:ml-20"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+        >
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path
+                d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"
+            />
+        </svg>
+    </appbar-button>
+</template>
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'DetailsLayersAppbarButtonV',
+    methods: {
+        onClick() {
+            this.$iApi.panel.toggleMinimize('details-layers-panel');
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/packages/ramp-core/src/fixtures/details/templates/html-default.vue
+++ b/packages/ramp-core/src/fixtures/details/templates/html-default.vue
@@ -4,7 +4,7 @@
         v-if="identifyData"
         v-html="identifyData.data"
     ></div>
-    <div v-else>{{ $t('details.results.empty') }}</div>
+    <div v-else>{{ $t('details.layers.results.empty') }}</div>
 </template>
 
 <script lang="ts">

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -59,11 +59,11 @@ export default defineComponent({
 
     methods: {
         openDetails() {
-            const fakeIdentifyItem = deepmerge({}, { data: this.params.data });
-            delete fakeIdentifyItem['data']['rvInteractive'];
-            delete fakeIdentifyItem['data']['rvSymbol'];
+            let data = Object.assign({}, this.params.data);
+            delete data['rvInteractive'];
+            delete data['rvSymbol'];
             this.$iApi.event.emit(GlobalEvents.DETAILS_OPEN, {
-                identifyItem: fakeIdentifyItem,
+                data: data,
                 uid: this.params.uid
             });
         }

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -355,7 +355,7 @@ export interface IdentifyItem {
 export interface IdentifyResult {
     items: Array<IdentifyItem>;
     uid: string; // this would match to the sublayer. TODO might want to name the property something more specific to that, like sublayerUid? indexUid? childUid? might be ok with uid as the parentUid is different name
-    loadPromise: Promise<void>; // TODO confirm we still need this. the .done of IdentifyResultSet should provide the same information. maybe it's a binding thing (bind to bool > bind to promise?)
+    loadPromise: Promise<void>;
 }
 
 export interface IdentifyResultSet {


### PR DESCRIPTION
## Closes #829

## Changes in this PR
- [FEAT] Implemented option 2b from the [Figma mockup](https://www.figma.com/proto/MiUi47Qof2LNwX2wD7zMv0/RAMP-2021-12?node-id=140%3A878&scaling=contain&page-id=0%3A1&starting-point-node-id=140%3A878&show-proto-sidebar=1)
- [FIX] Calling `openFeature` from `DetailsAPI` no longer requires the data to be wrapped in a fake `IdentifyItem` object 

## Comments
- The temporary buttons for details has now been split into `details-layers` and `details-items` 
    - These buttons would need to be specified each time in the temporary buttons appbar config (both needs to be provided so that the appbar can find the `componentId` of each button) 
    - Having to specify two buttons each time for the details panel may be undesired, but this could be addressed in #817 since it addresses the overall problem with setting up appbar buttons

---

[**Demo**](http://ramp4-app.azureedge.net/demo/users/sharvenp/829/host/index.html)
[**Demo WMS**](http://ramp4-app.azureedge.net/demo/users/sharvenp/829/host/index-e2e.html?script=wms-layer)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/928)
<!-- Reviewable:end -->
