### PR TITLE
all panels open in mobile mode, take up whole screen

### DIFF
--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -206,6 +206,10 @@ export class PanelInstance extends APIScope {
         if (!this.style['flex-basis']) {
             this.style['flex-basis'] = this.style.width || '350px';
         }
+
+        // set the panel width to 100% for mobile resolutions. The flex-basis property above
+        // will handle the regular width.
+        this.style['width'] = '100%';
     }
 
     /**

--- a/src/scripts/resize-observer.js
+++ b/src/scripts/resize-observer.js
@@ -9,7 +9,7 @@ if ('ResizeObserver' in self) {
     var ro = new ResizeObserver(function (entries) {
         // Default breakpoints that should apply to all observed
         // elements that don't define their own custom breakpoints.
-        var defaultBreakpoints = { xs: 384, sm: 576, md: 768, lg: 960 };
+        var defaultBreakpoints = { xs: 200, sm: 576, md: 768, lg: 960 };
 
         entries.forEach(function (entry) {
             // If breakpoints are defined on the observed element,

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -116,6 +116,9 @@ const actions = {
             // If not in mobile view, all panels have a 12px margin to the right.
             if (!context.state.mobileView) {
                 panelWidth += 12;
+            } else {
+                // If in mobile view, a single panel will take up the whole view.
+                panelWidth = 0;
             }
 
             if (remainingWidth >= panelWidth) {


### PR DESCRIPTION
Closes #1088

This PR fixes the issue where most panels would not open if the screen was not wide enough. It also fixes the issue where panels were not taking up the entire screen in mobile mode due to having a pre-defined width. In mobile mode, the pre-defined width will now be ignored and panels will take up the whole screen.

Testing
---
You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-1088/demos/index.html).

To test, open the demo link above and play around with different fixtures using Google Chrome's phone emulator feature in dev tools. Try using a few different phones with different resolutions and ensure everything works as expected (all panels open properly, nothing covers navbar, etc.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1101)
<!-- Reviewable:end -->
