### PR TITLE
Graphic Style flag, Error fix

### DIFF
--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -337,6 +337,7 @@ export interface ArcGisServerUrl {
 export interface GetGraphicParams {
     getGeom?: boolean;
     getAttribs?: boolean;
+    getStyle?: boolean;
 }
 
 export interface GetGraphicServiceDetails {

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -408,7 +408,17 @@ export class FileLayer extends AttribLayer {
                 'did not get a single result on a query for a specific object id'
             );
         }
-        return resultArr[0];
+
+        const resGraphic = resultArr[0];
+
+        if (opts.getStyle) {
+            const esriSymb = toRaw(
+                this.renderer!.getGraphicSymbol(resGraphic.attributes)
+            );
+            resGraphic.style = this.$iApi.geo.geom.styleEsriToRamp(esriSymb);
+        }
+
+        return resGraphic;
     }
 
     // TODO we are using the getgraphic type as it's an unbound loosely typed feature

--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -7,7 +7,7 @@ import {
     SimpleRenderer,
     UniqueValueRenderer
 } from '@/api/internal';
-import { LineStyle } from '@/geo/api';
+import { LineStyleType } from '@/geo/api';
 import type { Attributes, LegendSymbology } from '@/geo/api';
 import {
     EsriRenderer,
@@ -392,18 +392,19 @@ export class SymbologyAPI extends APIScope {
         // line dash styles
         // if we need to revist the svg numbers, can see esri 4 styles at https://developers.arcgis.com/javascript/latest/sample-code/playground/live/index.html#/config=symbols/2d/SimpleLineSymbol.json
         const ESRI_DASH_MAPS = {
-            [LineStyle.SOLID]: 'none', // esriSLSSolid
-            [LineStyle.NONE]: 'none', // esriSLSNull
-            [LineStyle.DASH]: '5.333,4', // esriSLSDash
-            [LineStyle.DOT]: '1.333,4', // esriSLSDot
-            [LineStyle.DASHDOT]: '5.333,4,1.333,4', // esriSLSDashDot
-            [LineStyle.LONGDASH]: '10.666,4', // esriSLSLongDash
-            [LineStyle.LONGDASHDOT]: '10.666,4,1.333,4', // esriSLSLongDashDot
-            [LineStyle.LONGDASHDOTDOT]: '10.666,4,1.333,4,1.333,4', // esriSLSLongDashDotDot
-            [LineStyle.SHORTDOT]: '1.333,1.333', // esriSLSShortDot
-            [LineStyle.SHORTDASH]: '5.333,1.333', // esriSLSShortDash
-            [LineStyle.SHORTDASHDOT]: '5.333,1.333,1.333,1.333', // esriSLSShortDashDot
-            [LineStyle.SHORTDASHDOTDOT]: '5.333,1.333,1.333,1.333,1.333,1.333' // esriSLSShortDashDotDot
+            [LineStyleType.SOLID]: 'none', // esriSLSSolid
+            [LineStyleType.NONE]: 'none', // esriSLSNull
+            [LineStyleType.DASH]: '5.333,4', // esriSLSDash
+            [LineStyleType.DOT]: '1.333,4', // esriSLSDot
+            [LineStyleType.DASHDOT]: '5.333,4,1.333,4', // esriSLSDashDot
+            [LineStyleType.LONGDASH]: '10.666,4', // esriSLSLongDash
+            [LineStyleType.LONGDASHDOT]: '10.666,4,1.333,4', // esriSLSLongDashDot
+            [LineStyleType.LONGDASHDOTDOT]: '10.666,4,1.333,4,1.333,4', // esriSLSLongDashDotDot
+            [LineStyleType.SHORTDOT]: '1.333,1.333', // esriSLSShortDot
+            [LineStyleType.SHORTDASH]: '5.333,1.333', // esriSLSShortDash
+            [LineStyleType.SHORTDASHDOT]: '5.333,1.333,1.333,1.333', // esriSLSShortDashDot
+            [LineStyleType.SHORTDASHDOTDOT]:
+                '5.333,1.333,1.333,1.333,1.333,1.333' // esriSLSShortDashDotDot
         };
 
         // default stroke style

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@
 //    library name, and contains the "export" of the library (which is what this file does).
 //    A code snippet from rollup's source code that is likely doing this.
 //
-// 	if (hasExports) {
+//  if (hasExports) {
 //    if (name && !(extend && namedExportsMode)) {
 //      wrapperIntro = (useVariableAssignment ? `${cnst} ${name}` : `this${keypath(name, getPropertyAccess)}`) + `${_}=${_}${wrapperIntro}`;
 //    }


### PR DESCRIPTION
Adds a new parameter to `getGraphic` to support #127.
Caller can now ask that the Graphic returned have the appropriate Style defined on it.

Also corrects a compile error that got overwritten during the massive Vite rebase. Unsettling that the build would not notice very broken code.

[Demo](http://ramp4-app.azureedge.net/demo/users/james-rae/jamesparty/samples/index.html)

Difficult to test the new function at the moment, since nothing has done it. If you really want you can do so in the console with a bit of elbow grease.

```text
var r = debugInstance;
r.geo.layer.allLayers();
// inspect the array. look at the middle layer (index 1), Water Quality. 
// Open it's layerTree and find the first/only child. Copy the child's UID

var l = r.geo.layer.getLayer('<child uid here>');
l.getGraphic(1, {getAttribs: true, getStyle: true}).then(g => console.log('graphic result', g));
// result graphic should have style defined, have reasonable values
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1047)
<!-- Reviewable:end -->
