### PR TITLE
HALP!! Vue assistance

### DIFF
--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -8,114 +8,124 @@
             <close @click="panel.close()" />
         </template>
         <template #content>
-            <div
-                class="flex justify-between py-8 px-8 mb-8 bg-gray-100"
-                v-if="result.items.length > 1 && layerType !== 'ogc-wms'"
-            >
-                <button
-                    class="px-8 font-bold hover:bg-gray-200 focus:bg-gray-200"
-                    :aria-label="$t('details.item.see.list')"
-                    @click="seeList"
+            <div v-if="result.loaded">
+                <div
+                    class="flex justify-between py-8 px-8 mb-8 bg-gray-100"
+                    v-if="result.items.length > 1 && supportsFeatures"
                 >
-                    {{ $t('details.item.see.list') }}
-                </button>
-                <div class="flex bg-gray-200 py-8 items-center">
                     <button
-                        :content="$t('details.item.previous.item')"
-                        v-tippy="{ placement: 'top' }"
-                        @click="advanceItemIndex(-1)"
                         class="
-                            mx-2
-                            opacity-60
-                            hover:opacity-90
-                            disabled:opacity-30 disabled:cursor-default
+                            px-8
+                            font-bold
+                            hover:bg-gray-200
+                            focus:bg-gray-200
                         "
-                        :aria-label="$t('details.item.previous.item')"
-                        :disabled="currentIdx === 0"
+                        :aria-label="$t('details.item.see.list')"
+                        @click="seeList"
                     >
-                        <svg height="24" width="24" viewBox="0 0 23 23">
-                            <g>
-                                <path
-                                    d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
-                                />
-                            </g>
-                        </svg>
+                        {{ $t('details.item.see.list') }}
                     </button>
-                    <span class="px-8">
-                        {{
-                            $t('details.item.count', [
-                                currentIdx + 1,
-                                result.items.length
-                            ])
-                        }}
+                    <div class="flex bg-gray-200 py-8 items-center">
+                        <button
+                            :content="$t('details.item.previous.item')"
+                            v-tippy="{ placement: 'top' }"
+                            @click="advanceItemIndex(-1)"
+                            class="
+                                mx-2
+                                opacity-60
+                                hover:opacity-90
+                                disabled:opacity-30 disabled:cursor-default
+                            "
+                            :aria-label="$t('details.item.previous.item')"
+                            :disabled="currentIdx === 0"
+                        >
+                            <svg height="24" width="24" viewBox="0 0 23 23">
+                                <g>
+                                    <path
+                                        d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
+                                    />
+                                </g>
+                            </svg>
+                        </button>
+                        <span class="px-8">
+                            {{
+                                $t('details.item.count', [
+                                    currentIdx + 1,
+                                    result.items.length
+                                ])
+                            }}
+                        </span>
+                        <button
+                            :content="$t('details.item.next.item')"
+                            v-tippy="{ placement: 'top' }"
+                            @click="advanceItemIndex(1)"
+                            class="
+                                mx-2
+                                rotate-180
+                                opacity-60
+                                hover:opacity-90
+                                disabled:opacity-30 disabled:cursor-default
+                            "
+                            :aria-label="$t('details.item.next.item')"
+                            :disabled="currentIdx === result.items.length - 1"
+                        >
+                            <svg height="24" width="24" viewBox="0 0 23 23">
+                                <g>
+                                    <path
+                                        d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
+                                    />
+                                </g>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <div class="flex py-8" v-if="layerType !== 'ogc-wms'">
+                    <span
+                        v-if="icon"
+                        class="flex-none m-auto symbologyIcon"
+                        v-html="icon"
+                    ></span>
+                    <div v-else class="m-auto">
+                        <div class="animate-spin spinner h-20 w-20"></div>
+                    </div>
+                    <span class="flex-grow my-auto text-lg px-8">
+                        {{ itemName }}
                     </span>
                     <button
