### PR TITLE
navbar is no longer covered partially by panels

### DIFF
--- a/src/components/panel-stack/panel-container.vue
+++ b/src/components/panel-stack/panel-container.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="shadow-tm bg-white h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto min-w-0"
+        class="shadow-tm bg-white h-full xs:mr-0 sm:mr-12 last:mr-0 pointer-events-auto min-w-0 shrink-0"
         :class="panel.expanded ? 'flex-grow max-w-full' : ''"
         :style="panel.style"
         :data-cy="panel.id"

--- a/src/components/panel-stack/panel-stack.vue
+++ b/src/components/panel-stack/panel-stack.vue
@@ -38,13 +38,18 @@ export default defineComponent({
     data() {
         return {
             visible: get('panel/getVisible'),
-            stackWidth: sync('panel/stackWidth')
+            stackWidth: sync('panel/stackWidth'),
+            mobileView: sync('panel/mobileView')
         };
     },
 
     mounted(): void {
         // sync the `panel-stack` width into the store so that visible can get calculated
         const resizeObserver = new ResizeObserver((entries: any) => {
+            // Determine if the app is in mobile mode (the app container ONLY has the `xs` class on it. If it contains `sm`
+            // then the screen is too large).
+            this.mobileView = !this.$root?.$el.classList.contains('sm');
+
             this.stackWidth = entries[0].contentRect.width;
         });
 

--- a/src/components/shell.vue
+++ b/src/components/shell.vue
@@ -15,7 +15,7 @@
             </div>
             <keyboard-instructions-modal></keyboard-instructions-modal>
             <panel-stack
-                class="panel-stack sm:flex absolute inset-0 overflow-hidden xs:pl-40 sm:p-12 sm:pl-80 z-10 sm:pb-48 xs:pb-28"
+                class="panel-stack sm:flex absolute inset-0 overflow-hidden sm:p-12 z-10 sm:pl-80 xs:pl-40 sm:pb-48 xs:pb-28 xs:pr-0 sm:pr-40"
             ></panel-stack>
             <notification-floating-button
                 v-if="!appbarFixture"

--- a/src/store/modules/panel/panel-state.ts
+++ b/src/store/modules/panel/panel-state.ts
@@ -53,6 +53,14 @@ export class PanelState {
      * @memberof PanelState
      */
     stackWidth = 0;
+
+    /**
+     * True if the app contains the `xs` class, indicating that panels have no extra margin.
+     *
+     * @type {boolean}
+     * @memberof PanelState
+     */
+     mobileView = false;
 }
 
 // this should have been `AsyncComponentPromise` type, but something is off there

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -14,6 +14,7 @@ export enum PanelAction {
     removePanel = 'removePanel',
     setWidth = 'setWidth',
     setStackWidth = 'setStackWidth',
+    setMobileView = 'setMobileView',
     updateVisible = 'updateVisible'
 }
 
@@ -99,20 +100,28 @@ const actions = {
         context.dispatch(PanelAction.updateVisible);
     },
 
+    [PanelAction.setMobileView](context: PanelContext, value: boolean): void {
+        context.commit('SET_MOBILE_VIEW', value);
+    },
+
     [PanelAction.updateVisible](context: PanelContext): void {
         //TODO: update when panel width system is in place
         let remainingWidth = context.state.stackWidth;
         let nowVisible: PanelInstance[] = [];
 
         // add panels until theres no space in the stack
-        for (
-            let i = context.state.orderedItems.length - 1;
-            i >= 0 &&
-            remainingWidth >= (context.state.orderedItems[i].width || 350);
-            i--
-        ) {
-            remainingWidth -= context.state.orderedItems[i].width || 350;
-            nowVisible.unshift(context.state.orderedItems[i]);
+        for (let i = context.state.orderedItems.length - 1; i >= 0; i--) {
+            let panelWidth = context.state.orderedItems[i].width || 350;
+
+            // If not in mobile view, all panels have a 12px margin to the right.
+            if (!context.state.mobileView) {
+                panelWidth += 12;
+            }
+
+            if (remainingWidth >= panelWidth) {
+                remainingWidth -= panelWidth;
+                nowVisible.unshift(context.state.orderedItems[i]);
+            }
         }
 
         // if pinned isn't visible we need to change the order of the panels (to make it visible)

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -95,6 +95,13 @@ module.exports = {
     },
     plugins: [
         plugin(function ({ addVariant, e }) {
+            addVariant('xs', ({ modifySelectors, separator }) => {
+                modifySelectors(({ className }) => {
+                    return `.xs .${e(`xs${separator}${className}`)}`;
+                });
+            });
+        }),
+        plugin(function ({ addVariant, e }) {
             addVariant('sm', ({ modifySelectors, separator }) => {
                 modifySelectors(({ className }) => {
                     return `.sm .${e(`sm${separator}${className}`)}`;


### PR DESCRIPTION
Closes #898 

This PR adds right padding to the panel stack in order to prevent panels from covering the mapnav fixture. 

This PR also fixes an issue where panels in mobile mode were appearing behind the appbar (it doesn't seem like the `xs` breakpoint was working correctly).

Testing
---
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-898/demos/index.html).

To test this PR, open the demo link above and open the grid. You should notice that the mapnav is no longer partially cut off. If resolution is changed to mobile mode, it is still covered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1087)
<!-- Reviewable:end -->
