### PR TITLE
Implement `toggleSymbology` flag + Add fixtures config to layer config

### DIFF
--- a/packages/ramp-core/public/ramp-starter.js
+++ b/packages/ramp-core/public/ramp-starter.js
@@ -285,6 +285,11 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
+                            },
+                            fixtures: {
+                                details: {
+                                    template: 'Water-Quantity-Template'
+                                }
                             }
                         },
                         {
@@ -347,6 +352,11 @@ let config = {
                     customRenderer: {},
                     metadata: {
                         url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/README.md'
+                    },
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
                     }
                 }
                 /*
@@ -450,17 +460,6 @@ let config = {
                         'settings'
                     ]
                 },
-                details: {
-                    items: [
-                        {
-                            id: 'WaterQuantity'
-                        },
-                        {
-                            id: 'WFSLayer',
-                            template: 'WFSLayer-Custom'
-                        }
-                    ]
-                },
                 mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
                 'export-v1-title': {
                     text: 'All Your Base are Belong to Us'
@@ -490,6 +489,69 @@ rInstance.$element.component('WFSLayer-Custom', {
             <img src="https://i.imgur.com/WtY0tdC.gif" />
         </div>
     `
+});
+
+rInstance.$element.component('Water-Quantity-Template', {
+    props: ['identifyData'],
+    template: `
+        <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
+            <div v-html="renderHeader()" />
+            <div v-html="createSection('Station ID', 'StationID')" />
+            <div v-html="createSection('Province', 'E_Province')" />
+            <div v-html="createSection('Report Year', 'Report_Year')" />
+            <div style="display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;">
+                <div style="flex: 1 1 0%; width: 100%;">
+                    Latitude
+                </div>
+                <div style="flex: 1 1 0%; width: 100%;">
+                    Longitude
+                </div>
+            </div>
+            <div style="display: flex; flex-direction: row;">
+                <div style="flex: 1 1 0%; width: 100%;">
+                    {{this.identifyData.data['Latitude']}}
+                </div>
+                <div style="flex: 1 1 0%; width: 100%;">
+                    {{this.identifyData.data['Longitude']}}
+                </div>
+            </div>
+            <div style="display: flex; flex-direction: column; padding-top: 5px; color: #4299e1;">
+                <span style="font-weight: bold; color: #a0aec0;">Links</span>
+                <span v-html="this.identifyData.data['E_DetailPageURL']"></span>
+                <span v-html="this.identifyData.data['E_URL_Historical']"></span>
+                <span v-html="this.identifyData.data['E_URL_RealTime']"></span>
+            </div>
+        </div>
+    `,
+    methods: {
+        renderHeader() {
+            if (this.identifyData.data['Symbol'] === '3') {
+                return `
+                    <span style="display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                        ${this.identifyData.data['StationName']}
+                    </span>
+                `;
+            } else {
+                return `
+                    <span style="display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                        ${this.identifyData.data['StationName']}
+                    </span>
+                `;
+            }
+        },
+        createSection(title, id) {
+            return `
+            <div style="display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;">
+                <span style="color: #a0aec0; font-weight: bold;">
+                    ${title}
+                </span>
+                <span>
+                    ${this.identifyData.data[id]}
+                </span>
+            </div>
+            `;
+        }
+    }
 });
 
 // add export-v1 fixtures

--- a/packages/ramp-core/public/starter-scripts/cam.js
+++ b/packages/ramp-core/public/starter-scripts/cam.js
@@ -259,50 +259,50 @@ let config = {
                                 search: { enabled: false },
                                 columns: [
                                     {
-                                        data: 'Category'
+                                        name: 'Category'
                                     },
                                     {
-                                        data: 'Recipient_type'
+                                        name: 'Recipient_type'
                                     },
                                     {
-                                        data: 'Department___Agency___Crown_Corporation'
+                                        name: 'Department___Agency___Crown_Corporation'
                                     },
                                     {
-                                        data: 'Province_Territory'
+                                        name: 'Province_Territory'
                                     },
                                     {
-                                        data: 'Municipality___Community'
+                                        name: 'Municipality___Community'
                                     },
                                     {
-                                        data: 'Program_name'
+                                        name: 'Program_name'
                                     },
                                     {
-                                        data: 'Project_name'
+                                        name: 'Project_name'
                                     },
                                     {
-                                        data: 'Project_description'
+                                        name: 'Project_description'
                                     },
                                     {
-                                        data: 'Ultimate_recipient_name'
+                                        name: 'Ultimate_recipient_name'
                                     },
                                     {
-                                        data: 'Funding_date___estimated_start_date'
+                                        name: 'Funding_date___estimated_start_date'
                                     },
                                     {
-                                        data: 'Program_contribution'
+                                        name: 'Program_contribution'
                                     },
                                     {
-                                        data: 'Estimated_total_project_cost'
+                                        name: 'Estimated_total_project_cost'
                                     },
                                     {
-                                        data: 'Additional_information'
+                                        name: 'Additional_information'
                                     },
                                     {
-                                        data: 'Icon',
+                                        name: 'Icon',
                                         visible: false
                                     },
                                     {
-                                        data: 'OBJECTID'
+                                        name: 'OBJECTID'
                                     }
                                 ]
                             }
@@ -837,57 +837,59 @@ let config = {
                                 opacity: 1,
                                 visibility: true
                             },
-                            table: {
-                                lazyFilter: true,
-                                search: { enabled: false },
-                                columns: [
-                                    {
-                                        data: 'Category'
-                                    },
-                                    {
-                                        data: 'Recipient_type'
-                                    },
-                                    {
-                                        data: 'Department___Agency___Crown_Corporation'
-                                    },
-                                    {
-                                        data: 'Province_Territory'
-                                    },
-                                    {
-                                        data: 'Municipality___Community'
-                                    },
-                                    {
-                                        data: 'Program_name'
-                                    },
-                                    {
-                                        data: 'Project_name'
-                                    },
-                                    {
-                                        data: 'Project_description'
-                                    },
-                                    {
-                                        data: 'Ultimate_recipient_name'
-                                    },
-                                    {
-                                        data: 'Funding_date___estimated_start_date'
-                                    },
-                                    {
-                                        data: 'Program_contribution'
-                                    },
-                                    {
-                                        data: 'Estimated_total_project_cost'
-                                    },
-                                    {
-                                        data: 'Additional_information'
-                                    },
-                                    {
-                                        data: 'Icon',
-                                        visible: false
-                                    },
-                                    {
-                                        data: 'OBJECTID'
-                                    }
-                                ]
+                            fixtures: {
+                                grid: {
+                                    lazyFilter: true,
+                                    search: { enabled: false },
+                                    columns: [
+                                        {
+                                            name: 'Category'
+                                        },
+                                        {
+                                            name: 'Recipient_type'
+                                        },
+                                        {
+                                            name: 'Department___Agency___Crown_Corporation'
+                                        },
+                                        {
+                                            name: 'Province_Territory'
+                                        },
+                                        {
+                                            name: 'Municipality___Community'
+                                        },
+                                        {
+                                            name: 'Program_name'
+                                        },
+                                        {
+                                            name: 'Project_name'
+                                        },
+                                        {
+                                            name: 'Project_description'
+                                        },
+                                        {
+                                            name: 'Ultimate_recipient_name'
+                                        },
+                                        {
+                                            name: 'Funding_date___estimated_start_date'
+                                        },
+                                        {
+                                            name: 'Program_contribution'
+                                        },
+                                        {
+                                            name: 'Estimated_total_project_cost'
+                                        },
+                                        {
+                                            name: 'Additional_information'
+                                        },
+                                        {
+                                            name: 'Icon',
+                                            visible: false
+                                        },
+                                        {
+                                            name: 'OBJECTID'
+                                        }
+                                    ]
+                                }
                             }
                         }
                     ],

--- a/packages/ramp-core/public/starter-scripts/cesi.js
+++ b/packages/ramp-core/public/starter-scripts/cesi.js
@@ -262,24 +262,26 @@ let config = {
                                 opacity: 1
                             },
                             nameField: 'Name',
-                            table: {
-                                columns: [
-                                    { data: 'CompanyName' },
-                                    { data: 'Name' },
-                                    { data: 'E_Province' },
-                                    { data: 'City' },
-                                    { data: 'Latitude' },
-                                    { data: 'Longitude' },
-                                    { data: 'E_NAIC_Name' },
-                                    { data: 'CO2_eq' },
-                                    { data: 'E_Units' },
-                                    { data: 'Report_Year' },
-                                    { data: 'E_DetailPageURL' },
-                                    {
-                                        data: 'OBJECTID',
-                                        visible: false
-                                    }
-                                ]
+                            fixtures: {
+                                grid: {
+                                    columns: [
+                                        { name: 'CompanyName' },
+                                        { name: 'Name' },
+                                        { name: 'E_Province' },
+                                        { name: 'City' },
+                                        { name: 'Latitude' },
+                                        { name: 'Longitude' },
+                                        { name: 'E_NAIC_Name' },
+                                        { name: 'CO2_eq' },
+                                        { name: 'E_Units' },
+                                        { name: 'Report_Year' },
+                                        { name: 'E_DetailPageURL' },
+                                        {
+                                            name: 'OBJECTID',
+                                            visible: false
+                                        }
+                                    ]
+                                }
                             }
                         }
                     ]
@@ -297,24 +299,26 @@ let config = {
                     state: {
                         visibility: false
                     },
-                    table: {
-                        columns: [
-                            { data: 'NPRI_ID' },
-                            { data: 'GridColumn1' },
-                            { data: 'Company_Name' },
-                            { data: 'GridColumn3' },
-                            { data: 'GridColumn2' },
-                            { data: 'Address' },
-                            { data: 'PostalCode' },
-                            { data: 'Latitude' },
-                            { data: 'Longitude' },
-                            { data: 'E_NPRI_URL' },
-                            { data: 'GridColumn5' },
-                            { data: 'Units' },
-                            { data: 'Report_Year' },
-                            { data: 'E_DetailPageURL' },
-                            { data: 'OBJECTID', visible: false }
-                        ]
+                    fixtures: {
+                        grid: {
+                            columns: [
+                                { name: 'NPRI_ID' },
+                                { name: 'GridColumn1' },
+                                { name: 'Company_Name' },
+                                { name: 'GridColumn3' },
+                                { name: 'GridColumn2' },
+                                { name: 'Address' },
+                                { name: 'PostalCode' },
+                                { name: 'Latitude' },
+                                { name: 'Longitude' },
+                                { name: 'E_NPRI_URL' },
+                                { name: 'GridColumn5' },
+                                { name: 'Units' },
+                                { name: 'Report_Year' },
+                                { name: 'E_DetailPageURL' },
+                                { name: 'OBJECTID', visible: false }
+                            ]
+                        }
                     }
                 },
                 {
@@ -330,20 +334,22 @@ let config = {
                     state: {
                         visibility: false
                     },
-                    table: {
-                        columns: [
-                            { data: 'StationName' },
-                            { data: 'Address' },
-                            { data: 'City' },
-                            { data: 'E_Province' },
-                            { data: 'Latitude' },
-                            { data: 'Longitude' },
-                            { data: 'PM2_5' },
-                            { data: 'E_Units' },
-                            { data: 'Report_Year' },
-                            { data: 'E_DetailPageURL' },
-                            { data: 'OBJECTID', visible: false }
-                        ]
+                    fixtures: {
+                        grid: {
+                            columns: [
+                                { name: 'StationName' },
+                                { name: 'Address' },
+                                { name: 'City' },
+                                { name: 'E_Province' },
+                                { name: 'Latitude' },
+                                { name: 'Longitude' },
+                                { name: 'PM2_5' },
+                                { name: 'E_Units' },
+                                { name: 'Report_Year' },
+                                { name: 'E_DetailPageURL' },
+                                { name: 'OBJECTID', visible: false }
+                            ]
+                        }
                     }
                 },
                 {
@@ -359,20 +365,22 @@ let config = {
                     state: {
                         visibility: false
                     },
-                    table: {
-                        columns: [
-                            { data: 'StationName' },
-                            { data: 'Address' },
-                            { data: 'City' },
-                            { data: 'E_Province' },
-                            { data: 'Latitude' },
-                            { data: 'Longitude' },
-                            { data: 'SO2' },
-                            { data: 'E_Units' },
-                            { data: 'Report_Year' },
-                            { data: 'E_DetailPageURL' },
-                            { data: 'OBJECTID', visible: false }
-                        ]
+                    fixtures: {
+                        grid: {
+                            columns: [
+                                { name: 'StationName' },
+                                { name: 'Address' },
+                                { name: 'City' },
+                                { name: 'E_Province' },
+                                { name: 'Latitude' },
+                                { name: 'Longitude' },
+                                { name: 'SO2' },
+                                { name: 'E_Units' },
+                                { name: 'Report_Year' },
+                                { name: 'E_DetailPageURL' },
+                                { name: 'OBJECTID', visible: false }
+                            ]
+                        }
                     }
                 },
                 {
@@ -384,23 +392,25 @@ let config = {
                     state: {
                         visibility: false
                     },
-                    table: {
-                        columns: [
-                            { data: 'NPRI_ID' },
-                            { data: 'GridColumn1' },
-                            { data: 'Company_Name' },
-                            { data: 'GridColumn3' },
-                            { data: 'GridColumn2' },
-                            { data: 'Address' },
-                            { data: 'Latitude' },
-                            { data: 'Longitude' },
-                            { data: 'E_NPRI_URL' },
-                            { data: 'GridColumn5' },
-                            { data: 'E_Units' },
-                            { data: 'Report_Year' },
-                            { data: 'E_DetailPageURL' },
-                            { data: 'OBJECTID', visible: false }
-                        ]
+                    fixtures: {
+                        grid: {
+                            columns: [
+                                { name: 'NPRI_ID' },
+                                { name: 'GridColumn1' },
+                                { name: 'Company_Name' },
+                                { name: 'GridColumn3' },
+                                { name: 'GridColumn2' },
+                                { name: 'Address' },
+                                { name: 'Latitude' },
+                                { name: 'Longitude' },
+                                { name: 'E_NPRI_URL' },
+                                { name: 'GridColumn5' },
+                                { name: 'E_Units' },
+                                { name: 'Report_Year' },
+                                { name: 'E_DetailPageURL' },
+                                { name: 'OBJECTID', visible: false }
+                            ]
+                        }
                     },
                     disabledControls: ['metadata']
                 },
@@ -417,24 +427,26 @@ let config = {
                     state: {
                         visibility: false
                     },
-                    table: {
-                        columns: [
-                            { data: 'NPRI_ID' },
-                            { data: 'FacilityName' },
-                            { data: 'Company_Name' },
-                            { data: 'Address' },
-                            { data: 'City' },
-                            { data: 'E_Province' },
-                            { data: 'PostalCode' },
-                            { data: 'Latitude' },
-                            { data: 'Longitude' },
-                            { data: 'E_NPRI_URL' },
-                            { data: 'Pb' },
-                            { data: 'E_Units' },
-                            { data: 'Report_Year' },
-                            { data: 'E_DetailPageURL' },
-                            { data: 'OBJECTID', visible: false }
-                        ]
+                    fixtures: {
+                        grid: {
+                            columns: [
+                                { name: 'NPRI_ID' },
+                                { name: 'FacilityName' },
+                                { name: 'Company_Name' },
+                                { name: 'Address' },
+                                { name: 'City' },
+                                { name: 'E_Province' },
+                                { name: 'PostalCode' },
+                                { name: 'Latitude' },
+                                { name: 'Longitude' },
+                                { name: 'E_NPRI_URL' },
+                                { name: 'Pb' },
+                                { name: 'E_Units' },
+                                { name: 'Report_Year' },
+                                { name: 'E_DetailPageURL' },
+                                { name: 'OBJECTID', visible: false }
+                            ]
+                        }
                     }
                 },
                 {
@@ -458,24 +470,26 @@ let config = {
                                 opacity: 1
                             },
                             nameField: 'E_PA_Name',
-                            table: {
-                                columns: [
-                                    { data: 'E_PA_Name' },
-                                    { data: 'E_PA_Bio_Name' },
-                                    { data: 'E_Province' },
-                                    { data: 'E_PA_Type' },
-                                    { data: 'PA_Area_ha' },
-                                    { data: 'Protected_Date' },
-                                    { data: 'E_Management' },
-                                    { data: 'E_PA_Zone_Desc' },
-                                    { data: 'E_URL' },
-                                    { data: 'Report_Year' },
-                                    { data: 'E_DetailPageURL' },
-                                    {
-                                        data: 'OBJECTID',
-                                        visible: false
-                                    }
-                                ]
+                            fixtures: {
+                                grid: {
+                                    columns: [
+                                        { name: 'E_PA_Name' },
+                                        { name: 'E_PA_Bio_Name' },
+                                        { name: 'E_Province' },
+                                        { name: 'E_PA_Type' },
+                                        { name: 'PA_Area_ha' },
+                                        { name: 'Protected_Date' },
+                                        { name: 'E_Management' },
+                                        { name: 'E_PA_Zone_Desc' },
+                                        { name: 'E_URL' },
+                                        { name: 'Report_Year' },
+                                        { name: 'E_DetailPageURL' },
+                                        {
+                                            name: 'OBJECTID',
+                                            visible: false
+                                        }
+                                    ]
+                                }
                             }
                         }
                     ],
@@ -508,24 +522,26 @@ let config = {
                     state: {
                         visibility: false
                     },
-                    table: {
-                        columns: [
-                            { data: 'StationID' },
-                            { data: 'StationName' },
-                            { data: 'E_Overall_Condition' },
-                            { data: 'E_SampleType' },
-                            { data: 'E_Regulated' },
-                            { data: 'DrainageArea_sqkm' },
-                            { data: 'E_Province' },
-                            { data: 'Latitude' },
-                            { data: 'Longitude' },
-                            { data: 'E_URL_RealTime' },
-                            { data: 'E_URL_Historical' },
-                            { data: 'E_Measure' },
-                            { data: 'Report_Year' },
-                            { data: 'E_DetailPageURL' },
-                            { data: 'OBJECTID', visible: false }
-                        ]
+                    fixtures: {
+                        grid: {
+                            columns: [
+                                { name: 'StationID' },
+                                { name: 'StationName' },
+                                { name: 'E_Overall_Condition' },
+                                { name: 'E_SampleType' },
+                                { name: 'E_Regulated' },
+                                { name: 'DrainageArea_sqkm' },
+                                { name: 'E_Province' },
+                                { name: 'Latitude' },
+                                { name: 'Longitude' },
+                                { name: 'E_URL_RealTime' },
+                                { name: 'E_URL_Historical' },
+                                { name: 'E_Measure' },
+                                { name: 'Report_Year' },
+                                { name: 'E_DetailPageURL' },
+                                { name: 'OBJECTID', visible: false }
+                            ]
+                        }
                     }
                 },
                 {
@@ -545,8 +561,12 @@ let config = {
                                 visibility: true,
                                 opacity: 1
                             },
-                            table: {
-                                columns: [{ data: 'OBJECTID', visible: false }]
+                            fixtures: {
+                                grid: {
+                                    columns: [
+                                        { name: 'OBJECTID', visible: false }
+                                    ]
+                                }
                             }
                         },
                         {
@@ -555,10 +575,12 @@ let config = {
                                 visibility: false,
                                 opacity: 1
                             },
-                            table: {
-                                columns: [
-                                    { data: 'OBJECTID_2', visible: false }
-                                ]
+                            fixtures: {
+                                grid: {
+                                    columns: [
+                                        { name: 'OBJECTID_2', visible: false }
+                                    ]
+                                }
                             }
                         }
                     ],

--- a/packages/ramp-core/public/starter-scripts/custom-renderer.js
+++ b/packages/ramp-core/public/starter-scripts/custom-renderer.js
@@ -512,6 +512,11 @@ let config = {
                             }
                         ]
                     },
+                    fixtures: {
+                        legend: {
+                            toggleSymbology: false
+                        }
+                    },
                     state: {
                         opacity: 1,
                         visibility: false

--- a/packages/ramp-core/public/starter-scripts/grid.js
+++ b/packages/ramp-core/public/starter-scripts/grid.js
@@ -103,8 +103,7 @@ let config = {
                 },
                 appbar: {
                     items: ['legend']
-                },
-                details: { items: [] }
+                }
             }
         }
     }

--- a/packages/ramp-core/public/starter-scripts/map-image-layer.js
+++ b/packages/ramp-core/public/starter-scripts/map-image-layer.js
@@ -62,6 +62,11 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
+                            },
+                            fixtures: {
+                                legend: {
+                                    toggleSymbology: false
+                                }
                             }
                         },
                         {
@@ -69,6 +74,11 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
+                            },
+                            fixtures: {
+                                legend: {
+                                    toggleSymbology: false
+                                }
                             }
                         }
                     ],

--- a/packages/ramp-core/public/starter-scripts/panel-party.js
+++ b/packages/ramp-core/public/starter-scripts/panel-party.js
@@ -271,6 +271,11 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
+                            },
+                            fixtures: {
+                                details: {
+                                    template: 'Water-Quantity-Template'
+                                }
                             }
                         }
                     ],
@@ -316,7 +321,12 @@ let config = {
                     state: {
                         visibility: true
                     },
-                    customRenderer: {}
+                    customRenderer: {},
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
+                    }
                 }
                 /*
             {
@@ -398,18 +408,6 @@ let config = {
                     ]
                 },
                 mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
-                details: {
-                    items: [
-                        {
-                            id: 'WaterQuantity',
-                            template: 'Water-Quantity-Template'
-                        },
-                        {
-                            id: 'WFSLayer',
-                            template: 'WFSLayer-Custom'
-                        }
-                    ]
-                },
                 'export-v1-title': {
                     text: 'All Your Base are Belong to Us'
                 }

--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -144,7 +144,12 @@ let config = {
                             currentStyle: 'PRECIPMM'
                         }
                     ],
-                    featureInfoMimeType: 'text/plain'
+                    featureInfoMimeType: 'text/plain',
+                    fixtures: {
+                        details: {
+                            template: 'GeoMet-Template'
+                        }
+                    }
                 }
             ],
             fixtures: {
@@ -171,14 +176,6 @@ let config = {
                     temporaryButtons: ['details-layers', 'details-items']
                 },
                 mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
-                details: {
-                    items: [
-                        {
-                            id: 'GeoMet',
-                            template: 'GeoMet-Template'
-                        }
-                    ]
-                },
                 'export-v1-title': {
                     text: 'WMS'
                 }

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -135,23 +135,13 @@
             "type": "object",
             "description": "Provides configuration to the details fixture.",
             "properties": {
-                "templates": {
-                    "type": "array",
-                    "default": [],
-                    "description": "List of links to custom details templates for a defined layer.",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "layerId": {
-                                "type": "string",
-                                "description": "Custom Vue component to render as details template. Layer ID must exist."
-                            }
-                        },
-                        "required": ["layerId"]
-                    }
+                "template": {
+                    "type": "string",
+                    "description": "Custom Vue component to render as details template"
                 }
             },
-            "unevaluatedProperties": false
+            "required": ["template"],
+            "additionalProperties": false
         },
         "geosearch": {
             "type": "object",
@@ -703,11 +693,6 @@
                     "default": "esri-map-image",
                     "description": "Service type shorthand for map image layers."
                 },
-                "toggleSymbology": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Allows individual symbols to have visibility toggled on/off."
-                },
                 "singleEntryCollapse": {
                     "type": "boolean",
                     "default": false,
@@ -766,6 +751,9 @@
                     ],
                     "default": "png32",
                     "description": "The format of the layer image output."
+                },
+                "fixtures": {
+                    "$ref": "#/$defs/layerFixtureConfig"
                 }
             },
             "required": ["id", "layerType", "layerEntries", "url"],
@@ -803,9 +791,6 @@
                     "default": false,
                     "description": "A flag indicating this entry is only for state tracking (i.e. it should not be displayed on the UI and all of the controls will be ignored, but the layer itself will be displayed on the map with the given state settings)."
                 },
-                "table": {
-                    "$ref": "#/$defs/tableNode"
-                },
                 "fieldMetadata": {
                     "type": "object",
                     "description": "Specifies options for the fields of a layer.",
@@ -823,6 +808,9 @@
                             "description": "If true, only fields in fieldInfo are downloaded. Otherwise, download all fields."
                         }
                     }
+                },
+                "fixtures": {
+                    "$ref": "#/$defs/layerFixtureConfig"
                 }
             },
             "required": ["index"],
@@ -881,11 +869,6 @@
                     "enum": ["esri-feature"],
                     "description": "Service type shorthand for feature layers."
                 },
-                "toggleSymbology": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Allows individual symbols to have visibility toggled on/off."
-                },
                 "tolerance": {
                     "type": "number",
                     "default": 5,
@@ -916,9 +899,6 @@
                 "state": {
                     "$ref": "#/$defs/initialLayerSettings"
                 },
-                "table": {
-                    "$ref": "#/$defs/tableNode"
-                },
                 "customRenderer": {
                     "type": "object",
                     "description": "Optional renderer object to apply to the layer. Follows ESRI ArcGIS Server json convention.",
@@ -930,6 +910,9 @@
                     "items": {
                         "$ref": "#/$defs/fieldMetadataEntry"
                     }
+                },
+                "fixtures": {
+                    "$ref": "#/$defs/layerFixtureConfig"
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1011,9 +994,6 @@
                 "state": {
                     "$ref": "#/$defs/initialLayerSettings"
                 },
-                "table": {
-                    "$ref": "#/$defs/tableNode"
-                },
                 "customRenderer": {
                     "type": "object",
                     "description": "Optional renderer object to apply to the layer. Follows ESRI ArcGIS Server json convention.",
@@ -1025,6 +1005,9 @@
                     "items": {
                         "$ref": "#/$defs/fieldMetadataEntry"
                     }
+                },
+                "fixtures": {
+                    "$ref": "#/$defs/layerFixtureConfig"
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1098,9 +1081,6 @@
                 "state": {
                     "$ref": "#/$defs/initialLayerSettings"
                 },
-                "table": {
-                    "$ref": "#/$defs/tableNode"
-                },
                 "xyInAttribs": {
                     "type": "boolean",
                     "default": false,
@@ -1117,6 +1097,9 @@
                     "items": {
                         "$ref": "#/$defs/fieldMetadataEntry"
                     }
+                },
+                "fixtures": {
+                    "$ref": "#/$defs/layerFixtureConfig"
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1274,6 +1257,29 @@
             "required": ["id"],
             "unevaluatedProperties": false
         },
+        "layerFixtureConfig": {
+            "type": "object",
+            "description": "Fixture configuration that is specific to a layer.",
+            "properties": {
+                "details": {
+                    "$ref": "#/$defs/details"
+                },
+                "grid": {
+                    "$ref": "#/$defs/tableNode"
+                },
+                "legend": {
+                    "type": "object",
+                    "description": "Layer-specific legend configuration",
+                    "properties": {
+                        "toggleSymbology": {
+                            "type": "boolean",
+                            "default": true,
+                            "description": "Allows individual symbols to have visibility toggled on/off."
+                        }
+                    }
+                }
+            }
+        },
         "fieldMetadataEntry": {
             "type": "object",
             "description": "Specifies field info for layer.",
@@ -1381,11 +1387,12 @@
         "columnNode": {
             "type": "object",
             "description": "Specifies column properties. The ordering of columns in the table header is the same as the order they appear in this array.",
+            "allOf": [
+                {
+                    "$ref": "#/$defs/fieldMetadataEntry"
+                }
+            ],
             "properties": {
-                "data": {
-                    "type": "string",
-                    "description": "The field name (data) to use to link to the layer column. Must exist in the layer."
-                },
                 "title": {
                     "type": "string",
                     "default": "",
@@ -1416,7 +1423,6 @@
                     "$ref": "#/$defs/filterNode"
                 }
             },
-            "required": ["data"],
             "unevaluatedProperties": false
         },
         "filterNode": {

--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -79,15 +79,26 @@ export class DetailsAPI extends FixtureInstance {
     }
 
     /**
-     * Read the details section of the configuration file and save any custom template bindings in the store.
+     * Read the details section of the layers' fixture config
      *
-     * @param {DetailsConfig} [config]
      * @memberof DetailsAPI
      */
