### PR TITLE
Implementation for greedy auto open identify item screen

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -42,6 +42,12 @@ export enum GlobalEvents {
     CONFIG_CHANGE = 'config/configchanged',
 
     /**
+     * Fires when details panel is closed.
+     * Payload: none
+     */
+    DETAILS_CLOSED = 'details/closed',
+
+    /**
      * Fires when a request is issued to show the details of an identify result.
      * Payload: `({ identifyItem: IdentifyItem, uid: string })`
      */

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -30,12 +30,6 @@ export class DetailsAPI extends FixtureInstance {
                 id: 'details-layers-panel'
             });
         }
-
-        // Close the items panel.
-        const itemsPanel = this.$iApi.panel.get('details-items-panel');
-        if (itemsPanel.isOpen) {
-            itemsPanel.close();
-        }
     }
 
     /**

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -5,7 +5,7 @@
         </template>
         <template #controls>
             <minimize @click="panel.minimize()" />
-            <close @click="panel.close()" />
+            <close @click="close()" />
         </template>
         <template #content>
             <div v-if="result.loaded">
@@ -120,6 +120,7 @@ import { get } from '@/store/pathify-helper';
 import { DetailsStore } from './store';
 
 import type { LayerInstance, PanelInstance } from '@/api/internal';
+import { GlobalEvents } from '@/api';
 import { IdentifyResultFormat } from '@/geo/api';
 
 import type { FieldDefinition, IdentifyResult, IdentifyItem } from '@/geo/api';
@@ -243,6 +244,14 @@ export default defineComponent({
         }
     },
     methods: {
+        /**
+         * Close details screen
+         */
+        close() {
+            this.panel.close();
+            this.$iApi.event.emit(GlobalEvents.DETAILS_CLOSED);
+        },
+
         /**
          * Initialize the details screen
          */

--- a/src/fixtures/details/layers-screen.vue
+++ b/src/fixtures/details/layers-screen.vue
@@ -4,8 +4,8 @@
             {{ $t('details.layers.title') }}
         </template>
         <template #controls>
-            <minimize @click="panel.minimize()"></minimize>
-            <close @click="panel.close()"></close>
+            <minimize @click="panel?.minimize()"></minimize>
+            <close @click="panel?.close()"></close>
         </template>
         <template #content>
             <!-- Grond total -->
