### PR TITLE
Layer Types and States

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -85,6 +85,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed                             |
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added                         |
 | FIXTURE_REMOVED<br>'fixture/removed'               | FixtureInstance object                                         | A fixture has been removed                       |
+| LAYER_DRAWSTATECHANGE<br>'layer/drawstatechange'   | _state_: new value, layer: LayerInstance object                | The layer draw state changed                     |
 | LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, layer: LayerInstance object              | The layer opacity changed                        |
 | LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was added to the map                   |
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
@@ -107,7 +108,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_MOUSEMOVE<br>'map/mousemove'                   | MapMove object                                                 | The mouse moved over the map                     |
 | MAP_REFRESH_END<br>'map/refreshend'                | none                                                           | The map view started refreshing                  |
 | MAP_REFRESH_START<br>'map/refreshstart'            | none                                                           | The map view finished refreshing                 |
-| MAP_RESIZED<br>'map/resized'                       | { height: number, width: number }                              | The map view changed size                        |
+| MAP_RESIZED<br>'map/resized'                       | _height_: new height, _width_: new width                       | The map view changed size                        |
 | MAP_SCALECHANGE<br>'map/scalechanged'              | scale denominator: number                                      | The map scale changed                            |
 | MAP_START<br>'map/start'                           | none                                                           | The map startup was requested                    |
 | PANEL_CLOSED<br>'panel/closed'                     | PanelInstance object                                           | A panel was closed                               |

--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -195,10 +195,34 @@ Determine if the layer is in a valid state. Invalid states would be pre-loaded o
 myLayer.isValidState; // true
 ```
 
-Get the state of the layer. This can provide a finer level of detail compared to `.isValidState`, such as if layer data is currently being refreshed from the server.
+Get the state of the layer. This state tracks the loading life cycle (i.e. loading, loaded, error)
 
 ```js
