### PR TITLE
add isLayerRoot and isLogicalLayer getters to TreeNode

### DIFF
--- a/src/geo/api/layer/tree-node.ts
+++ b/src/geo/api/layer/tree-node.ts
@@ -2,13 +2,14 @@ export class TreeNode {
     layerIdx: number;
     name: string;
     children: Array<TreeNode>;
-    isLayer: boolean; // TODO: decide on the purpose of this flag post-layer-refactor?
     uid: string;
 
-    constructor(idx: number, uid: string, name = '', isLayer = true) {
+    private isRoot: boolean;
+
+    constructor(idx: number, uid: string, name = '', root = true) {
         this.layerIdx = idx;
         this.name = name;
-        this.isLayer = isLayer;
+        this.isRoot = root;
         this.children = [];
         this.uid = uid;
     }
@@ -47,5 +48,25 @@ export class TreeNode {
             // return nothing, or the bubbled up tree node, not the child (t) that was being iterated on
             return hit;
         }
+    }
+
+    /**
+     * Returns whether this node is bound to a logical layer.
+     *
+     * @method isLogicalLayer
+     * @returns {boolean} true if the layer is bound to a logical layer.
+     */
+    get isLogicalLayer(): boolean {
+        return this.layerIdx > -1 && this.children.length === 0;
+    }
+
+    /**
+     * Returns whether this node is a root node.
+     *
+     * @method isLayerRoot
+     * @returns {boolean} true if this node is a root node for this layer. 
+     */
+    get isLayerRoot(): boolean {
+        return this.isRoot;
     }
 }

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -49,10 +49,6 @@ export class MapImageLayer extends AttribLayer {
         this.layerType = LayerType.MAPIMAGE;
         this.isDynamic = false; // will get updated after layer load.
         this.hovertips = false;
-
-        // mark the root node of this layer as not layer
-        // TODO: revisit this once we decide on what `isLayer` should be
-        this.layerTree.isLayer = false;
         this.layerTree.layerIdx = -1;
     }
 
@@ -342,7 +338,7 @@ export class MapImageLayer extends AttribLayer {
                         sid,
                         _sublayer.uid,
                         (_sublayer as CommonLayer).name,
-                        true
+                        false
                     );
                     parentTreeNode.children.push(treeLeaf);
                 }


### PR DESCRIPTION
Closes #883 

This PR adds the `isLayerRoot` and `isLogicalLayer` getters to the TreeNode object. 

isLayerRoot will be true if the node is the root node for the layer (this will basically only ever be false if it's a child of a MapImageLayer, I believe).

isLogicalLayer will be true if the TreeNode is connected to a logical layer.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-883/demos/index.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1060)
<!-- Reviewable:end -->
