### PR TITLE
Add sublayer opacity watcher

### DIFF
--- a/src/geo/layer/esri-map-image/index.ts
+++ b/src/geo/layer/esri-map-image/index.ts
@@ -347,6 +347,15 @@ class MapImageLayer extends AttribLayer {
                         );
                         (_sublayer.parentLayer as CommonLayer) // the parent of a MapImageSublayer must be a CommonLayer
                             ?.checkVisibility();
+                    }),
+                    subLayer.watch('opacity', (newval: number) => {
+                        this.$iApi.event.emit(
+                            GlobalEvents.LAYER_OPACITYCHANGE,
+                            {
+                                opacity: newval,
+                                uid: _sublayer.uid
+                            }
+                        );
                     })
                 );
             }


### PR DESCRIPTION
## Closes #895

## Changes
- Added MapImage sublayer opacity watcher that fires the `LAYER_OPACITYCHANGE` event

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1006)
<!-- Reviewable:end -->
