### PR TITLE
Implement instance reloading + language switching

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -476,6 +476,15 @@ export class EventAPI extends APIScope {
     }
 
     /**
+     * Removes all event handlers, filtered to an event name if desired.
+     * @param {string} [event] name of the event. Omission will remove all handlers for all events
+     */
+    offAll(event = ''): void {
+        let active: Array<string> = this.activeHandlers(event);
+        active.forEach(h => this.off(h));
+    }
+
+    /**
      * Triggers an event.
      *
      * @param {string} event the name of the event

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -120,7 +120,6 @@ export class FixtureAPI extends APIScope {
         });
 
         this.$iApi.event.emit(GlobalEvents.FIXTURE_REMOVED, fixture);
-
         return fixture;
     }
 

--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -120,6 +120,7 @@ export default defineComponent({
             //      change before map exists. kicking out for now to make demos work.
             //      possibly this is evil in vue state land. if so, then someone figure out
             //      the root cause and fix that.
+
             if (!this.map || !newValue) {
                 return;
             }
@@ -170,10 +171,10 @@ export default defineComponent({
                     });
                 });
         },
-        onMapConfigChange(newValue: RampMapConfig, oldValue: RampMapConfig) {
+        onMapConfigChange(newValue: RampMapConfig) {
             console.log('new map config change: ', newValue, this.mapConfig);
 
-            if (newValue === oldValue) {
+            if (!newValue) {
                 return;
             }
 

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -129,17 +129,14 @@ export default defineComponent({
 
     created() {
         this.watchers.push(
-            this.$watch(
-                'mapConfig',
-                (newConfig: RampMapConfig, oldConfig: RampMapConfig) => {
-                    if (newConfig === oldConfig) {
-                        return;
-                    }
-                    this.$iApi.geo.map.caption.createCaption(
-                        this.mapConfig.caption
-                    );
+            this.$watch('mapConfig', (newConfig: RampMapConfig) => {
+                if (!newConfig) {
+                    return;
                 }
-            )
+                this.$iApi.geo.map.caption.createCaption(
+                    this.mapConfig.caption
+                );
+            })
         );
     },
 

--- a/src/fixtures/appbar/index.ts
+++ b/src/fixtures/appbar/index.ts
@@ -34,7 +34,7 @@ class AppbarFixture extends AppbarAPI {
         );
 
         this._parseConfig(this.config);
-        this.$vApp.$watch(
+        let unwatch = this.$vApp.$watch(
             () => this.config,
             (value: AppbarFixtureConfig | undefined) => this._parseConfig(value)
         );
@@ -78,6 +78,7 @@ class AppbarFixture extends AppbarAPI {
         this.removed = () => {
             this.$vApp.$store.unregisterModule('appbar');
             eventHandlers.forEach(h => this.$iApi.event.off(h));
+            unwatch();
             destroy();
         };
     }

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -64,24 +64,27 @@ class DetailsFixture extends DetailsAPI {
             this.$iApi.panel.remove('details-items-panel');
             this.$iApi.panel.remove('details-layers-panel');
 
-            /*
-                TODO: Fix this hack!
+            // /*
+            //     TODO: Fix this hack!
 
-                Removing the layers panel will close it first.
+            //     Removing the layers panel will close it first.
 
-                However when a panel closes, it plays a fade-out animation for 1 second before actually closing.
+            //     However when a panel closes, it plays a fade-out animation for 1 second before actually closing.
 
-                During the animation, the component is still active and so unregistering the details store below
-                will trigger the payload watcher in the layers panel, which causes an exception because the
-                watcher is directly bound to the vuex path - which doesn't exist anymore.
+            //     During the animation, the component is still active and so unregistering the details store below
+            //     will trigger the payload watcher in the layers panel, which causes an exception because the
+            //     watcher is directly bound to the vuex path - which doesn't exist anymore.
 
-                Hence we delay unregistering the details by 1.2s to ensure the layers panel is completely closed
-                and unmounted.
-            */
-            setTimeout(
-                () => this.$vApp.$store.unregisterModule('details'),
-                1200
-            );
+            //     Hence we delay unregistering the details by 1.2s to ensure the layers panel is completely closed
+            //     and unmounted.
+            // */
+            // setTimeout(
+            //     () => this.$vApp.$store.unregisterModule('details'),
+            //     1200
+            // );
+            // TODO: To get around the above hack, the `get` method in the pathify-helper script will return `undefined` and throw soft console error when the path is undefined
+            //       This way the hard error doesn't stop the fixture removal process
+            this.$vApp.$store.unregisterModule('details');
         };
     }
 }

