### PR TITLE
fix grid column filter functionality and CSS

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -700,15 +700,13 @@ export default defineComponent({
 
             // default to regex filtering for text columns
             colDef.filterParams.textMatcher = function (
-                filter: any,
-                gridValue: any,
-                filterText: any
+                params: any
             ) {
                 // treat * as a regular special character
-                const newFilterText = filterText.replace(/\*/, '\\*');
+                const newFilterText = params.filterText.replace(/\*/, '\\*');
                 // surround filter text with .* to match anything before and after
                 const re = new RegExp(`^.*${newFilterText}.*`);
-                return re.test(gridValue);
+                return re.test(params.value);
             };
 
             // modified from: https://www.ag-grid.com/javascript-grid-filter-text/#text-formatter
@@ -1167,10 +1165,18 @@ interface ColumnDefinition {
 :deep(.ag-pinned-left-header .ag-header-cell) {
     padding: 0px !important;
 }
+:deep(.ag-floating-filter-full-body input) {
+    border-width: 2px;
+    padding: 5px;
+    background: white;
+}
 :deep(.ag-header-cell) {
     background: #f9f9f9;
 }
 :deep(.ag-root .rv-input::placeholder) {
+    font-size: 12px;
+}
+:deep(.ag-root .rv-input) {
     font-size: 12px;
 }
 


### PR DESCRIPTION
Closes #1007 

Fixes the broken grid column filters and makes the font slightly smaller in the input boxes to match the placeholder text.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-1007/demos/index.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1025)
<!-- Reviewable:end -->
