### PR TITLE
Fixed alignment of ➕ and 👁 icons on legend panel

### DIFF
--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -3,7 +3,7 @@
         <!-- open import wizard -->
         <button
             @click="openWizard"
-            class="relative mr-auto text-gray-500 hover:text-black p-8 mb-3"
+            class="relative mr-auto text-gray-500 hover:text-black mb-3"
             v-show="getWizardExists() && isControlAvailable('wizard')"
             :content="$t('legend.header.addlayer')"
             v-tippy="{ placement: 'right' }"
@@ -78,10 +78,7 @@
         >
             <template #header>
                 <div class="flex p-8">
-                    <svg
-                        class="fill-current w-18 h-18 mx-5"
-                        viewBox="0 0 23 21"
-                    >
+                    <svg class="fill-current w-18 h-18" viewBox="0 0 23 21">
                         <path
                             d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
                         />


### PR DESCRIPTION
Closes #941.

This PR adjusts padding to fix the alignment of the 'Add Layer' and 'Toggle Visibility' icons on the legend panel.

Before:
![161068501-9e1d2265-37f6-4b09-9060-ad6ed2c1bdec](https://user-images.githubusercontent.com/89807997/167696485-724bc876-44f7-4185-a7df-cb775085f157.png)

After:
![2022-05-10 14_21_41-ramp-core — Mozilla Firefox](https://user-images.githubusercontent.com/89807997/167696484-edb8b984-042e-45ae-9049-8216022a2255.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1024)
<!-- Reviewable:end -->
