### PR TITLE
Implement clean fixture removal

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -1,5 +1,7 @@
 import { createInstance, geo } from '@/main';
 
+window.debugInstance = null;
+
 // TODO: Location for version string needs to be finalized
 // document.getElementById('ramp-version').innerText =
 //     'v.' +
@@ -593,3 +595,5 @@ function animateToggle() {
     document.getElementById('animate-status').innerText =
         'Animate: ' + rInstance.animate;
 }
+
+window.debugInstance = rInstance;

--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -84,6 +84,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | CONFIG_CHANGE<br>'config/change'                   | RampConfig object                                              | The config was changed                           |
 | FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed                             |
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added                         |
+| FIXTURE_REMOVED<br>'fixture/removed'               | FixtureInstance object                                         | A fixture has been removed                       |
 | LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, _uid_: affected uid                      | The layer opacity changed                        |
 | LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was added to the map                   |
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
@@ -95,6 +96,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_BLUR<br>'map/blur'                             | FocusEvent object                                              | The map lost focus                               |
 | MAP_CLICK<br>'map/click'                           | MapClick object                                                | The map was clicked                              |
 | MAP_CREATED<br>'map/created'                       | none                                                           | The map was created                              |
+| MAP_DESTROYED<br>'map/destroyed'                   | none                                                           | The map was destroyed                            |
 | MAP_DOUBLECLICK<br>'map/doubleclick'               | MapClick object                                                | The map was double clicked                       |
 | MAP_EXTENTCHANGE<br>'map/extentchanged'            | RAMP Extent object                                             | The map extent changed                           |
 | MAP_GRAPHICHIT<br>'map/graphichit'                 | { layer, graphicHit, attributes, icon, screenPoint}            | A graphic was found where the mouse/crosshair is |

--- a/schema.json
+++ b/schema.json
@@ -66,6 +66,17 @@
                 }
             }
         },
