### PR TITLE
Implementation for layer error component and reloader option

### DIFF
--- a/src/fixtures/legend/components/component.vue
+++ b/src/fixtures/legend/components/component.vue
@@ -10,12 +10,14 @@
 </template>
 
 <script lang="ts">
+import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
+
+import { LegendItem, LegendTypes } from '../store/legend-defs';
 import LayerEntryV from './entry.vue';
 import LegendGroupV from './group.vue';
 import LegendPlaceholderV from './placeholder.vue';
-import { defineComponent } from 'vue';
-import type { PropType } from 'vue';
-import { LegendItem, LegendTypes } from '../store/legend-defs';
+import LegendErrorV from './error.vue';
 
 export default defineComponent({
     name: 'LegendComponentV',
@@ -29,15 +31,20 @@ export default defineComponent({
                 [LegendTypes.Set]: LegendGroupV,
                 [LegendTypes.Group]: LegendGroupV,
                 [LegendTypes.Entry]: LayerEntryV,
-                [LegendTypes.Placeholder]: LegendPlaceholderV
+                [LegendTypes.Placeholder]: LegendPlaceholderV,
+                [LegendTypes.Error]: LegendErrorV
             };
         }
     },
     mounted() {
-        this.legendItem.loadPromise.then(() => {
-            // need to manually update once the item loads to avoid some reactivity nuisances
-            this.$forceUpdate();
-        });
+        // need to manually update once the item loads/fails to avoid some reactivity nuisances
+        this.legendItem.loadPromise
+            .then(() => {
+                this.$forceUpdate();
+            })
+            .catch(() => {
+                this.$forceUpdate();
+            });
     }
 });
 </script>

