### PR TITLE
update layer global events to return LayerInstance object instead of uid

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -85,13 +85,13 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed                             |
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added                         |
 | FIXTURE_REMOVED<br>'fixture/removed'               | FixtureInstance object                                         | A fixture has been removed                       |
-| LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, _uid_: affected uid                      | The layer opacity changed                        |
+| LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, layer: LayerInstance object              | The layer opacity changed                        |
 | LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was added to the map                   |
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
 | LAYER_RELOAD_START<br>'layer/reloadstart'          | LayerInstance object                                           | The layer started reloading                      |
 | LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |
-| LAYER_STATECHANGE<br>'layer/statechange'           | _state_: new value, _uid_: affected uid                        | The layer state changed                          |
-| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _uid_: affected uid                   | The layer visibility changed                     |
+| LAYER_STATECHANGE<br>'layer/statechange'           | _state_: new value, layer: LayerInstance object                | The layer state changed                          |
+| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, layer: LayerInstance object           | The layer visibility changed                     |
 | MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | basemapId: string, schemaChanged: boolean                      | The basemap was changed                          |
 | MAP_BLUR<br>'map/blur'                             | FocusEvent object                                              | The map lost focus                               |
 | MAP_CLICK<br>'map/click'                           | MapClick object                                                | The map was clicked                              |

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -85,7 +85,7 @@ export enum GlobalEvents {
 
     /**
      * Fires when the opacity of a layer changes.
-     * Payload: `({ uid: string, opacity: number })`
+     * Payload: `({ layer: LayerInstance, opacity: number })`
      */
     LAYER_OPACITYCHANGE = 'layer/opacitychange',
 
@@ -115,13 +115,13 @@ export enum GlobalEvents {
 
     /**
      * Fires when the state of a layer changes.
-     * Payload: `({ uid: string, state: string })`
+     * Payload: `({ layer: LayerInstance, state: string })`
      */
     LAYER_STATECHANGE = 'layer/statechange',
 
     /**
      * Fires when the visibility of a layer changes.
-     * Payload: `({ uid: string, visibility: boolean })`
+     * Payload: `({ layer: LayerInstance, visibility: boolean })`
      */
     LAYER_VISIBILITYCHANGE = 'layer/visibilitychange',
 

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -490,15 +490,16 @@ export default defineComponent({
                     GlobalEvents.LAYER_VISIBILITYCHANGE,
                     ({
                         visibility,
-                        uid
+                        layer
                     }: {
                         visibility: boolean;
-                        uid: string;
+                        layer: LayerInstance;
                     }) => {
                         if (
-                            uid &&
-                            (uid === this.layerUid ||
-                                uid === this.getLayerByUid(this.layerUid)!.uid)
+                            layer.uid &&
+                            (layer.uid === this.layerUid ||
+                                layer.uid ===
+                                    this.getLayerByUid(this.layerUid)!.uid)
                         ) {
                             this.applyLayerFilters();
                         }
@@ -699,9 +700,7 @@ export default defineComponent({
             // see: https://github.com/ramp4-pcar4/ramp4-pcar4/pull/57#pullrequestreview-377999397
 
             // default to regex filtering for text columns
-            colDef.filterParams.textMatcher = function (
-                params: any
-            ) {
+            colDef.filterParams.textMatcher = function (params: any) {
                 // treat * as a regular special character
                 const newFilterText = params.filterText.replace(/\*/, '\\*');
                 // surround filter text with .* to match anything before and after

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -161,7 +161,7 @@ export default defineComponent({
             this.$iApi.event.on(
                 GlobalEvents.LAYER_VISIBILITYCHANGE,
                 (newVisibility: any) => {
-                    if (this.uid === newVisibility.uid) {
+                    if (this.uid === newVisibility.layer.uid) {
                         this.visibilityModel = newVisibility.visibility;
                     }
                 }
@@ -172,7 +172,7 @@ export default defineComponent({
             this.$iApi.event.on(
                 GlobalEvents.LAYER_OPACITYCHANGE,
                 (newOpacity: any) => {
-                    if (this.uid === newOpacity.uid) {
+                    if (this.uid === newOpacity.layer.uid) {
                         this.opacityModel = Math.round(
                             newOpacity.opacity * 100
                         );

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -112,7 +112,7 @@ export class CommonLayer extends LayerInstance {
         this.state = newState;
         this.$iApi.event.emit(GlobalEvents.LAYER_STATECHANGE, {
             state: newState,
-            uid: this.uid
+            layer: this
         });
     }
 
@@ -158,7 +158,7 @@ export class CommonLayer extends LayerInstance {
                 //      also might want some redundant params, like layer id.
                 this.$iApi.event.emit(GlobalEvents.LAYER_VISIBILITYCHANGE, {
                     visibility: newval,
-                    uid: this.uid
+                    layer: this
                 });
             })
         );
@@ -171,7 +171,7 @@ export class CommonLayer extends LayerInstance {
                 //      also might want some redundant params, like layer id.
                 this.$iApi.event.emit(GlobalEvents.LAYER_OPACITYCHANGE, {
                     opacity: newval,
-                    uid: this.uid
+                    layer: this
                 });
             })
         );

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -352,7 +352,7 @@ export class MapImageLayer extends AttribLayer {
                             GlobalEvents.LAYER_VISIBILITYCHANGE,
                             {
                                 visibility: _sublayer.visibility,
-                                uid: _sublayer.uid
+                                layer: _sublayer
                             }
                         );
                         (_sublayer.parentLayer as CommonLayer) // the parent of a MapImageSublayer must be a CommonLayer
@@ -363,7 +363,7 @@ export class MapImageLayer extends AttribLayer {
                             GlobalEvents.LAYER_OPACITYCHANGE,
                             {
                                 opacity: newval,
-                                uid: _sublayer.uid
+                                layer: _sublayer
                             }
                         );
                     })


### PR DESCRIPTION
Closes #885 

This PR normalizes what is returned by global layer events such as visibility and opacity changes. These events will now return the LayerInstance object instead of simply returning the uid.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-885/demos/index.html#).

To test this PR, go to the demo link above and paste the following in console:

> debugInstance.event.on('layer/opacitychange', (payload) => { console.log("OPACITY CHANGED: ", payload) });
> debugInstance.event.on('layer/visibilitychange', (payload) => { console.log("VISIBILITY CHANGED: ", payload) });

After this, play around by changing the visibility and opacity of different layers. The event payload should be printed in console, and should contain the LayerInstance object instead of a uid.

~~**Note**: once PR #1066 is merged, the event listener for the opacity change in the settings file will need to be updated to use the new return value as well.~~ DONE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1077)
<!-- Reviewable:end -->
