### PR TITLE
Implement layer hovertips config flag

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -331,7 +331,8 @@ let config = {
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/9',
                     state: {
                         opacity: 0.8,
-                        visibility: true
+                        visibility: true,
+                        hovertips: false
                     },
                     tolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -442,6 +442,7 @@ export interface RampLayerStateConfig {
     visibility?: boolean;
     opacity?: number;
     identify?: boolean;
+    hovertips?: boolean;
 }
 
 export interface RampLayerFieldInfoConfig {

--- a/packages/ramp-core/src/geo/layer/esri-map-image/index.ts
+++ b/packages/ramp-core/src/geo/layer/esri-map-image/index.ts
@@ -42,6 +42,7 @@ class MapImageLayer extends AttribLayer {
         this.supportsSublayers = true;
         this.layerType = LayerType.MAPIMAGE;
         this.isDynamic = false; // will get updated after layer load.
+        this.hovertips = false;
 
         // mark the root node of this layer as not layer
         // TODO: revisit this once we decide on what `isLayer` should be

--- a/packages/ramp-core/src/geo/layer/esri-map-image/map-image-sublayer.ts
+++ b/packages/ramp-core/src/geo/layer/esri-map-image/map-image-sublayer.ts
@@ -28,6 +28,7 @@ export class MapImageSublayer extends AttribLayer {
 
         this.dataFormat = DataFormat.ESRI_FEATURE;
         this.tooltipField = '';
+        this.hovertips = false;
 
         if (!parent.esriLayer) {
             throw new Error(

--- a/packages/ramp-core/src/geo/layer/esri-tile/index.ts
+++ b/packages/ramp-core/src/geo/layer/esri-tile/index.ts
@@ -11,6 +11,7 @@ class TileLayer extends CommonLayer {
     constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);
         this.supportsIdentify = false;
+        this.hovertips = false;
         this.layerType = LayerType.TILE;
         this.dataFormat = DataFormat.ESRI_TILE;
     }

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -394,6 +394,7 @@ export class LayerInstance extends APIScope {
     isCosmetic: boolean;
     userAdded: boolean;
     identify: boolean;
+    hovertips: boolean;
 
     esriLayer: __esri.Layer | undefined;
     esriSubLayer: __esri.Sublayer | undefined; // used only by sublayers
@@ -431,6 +432,7 @@ export class LayerInstance extends APIScope {
         this.isCosmetic = config.cosmetic || false;
         this.userAdded = false;
         this.identify = false; // will be updated later based on config/supportsIdentify value
+        this.hovertips = config.state?.hovertips ?? true;
         this._sublayers = [];
     }
 

--- a/packages/ramp-core/src/geo/layer/ogc-wms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogc-wms/index.ts
@@ -25,6 +25,7 @@ export default class WmsLayer extends CommonLayer {
     constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);
         this.supportsIdentify = true;
+        this.hovertips = false;
         this.layerType = LayerType.WMS;
         this.mimeType = rampConfig.featureInfoMimeType || ''; // TODO is there a default? will that be in the config defaulting?
         this.sublayerNames = [];

--- a/packages/ramp-core/src/geo/layer/osm-tile/index.ts
+++ b/packages/ramp-core/src/geo/layer/osm-tile/index.ts
@@ -19,6 +19,7 @@ class OsmTileLayer extends CommonLayer {
         this.layerType = LayerType.OSM;
         this.dataFormat = DataFormat.OSM_TILE;
         this.supportsFeatures = false;
+        this.hovertips = false;
     }
 
     async initiate(): Promise<void> {

--- a/packages/ramp-core/src/geo/map/maptip.ts
+++ b/packages/ramp-core/src/geo/map/maptip.ts
@@ -79,6 +79,11 @@ export class MaptipAPI extends APIScope {
             return;
         }
 
+        if (!layerInstance.hovertips) {
+            // the hit layer doesn't support hovertips
+            return;
+        }
+
         // Get the icon svg string for the graphic
         const icon: string = await layerInstance.getIcon(graphicHit.oid);
 


### PR DESCRIPTION
## Closes #915 

## Changes in this PR
- [FIX] Use layer `hovertips` config flag when creating maptips

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/915/host/index.html)
- Disabled hovertips on `CleanAir` for testing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/935)
<!-- Reviewable:end -->
