### PR TITLE
Fix reorder workflow for layers and prod build issues

### DIFF
--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -19,7 +19,7 @@
 import { defineComponent, ref } from 'vue';
 import { get } from '@/store/pathify-helper';
 import type { RampLayerConfig, RampMapConfig } from '@/geo/api';
-import { GlobalEvents, LayerInstance, MapAPI } from '@/api/internal';
+import type { LayerInstance } from '@/api/internal';
 
 import { ConfigStore } from '@/store/modules/config';
 import { LayerStore } from '@/store/modules/layer';
@@ -193,10 +193,15 @@ export default defineComponent({
             layers
                 .filter(Boolean)
                 .forEach((layer: LayerInstance | null, index: number) => {
-                    this.$iApi.geo.map.reorder(
-                        layer!,
-                        oldValue ? oldValue.length + index : index
-                    );
+                    // wait on layer load to check for valid state
+                    layer?.isLayerLoaded().then(() => {
+                        if (layer?.isValidState) {
+                            this.$iApi.geo.map.reorder(
+                                layer!,
+                                oldValue ? oldValue.length + index : index
+                            );
+                        }
+                    });
                 });
         },
         onMapConfigChange(newValue: RampMapConfig, oldValue: RampMapConfig) {

--- a/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/src/fixtures/layer-reorder/components/layer-component.vue
@@ -31,6 +31,9 @@
                     :content="element.name"
                     v-focus-container
                 >
+                    <!-- TODO: fix this hack that prevents duplicate UI bug on prod (to reproduce: remove this, run prod build and open -> close -> re-open reorder panel) -->
+                    <div class="hidden"></div>
+
                     <div
                         class="flex items-center p-5 ms-5 h-44 cursor-pointer hover:bg-gray-200"
                     >

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -134,7 +134,7 @@ export class CommonLayer extends LayerInstance {
 
         if (this.isSublayer) {
             // early back out, we don't want the below code to run for sublayers
-            console.warn('Attempted to intiate a sublayer as a CommonLayer');
+            console.warn('Attempted to initiate a sublayer as a CommonLayer');
             return Promise.resolve();
         }
 

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -446,17 +446,18 @@ export class MapAPI extends CommonMapAPI {
             );
             // set map order
             this.esriMap.reorder(layer.esriLayer, esriLayerIndex);
+
+            // sync layer store order with map order
+            this.$vApp.$store.set(LayerStore.reorderLayer, { layer, index });
+            this.$iApi.event.emit(GlobalEvents.MAP_REORDER, {
+                layer,
+                newIndex: index
+            });
         } else {
             console.error(
                 'Attempted reorder without an esri layer. Likely layer.initiate() was not called or had not finished.'
             );
         }
-        // sync layer store order with map order
-        this.$vApp.$store.set(LayerStore.reorderLayer, { layer, index });
-        this.$iApi.event.emit(GlobalEvents.MAP_REORDER, {
-            layer,
-            newIndex: index
-        });
     }
 
     /**

--- a/src/store/modules/layer/layer-store.ts
+++ b/src/store/modules/layer/layer-store.ts
@@ -157,10 +157,14 @@ const mutations = {
             index = state.layers.length
         }: { layer: LayerInstance; index: number }
     ) => {
-        state.layers.splice(state.layers.indexOf(layer), 1);
-        state.layers.splice(index, 0, layer);
-        // copy to new array to trigger reactivity
-        state.layers = [...state.layers];
+        // find and swap layer with target index
+        const layerIdx = state.layers.findIndex(l => l.uid === layer.uid);
+        if (layerIdx !== -1 && layerIdx !== index) {
+            state.layers.splice(layerIdx, 1);
+            state.layers.splice(index, 0, layer);
+            // copy to new array to trigger reactivity
+            state.layers = [...state.layers];
+        }
     },
     REMOVE_LAYER: (state: LayerState, value: LayerInstance) => {
         // copy to new array so watchers will have a reference to the old value


### PR DESCRIPTION
Closes #990 
Closes #1005 

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/990-reorder-missing/samples/index.html)

**Changes**: 
- changed `REORDER_LAYER` method which was not swapping array items properly on initial map load (`indexOf(layer)` call always returned -1) which fixes CleanAir layer from getting overwritten in store
- waits on layer load and checks for valid state before attempting reorder call 
- prevent map reorder events from firing when layer has has no defined ESRI layer
- used a hack (adding empty div) to stop duplicate element UI bug appearing in reorder panel upon closing and re-opening panel on prod build, spent a bunch of time but couldn't find a better solution or the root cause behind this, may log a separate issue with more info on this afterwards but if anyone has any ideas for why this is happening let me know 

**Testing**:
- opening settings for `ClearAir` layer works without errors now that is no longer overwritten in store
- deleting `CleanAir` layer works without errors
- no console errors for early attempted reorder call
- reordering layers works and no UI bugs 

Logged issue to add a layer error indicator once it fails to load (#1026).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1038)
<!-- Reviewable:end -->