+        "scrollguard": {
+            "type": "object",
+            "description": "Provides the configuration to the scrollguard fixture",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indicates if the scrollguard should be active"
+                }
+            }
+        },
         "appbar": {
             "type": "object",
             "description": "Provides configuration to the appbar fixture. If not supplied, the default appbar controls are displayed.",
@@ -1886,6 +1897,10 @@
                 "overviewmap": {
                     "$ref": "#/$defs/overviewmap",
                     "description": "Provides the configuration to the overviewmap fixture"
+                },
+                "scrollguard": {
+                    "$ref": "#/$defs/scrollguard",
+                    "description": "Provides the configuration to the scrollguard fixture"
                 }
             },
             "unevaluatedProperties": false

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -109,9 +109,17 @@ export class FixtureAPI extends APIScope {
     ): T {
         const fixture = this.get<T>(fixtureOrId);
 
+        if (!fixture) {
+            throw new Error(
+                `Could not find fixture ${fixtureOrId} for removal`
+            );
+        }
+
         this.$vApp.$store.set(`fixture/${FixtureMutation.REMOVE_FIXTURE}!`, {
             value: fixture
         });
+
+        this.$iApi.event.emit(GlobalEvents.FIXTURE_REMOVED, fixture);
 
         return fixture;
     }

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -276,6 +276,19 @@ export class PanelInstance extends APIScope {
     }
 
     /**
+     * Remove this panel.
+     * This is a proxy to `InstanceAPI.panel.remove(...)`.
+     *
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    remove(): this {
+        this.$iApi.panel.remove(this);
+
+        return this;
+    }
+
+    /**
      * Toggle panel.
      * This is a proxy to `InstanceAPI.panel.toggle(...)`.
      *

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -84,6 +84,25 @@ export class PanelAPI extends APIScope {
     }
 
     /**
+     * Removes a panel instance
+     *
+     * @param {(string | PanelInstance)} value
+     * @memberof PanelAPI
+     */
+    remove(value: string | PanelInstance): void {
+        let panel: PanelInstance = this.get(value);
+
+        // close the panel if it is open
+        if (panel.isOpen) {
+            this.close(panel);
+        }
+
+        this.$vApp.$store.set(`panel/${PanelMutation.REMOVE_PANEL}!`, {
+            panel
+        });
+    }
+
+    /**
      * Finds and returns a panel with the id specified.
      *
      * @param {(string | PanelInstance)} value

--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -46,9 +46,19 @@ export default defineComponent({
     data() {
         return {
             open: false,
-            popper: null as any
+            popper: null as any,
+            watchers: [] as Array<Function>
         };
     },
+
+    created() {
+        this.watchers.push(
+            this.$watch('open', () => {
+                this.popper.update();
+            })
+        );
+    },
+
     mounted() {
         window.addEventListener(
             'click',
@@ -80,7 +90,7 @@ export default defineComponent({
         });
     },
     beforeUnmount() {
-        this.open = false;
+        this.watchers.forEach(unwatch => unwatch());
         window.removeEventListener(
             'click',
             event => {
@@ -90,12 +100,9 @@ export default defineComponent({
             },
             { capture: true }
         );
+        this.open = false;
     },
-    watch: {
-        open() {
-            this.popper.update();
-        }
-    },
+
     methods: {
         closeDropdown() {
             this.open = false;

--- a/src/components/keyboard-instructions.vue
+++ b/src/components/keyboard-instructions.vue
@@ -41,17 +41,24 @@ export default defineComponent({
     data() {
         return {
             open: false,
-            instructionSections: ['app', 'lists', 'map']
+            instructionSections: ['app', 'lists', 'map'],
+            handlers: [] as Array<string>
         };
     },
 
     mounted() {
-        this.$iApi.event.on('openKeyboardInstructions', () => {
-            this.open = true;
-            this.$nextTick(() => {
-                (this.$refs.firstEl as HTMLElement)?.focus();
-            });
-        });
+        this.handlers.push(
+            this.$iApi.event.on('openKeyboardInstructions', () => {
+                this.open = true;
+                this.$nextTick(() => {
+                    (this.$refs.firstEl as HTMLElement)?.focus();
+                });
+            })
+        );
+    },
+
+    beforeUnmount() {
+        this.handlers.forEach(handler => this.$iApi.event.off(handler));
     },
 
     methods: {

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -112,7 +112,8 @@ export default defineComponent({
             attribution: get(MapCaptionStore.attribution),
             cursorCoords: get(MapCaptionStore.cursorCoords),
             mapConfig: get(ConfigStore.getMapConfig),
-            lang: [] as string[]
+            lang: [] as Array<string>,
+            watchers: [] as Array<Function>
         };
     },
 
@@ -121,13 +122,24 @@ export default defineComponent({
         'about-ramp-dropdown': AboutRampDropdown
     },
 
-    watch: {
-        mapConfig(newConfig: RampMapConfig, oldConfig: RampMapConfig) {
-            if (newConfig === oldConfig) {
-                return;
-            }
-            this.$iApi.geo.map.caption.createCaption(this.mapConfig.caption);
-        }
+    created() {
+        this.watchers.push(
+            this.$watch(
+                'mapConfig',
+                (newConfig: RampMapConfig, oldConfig: RampMapConfig) => {
+                    if (newConfig === oldConfig) {
+                        return;
+                    }
+                    this.$iApi.geo.map.caption.createCaption(
+                        this.mapConfig.caption
+                    );
+                }
+            )
+        );
+    },
+
+    beforeUnmount() {
+        this.watchers.forEach(unwatch => unwatch());
     },
 
     updated() {

--- a/src/fixtures/appbar/index.ts
+++ b/src/fixtures/appbar/index.ts
@@ -8,8 +8,6 @@ import messages from './lang/lang.csv?raw';
 // "It's a trap!" -- Admiral Appbar
 
 class AppbarFixture extends AppbarAPI {
-    eventHandlers: string[] = [];
-
     initialized() {
         console.log(`[fixture] ${this.id} initialized`);
     }
@@ -41,8 +39,10 @@ class AppbarFixture extends AppbarAPI {
             (value: AppbarFixtureConfig | undefined) => this._parseConfig(value)
         );
 
+        let eventHandlers: string[] = [];
+
         // Add and remove temp appbar buttons when panels are opened and close
-        this.eventHandlers.push(
+        eventHandlers.push(
             this.$iApi.event.on(
                 GlobalEvents.PANEL_OPENED,
                 (panel: PanelInstance) => {
@@ -54,7 +54,7 @@ class AppbarFixture extends AppbarAPI {
             )
         );
 
-        this.eventHandlers.push(
+        eventHandlers.push(
             this.$iApi.event.on(
                 GlobalEvents.PANEL_CLOSED,
                 (panel: PanelInstance) => {
@@ -68,20 +68,18 @@ class AppbarFixture extends AppbarAPI {
 
         // since components used in appbar can be registered after this point, listen to the global component registration event and re-validate items
         // TODO revisit. this seems to be self-contained to the appbar fixture, so ideally can stay as is and not worry about events api.
-        this.eventHandlers.push(
+        eventHandlers.push(
             this.$iApi.event.on(
                 GlobalEvents.COMPONENT,
                 this._validateItems.bind(this)
             )
         );
-    }
 
-    removed() {
-        this.$vApp.$store.unregisterModule('appbar');
-
-        this.eventHandlers.forEach(eventHandler =>
-            this.$iApi.event.off(eventHandler)
-        );
+        this.removed = () => {
+            this.$vApp.$store.unregisterModule('appbar');
+            eventHandlers.forEach(h => this.$iApi.event.off(h));
+            destroy();
+        };
     }
 }
 

--- a/src/fixtures/basemap/index.ts
+++ b/src/fixtures/basemap/index.ts
@@ -24,7 +24,13 @@ class BasemapFixture extends FixtureInstance {
         );
     }
 
-    removed() {}
+    removed() {
+        console.log(`[fixture] ${this.id} removed`);
+        // TODO:
+        // - remove mapnav button
+        // - remove appbar button (blocked by #882)
+        this.$iApi.panel.remove('basemap-panel');
+    }
 }
 
 export default BasemapFixture;

--- a/src/fixtures/crosshairs/crosshairs.vue
+++ b/src/fixtures/crosshairs/crosshairs.vue
@@ -54,25 +54,35 @@ export default defineComponent({
     name: 'CrosshairsV',
     data() {
         return {
-            visible: false
+            visible: false,
+            handlers: [] as Array<string>
         };
     },
 
     mounted() {
-        this.$iApi.event.on(GlobalEvents.MAP_EXTENTCHANGE, () => {
-            // display crosshairs if pan/zoom keys are active
-            if (this.$iApi.geo.map.keysActive) {
-                this.visible = true;
-            }
-        });
+        this.handlers.push(
+            this.$iApi.event.on(GlobalEvents.MAP_EXTENTCHANGE, () => {
+                // display crosshairs if pan/zoom keys are active
+                if (this.$iApi.geo.map.keysActive) {
+                    this.visible = true;
+                }
+            })
+        );
 
-        this.$iApi.event.on(GlobalEvents.MAP_MOUSEDOWN, () => {
-            this.visible = false;
-        });
+        this.handlers.push(
+            this.$iApi.event.on(GlobalEvents.MAP_MOUSEDOWN, () => {
+                this.visible = false;
+            })
+        );
 
-        this.$iApi.event.on(GlobalEvents.MAP_BLUR, () => {
-            this.visible = false;
-        });
+        this.handlers.push(
+            this.$iApi.event.on(GlobalEvents.MAP_BLUR, () => {
+                this.visible = false;
+            })
+        );
+    },
+    beforeUnmount() {
+        this.handlers.forEach(h => this.$iApi.event.off(h));
     }
 });
 </script>

--- a/src/fixtures/crosshairs/index.ts
+++ b/src/fixtures/crosshairs/index.ts
@@ -5,17 +5,19 @@ import { FixtureInstance } from '@/api';
 class CrosshairsFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
-
         const { vNode, destroy, el } = this.mount(CrosshairsV, {
             app: this.$element
         });
+
         const innerShell =
             this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);
-    }
 
-    removed(): void {
-        console.log(`[fixture] ${this.id} removed`);
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            destroy();
+        };
     }
 }
 

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -51,14 +51,38 @@ class DetailsFixture extends DetailsAPI {
         // Parse the details portion of the configuration file and save any custom
         // template bindings in the details store.
         this._parseConfig(this.config);
-        this.$vApp.$watch(
+        let unwatch = this.$vApp.$watch(
             () => this.config,
             (value: DetailsConfig | undefined) => this._parseConfig(value)
         );
-    }
 
-    removed() {
-        this.$vApp.$store.unregisterModule('details');
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            // TODO: remove appbar buttons (blocked by #882)
+            unwatch();
+            this.$iApi.panel.remove('details-items-panel');
+            this.$iApi.panel.remove('details-layers-panel');
+
+            /*
+                TODO: Fix this hack!
+
+                Removing the layers panel will close it first.
+
+                However when a panel closes, it plays a fade-out animation for 1 second before actually closing.
+
+                During the animation, the component is still active and so unregistering the details store below
+                will trigger the payload watcher in the layers panel, which causes an exception because the
+                watcher is directly bound to the vuex path - which doesn't exist anymore.
+
+                Hence we delay unregistering the details by 1.2s to ensure the layers panel is completely closed
+                and unmounted.
+            */
+            setTimeout(
+                () => this.$vApp.$store.unregisterModule('details'),
+                1200
+            );
+        };
     }
 }
 

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -152,7 +152,6 @@ export default defineComponent({
         return {
             defaultTemplates: get(DetailsStore.defaultTemplates),
             templateBindings: get(DetailsStore.templates),
-            payload: get(DetailsStore.payload),
             getLayerByUid: get('layer/getLayerByUid'),
             identifyTypes: IdentifyResultFormat.UNKNOWN,
             icon: '' as string,

--- a/src/fixtures/details/result-screen.vue
+++ b/src/fixtures/details/result-screen.vue
@@ -54,7 +54,6 @@
 import { defineComponent } from 'vue';
 import type { PropType } from 'vue';
 import { get } from '@/store/pathify-helper';
-import { DetailsStore } from './store';
 
 import type { LayerInstance, PanelInstance } from '@/api';
 import type { IdentifyResult } from '@/geo/api';
@@ -78,7 +77,6 @@ export default defineComponent({
     },
     data() {
         return {
-            payload: get(DetailsStore.payload),
             getLayerByUid: get('layer/getLayerByUid'),
             icon: [] as string[]
         };

--- a/src/fixtures/export-basic/index.ts
+++ b/src/fixtures/export-basic/index.ts
@@ -4,6 +4,10 @@ import ExportBasicAppbarButtonV from './appbar-button.vue';
 import ExportBasicScreenV from './screen.vue';
 
 import messages from './lang/lang.csv?raw';
+import ExportBasicTitleFixture from '../export-basic-title';
+import ExportBasicMapFixture from '../export-basic-map';
+import ExportBasicLegendFixture from '../export-basic-legend';
+
 class ExportBasicFixture extends ExportBasicAPI {
     initialized(): void {
         // load sub-fixtures required by the export-basic
@@ -40,6 +44,20 @@ class ExportBasicFixture extends ExportBasicAPI {
 
     removed(): void {
         console.log(`[fixture] ${this.id} removed`);
+        // TODO: remove appbar button (blocked by #882)
+
+        // remove sub fixtures
+        this.$iApi.fixture
+            .get<ExportBasicTitleFixture>('export-basic-title')
+            ?.remove();
+        this.$iApi.fixture
+            .get<ExportBasicMapFixture>('export-basic-map')
+            ?.remove();
+        this.$iApi.fixture
+            .get<ExportBasicLegendFixture>('export-basic-legend')
+            ?.remove();
+
+        this.$iApi.panel.remove('export-basic-panel');
     }
 }
 

--- a/src/fixtures/export-basic/screen.vue
+++ b/src/fixtures/export-basic/screen.vue
@@ -48,10 +48,12 @@ export default defineComponent({
 
     data(): {
         fixture: ExportBasicAPI | null;
+        resizeObserver: ResizeObserver | null;
         make: Function;
     } {
         return {
             fixture: null,
+            resizeObserver: null,
             make: debounce(300, function (this: any) {
                 if (!this.fixture) {
                     return;
@@ -69,12 +71,15 @@ export default defineComponent({
 
     mounted() {
         this.fixture = this.$iApi.fixture.get('export-basic') as ExportBasicAPI;
-
-        const resizeObserver = new ResizeObserver(() => {
+        this.resizeObserver = new ResizeObserver(() => {
             this.make();
         });
+        this.resizeObserver.observe(this.$el);
+    },
 
-        resizeObserver.observe(this.$el);
+    beforeUnmount() {
+        // remove the resize observer
+        this.resizeObserver!.disconnect();
     }
 });
 </script>

--- a/src/fixtures/geosearch/bottom-filters.vue
+++ b/src/fixtures/geosearch/bottom-filters.vue
@@ -42,7 +42,7 @@ export default defineComponent({
         };
     },
 
-    created() {
+    mounted() {
         // TODO decide if this event handler should go into the default ramp events, or remain as hard-bound to geosearch.
         //      hard-bound means no one outside can un-hook and replace with a different reaction.
         //      going default means the handler function needs to be public / on the geosearch api.
@@ -56,8 +56,6 @@ export default defineComponent({
     },
 
     /**
-     * beforeUnmount lifecycle hook (previously beforeDestroy in Vue2)
-     *
      * This is called while the component is still functional right before everything is removed.
      */
     beforeUnmount() {

--- a/src/fixtures/geosearch/index.ts
+++ b/src/fixtures/geosearch/index.ts
@@ -30,7 +30,10 @@ class GeosearchFixture extends GeosearchAPI {
     }
 
     removed() {
+        console.log(`[fixture] ${this.id} removed`);
+        // TODO: remove appbar button (blocked by #882)
         this.$vApp.$store.unregisterModule('geosearch');
+        this.$iApi.panel.remove('geosearch-panel');
     }
 }
 

--- a/src/fixtures/grid/api/grid.ts
+++ b/src/fixtures/grid/api/grid.ts
@@ -32,10 +32,7 @@ export class GridAPI extends FixtureInstance {
             this.$vApp.$store.set('grid/addGrid!', gridSettings);
         }
 
-        const prevUid = this.$vApp.$store.get(
-            GridStore.currentUid,
-            uid ? uid : null
-        );
+        const prevUid = this.$vApp.$store.get(GridStore.currentUid);
         this.$vApp.$store.set(GridStore.currentUid, uid ? uid : null);
 
         const panel = this.$iApi.panel.get('grid-panel');

--- a/src/fixtures/grid/index.ts
+++ b/src/fixtures/grid/index.ts
@@ -30,6 +30,8 @@ class GridFixture extends GridAPI {
     }
 
     removed() {
+        // TODO: remove appbar button (blocked by #882)
+        this.$iApi.panel.remove('grid-panel');
         this.$vApp.$store.unregisterModule('grid');
     }
 }

--- a/src/fixtures/grid/store/grid-store.ts
+++ b/src/fixtures/grid/store/grid-store.ts
@@ -38,8 +38,9 @@ const mutations = {
         state.grids = { ...state.grids, [value.uid]: value };
     },
     [GridMutation.REMOVE_GRID](state: GridState, uid: string): void {
-        // TODO: fix this
-        //Vue.delete(state.grids, uid);
+        if (state.grids[uid] !== undefined) {
+            delete state.grids[uid];
+        }
     }
 };
 

--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -57,6 +57,24 @@ export default defineComponent({
         });
     },
 
+    beforeUnmount() {
+        this.params.eGridCell.removeEventListener(
+            'keydown',
+            (e: KeyboardEvent) => {
+                if (e.key === 'Enter') {
+                    this.openDetails();
+                }
+            }
+        );
+
+        this.params.eGridCell.removeEventListener('focus', () => {
+            (this.$el as any)._tippy.show();
+        });
+        this.params.eGridCell.removeEventListener('blur', () => {
+            (this.$el as any)._tippy.hide();
+        });
+    },
+
     methods: {
         openDetails() {
             let data = Object.assign({}, this.params.data);

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -57,6 +57,23 @@ export default defineComponent({
         });
     },
 
+    beforeUnmount() {
+        this.params.eGridCell.removeEventListener(
+            'keydown',
+            (e: KeyboardEvent) => {
+                if (e.key === 'Enter') {
+                    this.zoomToFeature();
+                }
+            }
+        );
+        this.params.eGridCell.removeEventListener('focus', () => {
+            (this.$el as any)._tippy.show();
+        });
+        this.params.eGridCell.removeEventListener('blur', () => {
+            (this.$el as any)._tippy.hide();
+        });
+    },
+
     methods: {
         zoomToFeature() {
             const layer: LayerInstance | undefined = this.getLayerByUid(

--- a/src/fixtures/help/index.ts
+++ b/src/fixtures/help/index.ts
@@ -33,14 +33,19 @@ class HelpFixture extends HelpAPI {
         );
         // parse help section of config and store information in help store
         this._parseConfig(this.config);
-        this.$vApp.$watch(
+        let unwatch = this.$vApp.$watch(
             () => this.config,
             (value: any) => this._parseConfig(value)
         );
-    }
 
-    removed() {
-        this.$vApp.$store.unregisterModule('help');
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            // TODO: remove mapnav button (probably need to discuss how to do this properly)
+            unwatch();
+            this.$vApp.$store.unregisterModule('help');
+            this.$iApi.panel.remove('help-panel');
+        };
     }
 }
 

--- a/src/fixtures/help/screen.vue
+++ b/src/fixtures/help/screen.vue
@@ -46,60 +46,67 @@ export default defineComponent({
     data() {
         return {
             folderName: get(HelpStore.folderName),
-            helpSections: [] as Array<any>
+            helpSections: [] as Array<any>,
+            watchers: [] as Array<Function>
         };
     },
 
-    mounted() {
+    created() {
         // make help request when fixture loads or locale changes
-        this.$watch(
-            '$i18n.locale',
-            (newLocale: any, oldLocale: any) => {
-                if (newLocale === oldLocale) return;
-                // path to where HELP is hosted is different if RAMP is built as prod library
-                const base = '../help';
+        this.watchers.push(
+            this.$watch(
+                '$i18n.locale',
+                (newLocale: any, oldLocale: any) => {
+                    if (newLocale === oldLocale) return;
+                    // path to where HELP is hosted is different if RAMP is built as prod library
+                    const base = '../help';
 
-                const folder = this.folderName || 'default';
-                const renderer = new marked.Renderer();
-                // make it easier to use images in markdown by prepending path to href if href is not an external source
-                // this avoids the need for ![](help/images/myimg.png) to just ![](myimg.png). This overrides the default image renderer completely.
-                renderer.image = (href: string, title: string) => {
-                    if (href.indexOf('http') === -1) {
-                        href = `${base}/${folder}/images/` + href;
-                    }
-                    return `<img src="${href}" alt="${title}">`;
-                };
-                axios.get(`${base}/${folder}/${newLocale}.md`).then(r => {
-                    // matches help sections from markdown file where each section begins with one hashbang and a space
-                    // followed by the section header, exactly 2 newlines, then up to but not including a double newline
-                    // note that the {2,} below is used as the double line deparator since each double new line is actually 6
-                    // but we'll also accept more than a double space
-                    const reg = /^#\s(.*)\n{2}(?:.+|\n(?!\n{2,}))*/gm;
-                    // remove new line character ASCII (13) so that above regex is compatible with all
-                    // operating systems (markdown file varies by OS new line preference)
-                    let helpMd = r.data.replace(
-                        new RegExp(String.fromCharCode(13), 'g'),
-                        ''
-                    );
-                    this.helpSections = [];
-                    let section;
-                    while ((section = reg.exec(helpMd))) {
-                        this.helpSections.push({
-                            header: section[1],
-                            // parse markdown on info section, split/splice/join removes the header
-                            // since we can't put info section into its own regex grouping
-                            info: marked(
-                                section[0].split('\n').splice(2).join('\n'),
-                                {
-                                    renderer
-                                }
-                            )
-                        });
-                    }
-                });
-            },
-            { immediate: true }
+                    const folder = this.folderName || 'default';
+                    const renderer = new marked.Renderer();
+                    // make it easier to use images in markdown by prepending path to href if href is not an external source
+                    // this avoids the need for ![](help/images/myimg.png) to just ![](myimg.png). This overrides the default image renderer completely.
+                    renderer.image = (href: string, title: string) => {
+                        if (href.indexOf('http') === -1) {
+                            href = `${base}/${folder}/images/` + href;
+                        }
+                        return `<img src="${href}" alt="${title}">`;
+                    };
+                    axios.get(`${base}/${folder}/${newLocale}.md`).then(r => {
+                        // matches help sections from markdown file where each section begins with one hashbang and a space
+                        // followed by the section header, exactly 2 newlines, then up to but not including a double newline
+                        // note that the {2,} below is used as the double line deparator since each double new line is actually 6
+                        // but we'll also accept more than a double space
+                        const reg = /^#\s(.*)\n{2}(?:.+|\n(?!\n{2,}))*/gm;
+                        // remove new line character ASCII (13) so that above regex is compatible with all
+                        // operating systems (markdown file varies by OS new line preference)
+                        let helpMd = r.data.replace(
+                            new RegExp(String.fromCharCode(13), 'g'),
+                            ''
+                        );
+                        this.helpSections = [];
+                        let section;
+                        while ((section = reg.exec(helpMd))) {
+                            this.helpSections.push({
+                                header: section[1],
+                                // parse markdown on info section, split/splice/join removes the header
+                                // since we can't put info section into its own regex grouping
+                                info: marked(
+                                    section[0].split('\n').splice(2).join('\n'),
+                                    {
+                                        renderer
+                                    }
+                                )
+                            });
+                        }
+                    });
+                },
+                { immediate: true }
+            )
         );
+    },
+
+    beforeUnmount() {
+        this.watchers.forEach(unwatch => unwatch());
     },
 
     methods: {

--- a/src/fixtures/layer-reorder/index.ts
+++ b/src/fixtures/layer-reorder/index.ts
@@ -33,6 +33,8 @@ class LayerReorderFixture extends LayerReorderAPI {
 
     removed() {
         console.log(`[fixture] ${this.id} removed`);
+        // TODO: remove appbar button (blocked by #882)
+        this.$iApi.panel.remove('layer-reorder-panel'); 
     }
 }
 

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -2,7 +2,6 @@ import { FixtureInstance, LayerInstance } from '@/api';
 import { LegendStore } from '../store';
 import type { LegendConfig } from '../store';
 import { LegendItem, LegendEntry, LegendGroup } from '../store/legend-defs';
-import { LayerStore } from '@/store/modules/layer';
 
 export class LegendAPI extends FixtureInstance {
     /**
@@ -91,6 +90,11 @@ export class LegendAPI extends FixtureInstance {
         this.$vApp.$store.set(LegendStore.children, legendEntries);
 
         // TODO: validate legend items?
+
+        // update legend in case layers were added before the legend was created
+        this.$iApi.geo.layer.allLayers().forEach(l => {
+            this.updateLegend(l);
+        });
     }
 
     /**

--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -9,7 +9,8 @@
                     items-center
                     hover:bg-gray-200
                     ${
-                        legendItem._controlAvailable('datatable')
+                        legendItem._controlAvailable('datatable') &&
+                        getDatagridExists()
                             ? 'cursor-pointer'
                             : 'cursor-default'
                     }
@@ -20,7 +21,8 @@
                 @mouseover.stop="$event.currentTarget._tippy.show()"
                 @mouseout.self="$event.currentTarget._tippy.hide()"
                 :content="
-                    legendItem._controlAvailable('datatable')
+                    legendItem._controlAvailable('datatable') &&
+                    getDatagridExists()
                         ? $t('legend.entry.data')
                         : ''
                 "
@@ -145,7 +147,6 @@
                         v-if="isAnimationEnabled"
                     ></div>
                     <div class="flex-1 text-gray-500" v-truncate>
-                        <!-- TODO: add official translation -->
                         <span>{{ $t('legend.symbology.loading') }}</span>
                     </div>
                 </div>
@@ -158,7 +159,7 @@
 import { defineComponent, toRaw } from 'vue';
 import type { PropType } from 'vue';
 import { GlobalEvents } from '@/api';
-import { Controls, LegendEntry, LegendGroup } from '../store/legend-defs';
+import { Controls, LegendEntry } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
 import LegendSymbologyStackV from './symbology-stack.vue';
 import LegendOptionsV from './legend-options.vue';
@@ -239,7 +240,10 @@ export default defineComponent({
          * Toggles data table panel to open/close for the LegendItem.
          */
         toggleGrid(): void {
-            if (this.legendItem!._controlAvailable(Controls.Datatable)) {
+            if (
+                this.legendItem!._controlAvailable(Controls.Datatable) &&
+                this.getDatagridExists()
+            ) {
                 this.$iApi.event.emit(
                     GlobalEvents.GRID_TOGGLE,
                     this.legendItem!.layerUID
@@ -260,6 +264,17 @@ export default defineComponent({
             svg?.setAttribute('height', item.imgHeight);
             svg?.setAttribute('width', item.imgWidth);
             return span.outerHTML;
+        },
+
+        /**
+         * Indicates if the data grid fixture has been added
+         */
+        getDatagridExists(): boolean {
+            try {
+                return !!this.$iApi.fixture.get('grid');
+            } catch (e) {
+                return false;
+            }
         }
     }
 });

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -23,7 +23,9 @@
                 href="#"
                 class="flex leading-snug items-start w-auto"
                 :class="{
-                    disabled: !legendItem._controlAvailable(`metadata`)
+                    disabled:
+                        !legendItem._controlAvailable(`metadata`) ||
+                        !getFixtureExists('metadata')
                 }"
                 @click="toggleMetadata"
             >
@@ -39,7 +41,9 @@
                 href="#"
                 class="flex leading-snug items-center w-auto"
                 :class="{
-                    disabled: !legendItem._controlAvailable(`settings`)
+                    disabled:
+                        !legendItem._controlAvailable(`settings`) ||
+                        !getFixtureExists('settings')
                 }"
                 @click="toggleSettings"
             >
@@ -57,7 +61,9 @@
                 href="#"
                 class="flex leading-snug items-center w-auto"
                 :class="{
-                    disabled: !legendItem._controlAvailable(`datatable`)
+                    disabled:
+                        !legendItem._controlAvailable(`datatable`) ||
+                        !getFixtureExists('grid')
                 }"
                 @click="toggleGrid"
             >
@@ -163,7 +169,10 @@ export default defineComponent({
          * Toggles data table panel to open/close for the LegendItem.
          */
         toggleGrid() {
-            if (this.legendItem!._controlAvailable(Controls.Datatable)) {
+            if (
+                this.legendItem!._controlAvailable(Controls.Datatable) &&
+                this.getFixtureExists('grid')
+            ) {
                 this.$iApi.event.emit(
                     GlobalEvents.GRID_TOGGLE,
                     this.legendItem!.layerUID
@@ -175,7 +184,10 @@ export default defineComponent({
          * Toggles settings panel to open/close type for the LegendItem.
          */
         toggleSettings() {
-            if (this.legendItem!._controlAvailable(Controls.Settings)) {
+            if (
+                this.legendItem!._controlAvailable(Controls.Settings) &&
+                this.getFixtureExists('settings')
+            ) {
                 this.$iApi.event.emit(
                     GlobalEvents.SETTINGS_TOGGLE,
                     this.legendItem!.layerUID
@@ -187,6 +199,10 @@ export default defineComponent({
          * Toggles metadata panel to open/close for the LegendItem.
          */
         toggleMetadata() {
+            if (!this.getFixtureExists('metadata')) {
+                return;
+            }
+
             const metaConfig =
                 this.legendItem?.layer?.config.metadata ||
                 this.legendItem?.layer?.parentLayer?.config?.metadata ||
@@ -230,6 +246,17 @@ export default defineComponent({
         reloadLayer() {
             if (this.legendItem!._controlAvailable(Controls.Reload)) {
                 toRaw(this.legendItem!.layer!).reload();
+            }
+        },
+
+        /**
+         * Indicates if the fixture with the given name has been added
+         */
+        getFixtureExists(fixtureName: string): boolean {
+            try {
+                return !!this.$iApi.fixture.get(fixtureName);
+            } catch (e) {
+                return false;
             }
         }
     }

--- a/src/fixtures/legend/index.ts
+++ b/src/fixtures/legend/index.ts
@@ -26,21 +26,25 @@ class LegendFixture extends LegendAPI {
             }
         );
 
-        // TODO: register legend panel
         this.$iApi.component('legend-appbar-button', LegendAppbarButtonV);
         this.$vApp.$store.registerModule('legend', legend());
 
         // parse legend section of config and store information in legend store
-        this._parseConfig(this.config);
-
-        this.$vApp.$watch(
+        // here we create a copy of the config because the config parser will mutate the layer ids in the config
+        this._parseConfig(JSON.parse(JSON.stringify(this.config)));
+        let unwatch = this.$vApp.$watch(
             () => this.config,
-            (value: any) => this._parseConfig(value)
+            (value: any) => this._parseConfig(JSON.parse(JSON.stringify(value)))
         );
-    }
 
-    removed() {
-        this.$vApp.$store.unregisterModule('legend');
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            // TODO: remove appbar button (blocked by #882)
+            unwatch();
+            this.$iApi.panel.remove('legend-panel');
+            this.$vApp.$store.unregisterModule('legend');
+        };
     }
 }
 

--- a/src/fixtures/mapnav/index.ts
+++ b/src/fixtures/mapnav/index.ts
@@ -26,21 +26,26 @@ class MapnavFixture extends MapnavAPI {
         innerShell.appendChild(el.childNodes[0]);
 
         this._parseConfig(this.config);
-        this.$vApp.$watch(
+        let unwatch = this.$vApp.$watch(
             () => this.config,
             (value: MapnavFixtureConfig | undefined) => this._parseConfig(value)
         );
 
         // since components used in appbar can be registered after this point, listen to the global component registration event and re-validate items
         // TODO revist. this seems to be self-contained to the mapnav fixture, so ideally can stay as is and not worry about events api.
-        this.$iApi.event.on(
+        let handler = this.$iApi.event.on(
             GlobalEvents.COMPONENT,
             this._validateItems.bind(this)
         );
-    }
 
-    removed() {
-        this.$vApp.$store.unregisterModule('mapnav');
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            unwatch();
+            this.$vApp.$store.unregisterModule('mapnav');
+            this.$iApi.event.off(handler);
+            destroy();
+        };
     }
 }
 

--- a/src/fixtures/mapnav/store/mapnav-state.ts
+++ b/src/fixtures/mapnav/store/mapnav-state.ts
@@ -1,6 +1,6 @@
 export class MapnavState {
     /**
-     * A set of all open (visible and hidden) panels.
+     * A set of all open (visible and hidden) mapnav items.
      *
      * @type {MapnavItem[]}
      * @memberof MapnavState

--- a/src/fixtures/mapnav/store/mapnav-store.ts
+++ b/src/fixtures/mapnav/store/mapnav-store.ts
@@ -10,6 +10,14 @@ type MapnavContext = ActionContext<MapnavState, RootState>;
 type StoreActions = { [key: string]: Action<MapnavState, RootState> };
 type StoreMutations = { [key: string]: Mutation<MapnavState> };
 
+export enum MapnavAction {
+    REMOVE_ITEM = 'removeItem'
+}
+
+export enum MapnavMutation {
+    REMOVE_ITEM = 'REMOVE_ITEM'
+}
+
 const getters = {
     /**
      * Return a list of mapnav items with registered components (ones that can be rendered right now).
@@ -24,9 +32,24 @@ const getters = {
     }
 };
 
-const actions = {};
+const actions = {
+    [MapnavAction.REMOVE_ITEM](context: MapnavContext, value: string) {
+        const item = context.state.items[value];
+        if (item) {
+            context.commit(MapnavMutation.REMOVE_ITEM, item);
+        }
+    }
+};
 
-const mutations = {};
+const mutations = {
+    [MapnavMutation.REMOVE_ITEM](state: MapnavState, value: string) {
+        delete state.items[value];
+        let index = state.order.indexOf(value);
+        if (index !== -1) {
+            state.order.splice(index, 1);
+        }
+    }
+};
 
 export function mapnav() {
     const state = new MapnavState();

--- a/src/fixtures/metadata/index.ts
+++ b/src/fixtures/metadata/index.ts
@@ -22,19 +22,23 @@ class MetadataFixture extends MetadataAPI {
             { i18n: { messages } }
         );
 
-        const handler = (payload: any) => {
-            const metadataFixture: MetadataAPI =
-                this.$iApi.fixture.get('metadata');
-            metadataFixture.openMetadata(payload);
-        };
-
         this.$iApi.component('metadata-appbar-button', MetadataAppbarButtonV);
 
-        this.$iApi.event.on(
+        let handler = this.$iApi.event.on(
             GlobalEvents.METADATA_OPEN,
-            handler,
-            'metadata_opened_handler'
+            (payload: any) => {
+                const metadataFixture: MetadataAPI =
+                    this.$iApi.fixture.get('metadata');
+                metadataFixture.openMetadata(payload);
+            }
         );
+
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            // TODO: remove appbar button (blocked by #882)
+            this.$iApi.event.off(handler);
+            this.$iApi.panel.remove('metadata-panel');
+        };
     }
 }
 

--- a/src/fixtures/northarrow/northarrow.vue
+++ b/src/fixtures/northarrow/northarrow.vue
@@ -21,6 +21,7 @@ import {
 } from '@/geo/api';
 import flag from './flag.json';
 import { debounce } from 'throttle-debounce';
+import { POLE_MARKER_LAYER_ID } from '.'; // imports from index.ts
 
 export default defineComponent({
     name: 'NortharrowV',
@@ -41,7 +42,8 @@ export default defineComponent({
                     <path id="path6038" d="M297.256 144.666l-7.726 19.568 7.726-7.726" fill="#6d6d6d" stroke-width=".296" stroke-linecap="square"/>
                 </g>
             </svg>`,
-            poleMarkerAdded: false
+            poleMarkerAdded: false,
+            handlers: [] as Array<string>
         };
     },
 
@@ -54,10 +56,17 @@ export default defineComponent({
         if (this.$iApi.geo.map.esriView?.ready) {
             this.updateNortharrow(this.$iApi.geo.map.getExtent());
         }
-        this.$iApi.event.on(
-            GlobalEvents.MAP_EXTENTCHANGE,
-            debounce(300, this.updateNortharrow)
+
+        this.handlers.push(
+            this.$iApi.event.on(
+                GlobalEvents.MAP_EXTENTCHANGE,
+                debounce(300, this.updateNortharrow)
+            )
         );
+    },
+
+    beforeUnmount() {
+        this.handlers.forEach(h => this.$iApi.event.off(h));
     },
 
     methods: {
@@ -146,7 +155,7 @@ export default defineComponent({
 
                         const poleLayer =
                             await this.$iApi.geo.layer.createLayer({
-                                layerId: 'PoleMarker',
+                                id: POLE_MARKER_LAYER_ID,
                                 layerType: LayerType.GRAPHIC,
                                 cosmetic: true // mark this layer as a cosmetic layer
                             });

--- a/src/fixtures/overviewmap/index.ts
+++ b/src/fixtures/overviewmap/index.ts
@@ -15,7 +15,7 @@ class OverviewmapFixture extends OverviewmapAPI {
         );
 
         this._parseConfig(this.config);
-        this.$vApp.$watch(
+        let unwatch = this.$vApp.$watch(
             () => this.config,
             (value: OverviewmapConfig | undefined) => this._parseConfig(value)
         );
@@ -26,11 +26,14 @@ class OverviewmapFixture extends OverviewmapAPI {
         const innerShell =
             this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);
-    }
 
-    removed() {
-        console.log(`[fixture] ${this.id} removed`);
-        this.$vApp.$store.unregisterModule('overviewmap');
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            unwatch();
+            this.$vApp.$store.unregisterModule('overviewmap');
+            destroy();
+        };
     }
 }
 

--- a/src/fixtures/overviewmap/overviewmap.vue
+++ b/src/fixtures/overviewmap/overviewmap.vue
@@ -65,17 +65,11 @@ export default defineComponent({
             mapConfig: get(OverviewmapStore.mapConfig),
             basemaps: get(OverviewmapStore.basemaps),
             startMinimized: get(OverviewmapStore.startMinimized),
-
-            // TODO: find a way to fix this declaration (should be something like overviewMap: OverviewMapAPI but that gave a compile error)
             overviewMap: new OverviewMapAPI(this.$iApi),
             minimized: true,
             hoverOnExtent: false,
             handlers: [] as Array<string>
         };
-    },
-
-    created() {
-        this.overviewMap = new OverviewMapAPI(this.$iApi);
     },
 
     mounted() {
@@ -96,6 +90,13 @@ export default defineComponent({
                         this.overviewMap.updateOverview(newExtent);
                     }
                 )
+            );
+
+            // adapt the overview map's basemap whenever the main map is created
+            this.handlers.push(
+                this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
+                    this._adaptBasemap();
+                })
             );
 
             // adapt the overview map's basemap whenever the main map refreshes
@@ -139,6 +140,10 @@ export default defineComponent({
     beforeUnmount() {
         // Remove all event handlers for this component
         this.handlers.forEach(handler => this.$iApi.event.off(handler));
+
+        this.overviewMap.destroyMap();
+        this.overviewMap = undefined;
+        delete this.overviewMap;
     },
 
     methods: {

--- a/src/fixtures/panguard/index.ts
+++ b/src/fixtures/panguard/index.ts
@@ -16,10 +16,12 @@ class PanguardFixture extends FixtureInstance {
         const innerShell =
             this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);
-    }
 
-    removed(): void {
-        console.log(`[fixture] ${this.id} removed`);
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            destroy();
+        };
     }
 }
 

--- a/src/fixtures/scrollguard/index.ts
+++ b/src/fixtures/scrollguard/index.ts
@@ -15,7 +15,7 @@ class ScrollguardFixture extends ScrollguardAPI {
         this.$vApp.$store.registerModule('scrollguard', scrollguard());
 
         this._parseConfig(this.config);
-        this.$vApp.$watch(
+        let unwatch = this.$vApp.$watch(
             () => this.config,
             (value: ScrollguardConfig | undefined) => this._parseConfig(value)
         );
@@ -23,13 +23,18 @@ class ScrollguardFixture extends ScrollguardAPI {
         const { vNode, destroy, el } = this.mount(ScrollguardV, {
             app: this.$element
         });
+
         const innerShell =
             this.$vApp.$el.getElementsByClassName('inner-shell')[0];
         innerShell.appendChild(el.childNodes[0]);
-    }
 
-    removed(): void {
-        console.log(`[fixture] ${this.id} removed`);
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            unwatch();
+            this.$vApp.$store.unregisterModule('scrollguard');
+            destroy();
+        };
     }
 }
 

--- a/src/fixtures/scrollguard/map-scrollguard.vue
+++ b/src/fixtures/scrollguard/map-scrollguard.vue
@@ -20,6 +20,15 @@ export default defineComponent({
             capture: true
         });
     },
+    beforeUnmount() {
+        (
+            this.$iApi.$vApp.$el.querySelector(
+                '.inner-shell + .esri-view'
+            )! as HTMLElement
+        ).removeEventListener('wheel', this.wheelHandler, {
+            capture: true
+        });
+    },
     data() {
         return {
             enabled: get(ScrollguardStore.enabled)

--- a/src/fixtures/settings/index.ts
+++ b/src/fixtures/settings/index.ts
@@ -25,6 +25,12 @@ class SettingsFixture extends SettingsAPI {
 
         this.$iApi.component('settings-appbar-button', SettingsAppbarButtonV);
     }
+
+    removed() {
+        console.log(`[fixture] ${this.id} removed`);
+        // TODO: handle appbar button (blocked by #882)
+        this.$iApi.panel.remove('settings-panel');
+    }
 }
 
 export default SettingsFixture;

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -125,16 +125,21 @@ export default defineComponent({
             opacityModel: this.layer.opacity * 100,
             identifyModel: this.layer.identify,
             snapshotToggle: false,
-            handlers: [] as Array<string>
+            handlers: [] as Array<string>,
+            watchers: [] as Array<Function>
         };
     },
-    watch: {
-        uid(newUid: string, oldUid: string) {
-            if (newUid !== oldUid) {
-                this.loadLayerProperties();
-            }
-        }
+
+    created() {
+        this.watchers.push(
+            this.$watch('uid', (newUid: string, oldUid: string) => {
+                if (newUid !== oldUid) {
+                    this.loadLayerProperties();
+                }
+            })
+        );
     },
+
     mounted() {
         this.loadLayerProperties();
 
@@ -163,8 +168,9 @@ export default defineComponent({
         );
     },
     beforeUnmount() {
-        // Remove all event handlers for this component
+        // Remove all event handlers and watchers for this component
         this.handlers.forEach(handler => this.$iApi.event.off(handler));
+        this.watchers.forEach(unwatch => unwatch());
     },
     methods: {
         // Update the layer visibility.

--- a/src/fixtures/settings/templates/slider-control.vue
+++ b/src/fixtures/settings/templates/slider-control.vue
@@ -33,18 +33,28 @@ export default defineComponent({
             required: true
         }
     },
-    watch: {
-        // watch the config for changes to the opacity value
-        config: {
-            handler(newConfig) {
-                this.value = newConfig.value;
-            },
-            deep: true
-        }
+
+    created() {
+        this.watchers.push(
+            // watch the config for changes to the opacity value
+            this.$watch(
+                'config',
+                (newConfig: any) => {
+                    this.value = newConfig.value;
+                },
+                { deep: true }
+            )
+        );
     },
+
+    beforeUnmount() {
+        this.watchers.forEach(unwatch => unwatch());
+    },
+
     data() {
         return {
-            value: this.config.value
+            value: this.config.value,
+            watchers: [] as Array<Function>
         };
     }
 });

--- a/src/fixtures/settings/templates/toggle-switch-control.vue
+++ b/src/fixtures/settings/templates/toggle-switch-control.vue
@@ -58,21 +58,32 @@ export default defineComponent({
         return {
             isOn: this.config.value,
             isDisabled: !!this.config.disabled,
-            toggleKey: 0 // this key forces Vue to rerender Toggle
+            toggleKey: 0, // this key forces Vue to rerender Toggle
+            watchers: [] as Array<Function>
         };
     },
-    watch: {
-        config: {
-            handler(nConf, oConf) {
-                this.isOn = nConf.value;
-                this.isDisabled = !!nConf.disabled;
-                // The Toggle component has a bug where if doesn't update its css classes when the disabled property changes.
-                // The :key binding on the Toggle template is incremented if disabled changes, forcing a rerender
-                this.toggleKey += this.isDisabled !== oConf.disabled ? 1 : 0;
-            },
-            deep: true
-        }
+
+    created() {
+        this.watchers.push(
+            this.$watch(
+                'config',
+                (nConf: any, oConf: any) => {
+                    this.isOn = nConf.value;
+                    this.isDisabled = !!nConf.disabled;
+                    // The Toggle component has a bug where if doesn't update its css classes when the disabled property changes.
+                    // The :key binding on the Toggle template is incremented if disabled changes, forcing a rerender
+                    this.toggleKey +=
+                        this.isDisabled !== oConf.disabled ? 1 : 0;
+                },
+                { deep: true }
+            )
+        );
     },
+
+    beforeUnmount() {
+        this.watchers.forEach(unwatch => unwatch());
+    },
+
     methods: {
         handleKeyup() {
             if (!this.isDisabled) {

--- a/src/fixtures/wizard/index.ts
+++ b/src/fixtures/wizard/index.ts
@@ -26,15 +26,19 @@ class WizardFixture extends WizardAPI {
             }
         );
 
-        this.$vApp.$store.registerModule('wizard', wizard());
-        this.$vApp.$store.set(
-            'wizard/layerSource',
-            new LayerSource(this.$iApi)
-        );
-    }
+        let layerSource: LayerSource | undefined = new LayerSource(this.$iApi);
 
-    removed() {
-        this.$vApp.$store.unregisterModule('wizard');
+        this.$vApp.$store.registerModule('wizard', wizard());
+        this.$vApp.$store.set('wizard/layerSource', layerSource);
+
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            // TODO: handle appbar button (blocked by #882)
+            this.$iApi.panel.remove('wizard-panel');
+            this.$vApp.$store.unregisterModule('wizard');
+            layerSource = undefined; // will be cleaned up by JS garbage collector
+        };
     }
 }
 

--- a/src/fixtures/wizard/stepper.vue
+++ b/src/fixtures/wizard/stepper.vue
@@ -16,6 +16,12 @@ export default defineComponent({
         }
     },
 
+    data() {
+        return {
+            watchers: [] as Array<Function>
+        };
+    },
+
     setup(props) {
         const stepper = reactive({
             activeIndex: props.activeStep,
@@ -27,10 +33,16 @@ export default defineComponent({
         return { stepper };
     },
 
-    watch: {
-        activeStep() {
-            this.stepper.activeIndex = this.activeStep;
-        }
+    created() {
+        this.watchers.push(
+            this.$watch('activeStep', () => {
+                this.stepper.activeIndex = this.activeStep;
+            })
+        );
+    },
+
+    beforeUnmount() {
+        this.watchers.forEach(unwatch => unwatch());
     }
 });
 </script>

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -197,7 +197,7 @@ export class LayerAPI extends APIScope {
      *
      * @param layerId layer id or uid of the layer
      */
-    getLayer(layerId: string): LayerInstance {
+    getLayer(layerId: string): LayerInstance | undefined {
         // since this would be a fairly common thing to want to do via the instance API,
         // this function acts as a nice / obvious endpoint and saves caller
         // from figuring out how to use the store.
@@ -211,15 +211,6 @@ export class LayerAPI extends APIScope {
             layer = this.$iApi.$vApp.$store.get(
                 LayerStore.getLayerByUid,
                 layerId
-            );
-        }
-
-        if (!layer) {
-            // TODO better to return undefined and console.error?
-            //      Returning undefined means function has two return types,
-            //      and makes caller always validate/cast to shut up typescript.
-            throw new Error(
-                `Could not find layer associated with '${layerId}'`
             );
         }
 

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -127,27 +127,63 @@ export class CommonMapAPI extends APIScope {
     }
 
     /**
+     * Destroys the ESRI map
+     *
+     * @protected
+     */
+    protected destroyMap(): void {
+        if (!this.esriMap || !this.esriView) {
+            this.noMapErr();
+            return;
+        }
+
+        // destroy the map view first
+        this.destroyMapView();
+
+        // destroy the map
+        this.esriMap.destroy();
+        delete this.esriMap;
+
+        // clear local basemap store
+        this._basemapStore.forEach(bm => bm.esriBasemap.destroy());
+        this._basemapStore = [];
+    }
+
+    /**
+     * Reloads the map with the given map config and target div
+     *
+     * @param {RampMapConfig} config the config for the map
+     * @param {string | HTMLDivElement | undefined} targetDiv the div to be used for the map view
+     */
+    reloadMap(config: RampMapConfig, targetDiv: string | HTMLDivElement): void {
+        if (!this.esriMap || !this.esriView) {
+            this.noMapErr();
+            return;
+        }
+        this.destroyMap();
+        this.createMap(config, targetDiv);
+    }
+
+    /**
      * Will generate a ESRI map view and add it to the page
      * Can optionally provide the basemap or basemap id to be used when creating the map view
      *
      * This method should be overidden by child map classes
      *
      * @param {string | Basemap | undefined} basemap the id of the basemap that should be used when creating the map view
-     * @private
-     * @abstract
+     * @protected
      */
     protected createMapView(basemap?: string | Basemap): void {
         this.abstractError();
     }
 
     /**
-     * Refreshes the map view by destroying it first and then recreating it
-     * Can optionally provide the basemap or basemap id to be used when creating the map
+     * Destroys the ESRI map view
      *
-     * @param {string | Basemap | undefined} basemap the basemap or basemap id that should be used when recreating the map view
+     * @protected
      */
-    refreshMap(basemap?: string | Basemap): void {
-        if (!this.esriView || !this.esriMap) {
+    protected destroyMapView(): void {
+        if (!this.esriView) {
             this.noMapErr();
             return;
         }
@@ -172,8 +208,6 @@ export class CommonMapAPI extends APIScope {
         this.esriView.navigation = null;
         this.esriView.destroy();
         delete this.esriView;
-
-        this.createMapView(basemap);
     }
 
     /**

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -10,7 +10,8 @@ type PanelContext = ActionContext<PanelState, RootState>;
 
 export enum PanelAction {
     openPanel = 'openPanel',
-    closePanel = 'removePanel',
+    closePanel = 'closePanel',
+    removePanel = 'removePanel',
     setWidth = 'setWidth',
     setStackWidth = 'setStackWidth',
     updateVisible = 'updateVisible'
@@ -21,7 +22,8 @@ export enum PanelMutation {
     OPEN_PANEL = 'OPEN_PANEL',
 
     ADD_TO_PANEL_ORDER = 'ADD_TO_PANEL_ORDER',
-    CLOSE_PANEL = 'REMOVE_PANEL',
+    CLOSE_PANEL = 'CLOSE_PANEL',
+    REMOVE_PANEL = 'REMOVE_PANEL',
 
     SET_ORDERED_ITEMS = 'SET_ORDERED_ITEMS',
     SET_PRIORITY = 'SET_PRIORITY',
@@ -66,6 +68,18 @@ const actions = {
         }
 
         context.commit(PanelMutation.CLOSE_PANEL, value);
+        context.dispatch(PanelAction.updateVisible);
+    },
+
+    [PanelAction.removePanel](
+        context: PanelContext,
+        value: { panel: PanelConfig }
+    ): void {
+        if (context.state.priority === value.panel) {
+            context.commit(PanelMutation.SET_PRIORITY, null);
+        }
+
+        context.commit(PanelMutation.REMOVE_PANEL, value);
         context.dispatch(PanelAction.updateVisible);
     },
 
@@ -177,6 +191,30 @@ const mutations = {
                 ...state.orderedItems.slice(0, index),
                 ...state.orderedItems.slice(index + 1)
             ];
+        }
+    },
+
+    [PanelMutation.REMOVE_PANEL](
+        state: PanelState,
+        { panel }: { panel: PanelInstance }
+    ): void {
+        // remove from items
+        if (state.items[panel.id] !== undefined) {
+            delete state.items[panel.id];
+        }
+
+        // remove from visible
+        const index = state.visible.indexOf(panel);
+        if (index !== -1) {
+            state.visible = [
+                ...state.visible.slice(0, index),
+                ...state.visible.slice(index + 1)
+            ];
+        }
+
+        // remove from pinner
+        if (state.pinned !== null && state.pinned.id == panel.id) {
+            state.pinned = null;
         }
     }
 };


### PR DESCRIPTION
## Closes #947

## Changes in this PR
- [FIX] All fixtures can be removed and will clean up properly
- [FIX] Updated all `watch` usages in components to the imperative `$watch()` instead to allow for proper removal
- [FIX] Legend items will no longer be stuck in placeholder state due to race condition
    - Also fixed bug where legend config parser was directly mutating the legend config in the store 
- [FIX] Add scrollguard config to schema
- [FEAT] Added `remove` method to `PanelAPI` that will remove registered panels
- [FEAT] Added RAMP reference as `window.debugInstance` in `demos/starter-scripts/main.js` for debugging
- [FEAT] MapAPI changes
	- Split old `reloadMap` method into `destroyMapView` and `createMapView` - these protected methods will be called in sequence in `setBasemap`
	- Added `destroyMap` protected method that first calls `destroyMapView`, then destroys the ESRI map and fires the `MAP_DESTROYED` event
	- Added new `reloadMap(rampConfig, targetDiv)` public method that first calls `destroyMap`, and then calls `createMap` with the given parameters

## Comments
- Appbar and mapnav buttons are not removed when fixtures are removed
	- Removing appbar buttons is blocked by #882
	- The mapnav api should be enhanced to follow the design of the appbar after so it can add/remove mapnav buttons as fixtures are added/removed
- Fixtures will not removed globally registered components (e.g. appbar buttons) when removed
	- These components will still be available after the fixture is removed and will be reused when the fixture is added back
	- Note that some fixtures (e.g. overviewmap) will mount components onto the Vue app instead of registering them - these components are properly destroyed when the fixture is removed
- I am currently using a hack in `details/index.ts` to delay the details store removal so that the layers screen store watcher doesn't trigger as it is closing (more details in the comment)
	- Is there a better way to do this?

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/947/demos/index.html)
### Steps to test

- Try removing fixtures with: `window.debugInstance.fixture.remove(<fixture_name>)`
	- The fixture should be removed from UI, vuex store, and any other references
- Try adding the same fixture back with: `window.debugInstance.fixture.add(<fixture_name>)`
	- The fixture should be added back and should function properly
- Try calling `window.debugInstance.geo.map.reloadMap(<map config>, window.debugInstance.geo.map._targetDiv)` with a different map config
	- The map should reload with the new map config (all layers will be deleted)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/976)
<!-- Reviewable:end -->
