### PR TITLE
Implement new details fixture schema + template defaulting

### DIFF
--- a/packages/ramp-core/public/starter-scripts/map-image-layer.js
+++ b/packages/ramp-core/public/starter-scripts/map-image-layer.js
@@ -117,7 +117,11 @@ let config = {
                     items: ['legend']
                 },
                 mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
-                details: { items: [] }
+                details: {
+                    templates: {
+                        esri: 'Details-Default-Template-Esri'
+                    }
+                }
             }
         }
     }
@@ -134,3 +138,43 @@ rInstance.fixture
     .then(() => {
         rInstance.panel.open('legend-panel');
     });
+
+rInstance.$element.component('Details-Default-Template-Esri', {
+    props: ['identifyData', 'fields'],
+    template: `
+        <div>
+            <div
+                class="p-5 pl-3 flex justify-end flex-wrap even:bg-green-100 border-2 border-black"
+                v-for="(val, name, itemIdx) in itemData()"
+                :key="itemIdx"
+            >
+                <span class="inline font-bold">{{ val.alias }}</span>
+                <span class="flex-auto"></span>
+                <span class="inline" v-html="val.value"></span>
+            </div>
+        </div>
+    `,
+    methods: {
+        itemData() {
+            const helper = {};
+            Object.assign(helper, this.identifyData.data);
+            if (helper.Symbol !== undefined) delete helper.Symbol;
+
+            let aliases = {};
+            this.fields.forEach(field => {
+                aliases[field.name] = field.alias || field.name;
+            });
+            Object.keys(helper).map(key => {
+                helper[key] = {
+                    value:
+                        typeof helper[key] === 'number'
+                            ? this.$iApi.$vApp.$n(helper[key], 'number')
+                            : helper[key],
+                    alias: aliases[key] || key
+                };
+            });
+
+            return helper;
+        }
+    }
+});

--- a/packages/ramp-core/public/starter-scripts/wms-layer.js
+++ b/packages/ramp-core/public/starter-scripts/wms-layer.js
@@ -178,6 +178,11 @@ let config = {
                 mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
                 'export-v1-title': {
                     text: 'WMS'
+                },
+                details: {
+                    templates: {
+                        json: 'Details-Default-Template-WMS'
+                    }
                 }
             }
         },
@@ -192,6 +197,11 @@ let options = {
     loadDefaultEvents: true
 };
 rInstance = new RAMP.Instance(document.getElementById('app'), config, options);
+
+rInstance.$element.component('Details-Default-Template-WMS', {
+    props: ['identifyData'],
+    template: `<div v-html="identifyData.data.data" />`
+});
 
 rInstance.$element.component('GeoMet-Template', {
     props: ['identifyData'],

--- a/packages/ramp-core/schema.json
+++ b/packages/ramp-core/schema.json
@@ -1788,12 +1788,27 @@
                     },
                     "description": "Provides configuration to geosearch. If not supplied, default geosearch services are used."
                 },
