### PR TITLE
sublayers adopt parent state if not defined in config

### DIFF
--- a/src/geo/layer/esri-map-image/index.ts
+++ b/src/geo/layer/esri-map-image/index.ts
@@ -299,10 +299,18 @@ class MapImageLayer extends AttribLayer {
                 if (!this._sublayers[sid]) {
                     this._sublayers[sid] = new MapImageSublayer(
                         {
+                            // TODO: Revisit once issue #961 is implemented. 
+                            // See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/1045#pullrequestreview-977116071
                             layerType: LayerType.SUBLAYER,
-                            state: subConfigs[sid].state,
-                            controls: subConfigs[sid].controls,
-                            disabledControls: subConfigs[sid].disabledControls
+                            // If the state isn't defined, use the same state as the parent.
+                            state: subConfigs[sid]?.state ?? {
+                                opacity: this.opacity,
+                                visibility: this.visibility,
+                                hovertips: this.hovertips,
+                                identify: this.identify
+                            },
+                            controls: subConfigs[sid]?.controls,
+                            disabledControls: subConfigs[sid]?.disabledControls
                         },
                         this.$iApi,
                         this,


### PR DESCRIPTION
Closes #1012 

Adding [this layer](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Nest/MapServer) to the map via the wizard or config(*) should now have the layers load on the map properly.

\* there is another problem that exists when adding through the config where the layer shows as loading forever in the legend, even though the layer appears to load correctly on the map. I will log this shortly (update: #1046).

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-1012/demos/index.html).

To test, ensure you can add the layer linked above to the map via the wizard. Selecting either `Group1` or `Group2` should work as expected now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1045)
<!-- Reviewable:end -->
