### PR TITLE
Multi-Ramp Options API Sample

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -25,8 +25,38 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app"></div>
+        <div id="main-container">
+            <div id="container1">
+                <h1 class="ramp-heading">RAMP Instance 1</h1>
+                <div id="app1"></div>
+            </div>
 
+            <div id="container2">
+                <h1 class="ramp-heading">RAMP Instance 2</h1>
+                <div id="app2"></div>
+            </div>
+        </div>
         <script type="module" src="./starter-scripts/main.js"></script>
+        <style>
+            #main-container {
+                display: flex;
+            }
+            .ramp-heading {
+                font-size: 28pt;
+                text-align: center;
+                font-weight: bolder;
+            }
+            #container1 {
+                width: 50vw;
+                height: 500px;
+                background-color: crimson;
+            }
+            #container2 {
+                width: 50vw;
+                margin-left: 5px;
+                height: 500px;
+                background-color: blue;
+            }
+        </style>
     </body>
 </html>

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -1,6 +1,7 @@
 import { createInstance, geo } from '@/main';
 
 window.debugInstance = null;
+window.debugInstance2 = null;
 
 // TODO: Location for version string needs to be finalized
 // document.getElementById('ramp-version').innerText =
@@ -485,7 +486,7 @@ let options = {
 };
 
 const rInstance = createInstance(
-    document.getElementById('app'),
+    document.getElementById('app1'),
     config,
     options
 );
@@ -602,5 +603,12 @@ function animateToggle() {
     document.getElementById('animate-status').innerText =
         'Animate: ' + rInstance.animate;
 }
-
 window.debugInstance = rInstance;
+
+const rInstance2 = createInstance(document.getElementById('app2'), config, {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+});
+rInstance2.start();
+window.debugInstance2 = rInstance2;

--- a/public/samples/index.html
+++ b/public/samples/index.html
@@ -26,9 +26,39 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app"></div>
-        <script src="./lib/ramp.iife.js"></script>
+        <div id="main-container">
+            <div id="container1">
+                <h1 class="ramp-heading">RAMP Instance 1</h1>
+                <div id="app1"></div>
+            </div>
 
+            <div id="container2">
+                <h1 class="ramp-heading">RAMP Instance 2</h1>
+                <div id="app2"></div>
+            </div>
+        </div>
+        <script src="./lib/ramp.iife.js"></script>
         <script type="module" src="./starter-scripts/main.js"></script>
+        <style>
+            #main-container {
+                display: flex;
+            }
+            .ramp-heading {
+                font-size: 28pt;
+                text-align: center;
+                font-weight: bolder;
+            }
+            #container1 {
+                width: 45vw;
+                height: 500px;
+                background-color: crimson;
+            }
+            #container2 {
+                width: 45vw;
+                margin-left: 5px;
+                height: 500px;
+                background-color: blue;
+            }
+        </style>
     </body>
 </html>

--- a/public/samples/starter-scripts/main.js
+++ b/public/samples/starter-scripts/main.js
@@ -12,6 +12,7 @@
 //     new Date(RAMP.version.timestamp).toLocaleDateString();
 
 window.debugInstance = null;
+window.debugInstance2 = null;
 
 let config = {
     configs: {
@@ -494,7 +495,7 @@ let options = {
 };
 
 const rInstance = RAMP.createInstance(
-    document.getElementById('app'),
+    document.getElementById('app1'),
     config,
     options
 );
@@ -614,3 +615,15 @@ function animateToggle() {
     document.getElementById('animate-status').innerText =
         'Animate: ' + rInstance.animate;
 }
+
+const rInstance2 = RAMP.createInstance(
+    document.getElementById('app2'),
+    config,
+    {
+        loadDefaultFixtures: true,
+        loadDefaultEvents: true,
+        startRequired: false
+    }
+);
+rInstance2.start();
+window.debugInstance2 = rInstance2;

--- a/src/app.vue
+++ b/src/app.vue
@@ -44,7 +44,7 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
 @use 'directives/focus-list/focus-list';
 .ramp-app {
     @include focus-list.default-focused-styling;
-    height: 100vh;
+    height: 90vh;
     font-family: $font-list;
     h1,
     h2,


### PR DESCRIPTION
**Not for pulling.**
PR is for investigation and analysis of multi-ramp page conflicts for options API.

[Demos](http://ramp4-app.azureedge.net/demo/users/SmokeTrails/options-multi-ramp/demos/index.html)
[Samples](http://ramp4-app.azureedge.net/demo/users/SmokeTrails/options-multi-ramp/samples/index.html)

I created two almost identical instances (same config, only difference is one uses default fixtures and the other uses custom) and attempted to display them on the webpage.

Interestingly, there is different behavior when attempting to do this in `demos/index.html` versus `public/samples/index.html`, so I have linked both builds above. From the little that I have investigated, the difference that I saw is that the `demos` version seems to import the `createInstance` function whereas the `samples` version does `RAMP.createInstance(element, config, options)`.

Another thing to note is that there is different behavior on the demo link above compared to if you ran `npm run dev` locally. They both have the same errors in the console, but the local version seems to render 1 out of 2 maps (instance 1), as seen below:

![Capture](https://user-images.githubusercontent.com/76517921/170329095-f06614d9-c6cc-4074-9907-2f343f13ce4a.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1063)
<!-- Reviewable:end -->
