### PR TITLE
Fix blank custom details template on demo page

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,8 @@ const baseConfig: UserConfigExport = {
     base: './',
     resolve: {
         alias: {
-            '@': resolve(__dirname, 'src')
+            '@': resolve(__dirname, 'src'),
+            vue: 'vue/dist/vue.esm-bundler.js'
         }
     },
     server: {
@@ -34,12 +35,6 @@ export default defineConfig(({ command, mode }) => {
                     }
                 }
             };
-            baseConfig.resolve = {
-                alias: {
-                    '@': resolve(__dirname, 'src'),
-                    'vue': 'vue/dist/vue.esm-bundler.js'
-                }
-            }
         } else {
             baseConfig.publicDir = false;
             baseConfig.root = 'demos';


### PR DESCRIPTION
Closes #1048 

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/1048-blank-demo-details/demos/index.html)

Adds a Vite config alias to `vue/dist/vue.esm-bundler.js` for demos build to resolve blank custom details templates on `demos/index.html`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1049)
<!-- Reviewable:end -->
