### PR TITLE
Maptip styling, dropdown menu CSS

### DIFF
--- a/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/src/components/about-ramp/about-ramp-dropdown.vue
@@ -129,6 +129,7 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .about-ramp-dropdown {
+    @apply p-0 #{!important};
     &:hover {
         @apply bg-white #{!important};
     }

--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -116,6 +116,7 @@ export default defineComponent({
 <style lang="scss">
 .rv-dropdown > * {
     display: block;
+    padding: 0.5rem 1rem;
     color: #2d3748;
 }
 .rv-dropdown > *:hover:not(.disabled) {

--- a/src/components/notification-center/caption-button.vue
+++ b/src/components/notification-center/caption-button.vue
@@ -96,6 +96,7 @@ export default defineComponent({
 }
 .notification-dropdown {
     min-height: 250px;
+    @apply p-0 #{!important};
     &:hover {
         @apply bg-white #{!important};
     }

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -55,14 +55,14 @@
             </template>
             <a
                 href="#"
-                class="flex leading-snug items-center w-116 py-8"
+                class="flex leading-snug items-center overflow-hidden whitespace-nowrap"
                 @click="expand"
             >
                 {{ $t('legend.header.groups.expand') }}
             </a>
             <a
                 href="#"
-                class="flex leading-snug items-center w-116 py-8"
+                class="flex leading-snug items-center overflow-hidden whitespace-nowrap"
                 @click="collapse"
             >
                 {{ $t('legend.header.groups.collapse') }}
@@ -87,14 +87,14 @@
             </template>
             <a
                 href="#"
-                class="flex leading-snug items-center w-100 py-8"
+                class="flex leading-snug items-center w-100 overflow-hidden whitespace-nowrap"
                 @click="show"
             >
                 {{ $t('legend.header.visible.show') }}
             </a>
             <a
                 href="#"
-                class="flex leading-snug items-center w-100 py-8"
+                class="flex leading-snug items-center w-100 overflow-hidden whitespace-nowrap"
                 @click="hide"
             >
                 {{ $t('legend.header.visible.hide') }}

--- a/src/geo/map/maptip.ts
+++ b/src/geo/map/maptip.ts
@@ -116,11 +116,13 @@ export class MaptipAPI extends APIScope {
         screenPoint: Point;
     }) {
         this.setContent(
-            `<div class="flex items-center">${info.icon} ${
+            `<div class="flex items-center space-x-5"><span>${
+                info.icon
+            }</span><span class="truncate">${
                 info.attributes[
                     info.layer.config.tooltipField || info.layer.nameField
                 ]
-            }</div>`
+            }</span></div>`
         );
     }
 


### PR DESCRIPTION
Closes #1008.
Closes #1009.
Closes #1044.

This PR styles maptips so that the icon and text are not so bunched up.

Before:
![labb4](https://user-images.githubusercontent.com/89807997/170548056-4acd2194-ea69-4a21-963e-e3fbc72c896b.png)![2022-05-26 14_08_21-ramp-core — Mozilla Firefox](https://user-images.githubusercontent.com/89807997/170549424-dae59d01-72d5-441c-b11b-0d435f56e218.png)

After:
![2022-05-26 14_00_12-ramp-core — Mozilla Firefox](https://user-images.githubusercontent.com/89807997/170548268-d15f5a4c-3bbe-4621-9a39-dd20d6a470da.png)![2022-05-26 14_07_46-ramp-core — Mozilla Firefox](https://user-images.githubusercontent.com/89807997/170549437-4c218d81-8c01-47c2-b464-fbc4f71e0355.png)



Also, large text content fields are now truncated in maptips, like in RAMP3. Since these changes are stylistic, they are open to opinion. Perhaps it is important to display the entire field in the tooltip?

Before:
![truncb4](https://user-images.githubusercontent.com/89807997/170548463-0e6f3e87-ebc5-4623-9ba2-2dad00150afb.png)
After:
![2022-05-26 13_59_34-ramp-core — Mozilla Firefox](https://user-images.githubusercontent.com/89807997/170548501-622ec443-0b33-4e55-880c-b4bc8b0efc5e.png)


This PR additionally fixes the CSS issues in the dropdown menus, which you can see by looking at layer options, language selection, etc.

# [Demo.](http://ramp4-app.azureedge.net/demo/users/roryhofland/1008/samples/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1075)
<!-- Reviewable:end -->