--- a/src/fixtures/details/layers-screen.vue
+++ b/src/fixtures/details/layers-screen.vue
@@ -125,12 +125,14 @@ export default defineComponent({
             // nobody writing a new layer type is going to have a clue they need
             // to wrap their identify outputs in reactive() due to disrespectful code.
 
-            // track last identify request timestamp and add to payload items
-            if (newPayload.length === 0) {
-                this.activeGreedy = 0;
+            // if no payload, just return
+            if (newPayload === undefined) {
                 return;
             }
-            this.activeGreedy = newPayload[0].requestTime;
+
+            // track last identify request timestamp and add to payload items
+            this.activeGreedy =
+                newPayload.length === 0 ? 0 : newPayload[0].requestTime;
 
             this.layerResults = newPayload;
 

--- a/src/fixtures/export/index.ts
+++ b/src/fixtures/export/index.ts
@@ -27,7 +27,7 @@ class ExportFixture extends ExportAPI {
 
         this.$iApi.component('export-appbar-button', ExportAppbarButtonV);
 
-        // store module intializer function is called "xport" instead of "export" because export is a reserved keyword
+        // store module initializer function is called "xport" instead of "export" because export is a reserved keyword
         this.$vApp.$store.registerModule('export', xport());
 
         this.$iApi.panel.register(

--- a/src/store/modules/config/config-store.ts
+++ b/src/store/modules/config/config-store.ts
@@ -13,6 +13,12 @@ import { i18n } from '@/lang';
 type ConfigContext = ActionContext<ConfigState, RootState>;
 
 const getters = {
+    getRegisteredConfigs: (
+        state: ConfigState
+    ): { [key: string]: RampConfig } => {
+        return state.registeredConfigs;
+    },
+
     getActiveConfig:
         (state: ConfigState) =>
         (lang: string): RampConfig => {
@@ -45,10 +51,12 @@ const actions = {
         context: ConfigContext,
         config: RampConfig
     ): void {
-        const newConfig = merge(context.state.config, config);
-        context.commit('SET_CONFIG', newConfig);
-        console.log('new config adding layers', newConfig.layers);
-        this.set(LayerStore.addLayerConfigs, newConfig.layers);
+        // Don't merge the configs because it causes issues when reloading, instead set the config directly
+        // const newConfig = merge(context.state.config, config);
+
+        context.commit('SET_CONFIG', config);
+        console.log('new config adding layers', config.layers);
+        this.set(LayerStore.addLayerConfigs, config.layers);
     },
     registerConfig: function (
         this: any,
@@ -69,17 +77,6 @@ const actions = {
                 context.state.registeredConfigs[lang] = config;
             }
         }
-    },
-    overrideConfig: function (
-        this: any,
-        context: ConfigContext,
-        newConfig: RampConfig
-    ): void {
-        this.set(LayerStore.addLayers, newConfig.layers);
-        // save and override registered and main config
-        context.dispatch('registerConfig', newConfig);
-        context.commit('SET_CONFIG', newConfig);
-        // TODO: trigger map reload?
     },
     updateConfig: function (
         this: any,
@@ -136,16 +133,6 @@ export enum ConfigStore {
      */
     registerConfig = 'config/registerConfig!',
     /**
-     * `function overrideConfig(newConfig: RampConfig) => void`
-     *
-     * Overrides current active config
-     *
-     * `@remarks` Action - use `@Call`
-     *
-     * `@param` config - new RAMP config to override existing one entirely
-     */
-    overrideConfig = 'config/overrideConfig!',
-    /**
      * `function updateConfig(fixtureConfig: any) => void`
      *
      * Update config based on a modified fixture snippet
@@ -165,6 +152,14 @@ export enum ConfigStore {
      * `@param` newBasemap - the new basemap config
      */
     setActiveBasemap = 'config/setActiveBasemap!',
+    /**
+     * Get all registered configs for each language
+     *
+     * `@remarks` Getter - use `@Get`
+     *
+     * `@returns` <{ [key: string]: RampConfig }> RAMP config for each registered language
+     */
+    getRegisteredConfigs = 'config/getRegisteredConfigs',
     /**
      * Get active config based on the current map language
      *

--- a/src/store/pathify-helper.js
+++ b/src/store/pathify-helper.js
@@ -7,7 +7,14 @@ export function get(path) {
     const property =
         path in store.getters
             ? computed(() => store.getters[path])
-            : computed(() => store.get(path));
+            : computed(() => {
+                  try {
+                      return store.get(path);
+                  } catch (err) {
+                      console.error(`vuex pathify error: ${err}`);
+                      return undefined;
+                  }
+              });
     // console.log('store: ', store, path, property);
     return property;
 }


### PR DESCRIPTION
## Closes #1043, Closes #894

## Changes
- Added `reload(configs?, options?)` method to `InstanceAPI`
- Added language switching where the instance is reloaded to use the alternate config after switching
- Added `offAll(event = '')`  method to `EventAPI` which removes all event handlers (can optionally filter to one event)
- Add `unwatch` watcher removal call to appbar fixture removal
- Add `getRegisteredConfigs` getter to config store which returns all configs registered for each supported language


## Notes
- In the first few lines of the `reload` method, the appbar and mapnav store is manually reset
    - I left a `TODO` comment for this, but once #882 is implemented and appbar/mapnav fixture removal is completely implemented, this can be removed
- I found an alternate way to deal with the details fixture removal hack
    - Previously the details store removal was delayed by 1.2s so that the panel closing animation is complete and the panel is unmounted (this is to avoid reactivity to trigger upon removing the details store)
    - This would mean instance reloading would also have to wait 1.2s for the details fixture to be removed
    - The alternate method was to return `undefined` when `get` is called on undefined store paths
    - Previously doing this will throw a hard-error which will crash RAMP, but by returning undefined a soft-error is thrown in the console and the `undefined` value is handled in the details fixture
    - An related issue is open which will improve this: #987)
    - Is this alternate method okay for now?

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/instance-reloading/samples/index.html)

- Currently the language switch menu does not work (fixed in PR #1057), so use this snippet to switch the language:
```js
window.debugInstance.setLanguage('fr');
// or window.debugInstance.setLanguage('en');
```
- To reload RAMP with a brand new config, use this [snippet](https://gist.github.com/sharvenp/8e5ebe47d1ff363347651efdfce1b052) (copy-paste into console) which loads the CAM config
    - Running this will reload the instance with the new config
    - This snippet defines a config for each language, so switching the language should update the map accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1059)
<!-- Reviewable:end -->
