### PR TITLE
Fix Legend Options Dropdown

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div @focusout="closeDropdown">
         <button
             class="text-gray-500 hover:text-black dropdown-button"
             @click="open = !open"
@@ -16,7 +16,6 @@
         </button>
         <div
             v-show="open"
-            @blur="open = false"
             class="rv-dropdown shadow-md border border-gray:200 py-8 bg-white rounded z-10"
             :class="{ 'text-center': centered }"
             ref="dropdown"
@@ -104,8 +103,10 @@ export default defineComponent({
     },
 
     methods: {
-        closeDropdown() {
-            this.open = false;
+        closeDropdown(e: Event) {
+            if (!e.currentTarget.contains(e.relatedTarget)) {
+                this.open = false
+            }
         }
     }
 });

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -9,7 +9,7 @@
             <template #header>
                 <div class="flex p-8">
                     <svg
-                        class="fill-current w-18 h-18 mx-8"
+                        class="inline-block fill-current w-18 h-18 mx-8"
                         viewBox="0 0 23 21"
                     >
                         <path
@@ -21,7 +21,7 @@
             <!-- metadata -->
             <a
                 href="#"
-                class="flex leading-snug items-start w-auto"
+                class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
                         !legendItem._controlAvailable(`metadata`) ||
@@ -29,7 +29,7 @@
                 }"
                 @click="toggleMetadata"
             >
-                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                     <path
                         d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
                     />
@@ -39,7 +39,7 @@
             <!-- settings -->
             <a
                 href="#"
-                class="flex leading-snug items-center w-auto"
+                class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
                         !legendItem._controlAvailable(`settings`) ||
@@ -47,7 +47,7 @@
                 }"
                 @click="toggleSettings"
             >
-                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                     <g id="tune">
                         <path
                             d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "
@@ -59,7 +59,7 @@
             <!-- datatable -->
             <a
                 href="#"
-                class="flex leading-snug items-center w-auto"
+                class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
                         !legendItem._controlAvailable(`datatable`) ||
@@ -67,7 +67,7 @@
                 }"
                 @click="toggleGrid"
             >
-                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                     <path
                         d="M 4.00002,3L 20,3C 21.1046,3 22,3.89543 22,5L 22,20C 22,21.1046 21.1046,22 20,22L 4.00001,22C 2.89544,22 2.00001,21.1046 2.00001,20L 2.00002,5C 2.00002,3.89543 2.89545,3 4.00002,3 Z M 4.00002,7L 4.00001,10L 8,10L 8,7.00001L 4.00002,7 Z M 10,7.00001L 9.99999,10L 14,10L 14,7.00001L 10,7.00001 Z M 20,10L 20,7L 16,7.00001L 16,10L 20,10 Z M 4.00002,12L 4.00002,15L 8,15L 8,12L 4.00002,12 Z M 4.00001,20L 8,20L 8,17L 4.00002,17L 4.00001,20 Z M 9.99999,12L 9.99999,15L 14,15L 14,12L 9.99999,12 Z M 9.99999,20L 14,20L 14,17L 9.99999,17L 9.99999,20 Z M 20,20L 20,17L 16,17L 16,20L 20,20 Z M 20,12L 16,12L 16,15L 20,15L 20,12 Z "
                     />
@@ -77,13 +77,13 @@
             <!-- symbology stack -->
             <a
                 href="#"
-                class="flex leading-snug items-center w-auto"
+                class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled: !legendItem._controlAvailable(`symbology`)
                 }"
                 @click="toggleSymbology"
             >
-                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                     <path
                         d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
                     />
@@ -93,13 +93,13 @@
             <!-- boundary zoom -->
             <a
                 href="#"
-                class="flex leading-snug items-center w-auto"
+                class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled: !legendItem._controlAvailable(`boundaryZoom`)
                 }"
                 @click="zoomToLayerBoundary"
             >
-                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
                     <path
                         d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                     />
@@ -111,13 +111,13 @@
             <!-- remove -->
             <a
                 href="#"
-                class="flex leading-snug items-center w-auto"
+                class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled: !legendItem._controlAvailable(`remove`)
                 }"
                 @click="removeLayer"
             >
-                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
                     <path
                         d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
                     ></path>
@@ -127,13 +127,13 @@
             <!-- reload -->
             <a
                 href="#"
-                class="flex leading-snug items-center w-auto"
+                class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled: !legendItem._controlAvailable(`reload`)
                 }"
                 @click="reloadLayer"
             >
-                <svg class="fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
                     <path
                         d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
                     ></path>


### PR DESCRIPTION
Closes #973.

Fixed formatting of legend options dropdown menu. 

| Before | After |
| ------- | ------ |
|![before](https://user-images.githubusercontent.com/76517921/167710550-4a8483ec-6609-4b64-801b-cc4f343914ab.png)| ![after](https://user-images.githubusercontent.com/76517921/167710695-004a7dab-7c1f-4008-87ca-40948e4789a3.png)     |

<br />
<br />

Also fixed the bug where "opening the dropdown and then clicking off-screen closes the dropdown, but hovering over the legend item opens the dropdown". See below:
<br />

![pr](https://user-images.githubusercontent.com/76517921/167712841-ae0a768f-d8da-457d-8a45-b5732702559f.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1028)
<!-- Reviewable:end -->
