### PR TITLE
Implement map mouse move throttling + start/end move events

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -54,6 +54,7 @@ let config = {
                         imperialScale: true
                     }
                 },
+                mapMouseThrottle: 200,
                 lodSets: [
                     {
                         id: 'LOD_NRCAN_Lambert_3978',

--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -106,6 +106,8 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_KEYUP<br>'map/keyup'                           | KeyboardEvent object                                           | A key was released                               |
 | MAP_MOUSEDOWN<br>'map/mousedown'                   | PointerEvent object                                            | A mouse button was depressed                     |
 | MAP_MOUSEMOVE<br>'map/mousemove'                   | MapMove object                                                 | The mouse moved over the map                     |
+| MAP_MOUSEMOVE_END<br>'map/mousemoveend'            | MapMove object                                                 | The mouse started moving over the map            |
+| MAP_MOUSEMOVE_START<br>'map/mousemovestart'        | MapMove object                                                 | The mouse stopped moving over the map            |
 | MAP_REFRESH_END<br>'map/refreshend'                | none                                                           | The map view started refreshing                  |
 | MAP_REFRESH_START<br>'map/refreshstart'            | none                                                           | The map view finished refreshing                 |
 | MAP_RESIZED<br>'map/resized'                       | _height_: new height, _width_: new width                       | The map view changed size                        |

--- a/schema.json
+++ b/schema.json
@@ -2119,7 +2119,14 @@
                 "pointZoomScale": {
                     "type": "number",
                     "default": 50000,
+                    "minimum": 1,
                     "description": "The zoom level when zooming to a point feature (e.g. when using the zoom button in the datagrid). Should be a positive integer."
+                },
+                "mapMouseThrottle": {
+                    "type": "number",
+                    "default": 0,
+                    "minimum": 0,
+                    "description": "The amount of throttling (in milliseconds) to be used for the map mouse move event. A value of 0 means no throttle."
                 }
             },
             "required": ["tileSchemas", "baseMaps"],

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -14,13 +14,11 @@ import type {
     MapMove,
     MouseCoords,
     RampBasemapConfig,
-    RampMapConfig,
     ScreenPoint
 } from '@/geo/api';
 import type { RampConfig } from '@/types';
 import { debounce, throttle } from 'throttle-debounce';
 import { MapCaptionStore } from '@/store/modules/map-caption';
-import { LayerStore } from '@/store/modules/layer';
 import { ConfigStore } from '@/store/modules/config';
 
 // TODO ensure some of the internal types used in the payload comments are published

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -208,6 +208,18 @@ export enum GlobalEvents {
     MAP_MOUSEMOVE = 'map/mousemove',
 
     /**
+     * Fires when the mouse moves stops moving over the map.
+     * Payload: `(params: MapMove)`
+     */
+    MAP_MOUSEMOVE_END = 'map/mousemoveend',
+
+    /**
+     * Fires when the mouse starts moving over the map.
+     * Payload: `(params: MapMove)`
+     */
+    MAP_MOUSEMOVE_START = 'map/mousemovestart',
+
+    /**
      * Fires when the map view finishes refreshing.
      * Payload: none
      */

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -649,4 +649,5 @@ export interface RampMapConfig {
     initialBasemapId: string;
     caption?: MapCaptionConfig;
     pointZoomScale?: number;
+    mapMouseThrottle?: number;
 }

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -81,7 +81,7 @@ export class CommonMapAPI extends APIScope {
      * List of ESRI watch handlers
      * @private
      */
-    protected handlers: Array<any>;
+    protected handlers: Array<{ type: string; handler: any }>;
 
     /**
      * The default zoom level when zooming to a point feature
@@ -128,7 +128,10 @@ export class CommonMapAPI extends APIScope {
             );
         }
         this.esriMap = markRaw(new EsriMap(esriConfig));
-        this.pointZoomScale = config.pointZoomScale && config.pointZoomScale > 0 ? config.pointZoomScale : 50000;
+        this.pointZoomScale =
+            config.pointZoomScale && config.pointZoomScale > 0
+                ? config.pointZoomScale
+                : 50000;
         this._targetDiv = targetDiv;
         this.createMapView(config.initialBasemapId);
     }
@@ -199,7 +202,7 @@ export class CommonMapAPI extends APIScope {
         this.created = false;
 
         // Clean up map view
-        this.handlers.forEach(h => h.remove());
+        this.handlers.forEach(h => h.handler.remove());
         this.handlers = [];
 
         // Destroy the current map view

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -75,36 +75,41 @@ export class OverviewMapAPI extends CommonMapAPI {
         };
         this.esriView.graphics.add(new EsriGraphic(graphic));
 
-        this.handlers.push(
-            this.esriView.on('mouse-wheel', esriMouseWheel => {
+        this.handlers.push({
+            type: 'mouse-wheel',
+            handler: this.esriView.on('mouse-wheel', esriMouseWheel => {
                 esriMouseWheel.stopPropagation();
             })
-        );
+        });
 
-        this.handlers.push(
-            this.esriView.on('double-click', esriDoubleClick => {
+        this.handlers.push({
+            type: 'double-click',
+            handler: this.esriView.on('double-click', esriDoubleClick => {
                 esriDoubleClick.stopPropagation();
             })
-        );
+        });
 
-        this.handlers.push(
-            this.esriView.on('key-down', esriKeyDown => {
+        this.handlers.push({
+            type: 'key-down',
+            handler: this.esriView.on('key-down', esriKeyDown => {
                 esriKeyDown.stopPropagation();
             })
-        );
+        });
 
-        this.handlers.push(
-            this.esriView.on('key-up', esriKeyUp => {
+        this.handlers.push({
+            type: 'key-up',
+            handler: this.esriView.on('key-up', esriKeyUp => {
                 esriKeyUp.stopPropagation();
             })
-        );
+        });
 
-        this.handlers.push(
-            this.esriView.on('drag', esriDrag => {
+        this.handlers.push({
+            type: 'drag',
+            handler: this.esriView.on('drag', esriDrag => {
                 esriDrag.stopPropagation();
                 this.mapDrag(esriDrag);
             })
-        );
+        });
 
         this.esriView.container.addEventListener('touchmove', e => {
             // need this for panning and zooming to work on mobile devices / touchscreens


### PR DESCRIPTION
## Closes #890, Closes #1029

## Changes
- Add `mapMouseThrottle` config property that controls the throttle time for map mouse move events
- Add `MAP_MOUSEMOVE_START` and `MAP_MOUSEMOVE_END` events fires when the mouse starts moving over the map, and stops moving over the map, respectively

## Notes
- When calling `setMapMouseThrottle` on the `MapAPI`, the delay on the old throttled function cannot be updated and so the only way to update the delay is by re-creating the handler
    - As far as I tested there seems to be no issues with replacing this ESRI `pointer-move` handler at runtime, but I could be missing something so please take a look at this

## [Demo](http://ramp4-app.azureedge.net/demo/users/sharvenp/890/samples/index.html)
-  Use this snippet to update the mouse throttle: `window.debugInstance.geo.map.setMapMouseThrottle(2000)`
    - The map caption coords formatter will update slower/faster depending on the set value
    - Note that the map caption coords has a minimum throttle of 200 ms on its update handler, so it won't update faster than that
- Use this snippet to test the mouse move start/end events:
```
window.debugInstance.event.on('map/mousemovestart', (evt) => console.log("MOUSE START: ", evt));
window.debugInstance.event.on('map/mousemoveend', (evt) => console.log("MOUSE END: ", evt));
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1100)
<!-- Reviewable:end -->
