### PR TITLE
Make map point zoom level configurable

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2115,6 +2115,11 @@
                         }
                     },
                     "required": ["mouseCoords", "scaleBar"]
+                },
+                "pointZoomScale": {
+                    "type": "number",
+                    "default": 50000,
+                    "description": "The zoom level when zooming to a point feature (e.g. when using the zoom button in the datagrid). Should be a positive integer."
                 }
             },
             "required": ["tileSchemas", "baseMaps"],

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -620,4 +620,5 @@ export interface RampMapConfig {
     tileSchemas: Array<RampTileSchemaConfig>;
     initialBasemapId: string;
     caption?: MapCaptionConfig;
+    pointZoomScale?: number;
 }

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -83,6 +83,12 @@ export class CommonMapAPI extends APIScope {
      */
     protected handlers: Array<any>;
 
+    /**
+     * The default zoom level when zooming to a point feature
+     * @private
+     */
+    protected pointZoomScale: number;
+
     protected constructor(iApi: InstanceAPI) {
         super(iApi);
 
@@ -90,6 +96,7 @@ export class CommonMapAPI extends APIScope {
         this._basemapStore = [];
         this._viewPromise = new DefPromise();
         this.handlers = [];
+        this.pointZoomScale = 50000;
     }
 
     protected noMapErr(): void {
@@ -121,7 +128,7 @@ export class CommonMapAPI extends APIScope {
             );
         }
         this.esriMap = markRaw(new EsriMap(esriConfig));
-
+        this.pointZoomScale = config.pointZoomScale && config.pointZoomScale > 0 ? config.pointZoomScale : 50000;
         this._targetDiv = targetDiv;
         this.createMapView(config.initialBasemapId);
     }
@@ -321,7 +328,7 @@ export class CommonMapAPI extends APIScope {
                 target: this.$iApi.geo.geom.geomRampToEsri(g)
             };
             if (g.type === GeometryType.POINT) {
-                zoomP.scale = scale || 50000;
+                zoomP.scale = scale || this.pointZoomScale;
             }
             const opts: any = { animate: animate };
             if (this.esriView) {
@@ -454,6 +461,26 @@ export class CommonMapAPI extends APIScope {
             this.noMapErr();
             return 1; // avoid returning zero, could cause divide-by-zero error in caller.
         }
+    }
+
+    /**
+     * Set's the map's pointZoomScale value to newScale.
+     * If newScale is not a positive number, a console error is thrown.
+     *
+     * The returned boolean indicates if the value has been successfully set.
+     *
+     * @param {number} newScale the new pointZoomScale value, which must be a positive number
+     * @returns {boolean} indicates if the value was set successfully
+     */
+    setPointZoomScale(newScale: number): boolean {
+        if (newScale > 0) {
+            this.pointZoomScale = newScale;
+            return true;
+        }
+        console.error(
+            `Cannot set pointZoomScale to non-positive number: ${newScale}.`
+        );
+        return false;
     }
 
     // TODO shared Map (not view-based) functions could go here.


### PR DESCRIPTION
Closes #857.

Can now change the default zoom level when zooming to a point feature (e.g. using the zoom button in the datagrid, clicking on location in geosearch, etc.)

## Changes 
* Made a new optional integer config property called `pointZoomScale` in the main `map` config schema in `schema.json`.
* Added a new `pointZoomScale` property to the `RampMapConfig` interface.
* In `CommonMapAPI`:
  * Created new protected property `pointZoomScale`.
  * In `createMap()`, looked for the new property in the config. If it exists, set our above property, otherwise default above to 50000.
  * In line `zoomP.scale = scale || 50000;` replaced 50000 with `this.pointZoomScale`.

## [Demo](http://ramp4-app.azureedge.net/demo/users/SmokeTrails/issue857-test/demos/index.html)
* To demo this change, the `geosearch` fixture has been modified so that a `scale` parameter is not passed into the `zoomMapTo` function, and instead the `pointZoomScale` property is used as the scale (Note that this modification is not part of the PR).
* First, go to the [demo](http://ramp4-app.azureedge.net/demo/users/SmokeTrails/issue857-test/demos/index.html) page open the `geosearch` fixture. 
* Search for any location of your choice (e.g. Toronto) and click it so that the map zooms to that location. Click the home button on the map to zoom back out. 
* Open the console and set the `pointZoomScale` property with the snippet `window.debugInstance.geo.map.pointZoomScale = MY_VALUE` (replace `MY_VALUE` with your number). Note that the default value was 50000, so to see a difference, set something very different, such as 5000 or 500000. 
* Next, click on the same location again in the `geosearch` fixture so that the map zooms to it, and notice the visual difference in the zoom scale compared to the first time. Feel free to play around with different numbers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1062)
<!-- Reviewable:end -->
