### PR TITLE
fix hidden legend group visibility

### DIFF
--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -135,6 +135,7 @@
                             :value="item"
                             :legendItem="legendItem"
                             :checked="item.visibility"
+                            :disabled="!legendItem._controlAvailable('visibility')"
                         />
                     </div>
                 </div>

--- a/src/fixtures/legend/store/legend-defs.ts
+++ b/src/fixtures/legend/store/legend-defs.ts
@@ -298,8 +298,9 @@ export class LegendEntry extends LegendItem {
             return;
         }
 
-        // if parent is turned off turn layer entry visiblity off
-        if (this._parent !== undefined && !this._parent.visibility) {
+        // if parent is turned off and this layer has the visibility control,
+        // turn layer entry visiblity off
+        if (this._parent !== undefined && !this._parent.visibility && this._controls.includes(Controls.Visibility)) {
             this._layer.visibility = false;
         } else if (this._parent?.type === LegendTypes.Set) {
             // toggle off visibility if entry is part of a visibility set with a set entry already toggled on


### PR DESCRIPTION
Closes #986 

This PR solves the problem outlined in the issue above. If the legend group is collapsed and the visibility is toggled, sublayers that do not have the visibility control will remain in their current state and will remain in that state when the legend group is expanded.

## Testing this PR

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-986/demos/index.html).

To test this PR, re-attempt these steps from the original issue:

1. Load the standard test page, let it load
2. Collapse the Visibility Set legend element.
3. Turn off visibility on the Visibility Set
4. Watch the one "locked" visibility layer stay visible.
5. Expand the Visibility Set legend element.

When the set is expanded, the layer should no longer turn invisible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1022)
<!-- Reviewable:end -->