--- a/src/fixtures/legend/components/error.vue
+++ b/src/fixtures/legend/components/error.vue
@@ -1,0 +1,153 @@
+<template>
+    <div class="legend-item">
+        <div
+            class="legend-item-header bg-red-200"
+            v-focus-item="'show-truncate'"
+            truncate-trigger
+        >
+            <div class="flex pr-10">
+                <!-- sad face for layer error -->
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="black"
+                    width="24px"
+                    height="24px"
+                >
+                    <path d="M0 0h24v24H0V0z" fill="none" />
+                    <path d="M0 0h24v24H0V0z" fill="none" />
+                    <circle cx="15.5" cy="9.5" r="1.5" />
+                    <circle cx="8.5" cy="9.5" r="1.5" />
+                    <circle cx="15.5" cy="9.5" r="1.5" />
+                    <circle cx="8.5" cy="9.5" r="1.5" />
+                    <path
+                        d="M 20,12C 20,7.6 16.4,4 12,4C 7.6,4 4,7.6 4,12C 4,16.4 7.6,20 12,20C 16.4,20 20,16.4 20,12 Z M 22,12C 22,17.5 17.5,22 12,22C 6.5,22 2,17.5 2,12C 2,6.5 6.5,2.00001 12,2.00001C 17.5,2.00001 22,6.5 22,12 Z M 15.5,8C 16.3,8 17,8.7 17,9.5C 17,10.3 16.3,11 15.5,11C 14.7,11 14,10.3 14,9.5C 14,8.7 14.7,8 15.5,8 Z M 10,9.5C 10,10.3 9.3,11 8.5,11C 7.7,11 7,10.3 7,9.5C 7,8.7 7.7,8 8.5,8C 9.3,8 10,8.7 10,9.5 Z M 12,14C 13.7524,14 15.2943,14.7212 16.1871,15.8129L 14.7697,17.2302C 14.3175,16.5078 13.2477,16 12,16C 10.7523,16 9.68254,16.5078 9.23024,17.2302L 7.81291,15.8129C 8.7057,14.7212 10.2476,14 12,14 Z"
+                    ></path>
+                </svg>
+            </div>
+
+            <!-- name -->
+            <div
+                class="flex-1 pointer-events-none"
+                v-truncate="{ externalTrigger: true }"
+            >
+                <span>{{ legendItem.name }}</span>
+            </div>
+
+            <!-- reload -->
+            <div class="relative">
+                <button
+                    class="text-gray-500 hover:text-black dropdown-button"
+                    :class="{
+                        disabled: !legendItem.controlAvailable(`reload`)
+                    }"
+                    @click="reloadLayer"
+                >
+                    <div class="flex p-8">
+                        <svg
+                            class="inline-block fill-current w-18 h-18"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            ></path>
+                        </svg>
+                    </div>
+                </button>
+            </div>
+
+            <!-- error -->
+            <!-- <div class="w-2 opacity-50 bg-red-600"></div> -->
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
+import { get } from '@/store/pathify-helper';
+import to from 'await-to-js';
+
+import { LayerStore } from '@/store/modules/layer';
+import { LayerControls, type RampLayerConfig } from '@/geo/api';
+import type { LayerInstance } from '@/api/internal';
+import type { LegendEntry } from '../store/legend-defs';
+
+export default defineComponent({
+    name: 'LegendErrorV',
+    props: {
+        legendItem: { type: Object as PropType<LegendEntry>, required: true }
+    },
+    data() {
+        return {
+            layerConfigs: get(LayerStore.layerConfigs)
+        };
+    },
+    methods: {
+        /**
+         * Reloads a layer on the map.
+         */
+        reloadLayer() {
+            if (this.legendItem!.controlAvailable(LayerControls.Reload)) {
+                // call reload on layer if it exists
+                if (this.legendItem.layer !== undefined) {
+                    this.legendItem!.layer!.reload();
+                } else {
+                    // otherwise attempt to re-create layer with layer config
+                    const layerConfig = this.layerConfigs.find(
+                        (lc: RampLayerConfig) => lc.id === this.legendItem.id
+                    );
+                    if (layerConfig !== undefined) {
+                        this.recreateLayer(layerConfig);
+                    }
+                }
+
+                // reload legend item state back to placeholder state
+                this.legendItem.reload();
+                // catch error if reload fails
+                this.legendItem.loadPromise.catch(() => {
+                    console.error(
+                        'Failed to reload layer - ',
+                        this.legendItem.name
+                    );
+                });
+            }
+        },
+        /**
+         * Attempt to recreate and instantiate layer from config.
+         */
+        async recreateLayer(layerConfig: RampLayerConfig) {
+            try {
+                // try to re-create new layer based on layerConfig
+                // same code to how layers are initialized when layer config array changes, expose this as layer API method?
+                await new Promise<LayerInstance>(async (resolve, reject) => {
+                    const layer = this.$iApi.geo.layer.createLayer(layerConfig);
+                    const [initiateErr] = await to(layer!.initiate());
+
+                    if (initiateErr) {
+                        reject(initiateErr);
+                    } else {
+                        this.$iApi.geo.map.addLayer(layer!);
+                    }
+
+                    resolve(layer!);
+                });
+            } catch {
+                return;
+            }
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped>
+.legend-item-header {
+    @apply px-5 py-5 pb-10 pr-0 flex items-center align-middle;
+}
+.legend-item-header:hover {
+    @apply bg-gray-200 cursor-pointer;
+}
+.disabled {
+    @apply text-gray-400 cursor-default;
+}
+</style>

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -29,7 +29,10 @@
                 }"
                 @click="toggleMetadata"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg
+                    class="inline-block fill-current w-18 h-18 mr-10"
+                    viewBox="0 0 23 21"
+                >
                     <path
                         d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
                     />
@@ -47,7 +50,10 @@
                 }"
                 @click="toggleSettings"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg
+                    class="inline-block fill-current w-18 h-18 mr-10"
+                    viewBox="0 0 23 21"
+                >
                     <g id="tune">
                         <path
                             d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "
@@ -67,7 +73,10 @@
                 }"
                 @click="toggleGrid"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg
+                    class="inline-block fill-current w-18 h-18 mr-10"
+                    viewBox="0 0 23 21"
+                >
                     <path
                         d="M 4.00002,3L 20,3C 21.1046,3 22,3.89543 22,5L 22,20C 22,21.1046 21.1046,22 20,22L 4.00001,22C 2.89544,22 2.00001,21.1046 2.00001,20L 2.00002,5C 2.00002,3.89543 2.89545,3 4.00002,3 Z M 4.00002,7L 4.00001,10L 8,10L 8,7.00001L 4.00002,7 Z M 10,7.00001L 9.99999,10L 14,10L 14,7.00001L 10,7.00001 Z M 20,10L 20,7L 16,7.00001L 16,10L 20,10 Z M 4.00002,12L 4.00002,15L 8,15L 8,12L 4.00002,12 Z M 4.00001,20L 8,20L 8,17L 4.00002,17L 4.00001,20 Z M 9.99999,12L 9.99999,15L 14,15L 14,12L 9.99999,12 Z M 9.99999,20L 14,20L 14,17L 9.99999,17L 9.99999,20 Z M 20,20L 20,17L 16,17L 16,20L 20,20 Z M 20,12L 16,12L 16,15L 20,15L 20,12 Z "
                     />
@@ -83,7 +92,10 @@
                 }"
                 @click="toggleSymbology"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg
