### PR TITLE
Fix how prop "params" is declared in components

### DIFF
--- a/packages/ramp-core/src/fixtures/grid/table-component.vue
+++ b/packages/ramp-core/src/fixtures/grid/table-component.vue
@@ -164,7 +164,7 @@
             :gridOptions="gridOptions"
             :columnDefs="columnDefs"
             :rowData="rowData"
-            :frameworkComponents="frameworkComponents"
+            :components="frameworkComponents"
             @grid-ready="onGridReady"
             @keydown="stopArrowKeyProp"
             @firstDataRendered="gridRendered"
@@ -704,7 +704,7 @@ export default defineComponent({
             // see: https://github.com/ramp4-pcar4/ramp4-pcar4/pull/57#pullrequestreview-377999397
 
             // default to regex filtering for text columns
-            colDef.filterParams.textCustomComparator = function (
+            colDef.filterParams.textMatcher = function (
                 filter: any,
                 gridValue: any,
                 filterText: any
@@ -787,7 +787,7 @@ export default defineComponent({
                             padding: '0px'
                         };
                     },
-                    cellRendererFramework: DetailsButtonRendererV,
+                    cellRenderer: DetailsButtonRendererV,
                     cellRendererParams: {
                         uid: this.layerUid,
                         $iApi: this.$iApi,
@@ -807,7 +807,7 @@ export default defineComponent({
                             padding: '0px'
                         };
                     },
-                    cellRendererFramework: ZoomButtonRendererV,
+                    cellRenderer: ZoomButtonRendererV,
                     cellRendererParams: {
                         uid: this.layerUid,
                         $iApi: this.$iApi,

--- a/packages/ramp-core/src/fixtures/grid/templates/clear-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/clear-filter.vue
@@ -47,11 +47,7 @@ export default defineComponent({
     directives: {
         tippy: tippyDirective
     },
-    data(props) {
-        return {
-            params: props.params as any
-        };
-    },
+    props: ['params'],
     async mounted() {
         // need to hoist events to top level cell wrapper to be keyboard accessible
         await nextTick;

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-date-filter.vue
@@ -47,9 +47,9 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomDateFilterV',
-    data(props) {
+    props: ['params'],
+    data() {
         return {
-            params: props.params as any,
             minVal: '' as any,
             maxVal: '' as any
         };

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-header.vue
@@ -115,9 +115,9 @@ export default defineComponent({
     directives: {
         tippy: tippyDirective
     },
-    data(props) {
+    props: ['params'],
+    data() {
         return {
-            params: props.params as any,
             sort: 0 as number,
             sortable: false as boolean,
             canMoveLeft: false as boolean,

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-number-filter.vue
@@ -43,9 +43,9 @@ import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomNumberFilterV',
-    data(props) {
+    props: ['params'],
+    data() {
         return {
-            params: props.params as any,
             minVal: '' as any,
             maxVal: '' as any
         };

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -27,9 +27,9 @@ import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomSelectorFilterV',
-    data(props) {
+    props: ['params'],
+    data() {
         return {
-            params: props.params as any,
             selectedOption: '' as String,
             options: [] as Array<String>
         };

--- a/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/custom-text-filter.vue
@@ -29,9 +29,9 @@ import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomTextFilterV',
-    data(props) {
+    props: ['params'],
+    data() {
         return {
-            params: props.params as any,
             filterValue: ''
         };
     },

--- a/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/details-button-renderer.vue
@@ -33,11 +33,7 @@ export default defineComponent({
     directives: {
         tippy: tippyDirective
     },
-    data(props) {
-        return {
-            params: props.params as any
-        };
-    },
+    props: ['params'],
     mounted() {
         // need to hoist events to top level cell wrapper to be keyboard accessible
         this.params.eGridCell.addEventListener(

--- a/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/packages/ramp-core/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -33,9 +33,9 @@ export default defineComponent({
     directives: {
         tippy: tippyDirective
     },
-    data(props) {
+    props: ['params'],
+    data() {
         return {
-            params: props.params as any,
             getLayerByUid: get('layer/getLayerByUid')
         };
     },


### PR DESCRIPTION
Removes the 70+ console warnings when opening a table. 

Also updates some changes to ag-grid prop names like `frameworkComponents` -> `components`, `textCustomComparator` -> `textMatcher`, and `cellRendererFramework` -> `cellRenderer`. 

[Demo](https://ramp4-app.azureedge.net/demo/users/milespetrov/927-table-console-errors/host/index.html)

Closes #927

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/943)
<!-- Reviewable:end -->
