### PR TITLE
Schema Mapping for Help Fixture

### DIFF
--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -465,4 +465,12 @@ function uiUpgrader(r2ui: any, r4c: any): void {
         });
         r4c.fixturesEnabled.push('mapnav');
     }
+
+    if (r2ui.help) {
+        r4c.fixtures.help = {
+            folderName: r2ui.help.folderName || 'default',
+            panelWidth: 350 // this property is not supported in the RAMP2 config - I'm guessing its ok to initialize to the default
+        };
+        r4c.fixturesEnabled.push('help');
+    }
 }


### PR DESCRIPTION
Closes #605. 

The help fixture inside the RAMP4 config has two properties:
* `folderName` - transferred `folderName` property from RAMP2 config for help fixture.
* `panelWidth` - this property is not supported inside the RAMP2 config for the help fixture, so I set it to the default value of 350.

