### PR TITLE
allow layer opacity and visibility to be undefined

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -317,8 +317,6 @@ let config = {
                         {
                             index: 5,
                             state: {
-                                opacity: 1,
-                                visibility: true
                             }
                         }
                     ],

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -312,8 +312,8 @@ export class CommonLayer extends LayerInstance {
         const esriConfig: any = {
             id: rampLayerConfig.id,
             url: rampLayerConfig.url,
-            opacity: rampLayerConfig?.state?.opacity,
-            visible: rampLayerConfig?.state?.visibility
+            opacity: rampLayerConfig?.state?.opacity ?? 1,
+            visible: rampLayerConfig?.state?.visibility ?? true
         };
 
         // TODO careful now. seems setting this willy nilly, even if undefined value, causes layer to keep pinging the server

--- a/src/geo/layer/esri-map-image/index.ts
+++ b/src/geo/layer/esri-map-image/index.ts
@@ -395,8 +395,8 @@ class MapImageLayer extends AttribLayer {
                     // apply any updates that were in the configuration snippets
                     const subC = subConfigs[mlFC.layerIdx];
                     if (subC) {
-                        mlFC.visibility = subC.state?.visibility || false;
-                        mlFC.opacity = subC.state?.opacity || 0;
+                        mlFC.visibility = subC.state?.visibility || true;
+                        mlFC.opacity = subC.state?.opacity || 1;
                         // mlFC.setQueryable(subC.state.identify); // TODO uncomment when done
                         mlFC.nameField = subC.nameField || mlFC.nameField || '';
                         mlFC.processFieldMetadata(subC.fieldMetadata);


### PR DESCRIPTION
Closes #993

Allows the `visibility` and `opacity` properties to be undefined in the layer schema. If they are undefined, opacity is set to 100% and visibility is set to true.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-993/samples/index.html).

The `visibility` and `opacity` properties were removed from the `Water Quality` layer for testing purposes. Notice that the visibility is still true, and opacity is set to 100%.

Side note: There seems to be a bug with the settings menu for the Clean Air layer that makes it not open (you can see this already exists on the [master branch](http://ramp4-app.azureedge.net/demo/branches/master/samples/index.html)). I'll log an issue for this (update: logged [here](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1005))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1004)
<!-- Reviewable:end -->
