### PR TITLE
Implement layer based controls + Cascading overrides

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -584,7 +584,7 @@ let config = {
                             }
                         }
                     ],
-                    disabledControls: ['query', 'data']
+                    disabledControls: ['identify', 'data']
                 }
             ],
             fixtures: {

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -287,6 +287,9 @@ let config = {
                             fixtures: {
                                 details: {
                                     template: 'Water-Quantity-Template'
+                                },
+                                settings: {
+                                    controls: ['visibility', 'opacity']
                                 }
                             }
                         },
@@ -296,7 +299,8 @@ let config = {
                             state: {
                                 opacity: 0.5,
                                 visibility: true
-                            }
+                            },
+                            disabledControls: ['opacity']
                         }
                     ],
                     state: {
@@ -316,8 +320,7 @@ let config = {
                     layerEntries: [
                         {
                             index: 5,
-                            state: {
-                            }
+                            state: {}
                         }
                     ],
                     state: {
@@ -337,24 +340,26 @@ let config = {
                     },
                     tolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
-                },
-                {
-                    id: 'WFSLayer',
-                    layerType: 'ogc-wfs',
-                    url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
-                    state: {
-                        visibility: true
-                    },
-                    customRenderer: {},
-                    metadata: {
-                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/README.md'
-                    },
-                    fixtures: {
-                        details: {
-                            template: 'WFSLayer-Custom'
-                        }
-                    }
                 }
+                // TODO: Revisit this in #1002
+                // Removing WFS layer for now since it is breaking other layers
+                // {
+                //     id: 'WFSLayer',
+                //     layerType: 'ogc-wfs',
+                //     url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                //     state: {
+                //         visibility: true
+                //     },
+                //     customRenderer: {},
+                //     metadata: {
+                //         url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/README.md'
+                //     },
+                //     fixtures: {
+                //         details: {
+                //             template: 'WFSLayer-Custom'
+                //         }
+                //     }
+                // }
                 /*
             {
                 id: 'TestTile',
@@ -389,7 +394,8 @@ let config = {
                                 exclusiveVisibility: [
                                     {
                                         layerId: 'CleanAir',
-                                        name: 'Clean Air in Set'
+                                        name: 'Clean Air in Set',
+                                        disabledControls: ['boundaryZoom']
                                     },
                                     {
                                         name: 'Group in Set',
@@ -399,12 +405,10 @@ let config = {
                                                 name: 'Water Quantity in Nested Group',
                                                 entryIndex: 1,
                                                 controls: [
+                                                    'datatable',
                                                     'metadata',
-                                                    'boundaryZoom',
-                                                    'refresh',
                                                     'reload',
                                                     'remove',
-                                                    'datatable',
                                                     'settings',
                                                     'symbology'
                                                 ]
@@ -422,21 +426,22 @@ let config = {
                                         ]
                                     }
                                 ]
-                            },
-                            {
-                                layerId: 'WFSLayer',
-                                name: 'WFSLayer',
-                                controls: [
-                                    'metadata',
-                                    'boundaryZoom',
-                                    'refresh',
-                                    'reload',
-                                    'remove',
-                                    'datatable',
-                                    'settings',
-                                    'symbology'
-                                ]
                             }
+                            // TODO: Revisit this in #1002
+                            // {
+                            //     layerId: 'WFSLayer',
+                            //     name: 'WFSLayer',
+                            //     controls: [
+                            //         'metadata',
+                            //         'boundaryZoom',
+                            //         'refresh',
+                            //         'reload',
+                            //         'remove',
+                            //         'datatable',
+                            //         'settings',
+                            //         'symbology'
+                            //     ]
+                            // }
                         ]
                     }
                 },

--- a/schema.json
+++ b/schema.json
@@ -269,15 +269,7 @@
                 },
                 "controls": {
                     "$ref": "#/$defs/legendGroupControls",
-                    "default": [
-                        "opacity",
-                        "visibility",
-                        "symbology",
-                        "identify",
-                        "reload",
-                        "remove",
-                        "settings"
-                    ]
+                    "default": ["visibility"]
                 },
                 "disabledControls": {
                     "$ref": "#/$defs/legendGroupControls",
@@ -313,10 +305,10 @@
             "items": {
                 "type": "string",
                 "enum": [
-                    "wizard",
-                    "layerReorder",
                     "groupToggle",
-                    "visibilityToggle"
+                    "layerReorder",
+                    "visibilityToggle",
+                    "wizard"
                 ]
             },
             "uniqueItems": true
@@ -327,13 +319,13 @@
             "items": {
                 "type": "string",
                 "enum": [
-                    "opacity",
-                    "visibility",
-                    "symbology",
                     "identify",
+                    "opacity",
                     "reload",
                     "remove",
-                    "settings"
+                    "settings",
+                    "symbology",
+                    "visibility"
                 ]
             },
             "uniqueItems": true
@@ -344,18 +336,18 @@
             "items": {
                 "type": "string",
                 "enum": [
-                    "opacity",
-                    "visibility",
+                    "boundaryZoom",
                     "boundingBox",
+                    "datatable",
                     "identify",
                     "metadata",
-                    "boundaryZoom",
+                    "opacity",
                     "refresh",
                     "reload",
                     "remove",
                     "settings",
-                    "data",
-                    "styles"
+                    "symbology",
+                    "visibility"
                 ]
             },
             "uniqueItems": true
@@ -400,6 +392,13 @@
                     "type": "string",
                     "default": "",
                     "description": "Optional description displayed above the symbology stack on mouse hover."
+                },
+                "controls": {
+                    "$ref": "#/$defs/layerControls"
+                },
+                "disabledControls": {
+                    "$ref": "#/$defs/layerControls",
+                    "default": []
                 },
                 "symbologyStack": {
                     "$ref": "#/$defs/symbologyStack"
@@ -694,6 +693,7 @@
                 "controls": {
                     "$ref": "#/$defs/layerControls",
                     "default": [
+                        "datatable",
                         "opacity",
                         "visibility",
                         "boundingBox",
@@ -703,7 +703,8 @@
                         "refresh",
                         "reload",
                         "remove",
-                        "settings"
+                        "settings",
+                        "symbology"
                     ]
                 },
                 "disabledControls": {
@@ -859,7 +860,8 @@
                         "refresh",
                         "reload",
                         "remove",
-                        "settings"
+                        "settings",
+                        "symbology"
                     ]
                 },
                 "disabledControls": {
@@ -914,7 +916,25 @@
                     "$ref": "#/$defs/extentWithReferenceNode"
                 },
                 "controls": {
-                    "$ref": "#/$defs/layerControls"
+                    "$ref": "#/$defs/layerControls",
+                    "default": [
+                        "datatable",
+                        "opacity",
+                        "visibility",
+                        "boundingBox",
+                        "identify",
+                        "metadata",
+                        "boundaryZoom",
+                        "refresh",
+                        "reload",
+                        "remove",
+                        "settings",
+                        "symbology"
+                    ]
+                },
+                "disabledControls": {
+                    "$ref": "#/$defs/layerControls",
+                    "default": []
                 },
                 "state": {
                     "$ref": "#/$defs/initialLayerSettings"
@@ -1013,6 +1033,7 @@
                 "controls": {
                     "$ref": "#/$defs/layerControls",
                     "default": [
+                        "datatable",
                         "opacity",
                         "visibility",
                         "boundingBox",
@@ -1022,7 +1043,8 @@
                         "refresh",
                         "reload",
                         "remove",
-                        "settings"
+                        "settings",
+                        "symbology"
                     ]
                 },
                 "disabledControls": {
@@ -1108,6 +1130,7 @@
                 "controls": {
                     "$ref": "#/$defs/layerControls",
                     "default": [
+                        "datatable",
                         "opacity",
                         "visibility",
                         "boundingBox",
@@ -1117,7 +1140,8 @@
                         "refresh",
                         "reload",
                         "remove",
-                        "settings"
+                        "settings",
+                        "symbology"
                     ]
                 },
                 "disabledControls": {
@@ -1195,6 +1219,7 @@
                 "controls": {
                     "$ref": "#/$defs/layerControls",
                     "default": [
+                        "datatable",
                         "opacity",
                         "visibility",
                         "boundingBox",
@@ -1204,7 +1229,8 @@
                         "refresh",
                         "reload",
                         "remove",
-                        "settings"
+                        "settings",
+                        "symbology"
                     ]
                 },
                 "disabledControls": {
@@ -1331,7 +1357,8 @@
                         "refresh",
                         "reload",
                         "remove",
-                        "settings"
+                        "settings",
+                        "symbology"
                     ]
                 },
                 "disabledControls": {
@@ -1381,7 +1408,24 @@
                     "description": "Current style for the layer entry in the WMS."
                 },
                 "controls": {
-                    "$ref": "#/$defs/layerControls"
+                    "$ref": "#/$defs/layerControls",
+                    "default": [
+                        "opacity",
+                        "visibility",
+                        "boundingBox",
+                        "identify",
+                        "metadata",
+                        "boundaryZoom",
+                        "refresh",
+                        "reload",
+                        "remove",
+                        "settings",
+                        "symbology"
+                    ]
+                },
+                "disabledControls": {
+                    "$ref": "#/$defs/layerControls",
+                    "default": []
                 },
                 "state": {
                     "$ref": "#/$defs/initialLayerSettings"
@@ -1408,6 +1452,19 @@
                             "type": "boolean",
                             "default": true,
                             "description": "Allows individual symbols to have visibility toggled on/off."
+                        }
+                    }
+                },
+                "settings": {
+                    "type": "object",
+                    "description": "Layer-specific settings configuration",
+                    "properties": {
+                        "controls": {
+                            "$ref": "#/$defs/layerControls"
+                        },
+                        "disabledControls": {
+                            "$ref": "#/$defs/layerControls",
+                            "default": []
                         }
                     }
                 }

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -28,20 +28,12 @@ export class LegendAPI extends FixtureInstance {
             this.getLayerFixtureConfigs();
 
         // parse the header controls, or default the controls
-        let controls: Array<string> = [];
-        if (!legendConfig?.headerControls) {
-            // use the default controls
-            controls = [
-                'wizard',
-                'layerReorder',
-                'groupToggle',
-                'visibilityToggle'
-            ];
-        } else {
-            legendConfig.headerControls.forEach(control => {
-                controls.push(control);
-            });
-        }
+        let controls: Array<string> = legendConfig?.headerControls?.slice() ?? [
+            'wizard',
+            'layerReorder',
+            'groupToggle',
+            'visibilityToggle'
+        ];
         this.$vApp.$store.set(LegendStore.headerControls, controls);
 
         if (!legendConfig || !legendConfig.root.children) {

--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -9,7 +9,7 @@
                     items-center
                     hover:bg-gray-200
                     ${
-                        legendItem._controlAvailable('datatable') &&
+                        legendItem.controlAvailable('datatable') &&
                         getDatagridExists()
                             ? 'cursor-pointer'
                             : 'cursor-default'
@@ -21,7 +21,7 @@
                 @mouseover.stop="$event.currentTarget._tippy.show()"
                 @mouseout.self="$event.currentTarget._tippy.hide()"
                 :content="
-                    legendItem._controlAvailable('datatable') &&
+                    legendItem.controlAvailable('datatable') &&
                     getDatagridExists()
                         ? $t('legend.entry.data')
                         : ''
@@ -41,9 +41,9 @@
                         tabindex="-1"
                         :class="{
                             'cursor-default':
-                                !legendItem._controlAvailable('symbology')
+                                !legendItem.controlAvailable('symbology')
                         }"
-                        :disabled="!legendItem._controlAvailable('symbology')"
+                        :disabled="!legendItem.controlAvailable('symbology')"
                         :content="
                             legendItem.symbologyExpanded
                                 ? $t('legend.symbology.hide')
@@ -57,7 +57,7 @@
                         <symbology-stack
                             :class="{
                                 'pointer-events-none':
-                                    !legendItem._controlAvailable('symbology')
+                                    !legendItem.controlAvailable('symbology')
                             }"
                             class="w-32 h-32"
                             :visible="legendItem.symbologyExpanded"
@@ -87,7 +87,7 @@
                         legendItem.parent.type === 'VisibilitySet'
                     "
                     :legendItem="legendItem"
-                    :disabled="!legendItem._controlAvailable('visibility')"
+                    :disabled="!legendItem.controlAvailable('visibility')"
                 />
             </div>
         </div>
@@ -135,7 +135,9 @@
                             :value="item"
                             :legendItem="legendItem"
                             :checked="item.visibility"
-                            :disabled="!legendItem._controlAvailable('visibility')"
+                            :disabled="
+                                !legendItem.controlAvailable('visibility')
+                            "
                         />
                     </div>
                 </div>
@@ -160,11 +162,11 @@
 import { defineComponent, toRaw } from 'vue';
 import type { PropType } from 'vue';
 import { GlobalEvents } from '@/api';
-import { Controls, LegendEntry } from '../store/legend-defs';
+import type { LegendEntry } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
 import LegendSymbologyStackV from './symbology-stack.vue';
 import LegendOptionsV from './legend-options.vue';
-import type { LegendSymbology } from '@/geo/api';
+import { LayerControls, type LegendSymbology } from '@/geo/api';
 
 export default defineComponent({
     name: 'LegendEntryV',
@@ -225,7 +227,7 @@ export default defineComponent({
          * Display symbology stack for the layer.
          */
         toggleSymbology(): void {
-            if (this.legendItem!._controlAvailable(Controls.Symbology)) {
+            if (this.legendItem!.controlAvailable(LayerControls.Symbology)) {
                 const expanded = this.legendItem!.toggleSymbologyExpand();
                 this.$iApi.updateAlert(
                     this.$t(
@@ -242,7 +244,7 @@ export default defineComponent({
          */
         toggleGrid(): void {
             if (
-                this.legendItem!._controlAvailable(Controls.Datatable) &&
+                this.legendItem!.controlAvailable(LayerControls.Datatable) &&
                 this.getDatagridExists()
             ) {
                 this.$iApi.event.emit(

--- a/src/fixtures/legend/components/group.vue
+++ b/src/fixtures/legend/components/group.vue
@@ -47,6 +47,7 @@
                         legendItem.parent.type === LegendTypes.Set
                     "
                     :legendItem="legendItem"
+                    :disabled="!legendItem.controlAvailable('visibility')"
                 />
             </div>
         </div>

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -24,7 +24,7 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem._controlAvailable(`metadata`) ||
+                        !legendItem.controlAvailable(`metadata`) ||
                         !getFixtureExists('metadata')
                 }"
                 @click="toggleMetadata"
@@ -42,7 +42,7 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem._controlAvailable(`settings`) ||
+                        !legendItem.controlAvailable(`settings`) ||
                         !getFixtureExists('settings')
                 }"
                 @click="toggleSettings"
@@ -62,7 +62,7 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem._controlAvailable(`datatable`) ||
+                        !legendItem.controlAvailable(`datatable`) ||
                         !getFixtureExists('grid')
                 }"
                 @click="toggleGrid"
@@ -79,7 +79,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem._controlAvailable(`symbology`)
+                    disabled: !legendItem.controlAvailable(`symbology`)
                 }"
                 @click="toggleSymbology"
             >
@@ -95,7 +95,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem._controlAvailable(`boundaryZoom`)
+                    disabled: !legendItem.controlAvailable(`boundaryZoom`)
                 }"
                 @click="zoomToLayerBoundary"
             >
@@ -113,7 +113,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem._controlAvailable(`remove`)
+                    disabled: !legendItem.controlAvailable(`remove`)
                 }"
                 @click="removeLayer"
             >
@@ -129,7 +129,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem._controlAvailable(`reload`)
+                    disabled: !legendItem.controlAvailable(`reload`)
                 }"
                 @click="reloadLayer"
             >
@@ -146,21 +146,22 @@
 
 <script lang="ts">
 import { GlobalEvents } from '@/api';
+import { LayerControls } from '@/geo/api';
 import { defineComponent, toRaw } from 'vue';
-import type { PropType } from 'vue';
-import { Controls, LegendEntry } from '../store/legend-defs';
+import { LegendEntry } from '../store/legend-defs';
 
 export default defineComponent({
     name: 'LegendOptionsV',
     props: {
         legendItem: LegendEntry
     },
+
     methods: {
         /**
          * Display symbology stack for the layer.
          */
         toggleSymbology(): void {
-            if (this.legendItem!._controlAvailable(Controls.Symbology)) {
+            if (this.legendItem!.controlAvailable(LayerControls.Symbology)) {
                 this.legendItem!.toggleSymbologyExpand();
             }
         },
@@ -170,7 +171,7 @@ export default defineComponent({
          */
         toggleGrid() {
             if (
-                this.legendItem!._controlAvailable(Controls.Datatable) &&
+                this.legendItem!.controlAvailable(LayerControls.Datatable) &&
                 this.getFixtureExists('grid')
             ) {
                 this.$iApi.event.emit(
@@ -185,7 +186,7 @@ export default defineComponent({
          */
         toggleSettings() {
             if (
-                this.legendItem!._controlAvailable(Controls.Settings) &&
+                this.legendItem!.controlAvailable(LayerControls.Settings) &&
                 this.getFixtureExists('settings')
             ) {
                 this.$iApi.event.emit(
@@ -199,26 +200,27 @@ export default defineComponent({
          * Toggles metadata panel to open/close for the LegendItem.
          */
         toggleMetadata() {
-            if (!this.getFixtureExists('metadata')) {
-                return;
-            }
-
-            const metaConfig =
-                this.legendItem?.layer?.config.metadata ||
-                this.legendItem?.layer?.parentLayer?.config?.metadata ||
-                {};
-
-            const name = metaConfig?.name || this.legendItem?.layer?.name || '';
             if (
-                this.legendItem!._controlAvailable(Controls.Metadata) &&
-                metaConfig.url
+                this.legendItem!.controlAvailable(LayerControls.Metadata) &&
+                this.getFixtureExists('metadata')
             ) {
-                // TODO: toggle metadata panel through API/store call
-                this.$iApi.event.emit(GlobalEvents.METADATA_OPEN, {
-                    type: 'html',
-                    layerName: name,
-                    url: metaConfig.url
-                });
+                const metaConfig =
+                    this.legendItem?.layer?.config.metadata ||
+                    this.legendItem?.layer?.parentLayer?.config?.metadata ||
+                    {};
+                const name =
+                    metaConfig?.name || this.legendItem?.layer?.name || '';
+
+                if (metaConfig.url) {
+                    // TODO: toggle metadata panel through API/store call
+                    this.$iApi.event.emit(GlobalEvents.METADATA_OPEN, {
+                        type: 'html',
+                        layerName: name,
+                        url: metaConfig.url
+                    });
+                } else {
+                    console.warn('Layer does not have a metadata url defined');
+                }
             }
         },
 
@@ -226,7 +228,7 @@ export default defineComponent({
          * Zoom to the boundary of layer
          */
         zoomToLayerBoundary() {
-            if (this.legendItem!._controlAvailable(Controls.BoundaryZoom)) {
+            if (this.legendItem!.controlAvailable(LayerControls.BoundaryZoom)) {
                 this.legendItem?.layer?.zoomToLayerBoundary();
             }
         },
@@ -235,7 +237,7 @@ export default defineComponent({
          * Removes layer from map.
          */
         removeLayer() {
-            if (this.legendItem!._controlAvailable(Controls.Remove)) {
+            if (this.legendItem!.controlAvailable(LayerControls.Remove)) {
                 this.$iApi.geo.map.removeLayer(this.legendItem!.layerUID!);
             }
         },
@@ -244,7 +246,7 @@ export default defineComponent({
          * Reloads a layer on the map.
          */
         reloadLayer() {
-            if (this.legendItem!._controlAvailable(Controls.Reload)) {
+            if (this.legendItem!.controlAvailable(LayerControls.Reload)) {
                 toRaw(this.legendItem!.layer!).reload();
             }
         },

--- a/src/fixtures/settings/templates/input-control.vue
+++ b/src/fixtures/settings/templates/input-control.vue
@@ -8,6 +8,7 @@
                 class="rv-input text-md w-full"
                 type="number"
                 :value="config.value"
+                :disabled="isDisabled"
                 min="0"
                 max="100"
             />
@@ -36,6 +37,29 @@ export default defineComponent({
             type: String,
             required: true
         }
+    },
+    created() {
+        this.watchers.push(
+            // watch the config for changes to the disabled value
+            this.$watch(
+                'config',
+                (newConfig: any) => {
+                    this.isDisabled = !!newConfig.disabled;
+                },
+                { deep: true }
+            )
+        );
+    },
+
+    beforeUnmount() {
+        this.watchers.forEach(unwatch => unwatch());
+    },
+
+    data() {
+        return {
+            isDisabled: !!this.config.disabled,
+            watchers: [] as Array<Function>
+        };
     }
 });
 </script>
@@ -53,5 +77,8 @@ export default defineComponent({
     outline: none;
     border-bottom: 2px solid #ddd;
     margin-bottom: 0px;
+}
+.rv-input:disabled {
+    color: #ddd;
 }
 </style>

--- a/src/fixtures/settings/templates/slider-control.vue
+++ b/src/fixtures/settings/templates/slider-control.vue
@@ -9,6 +9,7 @@
                 class="mr-16"
                 @change="config.onChange"
                 v-model="value"
+                :disabled="this.config.disabled"
                 :width="250"
                 :min="0"
                 :max="100"
@@ -41,6 +42,7 @@ export default defineComponent({
                 'config',
                 (newConfig: any) => {
                     this.value = newConfig.value;
+                    this.isDisabled = !!newConfig.disabled;
                 },
                 { deep: true }
             )
@@ -54,6 +56,7 @@ export default defineComponent({
     data() {
         return {
             value: this.config.value,
+            isDisabled: !!this.config.disabled,
             watchers: [] as Array<Function>
         };
     }

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -246,6 +246,21 @@ export enum IdentifyResultFormat {
     UNKNOWN = 'unknown'
 }
 
+export enum LayerControls {
+    BoundaryZoom = 'boundaryZoom',
+    Boundingbox = 'boundingBox',
+    Datatable = 'datatable',
+    Identify = 'identify',
+    Metadata = 'metadata',
+    Opacity = 'opacity',
+    Refresh = 'refresh',
+    Reload = 'reload',
+    Remove = 'remove',
+    Settings = 'settings',
+    Symbology = 'symbology',
+    Visibility = 'visibility'
+}
+
 // TODO since MapClick and MapMove are payloads on public events, is there a proper
 //      way they should be exposed from the main app as well (like, exported? in one of those .d.ts files?)?
 //      same question probably applies to a number of other interfaces here.
@@ -485,7 +500,8 @@ export interface RampLayerMapImageLayerEntryConfig {
     state?: RampLayerStateConfig;
     // following items need to be flushed out
     extent?: any;
-    controls?: any;
+    controls?: Array<LayerControls>;
+    disabledControls?: Array<LayerControls>;
     stateOnly?: any;
     table?: any;
     fieldMetadata?: RampLayerFieldMetadataConfig;
@@ -499,7 +515,8 @@ export interface RampLayerWmsLayerEntryConfig {
     name?: string; // this is display name in ramp. would override "title" on the service
     state?: RampLayerStateConfig;
     // following items need to be flushed out
-    controls?: any;
+    controls?: Array<LayerControls>;
+    disabledControls?: Array<LayerControls>;
     currentStyle?: string; // style to be used
     styleLegends?: Array<{ name: string; url: string }>; // map of styles to legend graphic url. overrides service urls.
     fixtures?: any; // layer-based fixture config
@@ -520,6 +537,8 @@ export interface RampLayerConfig {
     nameField?: string;
     tooltipField?: string;
     featureInfoMimeType?: string;
+    controls?: Array<LayerControls>;
+    disabledControls?: Array<LayerControls>;
     layerEntries?:
         | Array<RampLayerMapImageLayerEntryConfig>
         | Array<RampLayerWmsLayerEntryConfig>;

--- a/src/geo/layer/esri-map-image/index.ts
+++ b/src/geo/layer/esri-map-image/index.ts
@@ -300,7 +300,9 @@ class MapImageLayer extends AttribLayer {
                     this._sublayers[sid] = new MapImageSublayer(
                         {
                             layerType: LayerType.SUBLAYER,
-                            state: subConfigs[sid].state
+                            state: subConfigs[sid].state,
+                            controls: subConfigs[sid].controls,
+                            disabledControls: subConfigs[sid].disabledControls
                         },
                         this.$iApi,
                         this,

--- a/src/geo/layer/esri-map-image/map-image-sublayer.ts
+++ b/src/geo/layer/esri-map-image/map-image-sublayer.ts
@@ -10,7 +10,7 @@ export class MapImageSublayer extends AttribLayer {
     tooltipField: string;
 
     constructor(
-        config: { layerType: string; state?: RampLayerStateConfig },
+        config: any,
         $iApi: InstanceAPI,
         parent: MapImageLayer,
         layerIdx = 0


### PR DESCRIPTION
## Closes #884 

## Changes
- As per #836, implemented layer based controls with cascading overrides by legend and settings
- Schema updates for layer controls in legend entry/group, settings, and layer nodes
- Moved `Controls` enum from `legend-defs` to `geo-defs` to make it available across RAMP (now called `LayerControls`)
- Added `getLayerControls(layerId)` method to `LayerAPI` that gets the layer controls defined for the layer with the given id/uid (will also default controls if not specified)
- Added `controlAvailable(control)` method to `LayerInstance` that will return a boolean indicating if the given control is enabled on this layer instance
- Commented out `WFSLayer` for now so `CleanAir` layer can work (can be added back in by #1002)

## Comments
- `legend-options.vue` throws a console warning when the user tries to open metadata for a layer when the layer doesn't have a metadata url defined
    - Since it is possible for layers to have the `metadata` control available when they don't actually have a metadata url, the user will be confused as to why nothing happens when they click on it
    - ~~Maybe we can throw this warning in the notification center as well?~~
    - Alternatively the metadata control can be automatically removed if there is no url just like how the boundary zoom control is removed if layer has no extent (this has been implemented in this PR) ✅

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/884/demos/index.html)
_Note that the above demo links to the `demos/index.html` and not `samples/index.html` because I only commented out `WFSLayer` in the demo starter script_

- `CleanAir` has `boundaryZoom` disabled on the legend entry
- `CO2 in Nested Group` has the `opacity` control disabled at the layer level
- `Water Quantity` has `identify` control disabled in the settings panel and visibility disabled on the legend entry (example of overriding)
    - Note that visibility can still be toggled in the settings panel (legend and settings controls are separate)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1030)
<!-- Reviewable:end -->
