### PR TITLE
Schema Mapping - Geoseach fixture

### DIFF
--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -394,7 +394,22 @@ function servicesUpgrader(r2Services: any, r4c: any): void {
     }
 
     if (r2Services.search) {
-        // TODO port data to geoserach fixture config
+        r4c.fixtures.geosearch = {};
+
+        // required in ramp2
+        r4c.fixtures.geosearch.serviceUrls = {
+            geoNames: r2Services.search.serviceUrls.geoNames,
+            geoLocation: r2Services.search.serviceUrls.geoLocation,
+            geoProvince: r2Services.search.serviceUrls.provinces,
+            geoTypes: r2Services.search.serviceUrls.types
+        };
+
+        if (r2Services.search.settings) {
+            r4c.fixtures.geosearch.serviceUrls.settings =
+                r2Services.search.settings;
+        }
+
+        r4c.fixturesEnabled.push('geosearch');
     }
 
     if (r2Services.export) {


### PR DESCRIPTION
Closes #615, does part of #646

The RAMP2 `search` service is mapped to the RAMP4 `geosearch` fixture.

- `geoNames`, `geoLocation`, `settings` are mapped to props of the same name in the RAMP4 schema
- `provinces`, `types` are mapped to `geoProvince`, `geoTypes` respectively
- `geoSuggest` and `disabledSearches` are not mapped, as they have no equivalent property in the RAMP4 schema
-  `geosearch` is added to `fixturesEnabled`

Since `export`, `exportMapUrl`, and `proxyUrl` have already been mapped to their appropriate definitions, this completes the mapping of the `services` nugget of the RAMP2 schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1099)
<!-- Reviewable:end -->