@@ -57,6 +57,7 @@ export default defineComponent({
     data() {
         return {
             layerResults: [] as Array<IdentifyResult>,
+            lastLayerId: '' as string,
             payload: get(DetailsStore.payload),
             getLayerByUid: get('layer/getLayerByUid'),
             layers: get('layer/layers'),
@@ -97,7 +98,7 @@ export default defineComponent({
          * Load identify result items after all item's load promise has resolved
          */
         loadPayloadItems(newPayload: Array<IdentifyResult>): void {
-            // Note the incoming payload array needs to be made reactive at the source,
+            // NOTE: the incoming payload array needs to be made reactive at the source,
             // i.e. in the layer that ran the identify and created this stuff.
             // Not ideal. Have tried a number of workarounds but vue remains
             // disrespectful in ignoring changes to array elements and updating
@@ -119,6 +120,9 @@ export default defineComponent({
 
             this.layerResults = newPayload;
 
+            // procedure to auto open the individual item panel whenever possible
+            this.autoOpen(newPayload);
+
             // also wait for everything to finish so we can display a grand total
             Promise.all(
                 newPayload.map((item: IdentifyResult) => item.loading)
@@ -134,6 +138,80 @@ export default defineComponent({
         },
 
         /**
+         * Multiple greedy approach to auto-open identify item panel explained as follows:
+         * A new array of promises (loadingResults) is created that resolves for each item when it is done loading and contains non-empty results count, and is rejected otherwise.
+         * Case 1 - if no identify panels are open or only the identify summary panel is open:
+         *              wait for any of the promises to resolve and open the item screen for the first that does, track this layer ID (also tracked if item screen opened manually)
+         *              if no promises resolve, user clicked on empty map point with no data so reset last layer ID to none and close items screen
+         * Case 2 - if item panel is already open for a layer:
+         *              this layer takes priority so wait for it to resolve first, if there are new results refresh the panel to update
+         *              otherwise if there are no results for this previously open layer, follow the same steps as for case 1
+         */
+        autoOpen(newPayload: Array<IdentifyResult>): void {
+            // if the item panel is already open for a layer, wait on that layer to resolve first
+            const itemsPanel = this.$iApi.panel.get('details-items-panel');
+            if (this.lastLayerId && itemsPanel.isOpen) {
+                const lastIdx = this.layerResults.findIndex(
+                    (item: IdentifyResult) => (item.uid = this.lastLayerId)
+                );
+
+                if (lastIdx !== -1) {
+                    const lastIdentify = this.layerResults[lastIdx];
+                    // wait on last opened layer to see if it resolves with new results
+                    lastIdentify.loading.then(() => {
+                        // otherwise proceed as normal in case 1 by opening item panel for any layer that resolves
+                        lastIdentify.items.length > 0
+                            ? this.openResult(lastIdx)
+                            : this.autoOpenAny(newPayload);
+                    });
+                } else {
+                    // if last opened layer no longer exists throw an error
+                    console.error(
+                        'Last opened layer ID for details cannot be found.'
+                    );
+                }
+            } else {
+                // if no identify item panel was open or no last layer is tracked, proceed with case 1
+                this.autoOpenAny(newPayload);
+            }
+        },
+
+        /**
+         * Helper function for greedy auto-open function, implementation for case 1.
+         */
+        autoOpenAny(newPayload: Array<IdentifyResult>): void {
+            const loadingResults = newPayload.map((item: IdentifyResult) => {
+                return item.loading.then(() =>
+                    item.items.length > 0
+                        ? Promise.resolve(item.uid)
+                        : Promise.reject()
+                );
+            });
+
+            // wait on any layer promise to resolve first with new identify results
+            Promise.any(loadingResults)
+                .then((res: any) => {
+                    const idx = this.layerResults.findIndex(
+                        (item: IdentifyResult) => item.uid === res
+                    );
+                    if (idx !== -1) {
+                        this.openResult(idx);
+                    }
+                })
+                .catch(() => {
+                    // no promise resolved, clicked on empty map point with no identify results
+                    // then clear the last tracked layer and close the items panel
+                    this.lastLayerId = '';
+                    const itemsPanel = this.$iApi.panel.get(
+                        'details-items-panel'
+                    );
+                    if (itemsPanel.isOpen) {
+                        itemsPanel.close();
+                    }
+                });
+        },
+
+        /**
          * Switches the panel screen to display the data for a given result.
          */
         openResult(index: number) {
@@ -143,6 +221,8 @@ export default defineComponent({
                 let props: any = {
                     result: this.payload[index]
                 };
+                // track last open layer ID every time item panel is opened
+                this.lastLayerId = this.payload[index].uid;
 
                 if (!itemsPanel.isOpen) {
                     // open the items panel

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -374,6 +374,7 @@ export interface IdentifyResult {
     uid: string; // this would match to the logical layer.
     loaded: boolean;
     loading: Promise<void>; // represents the list of results has been found, but the content of items in the array may still be resolving
+    requestTime: number; // tracks timestamp of identify request
 }
 
 export interface MapIdentifyResult {

--- a/src/geo/layer/esri-feature/index.ts
+++ b/src/geo/layer/esri-feature/index.ts
@@ -190,7 +190,8 @@ class FeatureLayer extends AttribLayer {
             items: [],
             loading: dProm.getPromise(),
             loaded: false,
-            uid: this.uid
+            uid: this.uid,
+            requestTime: Date.now()
         });
 
         // run a spatial query

--- a/src/geo/layer/esri-map-image/index.ts
+++ b/src/geo/layer/esri-map-image/index.ts
@@ -550,7 +550,8 @@ class MapImageLayer extends AttribLayer {
                 items: [],
                 loading: dProm.getPromise(),
                 loaded: false,
-                uid: sublayer.uid
+                uid: sublayer.uid,
+                requestTime: Date.now()
             });
 
             if (sublayer.geomType !== GeometryType.POLYGON && pointBuffer) {

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -275,7 +275,8 @@ export class FileLayer extends AttribLayer {
             items: [],
             loading: dProm.getPromise(),
             loaded: false,
-            uid: this.uid
+            uid: this.uid,
+            requestTime: Date.now()
         });
 
         // run a spatial query

--- a/src/geo/layer/ogc-wms/index.ts
+++ b/src/geo/layer/ogc-wms/index.ts
@@ -212,7 +212,8 @@ export default class WmsLayer extends CommonLayer {
             items: [],
             loading: dProm.getPromise(),
             loaded: false,
-            uid: this.uid
+            uid: this.uid,
+            requestTime: Date.now()
         });
 
         this.getFeatureInfo(

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -20,6 +20,7 @@ import {
 import type {
     GraphicHitResult,
     IdentifyParameters,
+    IdentifyResult,
     MapClick,
     MapIdentifyResult,
     RampBasemapConfig,
@@ -799,6 +800,12 @@ export class MapAPI extends CommonMapAPI {
                 return layer.runIdentify(p);
             })
             .flat();
+
+        // update each item with current timestamp
+        const timestamp = Date.now();
+        identifyResults.forEach((item: IdentifyResult) => {
+            item.requestTime = timestamp;
+        });
 
         const fullResult: MapIdentifyResult = {
             results: identifyResults,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,12 @@ export default defineConfig(({ command, mode }) => {
                     }
                 }
             };
+            baseConfig.resolve = {
+                alias: {
+                    '@': resolve(__dirname, 'src'),
+                    'vue': 'vue/dist/vue.esm-bundler.js'
+                }
+            }
         } else {
             baseConfig.publicDir = false;
             baseConfig.root = 'demos';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,9 @@ export default defineConfig(({ command, mode }) => {
                     input: {
                         main: '/index.html'
                     }
-                }
+                },
+                minify: 'esbuild',
+                target: 'esnext'
             };
         }
     } else {


### PR DESCRIPTION
Closes #730 
Closes #977 

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/730-greedy-identify/samples/index.html)

**Changes**: 
- added implementation for self opening identify item screen based on multiple greedy approach outlined [here](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/730#issuecomment-1080829006)
- fixed blank custom details templates by adding Vue alias in build config options
- changed details event handler logic by keeping details item panel open unless it is manually closed or user clicks on an empty map point with no identify results (previously the items panel was closed and re-opened on every map click)

**Expected behaviour**: 

When details item screen is not open: 
- any identify click that returns results will auto open the items screen for the first layer that resolves
- an empty identify map click returning no results at all, only the identify summary screen is displayed

When details item screen is open:
- the last layer with item screen open is watched first on any identify click:
    - if layer resolves with non-empty identify results, refresh items panel for that layer
    - otherwise, proceed with the same above logic as if details item screen is not open 
    - if no identify results are returned, close the open item panel

**Testing**: 

Ensure custom details templates are working. Check that the above self-open behaviour works as intended and any other missed edge cases that breaks functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/994)
<!-- Reviewable:end -->