-                        :content="$t('details.item.next.item')"
-                        v-tippy="{ placement: 'top' }"
-                        @click="advanceItemIndex(1)"
-                        class="
-                            mx-2
-                            rotate-180
-                            opacity-60
-                            hover:opacity-90
-                            disabled:opacity-30 disabled:cursor-default
-                        "
-                        :aria-label="$t('details.item.next.item')"
-                        :disabled="currentIdx === result.items.length - 1"
+                        :content="$t('details.item.zoom')"
+                        v-tippy="{ placement: 'bottom' }"
+                        :aria-label="$t('details.item.zoom')"
+                        @click="zoomToFeature()"
+                        class="text-gray-600 m-8"
                     >
-                        <svg height="24" width="24" viewBox="0 0 23 23">
-                            <g>
-                                <path
-                                    d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
-                                />
-                            </g>
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            width="20"
+                        >
+                            <path
+                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                            />
+                            <path d="M0 0h24v24H0V0z" fill="none" />
+                            <path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z" />
                         </svg>
                     </button>
                 </div>
+                <component
+                    :is="detailsTemplate"
+                    :identifyData="identifyItem"
+                    :fields="fieldsList"
+                ></component>
             </div>
-            <div class="flex py-8" v-if="layerType !== 'ogc-wms'">
-                <span
-                    v-if="icon"
-                    class="flex-none m-auto symbologyIcon"
-                    v-html="icon"
-                ></span>
-                <div v-else class="m-auto">
-                    <div class="animate-spin spinner h-20 w-20"></div>
-                </div>
-                <span class="flex-grow my-auto text-lg px-8">
-                    {{ itemName }}
-                </span>
-                <button
-                    :content="$t('details.item.zoom')"
-                    v-tippy="{ placement: 'bottom' }"
-                    :aria-label="$t('details.item.zoom')"
-                    @click="zoomToFeature()"
-                    class="text-gray-600 m-8"
-                >
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        height="20"
-                        viewBox="0 0 24 24"
-                        width="20"
-                    >
-                        <path
-                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                        />
-                        <path d="M0 0h24v24H0V0z" fill="none" />
-                        <path d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z" />
-                    </svg>
-                </button>
-            </div>
-            <component
-                :is="detailsTemplate"
-                :identifyData="identifyItem"
-                :fields="fieldsList"
-            ></component>
+            <div v-else class="animate-spin spinner h-20 w-20 px-5"></div>
         </template>
     </panel-screen>
 </template>
 
 <script lang="ts">
+// this screen is the display of an individual result, and nav controls at the top to other views
+
 import { defineComponent, PropType } from 'vue';
 import { get } from '@/store/pathify-helper';
 import { DetailsStore } from './store';
