### PR TITLE
Info icon in basemap selector

### DIFF
--- a/src/fixtures/basemap/item.vue
+++ b/src/fixtures/basemap/item.vue
@@ -51,16 +51,26 @@
                 </div>
 
                 <div class="ml-auto pr-5">
-                    <svg
-                        class="fill-current w-16 h-16"
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
+                    <a
+                        @click.stop
+                        @keydown.enter.space.prevent
+                        :content="basemap.description"
+                        v-tippy="{
+                            placement: 'bottom',
+                            trigger: 'click focus'
+                        }"
                     >
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path
-                            d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
-                        />
-                    </svg>
+                        <svg
+                            class="fill-current w-16 h-16"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                        >
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path
+                                d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"
+                            />
+                        </svg>
+                    </a>
                 </div>
             </div>
 


### PR DESCRIPTION
Closes #1000.

Clicking the info icon no longer acts like selecting the basemap and instead displays an extra description. Clicking the other parts of the container still selects the basemap.

Update: [Demo](http://ramp4-app.azureedge.net/demo/users/SmokeTrails/issue1000/demos/index.html)

| Before | After |
|---------|------|
|![1000-before](https://user-images.githubusercontent.com/76517921/169155237-876e4b09-ddb0-456d-8698-74f188bbee64.gif)|![1000-after](https://user-images.githubusercontent.com/76517921/169155290-00a45774-f71b-4e46-a63a-2c8be0da40f6.gif)|

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1055)
<!-- Reviewable:end -->