-                "identify": {
-                    "$ref": "#/$defs/details",
-                    "default": {
-                        "templates": []
+                "details": {
+                    "description": "Provides default template configuration to the details fixture. If not supplied, RAMP default templates wil be used.",
+                    "type": "object",
+                    "properties": {
+                        "templates": {
+                            "type": "object",
+                            "description": "Specifies a custom Vue component to render as the default details template for each identify result format.",
+                            "propertyNames": {
+                                "enum": [
+                                    "esri",
+                                    "text",
+                                    "image",
+                                    "html",
+                                    "xml",
+                                    "json"
+                                ]
+                            },
+                            "additionalProperties": { "type": "string" }
+                        }
                     },
-                    "description": "Provides configuration to identify results and details panel. Default to no user custom templates."
+                    "required": ["templates"]
                 },
                 "help": {
                     "$ref": "#/$defs/help",

--- a/packages/ramp-core/src/api/config-upgrade.ts
+++ b/packages/ramp-core/src/api/config-upgrade.ts
@@ -372,6 +372,12 @@ function layerUpgrader(r2layer: any): any {
             );
     }
 
+    if (r2layer.details) {
+        console.warn(
+            `Details config provided in layer ${r2layer.id} cannot be mapped and will be skipped.`
+        );
+    }
+
     return r4layer;
 }
 

--- a/packages/ramp-core/src/fixtures/details/api/details.ts
+++ b/packages/ramp-core/src/fixtures/details/api/details.ts
@@ -2,6 +2,7 @@ import { FixtureInstance } from '@/api';
 import { IdentifyResult } from '@/geo/api';
 import {
     DetailsConfig,
+    DetailsConfigItem,
     DetailsItemSet,
     DetailsItemInstance,
     DetailsStore
@@ -81,24 +82,31 @@ export class DetailsAPI extends FixtureInstance {
     /**
      * Read the details section of the layers' fixture config
      *
+     * @param {DetailsConfig} [config]
      * @memberof DetailsAPI
      */
-    _parseConfig() {
+    _parseConfig(config?: DetailsConfig) {
+        // set the default templates if provided
+        if (config && config.templates) {
+            this.$vApp.$store.set(
+                DetailsStore.defaultTemplates,
+                config.templates
+            );
+        }
+
         // get all layer fixture configs
         let layerDetailsConfigs: any = this.getLayerFixtureConfigs();
-        let detailsConfig: DetailsConfig = {
-            items: []
-        };
+        let detailsConfigItems: DetailsConfigItem[] = [];
 
         // construct the details config from the layer fixture configs
         Object.keys(layerDetailsConfigs).forEach((layerId: string) => {
-            detailsConfig.items.push({
+            detailsConfigItems.push({
                 id: layerId,
                 template: layerDetailsConfigs[layerId].template
             });
         });
 
-        const detailsItems = detailsConfig.items.map(
+        const detailsItems = detailsConfigItems.map(
             (item: any) => new DetailsItemInstance(item)
         );
 

--- a/packages/ramp-core/src/fixtures/details/index.ts
+++ b/packages/ramp-core/src/fixtures/details/index.ts
@@ -49,10 +49,10 @@ class DetailsFixture extends DetailsAPI {
 
         // Parse the details portion of the configuration file and save any custom
         // template bindings in the details store.
-        this._parseConfig();
+        this._parseConfig(this.config);
         this.$vApp.$watch(
             () => this.config,
-            (value: DetailsConfig | undefined) => this._parseConfig()
+            (value: DetailsConfig | undefined) => this._parseConfig(value)
         );
     }
 

--- a/packages/ramp-core/src/fixtures/details/item-screen.vue
+++ b/packages/ramp-core/src/fixtures/details/item-screen.vue
@@ -153,6 +153,7 @@ export default defineComponent({
     },
     data() {
         return {
+            defaultTemplates: get(DetailsStore.defaultTemplates),
             templateBindings: get(DetailsStore.templates),
             payload: get(DetailsStore.payload),
             getLayerByUid: get('layer/getLayerByUid'),
@@ -221,7 +222,16 @@ export default defineComponent({
             ) {
                 return this.templateBindings[layer.id].template;
             }
-            // If nothing is found, use a default template.
+
+            // If nothing is found, use a default template from config
+            if (
+                this.defaultTemplates &&
+                this.defaultTemplates[this.identifyItem.format]
+            ) {
+                return this.defaultTemplates[this.identifyItem.format];
+            }
+
+            // If default template is not specified, use our default template
             if (this.layerType === 'ogc-wms') {
                 return 'html-default';
             } else {

--- a/packages/ramp-core/src/fixtures/details/store/details-state.ts
+++ b/packages/ramp-core/src/fixtures/details/store/details-state.ts
@@ -3,7 +3,10 @@ import { IdentifyResult } from '@/geo/api';
 export type DetailsItemSet = { [name: string]: DetailsItemInstance };
 
 export interface DetailsConfig {
-    items: DetailsConfigItem[];
+    /**
+     * The dictionary of default templates indexed by identify result format with value as the template component id.
+     */
+    templates: { [type: string]: string };
 }
 
 export interface DetailsConfigItem {
@@ -54,4 +57,11 @@ export class DetailsState {
      * @memberof DetailsState
      */
     templates: { [id: string]: DetailsItemInstance } = {};
+
+    /**
+     * Details default templates indexed by the identify result format
+     *
+     * @memberof DetailsState
+     */
+    defaultTemplates: { [type: string]: string } = {};
 }

--- a/packages/ramp-core/src/fixtures/details/store/details-store.ts
+++ b/packages/ramp-core/src/fixtures/details/store/details-store.ts
@@ -29,7 +29,8 @@ const mutations = {
 
 export enum DetailsStore {
     payload = 'details/payload',
-    templates = 'details/templates'
+    templates = 'details/templates',
+    defaultTemplates = 'details/defaultTemplates'
 }
 
 export function details() {


### PR DESCRIPTION
## Closes #612, Closes #613 

## Changes in this PR
- [FEAT] A default template to use for each identify result type can be specified in the details fixture config


## Comments
- The config upgrader will now throw a warning when it encounters a R2 layer config with a details config


[Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/613/host/index.html)
[Demo WMS](http://ramp4-app.azureedge.net/demo/users/sharvenp/613/host/index-e2e.html?script=wms-layer)
[Demo Map Image Layer](http://ramp4-app.azureedge.net/demo/users/sharvenp/613/host/index-e2e.html?script=map-image-layer)

- The WMS and Map Image Layer starter scripts both specify a default template to use that can be used for testing
    - Note that the WMS default template is just rendering the raw data as html so it will look unformatted 
