### PR TITLE
Refresh interval, expected response time not supported for release

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -665,12 +665,12 @@
                 "refreshInterval": {
                     "type": "number",
                     "default": 0,
-                    "description": "The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes."
+                    "description": "The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
                 },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
                 "metadataUrl": {
                     "type": "string",
@@ -739,7 +739,7 @@
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
                 "metadataUrl": {
                     "type": "string",
@@ -804,12 +804,12 @@
                 "refreshInterval": {
                     "type": "number",
                     "default": 0,
-                    "description": "The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes."
+                    "description": "The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
                 },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
                 "metadataUrl": {
                     "type": "string",
@@ -1000,12 +1000,12 @@
                 "refreshInterval": {
                     "type": "number",
                     "default": 0,
-                    "description": "Automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes."
+                    "description": "Automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
                 },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
                 "metadataUrl": {
                     "type": "string",
@@ -1285,12 +1285,12 @@
                 "refreshInterval": {
                     "type": "number",
                     "default": 0,
-                    "description": "Automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes."
+                    "description": "Automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
                 },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
                 "metadataUrl": {
                     "type": "string",

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -83,7 +83,8 @@
                 <div class="rv-settings-divider"></div>
             </div>
 
-            <div class="flex flex-col justify-center">
+            <!-- TODO: revisit issue #1019 after v1.0.0 -->
+            <!-- <div class="flex flex-col justify-center">
                 <span class="rv-subheader">{{
                     $t('settings.label.interval')
                 }}</span>
@@ -103,7 +104,7 @@
                 ></settings-component>
 
                 <div class="rv-settings-divider"></div>
-            </div>
+            </div> -->
         </template>
     </panel-screen>
 </template>

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -532,7 +532,8 @@ export interface RampLayerConfig {
     name?: string;
     state?: RampLayerStateConfig;
     customRenderer?: any; // TODO expand, if worth it. fairly complex object
-    refreshInterval?: number;
+    // TODO revisit issue #1019 after v1.0.0
+    // refreshInterval?: number;
     initialFilteredQuery?: string;
     fieldMetadata?: RampLayerFieldMetadataConfig;
     nameField?: string;

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -297,7 +297,7 @@ export class CommonLayer extends LayerInstance {
     }
 
     // TODO strongly type if it makes sense. unsure if we want client config definitions in here
-    //      that said if client shema is different that here, things are gonna break so maybe this is good idea
+    //      that said if client schema is different that here, things are gonna break so maybe this is good idea
     /**
      * Take a layer config from the RAMP application and derives a configuration for an ESRI layer
      *
@@ -317,9 +317,11 @@ export class CommonLayer extends LayerInstance {
         };
 
         // TODO careful now. seems setting this willy nilly, even if undefined value, causes layer to keep pinging the server
-        if (typeof rampLayerConfig.refreshInterval !== 'undefined') {
-            esriConfig.refreshInterval = rampLayerConfig.refreshInterval;
-        }
+        // TODO revisit issue #1019 after v1.0.0
+        // if (typeof rampLayerConfig.refreshInterval !== 'undefined') {
+        //     esriConfig.refreshInterval = rampLayerConfig.refreshInterval;
+        // }
+
         return esriConfig;
     }
 


### PR DESCRIPTION
Closes #1019, #1021.

This PR disables code related to the `refreshInterval` attribute. The relevant Refresh Interval setting in the settings panel is now hidden. Also, the schema has been updated to reflect that `refreshInterval` and `expectedResponseTime` are currently not supported. 

The unsupported status was simply appended to the current descriptions, which leaves in the planned behaviour. Maybe it would be preferable to replace the entire description with just 'Not currently supported.'

[Demo.](http://ramp4-app.azureedge.net/demo/users/roryhofland/1019/samples/index.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1093)
<!-- Reviewable:end -->
