### PR TITLE
Fix back button, only show if use can go back

### DIFF
--- a/packages/ramp-core/src/components/panel-stack/panel-screen.vue
+++ b/packages/ramp-core/src/components/panel-stack/panel-screen.vue
@@ -25,8 +25,8 @@
             tabindex="-1"
         >
             <back
-                v-if="$iApi.screenSize === 'xs'"
-                @click="panel.close()"
+                v-if="panel && $iApi.screenSize === 'xs'"
+                @click="panel?.close()"
             ></back>
             <h2 class="flex-grow text-lg py-16 pl-8 min-w-0" v-truncate>
                 <slot name="header"></slot>


### PR DESCRIPTION
Only display the back button if it does something (has a panel to close). 

[Demo](https://ramp4-app.azureedge.net/demo/users/milespetrov/925-back-button/host/index.html)

Closes #925

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/929)
<!-- Reviewable:end -->