-myLayer.state; // 'rv-loaded'
+myLayer.state; // 'loaded'
+```
+
+Get the drawing state of the layer. This state tracks the drawing life cycle (i.e. getting or processing spatial data for the current map view)
+
+```js
+myLayer.drawState; // 'refresh'
+```
+
+Get the layer type. This matches the value that was provided in the config snippet. One can derive where the layer data came from and what functionality it can support.
+
+```js
+myLayer.layerType; // 'esri-tile'
+```
+
+Get the format of the layer. This indicates the type of Esri layer that has been instantiated on the map stack for this layer.
+
+```js
+myLayer.layerFormat; // 'feature'
+```
+
+Get the format of the spatial data in the layer.
+
+```js
+myLayer.dataFormat; // 'esriRaster'
 ```
 
 Get the visible scale ranges for layer or sublayer. A value of `0` on a range indicates there is no limit. Scales are fractions (i.e. a value of `2000` actually means 1/2000 scale), so `min` and `max` can be counterintuitive (large scale means the view is closer to real life size, so the viewport is closer to the ground level).

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -84,6 +84,12 @@ export enum GlobalEvents {
     HELP_TOGGLE = 'help/toggle',
 
     /**
+     * Fires when the drawing state of a layer changes.
+     * Payload: `({ layer: LayerInstance, state: string })`
+     */
+    LAYER_DRAWSTATECHANGE = 'layer/drawstatechange',
+
+    /**
      * Fires when the opacity of a layer changes.
      * Payload: `({ layer: LayerInstance, opacity: number })`
      */

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -151,13 +151,8 @@ export interface Attributes {
     [key: string]: any;
 }
 
-// TODO revisit what this actually means now. Is the .layerType value on a layer config?
-//      or is it the type of ESRI layer that lives in the map.
-//      if the first, we might need to be careful as we can have custom values now.
-//      will enum cause a problem?
-//      ^ Mar 2022 whatever it means, it drives what layer class is used to construct the layer.
-//      So it's the value of the config item, and figures out what do generate from that.
-//      See https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/338
+// aligns with config values
+// describes the source of the layer
 export enum LayerType {
     // ESRI
     FEATURE = 'esri-feature',
@@ -181,6 +176,18 @@ export enum LayerType {
     UNKNOWN = 'unknown',
 
     SUBLAYER = 'sublayer'
+}
+
+// describes how the layer is implemented in the map stack (i.e. hints at the ESRI Layer class)
+export enum LayerFormat {
+    FEATURE = 'feature',
+    GRAPHIC = 'graphic',
+    IMAGERY = 'imagery',
+    MAPIMAGE = 'map-image',
+    OSM = 'osm-tile',
+    TILE = 'tile',
+    UNKNOWN = 'unknown',
+    WMS = 'wms'
 }
 
 // Format indicates what form the spatial data is encoded in.
@@ -243,16 +250,17 @@ export interface EpsgLookup {
     (code: string | number): Promise<string>;
 }
 
-export interface DojoWindow extends Window {
-    require?: any; // require is both a function, and has event handlers. probably a way to define in typescript interface, not going to right now.
+export enum LayerState {
+    NEW = 'new', // this means ramp layer class exists but needs to be initialized()
+    LOADING = 'loading',
+    LOADED = 'loaded',
+    ERROR = 'error'
 }
 
-export enum LayerState { // these are used as css classes; hence the `rv` prefix
-    NEW = 'rv-new', // this means layer class exists but needs to be initialized()
-    REFRESH = 'rv-refresh',
-    LOADING = 'rv-loading',
-    LOADED = 'rv-loaded',
-    ERROR = 'rv-error'
+export enum DrawState {
+    NOT_LOADED = 'not-loaded',
+    REFRESH = 'refresh',
+    UP_TO_DATE = 'up-to-date'
 }
 
 export enum IdentifyResultFormat {
@@ -546,7 +554,7 @@ export interface RampLayerWmsLayerEntryConfig {
 // TODO investigate if we want to make a fancy interface heirarchy instead of pile-of-?-properties
 export interface RampLayerConfig {
     id: string;
-    layerType: string;
+    layerType: LayerType;
     url?: string;
     name?: string;
     state?: RampLayerStateConfig;
@@ -589,7 +597,7 @@ export interface RampExtentSetConfig {
 
 export interface RampBasemapLayerConfig {
     id?: string;
-    layerType: string;
+    layerType: LayerType;
     url: string;
     opacity?: number;
 }

--- a/src/geo/layer/common-graphic-layer.ts
+++ b/src/geo/layer/common-graphic-layer.ts
@@ -4,13 +4,14 @@
 
 import { CommonLayer, InstanceAPI } from '@/api/internal';
 import type { EsriGraphicsLayer } from '@/geo/esri';
-import { DataFormat, Graphic } from '@/geo/api';
+import { DataFormat, Graphic, LayerFormat } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 
 export class CommonGraphicLayer extends CommonLayer {
     protected constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);
         this.dataFormat = DataFormat.ESRI_FEATURE;
+        this.layerFormat = LayerFormat.GRAPHIC;
 
         // Until we implement hovertip support on RAMP Graphics, turn off hovertips to stop
         // hittest errors in the console.

--- a/src/geo/layer/csv-layer.ts
+++ b/src/geo/layer/csv-layer.ts
@@ -1,10 +1,14 @@
-// handles static geojson (e.g. from a user file or hardcoded in a config) or a geojson file hosted on a web server
-
-import { FileLayer } from '@/api/internal';
+import { FileLayer, InstanceAPI } from '@/api/internal';
+import { LayerType, type RampLayerConfig } from '@/geo/api';
 
 // NOTE this is currently 100% untested
 
 export class CsvLayer extends FileLayer {
+    constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
+        super(rampConfig, $iApi);
+        this.layerType = LayerType.CSV;
+    }
+
     async initiate(): Promise<void> {
         // TODO check if .sourceGeoJson is already populated?
         //      if this initiate is a reload, do we want to re-use it, or re-download? decide.

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -4,6 +4,7 @@ import {
     DefPromise,
     GeometryType,
     IdentifyResultFormat,
+    LayerFormat,
     LayerType
 } from '@/geo/api';
 import type {
@@ -28,6 +29,7 @@ export class FeatureLayer extends AttribLayer {
         this.tooltipField = '';
         this.supportsIdentify = true;
         this.layerType = LayerType.FEATURE;
+        this.layerFormat = LayerFormat.FEATURE;
     }
 
     async initiate(): Promise<void> {

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -18,10 +18,11 @@ import type {
 import {
     DataFormat,
     DefPromise,
+    DrawState,
     Extent,
     GeometryType,
     IdentifyResultFormat,
-    LayerType,
+    LayerFormat,
     Point
 } from '@/geo/api';
 
@@ -82,8 +83,8 @@ export class FileLayer extends AttribLayer {
         super(rampConfig, $iApi);
         this.supportsIdentify = true;
         this.isFile = true;
-        this.layerType = LayerType.FEATURE;
         this.dataFormat = DataFormat.ESRI_FEATURE;
+        this.layerFormat = LayerFormat.FEATURE;
         this.tooltipField = '';
     }
 
@@ -243,6 +244,15 @@ export class FileLayer extends AttribLayer {
         //      Alllso, we might consider putting this promise in the onLoadActions of BaseLayer, if we find other layers
         //      become hooked on the power of the view and require it to be ready.
         loadPromises.push(this.viewPromise.getPromise());
+
+        // since no "update" cycle, mark layer as up to date after all load promises resolve.
+        // Note looks like the view promise handler in CommonLayer is already setting this.
+        // leaving commented code to avoid confusion
+        /*
+        Promise.all(loadPromises).then(() => {
+            this.updateDrawState(DrawState.UP_TO_DATE);
+        });
+        */
 
         return loadPromises;
     }

--- a/src/geo/layer/geojson-layer.ts
+++ b/src/geo/layer/geojson-layer.ts
@@ -1,8 +1,14 @@
 // handles static geojson (e.g. from a user file or hardcoded in a config) or a geojson file hosted on a web server
 
-import { FileLayer } from '@/api/internal';
+import { FileLayer, InstanceAPI } from '@/api/internal';
+import { LayerType, type RampLayerConfig } from '@/geo/api';
 
 export class GeoJsonLayer extends FileLayer {
+    constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
+        super(rampConfig, $iApi);
+        this.layerType = LayerType.GEOJSON;
+    }
+
     async initiate(): Promise<void> {
         // TODO check if .sourceGeoJson is already populated?
         //      if this initiate is a reload, do we want to re-use it, or re-download? decide.

--- a/src/geo/layer/graphic-layer.ts
+++ b/src/geo/layer/graphic-layer.ts
@@ -1,5 +1,5 @@
 import { CommonGraphicLayer, InstanceAPI } from '@/api/internal';
-import { LayerType } from '@/geo/api';
+import { DrawState, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { EsriGraphicsLayer } from '@/geo/esri';
 import { markRaw } from 'vue';
@@ -51,7 +51,7 @@ export class GraphicLayer extends CommonGraphicLayer {
         //      would probably want to create them here.
 
         this.layerTree.name = this.name;
-
+        this.updateDrawState(DrawState.UP_TO_DATE);
         return loadPromises;
     }
 

--- a/src/geo/layer/imagery-layer.ts
+++ b/src/geo/layer/imagery-layer.ts
@@ -1,7 +1,7 @@
 // TODO add proper comments
 
 import { CommonLayer, InstanceAPI } from '@/api/internal';
-import { DataFormat, LayerType } from '@/geo/api';
+import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { EsriImageryLayer } from '@/geo/esri';
 import { markRaw } from 'vue';
@@ -13,6 +13,7 @@ export class ImageryLayer extends CommonLayer {
         super(rampConfig, $iApi);
         this.supportsIdentify = false;
         this.layerType = LayerType.IMAGERY;
+        this.layerFormat = LayerFormat.IMAGERY;
         this.dataFormat = DataFormat.ESRI_RASTER;
     }
 
@@ -50,7 +51,7 @@ export class ImageryLayer extends CommonLayer {
         this.layerTree.name = this.name;
 
         const legendPromise = this.$iApi.geo.symbology
-            .mapServerToLocalLegend(this.origRampConfig.url)
+            .mapServerToLocalLegend(this.origRampConfig.url!)
             .then(legArray => {
                 this.legend = legArray;
             });

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -1,9 +1,13 @@
 import { APIScope, InstanceAPI } from '@/api/internal';
 import {
+    DataFormat,
+    DrawState,
     Extent,
     Graphic,
     LayerControls,
+    LayerFormat,
     LayerState,
+    LayerType,
     NoGeometry,
     ScaleSet,
     TreeNode
@@ -30,9 +34,6 @@ import type {
  * @extends {APIScope}
  */
 export class LayerInstance extends APIScope {
-    get layerType(): string {
-        return '';
-    }
     config: any = {};
 
     /**
@@ -46,8 +47,12 @@ export class LayerInstance extends APIScope {
 
     initialized: boolean;
     state: LayerState;
+    drawState: DrawState;
 
     layerIdx: number;
+    layerType: LayerType;
+    layerFormat: LayerFormat;
+    dataFormat: DataFormat;
     supportsIdentify: boolean;
     supportsFeatures: boolean;
     supportsSublayers: boolean;
@@ -84,8 +89,12 @@ export class LayerInstance extends APIScope {
 
         this.initialized = false;
         this.state = LayerState.NEW;
+        this.drawState = DrawState.NOT_LOADED;
 
         this.layerIdx = -1; // default value
+        this.layerFormat = LayerFormat.UNKNOWN;
+        this.layerType = LayerType.UNKNOWN;
+        this.dataFormat = DataFormat.UNKNOWN;
         this.supportsIdentify = false; // this is updated by subclasses as they will know the real deal.
         this.supportsFeatures = false;
         this.supportsSublayers = false;
@@ -491,66 +500,6 @@ export class LayerInstance extends APIScope {
     }
 
     /**
-     * Removes the specified fixture from R4MP instance.
-     * This is a proxy to `RAMP.fixture.remove(...)`.
-     *
-     * @returns {this}
-     * @memberof FixtureInstance
-     */
-    // TODO re-add this if we support removal
-    /*
-    remove(): this {
-        this.$iApi.fixture.remove(this);
-        return this;
-    }
-    */
-
-    /**
-     * A helper function to create a "subclass" of the base Vue constructor
-     *
-     * @param {VueConstructor<Vue>} vueConstructor
-     * @param {ComponentOptions<Vue>} [options={}]
-     * @param {boolean} [mount=true]
-     * @returns {Vue}
-     * @memberof FixtureInstance
-     */
-    // TODO i have no idea what this does, but since layers are not vue componets like fixtures are,
-    //      will assume we don't need this
-    /*
-    extend(vueConstructor: VueConstructor<Vue>, options: ComponentOptions<Vue> = {}, mount: boolean = true): Vue {
-        const component = new (Vue.extend(vueConstructor))({
-            iApi: this.$iApi,
-            ...options,
-            propsData: {
-                ...options.propsData,
-                fixture: this
-            }
-        });
-        component.$mount();
-        return component;
-    }
-    */
-
-    // added?(): void;
-    // removed?(): void;
-    // initialized?(): void;
-    // terminated?(): void;
-
-    /**
-     * Returns the fixture config section (JSON) taken from the global config.
-     *
-     * @readonly
-     * @type {*}
-     * @memberof FixtureInstance
-     */
-    // this might return if we vuex thing. for now, config is normal local property
-    /*
-    get config(): any {
-        return this.$vApp.$store.get('config/getFixtureConfig', this.id);
-    }
-    */
-
-    /**
      * Get the parent layer for this layer
      * Only supported for sublayers
      *
@@ -590,6 +539,24 @@ export class LayerInstance extends APIScope {
     get sublayers(): Array<LayerInstance> {
         return this._sublayers;
     }
+
+    /**
+     * Initiates actions after layer load.
+     * Should generally only be called internally by the RAMP core.
+     */
+    onLoad(): void {}
+
+    /**
+     * Updates layer state and raises events.
+     * Should generally only be called internally by the RAMP core.
+     */
+    updateState(newState: LayerState): void {}
+
+    /**
+     * Updates layer draw state and raises events.
+     * Should generally only be called internally by the RAMP core.
+     */
+    updateDrawState(newState: DrawState): void {}
 
     /**
      * Finds an sublayer index corresponding to the given uid.

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -1,5 +1,10 @@
-import { AttribLayer, InstanceAPI, type MapImageLayer } from '@/api/internal';
-import { DataFormat, LayerType } from '@/geo/api';
+import {
+    AttribLayer,
+    GlobalEvents,
+    InstanceAPI,
+    type MapImageLayer
+} from '@/api/internal';
+import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { markRaw } from 'vue';
 
@@ -15,12 +20,13 @@ export class MapImageSublayer extends AttribLayer {
         super(config as RampLayerConfig, $iApi);
 
         this.layerType = LayerType.SUBLAYER;
+        this.layerFormat = LayerFormat.MAPIMAGE;
         this.isSublayer = true;
         this.layerIdx = layerIdx;
         this.parentLayer = parent;
         this.id = `${parent.id}-${layerIdx}`;
 
-        this.dataFormat = DataFormat.ESRI_FEATURE;
+        this.dataFormat = DataFormat.ESRI_FEATURE; // this will get flipped to raster during the server metadata checks if needed
         this.tooltipField = '';
         this.hovertips = false;
 
@@ -58,6 +64,10 @@ export class MapImageSublayer extends AttribLayer {
      * Load actions for a MapImage sublayer
      */
     onLoadActions(): Array<Promise<void>> {
+        // Note we do not call super.onLoadActions, which you would see happen in
+        //      every other layer. We don't want to wire up the standard "top level"
+        //      layer stuff for sublayers.
+
         this.layerTree.name = this.name;
         this.layerTree.layerIdx = this.layerIdx;
 

--- a/src/geo/layer/osm-tile-layer.ts
+++ b/src/geo/layer/osm-tile-layer.ts
@@ -1,7 +1,7 @@
 // TODO add proper comments
 
 import { CommonLayer, InstanceAPI } from '@/api/internal';
-import { DataFormat, LayerType } from '@/geo/api';
+import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 
 import type { LegendSymbology, RampLayerConfig } from '@/geo/api';
 
@@ -15,6 +15,7 @@ export class OsmTileLayer extends CommonLayer {
         super(rampConfig, $iApi);
         this.supportsIdentify = false;
         this.layerType = LayerType.OSM;
+        this.layerFormat = LayerFormat.OSM;
         this.dataFormat = DataFormat.OSM_TILE;
         this.supportsFeatures = false;
         this.hovertips = false;

--- a/src/geo/layer/shapefile-layer.ts
+++ b/src/geo/layer/shapefile-layer.ts
@@ -1,8 +1,12 @@
-// handles static geojson (e.g. from a user file or hardcoded in a config) or a geojson file hosted on a web server
-
-import { FileLayer } from '@/api/internal';
+import { FileLayer, InstanceAPI } from '@/api/internal';
+import { LayerType, type RampLayerConfig } from '@/geo/api';
 
 export class ShapefileLayer extends FileLayer {
+    constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
+        super(rampConfig, $iApi);
+        this.layerType = LayerType.SHAPEFILE;
+    }
+
     async initiate(): Promise<void> {
         // TODO check if .sourceGeoJson is already populated?
         //      if this initiate is a reload, do we want to re-use it, or re-download? decide.

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -1,7 +1,7 @@
 // TODO add proper comments
 
 import { CommonLayer, InstanceAPI } from '@/api/internal';
-import { DataFormat, LayerType } from '@/geo/api';
+import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { EsriTileLayer } from '@/geo/esri';
 import { markRaw } from 'vue';
@@ -14,6 +14,7 @@ export class TileLayer extends CommonLayer {
         this.supportsIdentify = false;
         this.hovertips = false;
         this.layerType = LayerType.TILE;
+        this.layerFormat = LayerFormat.TILE;
         this.dataFormat = DataFormat.ESRI_TILE;
     }
 
@@ -51,7 +52,7 @@ export class TileLayer extends CommonLayer {
         this.layerTree.name = this.name;
 
         const legendPromise = this.$iApi.geo.symbology
-            .mapServerToLocalLegend(this.origRampConfig.url)
+            .mapServerToLocalLegend(this.origRampConfig.url!)
             .then(legArray => {
                 this.legend = legArray;
             });

--- a/src/geo/layer/wfs-layer.ts
+++ b/src/geo/layer/wfs-layer.ts
@@ -1,9 +1,14 @@
 // handles static geojson (e.g. from a user file or hardcoded in a config) or a geojson file hosted on a web server
 
-import { FileLayer } from '@/api/internal';
-import { UrlWrapper } from '@/geo/api';
+import { FileLayer, InstanceAPI } from '@/api/internal';
+import { LayerType, type RampLayerConfig, UrlWrapper } from '@/geo/api';
 
 export class WfsLayer extends FileLayer {
+    constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
+        super(rampConfig, $iApi);
+        this.layerType = LayerType.WFS;
+    }
+
     async initiate(): Promise<void> {
         const wrapper = new UrlWrapper(this.config.url);
 

--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -4,6 +4,7 @@ import {
     DefPromise,
     GeometryType,
     IdentifyResultFormat,
+    LayerFormat,
     LayerType,
     UrlWrapper
 } from '@/geo/api';
@@ -31,6 +32,7 @@ export class WmsLayer extends CommonLayer {
         this.supportsIdentify = true;
         this.hovertips = false;
         this.layerType = LayerType.WMS;
+        this.layerFormat = LayerFormat.WMS;
         this.mimeType = rampConfig.featureInfoMimeType || ''; // TODO is there a default? will that be in the config defaulting?
         this.sublayerNames = [];
         this.dataFormat = DataFormat.OGC_RASTER;
@@ -81,7 +83,7 @@ export class WmsLayer extends CommonLayer {
         };
 
         // do a GetCapabilities call for only the specified layer if it is a geomet layer
-        if (rampLayerConfig.url.indexOf('/geomet') !== -1) {
+        if (rampLayerConfig.url!.indexOf('/geomet') !== -1) {
             // multiple values for layer/layers parameter currently not supported by geomet
             esriConfig.customParameters.layers = lEntries[0].id;
         }

--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -877,6 +877,12 @@ export class SymbologyAPI extends APIScope {
      *
      */
     private async getMapServerLegend(layerUrl: string): Promise<any> {
+        if (!layerUrl) {
+            throw new Error(
+                'Legend server request is missing the required url.'
+            );
+        }
+
         // standard json request with error checking
         const reqParams: __esri.RequestOptions = {
             query: { f: 'json' }


### PR DESCRIPTION
Donethankses #887 and #888

- `layerType` normalized to config layer type
- new `layerFormat` to provide info on how the layer is implemented in the map stack
- `REFRESH` removed from standard layer `state`
- `state` enum values removed the `rv-` prefix, since we're not using them for CSS trickery anymore
- new `drawState` property and associated event
- make sublayers also change status / raise events on state changes (important for UID matching in handlers)
- made some `protected` layer functions public to clean things up and simplify code
- doc updates, comments bulldozer
- fixed some broken imports that were missed due to compiler happily ignoring build errors :trophy:

[Demo](http://ramp4-app.azureedge.net/demo/users/james-rae/jamesparty/samples/index.html)

No noticeable behavior changes. You can watch event madness in the console with this fun block. Adding a new layer via wizard is best way to see states cycle.

```text
var r = debugInstance;
r.event.on('layer/statechange', p => { console.log('state change', p); })
r.event.on('layer/drawstatechange', p => { console.log('draw state change', p); })
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1098)
<!-- Reviewable:end -->
