### PR TITLE
settings opacity slider reacts properly to opacity change via API

### DIFF
--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -170,6 +170,19 @@ export default defineComponent({
 
         this.handlers.push(
             this.$iApi.event.on(
+                GlobalEvents.LAYER_OPACITYCHANGE,
+                (newOpacity: any) => {
+                    if (this.uid === newOpacity.uid) {
+                        this.opacityModel = Math.round(
+                            newOpacity.opacity * 100
+                        );
+                    }
+                }
+            )
+        );
+
+        this.handlers.push(
+            this.$iApi.event.on(
                 GlobalEvents.LAYER_RELOAD_END,
                 (reloadedLayer: LayerInstance) => {
                     reloadedLayer.isLayerLoaded().then(() => {


### PR DESCRIPTION
Closes #1056

The opacity slider in the settings fixture will now be correctly updated when the layer opacity is updated using the API.


Testing
---
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-1056/demos/index.html).

To test this PR, use the same steps posted in the original issue:

* Open the setting panel for bottom layer "Water Quality in Nested Group"
* Run the script below in the console.
* You'll see the layer opacity change (watch the yellow dots in Newfoundland)

The opacity slider should also update as expected now.

```
var r = debugInstance;
var l = r.geo.layer.getLayer('WaterQuality');
var sl = l.getSublayer(5);
sl.opacity = 0.5;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1066)
<!-- Reviewable:end -->