-    _parseConfig(config?: DetailsConfig) {
-        if (!config) return;
+    _parseConfig() {
+        // get all layer fixture configs
+        let layerDetailsConfigs: any = this.getLayerFixtureConfigs();
+        let detailsConfig: DetailsConfig = {
+            items: []
+        };
 
-        const detailsItems = config.items.map(
+        // construct the details config from the layer fixture configs
+        Object.keys(layerDetailsConfigs).forEach((layerId: string) => {
+            detailsConfig.items.push({
+                id: layerId,
+                template: layerDetailsConfigs[layerId].template
+            });
+        });
+
+        const detailsItems = detailsConfig.items.map(
             (item: any) => new DetailsItemInstance(item)
         );
 

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -49,10 +49,10 @@ class DetailsFixture extends DetailsAPI {
 
         // Parse the details portion of the configuration file and save any custom
         // template bindings in the details store.
-        this._parseConfig(this.config);
+        this._parseConfig();
         this.$vApp.$watch(
             () => this.config,
-            (value: DetailsConfig | undefined) => this._parseConfig(value)
+            (value: DetailsConfig | undefined) => this._parseConfig()
         );
     }
 

--- a/packages/ramp-core/src/fixtures/legend/api/legend.ts
+++ b/packages/ramp-core/src/fixtures/legend/api/legend.ts
@@ -23,6 +23,10 @@ export class LegendAPI extends FixtureInstance {
      * @memberof LegendAPI
      */
     _parseConfig(legendConfig?: LegendConfig) {
+        // get all layer fixture configs to read layer-specific legend properties
+        let layerLegendConfigs: { [layerId: string]: any } =
+            this.getLayerFixtureConfigs();
+
         // parse the header controls, or default the controls
         let controls: Array<string> = [];
         if (!legendConfig?.headerControls) {
@@ -56,6 +60,9 @@ export class LegendAPI extends FixtureInstance {
         while (stack.length > 0) {
             // pop legend entry in stack and check if it has a corresponding layer
             const lastEntry = stack.pop();
+
+            // pass the layer fixture config to legend item for easy access
+            lastEntry.layerLegendConfigs = layerLegendConfigs;
 
             // (assuming visibility sets and groups will specify in config `exclusiveVisibility` or `children` properties, respectively)
             if (

--- a/packages/ramp-core/src/fixtures/legend/components/entry.vue
+++ b/packages/ramp-core/src/fixtures/legend/components/entry.vue
@@ -126,7 +126,10 @@
                             {{ item.label }}
                         </div>
                         <checkbox
-                            v-if="symbologyStack.length > 1"
+                            v-if="
+                                symbologyStack.length > 1 &&
+                                legendItem.toggleSymbology
+                            "
                             :value="item"
                             :legendItem="legendItem"
                             :checked="item.visibility"

--- a/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
+++ b/packages/ramp-core/src/fixtures/legend/store/legend-defs.ts
@@ -119,6 +119,7 @@ export class LegendEntry extends LegendItem {
     _layerParentId: string | undefined;
     _layerIdx: number | undefined;
     _symbologyExpanded: boolean;
+    _toggleSymbology: boolean;
 
     /**
      * Creates a new single legend entry.
@@ -132,6 +133,11 @@ export class LegendEntry extends LegendItem {
         this._layerParentId = legendEntry.layerParentId; // will only be defined for sublayers
         this._layerIdx = legendEntry.entryIndex; // will only be defined for sublayers
         this._symbologyExpanded = legendEntry.symbologyExpanded || false;
+
+        // read the toggleSymbology from the layer fixture config
+        this._toggleSymbology =
+            legendEntry.layerLegendConfigs[legendEntry.layerId]
+                ?.toggleSymbology ?? true;
 
         if (legendEntry.layer !== undefined) {
             // the legend entry config provides a layer, load layer properties from it
@@ -177,6 +183,11 @@ export class LegendEntry extends LegendItem {
     /** Returns true if symbology stack is expanded. */
     get symbologyExpanded(): boolean {
         return this._symbologyExpanded;
+    }
+
+    /** Indicates if this legend entry allows symbology to be toggled. */
+    get toggleSymbology(): boolean {
+        return this._toggleSymbology;
     }
 
     /**
@@ -434,6 +445,9 @@ export class LegendGroup extends LegendItem {
         children
             .filter((entry: any) => !entry.hidden)
             .forEach((entry: any) => {
+                // pass the layer fixture config to child items
+                entry.layerLegendConfigs = legendGroup.layerLegendConfigs;
+
                 // create new LegendGroup/LegendEntry and push to child array
                 if (
                     entry.exclusiveVisibility !== undefined ||

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -470,6 +470,7 @@ export interface RampLayerMapImageLayerEntryConfig {
     table?: any;
     fieldMetadata?: RampLayerFieldMetadataConfig;
     customRenderer?: any;
+    fixtures?: any; // layer-based fixture config
 }
 
 // i.e. a wms layer child
@@ -481,6 +482,7 @@ export interface RampLayerWmsLayerEntryConfig {
     controls?: any;
     currentStyle?: string; // style to be used
     styleLegends?: Array<{ name: string; url: string }>; // map of styles to legend graphic url. overrides service urls.
+    fixtures?: any; // layer-based fixture config
     // more...
 }
 
@@ -506,6 +508,7 @@ export interface RampLayerConfig {
     longField?: string; // csv coord field
     tolerance?: number; // click tolerance
     metadata?: { url: string; name?: string };
+    fixtures?: any; // layer-based fixture config
 }
 
 export interface RampExtentConfig {


### PR DESCRIPTION
## Closes #918

## Changes in this PR
- [FEAT] Symbology toggle can now be enabled/disabled using `toggleSymbology` config flag
- [FEAT] Added `fixtures` nugget to layer config as per #904 
    - Migrated `details` and `grid` configs on all starter scripts to this nugget
    - Added `getLayerFixtureConfig(layerId)` and `getLayerFixtureConfigs` to `FixtureInstance` which return the layer-fixture config for a specific layer id and for all layers, respectively
- [FEAT] Added custom details template `Water-Quality-Template` to `ramp-starter.js` for testing
- [FIX] Updated the grid column schema to extend from the `fieldMetadataEntry` so it inherits the `name` and `alias` properties

## Comments
- The flag can also be set in the parent `MapImageLayer`'s config, but since the legend entries are tied to the sublayers, setting this flag on the parent will be ignored for now
    - Maybe setting the flag on the parent overrides the `toggleSymbology` on sublayer entries?

---

[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/918/host/index.html)
[Demo - Map Image Layer](http://ramp4-app.azureedge.net/demo/users/sharvenp/918/host/index-e2e.html?script=map-image-layer)
[Demo - Custom Renderer](https://ramp4-app.azureedge.net/demo/users/sharvenp/918/host/index-e2e.html?script=custom-renderer)

- `Map Image Layer` has `toggleSymbology` disabled for both sublayers and `Custom Renderer` has it disabled for Class Breaks in File Layer
    - Expanding the symbology stack for these layers should not show checkboxes next to the symbols

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/936)
<!-- Reviewable:end -->
