### PR TITLE
Fixing dropdown menu alignment

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -105,7 +105,7 @@ export default defineComponent({
     methods: {
         closeDropdown(e: Event) {
             if (!e.currentTarget.contains(e.relatedTarget)) {
-                this.open = false
+                this.open = false;
             }
         }
     }
@@ -115,7 +115,7 @@ export default defineComponent({
 <style lang="scss">
 .rv-dropdown > * {
     display: block;
-    padding: 0.5rem 1rem 0.5rem 1rem;
+    padding: 0.5rem 0rem;
     color: #2d3748;
 }
 .rv-dropdown > *:hover:not(.disabled) {


### PR DESCRIPTION
Closes #1035.

This fixes the padding in the notifications dropdown menu.

Before:
<img src="https://user-images.githubusercontent.com/89807997/168150394-67cb3346-aca6-408d-84fe-f939d94c72ec.png">

After:
![after0](https://user-images.githubusercontent.com/89807997/168150434-588567e6-0282-4d44-b193-79733f2ca680.png)

Incidentally, this was also causing issues with other dropdown menus, such as the toggle layer button in the legend panel. This fixes those too.

Before:
![before1](https://user-images.githubusercontent.com/89807997/168151070-a05cd340-a6b9-43fe-90e6-08ba6616b53a.png)

After:
![after1](https://user-images.githubusercontent.com/89807997/168151069-53f20db2-7269-4d42-8183-6b46674d9820.png)