+                    class="inline-block fill-current w-18 h-18 mr-10"
+                    viewBox="0 0 23 21"
+                >
                     <path
                         d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
                     />
@@ -99,7 +111,10 @@
                 }"
                 @click="zoomToLayerBoundary"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                <svg
+                    class="inline-block fill-current w-18 h-18 mr-10"
+                    viewBox="0 0 24 24"
+                >
                     <path
                         d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                     />
@@ -117,7 +132,10 @@
                 }"
                 @click="removeLayer"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg
+                    class="inline-block fill-current w-18 h-18 mr-10"
+                    viewBox="0 0 23 21"
+                >
                     <path
                         d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
                     ></path>
@@ -133,7 +151,10 @@
                 }"
                 @click="reloadLayer"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                <svg
+                    class="inline-block fill-current w-18 h-18 mr-10"
+                    viewBox="0 0 24 24"
+                >
                     <path
                         d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
                     ></path>

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -35,7 +35,7 @@ export class LayerAPI extends APIScope {
      * Will generate a RAMP Layer based on the supplied config object.
      *
      * @param {Object} config a valid layer configuration object
-     * @returns {LayerInstance} Layer in uninitialted state
+     * @returns {LayerInstance} Layer in uninitialized state
      */
     createLayer(config: RampLayerConfig): LayerInstance {
         let closs: new (config: any, iApi: InstanceAPI) => LayerInstance;


### PR DESCRIPTION
Closes #1026 
Closes #1034 

[Demo](http://ramp4-app.azureedge.net/demo/users/yileifeng/layer-error-indicator/samples/index.html#)

**Changes**:
- Added a legend error component for failed layer entries, pretty basic (sad face, added reloader button aligned on right side, legend block highlighted red) - feel free to make any UI suggestions and I will make the changes (e.g. should there be a dropdown option to remove the error'd layer component from the legend? no highlight?)
- Added an Error state for legend item objects to display this error component that is set after 3 seconds if no layer has been loaded (if layer exists and has not finished loading it will remain in placeholder state) and the legend item is still in placeholder mode (is there an additional/better check to ensure layer has failed? long loading layer test cases?)
- Added method for reloading an error'd legend component (similar to how layer configs are turned into layers at startup) - attempt to recreate and initialize layer based on its layer config (before going through the error cycle check again)
    - Tested method using a different working layer config and this works 

**Testing/Comments**: 
- Attempt to reload failed layers
- Suggestions for UI enhancements 
- Any improvements for error check / reloading logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1094)
<!-- Reviewable:end -->