@@ -194,9 +204,16 @@ export default defineComponent({
             return layer?.layerType || '';
         },
 
+        supportsFeatures(): boolean {
+            const layer: LayerInstance | undefined = this.getLayerByUid(
+                this.result.uid
+            );
+            return layer?.supportsFeatures ?? false;
+        },
+
         fieldsList(): Array<FieldDefinition> {
             // wms layers do not support fields
-            if (this.layerType === 'ogc-wms') {
+            if (!this.supportsFeatures) {
                 return [];
             }
 
@@ -222,7 +239,7 @@ export default defineComponent({
                 return this.templateBindings[layer.id].template;
             }
             // If nothing is found, use a default template.
-            if (this.layerType === 'ogc-wms') {
+            if (!this.supportsFeatures) {
                 return 'html-default';
             } else {
                 return 'esri-default';
@@ -284,7 +301,7 @@ export default defineComponent({
         fetchIcon() {
             this.icon = '';
 
-            if (!this.identifyItem) {
+            if (!(this.identifyItem && this.identifyItem.loaded)) {
                 return;
             }
 

--- a/packages/ramp-core/src/fixtures/details/result-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/result-screen.vue
@@ -26,21 +26,27 @@
                     "
                     v-for="(item, idx) in result.items"
                     :key="idx"
-                    @click="openResult(idx)"
+                    @click="item.loaded && openResult(idx)"
+                    :disabled="!item.loaded"
                     v-focus-item
                     v-truncate
                 >
-                    <!-- TODO: test if itemIcon() call works as intended -->
-                    <span
-                        v-html="itemIcon(item.data, idx)"
-                        class="flex-none symbologyIcon"
-                    ></span>
-                    <span class="flex-initial py-5 px-10" v-truncate>
-                        {{
-                            item.data[nameField] ||
-                            $t('details.result.default.name', [idx + 1])
-                        }}
-                    </span>
+                    <div v-if="item.loaded">
+                        <span
+                            v-html="itemIcon(item.data, idx)"
+                            class="flex-none symbologyIcon"
+                        ></span>
+                        <span class="flex-initial py-5 px-10" v-truncate>
+                            {{
+                                item.data[nameField] ||
+                                $t('details.result.default.name', [idx + 1])
+                            }}
+                        </span>
+                    </div>
+                    <div
+                        v-else
+                        class="animate-spin spinner h-20 w-20 px-5"
+                    ></div>
                 </button>
             </div>
             <div v-else>{{ $t('details.layers.results.empty') }}</div>
@@ -49,6 +55,8 @@
 </template>
 
 <script lang="ts">
+// this screen is the list of results for one logical layer (one IdentifyResult object)
+
 import { defineComponent, PropType } from 'vue';
 import { get } from '@/store/pathify-helper';
 import { DetailsStore } from './store';

--- a/packages/ramp-core/src/geo/api/geo-defs.ts
+++ b/packages/ramp-core/src/geo/api/geo-defs.ts
@@ -322,6 +322,11 @@ export interface GetGraphicResult {
     geometry?: BaseGeometry;
 }
 
+export interface DiscreteGraphicResult {
+    oid: number; // oid of the result
+    graphic: Promise<GetGraphicResult>;
+}
+
 export interface QueryFeaturesParams {
     filterGeometry?: BaseGeometry; // filter by geometry
     filterSql?: string; // filter by sql query
@@ -341,27 +346,23 @@ export interface IdentifyParameters {
     sublayerIds?: Array<string | number>; // Optional array of sublayer uids or server indices. When defined, the given sublayers are queried for instead of the default (visible, queryable, on-scale sublayers)
 }
 
-// TODO for the identify structure, currently using uid to tie back to layers/sublayers. should we also include layerid / layerindex for completeness?
-
 export interface IdentifyItem {
-    data: any; // TODO figure out how we want to do this. we want the pipeline to be flexible and handle anything
+    data: any;
     format: IdentifyResultFormat;
-    // See https://github.com/ramp4-pcar4/r4design/issues/11
+    loaded: boolean;
+    loading: Promise<void>;
+    // See https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/334
     // name: string;
     // id: string;
     // symbol: string; // SVG code. does this need to be more flexible to handle WMS image symbols? would a symbol stack-ish thing be more appropriate?
 }
 
+// the result of identifying against a logical layer ( a feature class or WMS )
 export interface IdentifyResult {
     items: Array<IdentifyItem>;
-    uid: string; // this would match to the sublayer. TODO might want to name the property something more specific to that, like sublayerUid? indexUid? childUid? might be ok with uid as the parentUid is different name
-    loadPromise: Promise<void>;
-}
-
-export interface IdentifyResultSet {
-    results: Array<IdentifyResult>;
-    done: Promise<void>;
-    parentUid: string; // this would be the parent layer's uid.
+    uid: string; // this would match to the logical layer.
+    loaded: boolean;
+    loading: Promise<void>; // represents the list of results has been found, but the content of items in the array may still be resolving
 }
 
 export interface MapIdentifyResult {

--- a/packages/ramp-core/src/geo/api/layer/layer-base.ts
+++ b/packages/ramp-core/src/geo/api/layer/layer-base.ts
@@ -19,7 +19,6 @@ import {
     GetGraphicParams,
     GetGraphicResult,
     IdentifyParameters,
-    IdentifyResultSet,
     LayerState,
     LegendSymbology,
     ScaleSet,
@@ -63,7 +62,7 @@ export interface LayerBase {
     ): boolean;
 
     getLegend(layerIdx: number | string | undefined): Array<LegendSymbology>;
-    identify(options: IdentifyParameters): IdentifyResultSet;
+    identify(options: IdentifyParameters): Array<IdentifyResult>;
 
     // attribute layer props. layers that do not support attributes can just return dummy values
     getFeatureCount?(layerIdx: number | string | undefined): number;

--- a/packages/ramp-core/src/geo/layer/common-layer.ts
+++ b/packages/ramp-core/src/geo/layer/common-layer.ts
@@ -1,9 +1,5 @@
 // put things here that would be common to all layers
 // used for layer types defined by Core RAMP.
-// TODO add proper comments
-
-// import { InfoBundle, LayerState, RampLayerConfig, LegendSymbology, IdentifyParameters, IdentifyResultSet,
-//    FilterEventParam, AttributeSet, FieldDefinition, TabularAttributeSet, GetGraphicResult, GetGraphicParams } from '../gapiTypes';
 
 import { GlobalEvents, InstanceAPI, LayerInstance } from '@/api/internal';
 import {
@@ -15,7 +11,7 @@ import {
     GetGraphicResult,
     GetGraphicParams,
     IdentifyParameters,
-    IdentifyResultSet,
+    IdentifyResult,
     LayerState,
     LayerType,
     LegendSymbology,
@@ -787,27 +783,6 @@ export class CommonLayer extends LayerInstance {
         } else {
             this.noLayerErr();
         }
-    }
-
-    // ----------- LAYER ACTIONS -----------
-
-    /**
-     * Baseline identify function for layers that do not support identify.
-     * Will return an empty result. Layers that support identify should override this method.
-     *
-     * @param options not used, present for nice signature of overrided function
-     * @returns {IdentifyResultSet} an empty result set
-     */
-    runIdentify(options: IdentifyParameters): IdentifyResultSet {
-        // returns an empty set.
-        // serves as a fallback incase someone tries to identify on a non-identifiyable layer
-        // (callers can use this.supportsIdentify to check for that)
-        // and also as a "no results" option for subclasses to use.
-        return {
-            results: [],
-            done: Promise.resolve(),
-            parentUid: this.uid
-        };
     }
 
     // ----------- STUB METHODS -----------

--- a/packages/ramp-core/src/geo/layer/esri-feature/index.ts
+++ b/packages/ramp-core/src/geo/layer/esri-feature/index.ts
@@ -1,16 +1,16 @@
 import { AttribLayer, InstanceAPI } from '@/api/internal';
 import {
     DataFormat,
+    DefPromise,
     GeometryType,
+    IdentifyItem,
     IdentifyParameters,
     IdentifyResult,
     IdentifyResultFormat,
-    IdentifyResultSet,
     LayerType,
     Point,
     QueryFeaturesParams,
-    RampLayerConfig,
-    TreeNode
+    RampLayerConfig
 } from '@/geo/api';
 import { EsriFeatureLayer, EsriRendererFromJson } from '@/geo/esri';
 import { markRaw } from 'vue';
@@ -170,7 +170,7 @@ class FeatureLayer extends AttribLayer {
 
     // ----------- LAYER ACTIONS -----------
 
-    runIdentify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): Array<IdentifyResult> {
         // early kickout check. not loaded/error; not visible; not queryable; off scale
         if (
             !this.isValidState ||
@@ -179,22 +179,16 @@ class FeatureLayer extends AttribLayer {
             this.scaleSet.isOffScale(this.$iApi.geo.map.getScale()).offScale
         ) {
             // return empty result.
-            return super.runIdentify(options);
+            return [];
         }
 
-        let loadResolve: any;
-        const innerResult: IdentifyResult = {
-            uid: this.uid,
-            loadPromise: new Promise(resolve => {
-                loadResolve = resolve;
-            }),
-            items: []
-        };
+        const dProm = new DefPromise();
 
-        const result: IdentifyResultSet = {
-            results: [innerResult],
-            done: Promise.resolve(), // set below, this chills typescript
-            parentUid: this.uid
+        const result: IdentifyResult = {
+            items: [],
+            loading: dProm.getPromise(),
+            loaded: false,
+            uid: this.uid
         };
 
         // run a spatial query
@@ -219,28 +213,33 @@ class FeatureLayer extends AttribLayer {
 
         qOpts.filterSql = this.getCombinedSqlFilter();
 
-        result.done = this.queryFeatures(qOpts).then(results => {
-            // TODO might be a problem overwriting the array if something is watching/binding to the original
-            innerResult.items = results.map(gr => {
-                return {
-                    // TODO decide if we want to handle alias mapping here or not.
-                    //      if we do, our "ESRI" format will need to include field metadata.
-                    //      if we dont, we need to ensure an outside fixture can access field metadata via uid easily.
-                    data: gr.attributes, // this.attributesToDetails(vAtt.attributes, layerData.fields),
-                    format: IdentifyResultFormat.ESRI
-
-                    // See comments on IdentifyItem interface definition; we may decide to not keep these properties
-                    // id:  gr.attributes[myFC.oidField].toString(),
-                    // symbol: this.gapi.utils.symbology.getGraphicIcon(gr.attributes, myFC.renderer) // TODO update to myFC.getIcon
-                    // name: this.getFeatureName(vAtt.oid.toString(), vAtt.attributes),
+        this.queryFeaturesDiscrete(qOpts).then(results => {
+            results.forEach(dgr => {
+                const itemDProm = new DefPromise();
+                const item: IdentifyItem = {
+                    data: undefined,
+                    format: IdentifyResultFormat.ESRI,
+                    loaded: false,
+                    loading: itemDProm.getPromise()
                 };
+
+                result.items.push(item); // push, incase something was bound to the array
+
+                // allow the item to be returned, but update the item after its guts download
+                dgr.graphic.then(g => {
+                    item.data = g.attributes;
+                    itemDProm.resolveMe();
+                    item.loaded = true;
+                });
             });
 
-            // Resolve the load promise
-            loadResolve();
+            // Resolve the loading promise, set the flag
+            // This promise only indicates we have an array of results (each may still be loading their internals)
+            dProm.resolveMe();
+            result.loaded = true;
         });
 
-        return result;
+        return [result];
     }
 
     /**

--- a/packages/ramp-core/src/geo/layer/layer.ts
+++ b/packages/ramp-core/src/geo/layer/layer.ts
@@ -8,7 +8,7 @@ import {
     GetGraphicParams,
     GetGraphicResult,
     IdentifyParameters,
-    IdentifyResultSet,
+    IdentifyResult,
     LayerState,
     LegendSymbology,
     ScaleSet,
@@ -710,14 +710,10 @@ export class LayerInstance extends APIScope {
      * Will return an empty result. Layers that support identify should override this method.
      *
      * @param options not used, present for nice signature of overrided function
-     * @returns {IdentifyResultSet} an empty result set
+     * @returns {Array} an empty result set
      */
-    runIdentify(options: IdentifyParameters): IdentifyResultSet {
-        return {
-            results: [],
-            done: Promise.resolve(),
-            parentUid: this.uid
-        };
+    runIdentify(options: IdentifyParameters): Array<IdentifyResult> {
+        return [];
     }
 
     /**

--- a/packages/ramp-core/src/geo/layer/ogc-wms/index.ts
+++ b/packages/ramp-core/src/geo/layer/ogc-wms/index.ts
@@ -1,11 +1,12 @@
 import { CommonLayer, InstanceAPI } from '@/api/internal';
 import {
     DataFormat,
+    DefPromise,
     GeometryType,
+    IdentifyItem,
     IdentifyParameters,
     IdentifyResult,
     IdentifyResultFormat,
-    IdentifyResultSet,
     LayerType,
     LegendSymbology,
     Point,
@@ -165,7 +166,7 @@ export default class WmsLayer extends CommonLayer {
      * @param {Object} options     additional arguemets, see above.
      * @returns {Object} an object with identify results array and identify promise resolving when identify is complete; if an empty object is returned, it will be skipped
      */
-    runIdentify(options: IdentifyParameters): IdentifyResultSet {
+    runIdentify(options: IdentifyParameters): Array<IdentifyResult> {
         // TODO add full documentation for options parameter
 
         if (options.geometry.type !== GeometryType.POINT) {
@@ -197,60 +198,58 @@ export default class WmsLayer extends CommonLayer {
             this.scaleSet.isOffScale(map.getScale()).offScale
         ) {
             // return empty result.
-            return super.runIdentify(options);
+            return [];
         }
 
         // TODO prolly need to flush out the config interfaces for this badboy
 
-        let loadResolve: any;
-        const innerResult: IdentifyResult = {
-            uid: this.uid,
-            loadPromise: new Promise(resolve => {
-                loadResolve = resolve;
-            }),
-            items: []
+        const dProm = new DefPromise();
+
+        const result: IdentifyResult = {
+            items: [],
+            loading: dProm.getPromise(),
+            loaded: false,
+            uid: this.uid
         };
 
-        const result: IdentifyResultSet = {
-            results: [innerResult],
-            done: Promise.resolve(), // set below
-            parentUid: this.uid
-        };
-
-        result.done = this.getFeatureInfo(
+        this.getFeatureInfo(
             this.sublayerNames,
             <Point>options.geometry,
             this.mimeType
         ).then(response => {
             // check if a result is returned by the service. If not, do not add to the array of data
-            // TODO verify we want empty .items array
             // TODO is is possible to have more than one item as a result? check how this works
             if (response) {
+                // we have all the data already so can init the item as loaded
+                const item: IdentifyItem = {
+                    data: response,
+                    format: IdentifyResultFormat.UNKNOWN,
+                    loaded: true,
+                    loading: Promise.resolve()
+                };
+
                 if (typeof response !== 'string') {
                     // likely json or an image
                     // TODO improve the dection (maybe use the this.mimeType?)
-                    innerResult.items.push({
-                        format: IdentifyResultFormat.JSON,
-                        data: response
-                    });
+                    item.format = IdentifyResultFormat.JSON;
+                    result.items.push(item);
                 } else if (
                     response.indexOf('Search returned no results') === -1 &&
                     response !== ''
                 ) {
                     // TODO if service is french, will the "no results" message be different?
                     // TODO consider utilizing the infoMap variable above to detect HTML format.
-                    innerResult.items.push({
-                        format: IdentifyResultFormat.TEXT,
-                        data: response
-                    });
+                    item.format = IdentifyResultFormat.TEXT;
+                    result.items.push(item);
                 }
             }
 
-            // Resolve the load promise
-            loadResolve();
+            // Resolve the loading promise, set the flag
+            dProm.resolveMe();
+            result.loaded = true;
         });
 
-        return result;
+        return [result];
     }
 
     /**

--- a/packages/ramp-core/src/geo/map/ramp-map.ts
+++ b/packages/ramp-core/src/geo/map/ramp-map.ts
@@ -18,7 +18,6 @@ import {
     // IdentifyMode,
     IdentifyParameters,
     IdentifyResult,
-    IdentifyResultSet,
     MapClick,
     MapIdentifyResult,
     Point,
@@ -761,18 +760,13 @@ export class MapAPI extends CommonMapAPI {
         };
 
         // Perform an identify request on each layer. Does not perform the request on layers that do not have an identify function (layers that do not support identify).
-        const identifyInstances: IdentifyResultSet[] = layers
-            // This will filter out all MapImageLayers that are not visible, regardless of the visibility of the MapImageFCs (sublayers)
+        const identifyResults = layers
             .filter(layer => layer.supportsIdentify)
             .map(layer => {
                 p.tolerance = layer.clickTolerance;
                 return layer.runIdentify(p);
-            });
-
-        // Merge all results received by the identify into one array.
-        const identifyResults: IdentifyResult[] = (
-            [] as IdentifyResult[]
-        ).concat(...identifyInstances.map(({ results }) => results));
+            })
+            .flat();
 
         const fullResult: MapIdentifyResult = {
             results: identifyResults,


### PR DESCRIPTION
Not for pullin'

Working on https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/933 , the Vue part is wrecking me. Need some Vue Veterans to tell me what I'm doing wrong.

Only really need to look at `layers-screen.vue`.
You can run the [Demo](http://ramp4-app.azureedge.net/demo/users/james-rae/jamesparty/host/index.html). Click on some point and watch the spinners never resolve.

The old/current way had undefineds in the array of layers being queried (`this.layerResults`), and then replaced them with a real object once the query finished.
My way allows you to ditch the undefineds, but the template won't notice when object properties update. In particular, `item.loaded` is the boolean flag that should clue the template in that things are clickable / done spinning.

Debugging items on the demo:
- The UI itself has the `.loaded` value pre-pended to the layer name so you can see it not updating.
- On the console, there is a dump of `this.layerResults` "reactive check". You can see the array is reactive, but the objects inside are not, which I think is the root cause.
- Also on the console, every 10 seconds it outputs the actual value of `this.layerResults[].loaded` for all items, so you can see they did update.

Things I've tried:
- Clearing `this.layerResults` and pushing new items into it
- Cloning the `newPayload` and assigning to `this.layerResults` instead of direct-assign.
- As each item finishes loading, update `this.layerResults` with the same value to make Vue see it
  - using `this.layerResults[i] = same value`
  - using `this.layerResults.splice(i, 1, same value)`
- Using a computed property `isLoaded` that returns the array of all loaded status, and using `isLoaded[idx]` instead of `item.loaded`
- Using a method called `isLoaded(idx): boolean` that returns the loaded status of one item, and using  `isLoaded(idx)` instead of `item.loaded`
- Wrapping the objects of `this.layerResults` in `reactive()` when pushing them into the array.
- Using `toRaw()` on the incoming `newPayload`
- Changing the key in the button `v-for` to be a number of things, including just the `uid` which would be unique and not change. The current one is unique but also changes when the load finishes.
- Pushing the `layerResults` array into a property of a pointless object in the `data` collection in hopes to make it more reactive, being a child of an object.

I know I can revert back to "array of undefineds" but that seems ugly given the new structure; will do that if it's the only way.
UPDATE: `$forceUpdate()` also works. Which is still ugly but at least there are not undefined checks everywhere so that is currently the preferred bad solution. Thanks Sharven for the suggestion.

Main questions:
- See anything stupid?
- Is there a way to make the contents of `this.layerResults` reactive while using Options API ( `reactive()` isn't working).
  - I found an [article](https://stackoverflow.com/questions/46985067/vue-change-object-in-array-and-trigger-reactivity) about using `$set()` but that doesn't seem to be recognized, might be Vue2.

UPDATE 2: Found a way to make the children reactive. Doing `this.layerResults = newPayload.map(p => reactive(p));` does it. It worked one time then stopped again, and is now looking like Chrome or Rush is not running my latest source code. Proved it by adding a console log and didn't show. So now almost everything here is suspect due to that. April Fools to me I guess.

UPDATE 3: Yi Lei found that if you paint the identify result as `reactive()` when you create it in the layer, things work as you would expect. I don't understand yet why I can't do it after the fact in a different module, but will do for now. Thanks everybody.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/944)
<!-- Reviewable:end -->
