### PR TITLE
add config option to enable scrollguard fixture

### DIFF
--- a/packages/ramp-core/src/fixtures/scrollguard/api/scrollguard.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/api/scrollguard.ts
@@ -1,0 +1,31 @@
+import { FixtureInstance } from '@/api';
+import { ScrollguardConfig, ScrollguardStore } from '../store';
+
+export class ScrollguardAPI extends FixtureInstance {
+    /**
+     * Enables the scrollguard on the map if set to true.
+     *
+     * @param {boolean} value
+     * @memberof ScrollguardAPI
+     */
+    setEnabled(value: boolean) {
+        this.$vApp.$store.set(ScrollguardStore.enabled, value);
+    }
+
+    /**
+     * Parses the scrollguard config JSON snippet from the config file and save to the fixture store.
+     *
+     * @param {ScrollguardConfig} [ScrollguardConfig]
+     * @memberof ScrollguardAPI
+     */
+    _parseConfig(scrollguardConfig?: ScrollguardConfig) {
+        this.$vApp.$store.set(
+            ScrollguardStore.enabled,
+            scrollguardConfig?.enabled || false
+        );
+    }
+
+    get config(): ScrollguardConfig | undefined {
+        return super.config;
+    }
+}

--- a/packages/ramp-core/src/fixtures/scrollguard/index.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/index.ts
@@ -1,13 +1,22 @@
 import messages from './lang/lang.csv';
 import ScrollguardV from './map-scrollguard.vue';
-import { FixtureInstance } from '@/api';
+import { ScrollguardAPI } from './api/scrollguard';
+import { scrollguard, ScrollguardConfig } from './store';
 
-class ScrollguardFixture extends FixtureInstance {
+class ScrollguardFixture extends ScrollguardAPI {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
         // Manually add lang entries to i18n
         Object.entries(messages).forEach(value =>
             (<any>this.$vApp.$i18n).mergeLocaleMessage(...value)
+        );
+
+        this.$vApp.$store.registerModule('scrollguard', scrollguard());
+
+        this._parseConfig(this.config);
+        this.$vApp.$watch(
+            () => this.config,
+            (value: ScrollguardConfig | undefined) => this._parseConfig(value)
         );
 
         const { vNode, destroy, el } = this.mount(ScrollguardV, {

--- a/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
+++ b/packages/ramp-core/src/fixtures/scrollguard/map-scrollguard.vue
@@ -6,6 +6,8 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { get } from '@/store/pathify-helper';
+import { ScrollguardStore } from './store';
 
 export default defineComponent({
     name: 'MapScrollguardV',
@@ -18,9 +20,16 @@ export default defineComponent({
             capture: true
         });
     },
-
+    data() {
+        return {
+            enabled: get(ScrollguardStore.enabled)
+        };
+    },
     methods: {
         wheelHandler(event: WheelEvent) {
+            // If the scrollguard is disabled, do not block scrolling.
+            if (!this.enabled) return;
+
             const scrollGuardClassList = this.$el.classList;
 
             // prevent scroll unless ctrlKey is depressed

--- a/packages/ramp-core/src/fixtures/scrollguard/store/index.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/store/index.ts
@@ -1,0 +1,2 @@
+export * from './scrollguard-state';
+export * from './scrollguard-store';

--- a/packages/ramp-core/src/fixtures/scrollguard/store/scrollguard-state.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/store/scrollguard-state.ts
@@ -1,0 +1,7 @@
+export interface ScrollguardConfig {
+    enabled: boolean;
+}
+
+export class ScrollguardState {
+    enabled: boolean = false;
+}

--- a/packages/ramp-core/src/fixtures/scrollguard/store/scrollguard-store.ts
+++ b/packages/ramp-core/src/fixtures/scrollguard/store/scrollguard-store.ts
@@ -1,0 +1,50 @@
+import { ActionContext } from 'vuex';
+import { make } from 'vuex-pathify';
+
+import { ScrollguardState } from './scrollguard-state';
+import { RootState } from '@/store/state';
+
+type ScrollguardContext = ActionContext<ScrollguardState, RootState>;
+
+export enum ScrollguardAction {
+    setEnabled = 'setEnabled'
+}
+
+export enum ScrollguardMutation {
+    SET_ENABLED = 'SET_ENABLED'
+}
+
+const getters = {};
+
+const actions = {
+    [ScrollguardAction.setEnabled](
+        context: ScrollguardContext,
+        value: any
+    ): void {
+        context.commit(ScrollguardMutation.SET_ENABLED, value);
+    }
+};
+const mutations = {
+    [ScrollguardMutation.SET_ENABLED](
+        state: ScrollguardState,
+        value: any
+    ): void {
+        state.enabled = value;
+    }
+};
+
+export enum ScrollguardStore {
+    enabled = 'scrollguard/enabled'
+}
+
+export function scrollguard() {
+    const state = new ScrollguardState();
+
+    return {
+        namespaced: true,
+        state,
+        getters: { ...getters },
+        actions: { ...actions },
+        mutations: { ...mutations, ...make.mutations(state) }
+    };
+}


### PR DESCRIPTION
Closes #818 

Adds an optional config flag for the scrollguard fixture to enable it. If this option is not present in the config file, then the scrollguard will be set to disabled by default.

Also adds an API call to the fixture to enable/disable it as needed. It's worth noting that all of the store code in this PR is here to support this feature, so if we decide that it's not necessary the code can be simplified quite a bit.

---
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-818/host/index.html).

**To test:**

1. Open the demo link above.
2. Try to scroll. By default, it should let you now.
3. Open command line and paste in the following line: `rInstance.fixture.get("scrollguard").setEnabled(true)`
4. The scrollguard should appear as it used to.