### PR TITLE
Language switch reload prevention

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -124,12 +124,13 @@ export class InstanceAPI {
 
     /**
      * Initializes a Vue R4MP instance with the given config and options
+     *
      * @param {RampConfigs | undefined} configs language-keyed R4MP config
      * @param {RampOptions | undefined} options startup options for this R4MP instance
      */
     initialize(configs?: RampConfigs, options?: RampOptions): void {
         // TODO: decide whether to move to src/main.ts:createApp
-        // TODO: store a reference to the even bus in the global store [?]
+        // TODO: store a reference to the event bus in the global store [?]
         if (configs?.configs !== undefined) {
             let langConfigs: {
                 [key: string]: RampConfig;
@@ -197,6 +198,7 @@ export class InstanceAPI {
 
     /**
      * Reloads Vue R4MP instance with a new config
+     *
      * @param {RampConfigs} configs language-keyed R4MP config
      * @param {RampOptions} options startup options for this R4MP instance
      */
@@ -337,9 +339,19 @@ export class InstanceAPI {
             return;
         }
 
-        this.$vApp.$i18n.locale = language;
-        const activeConfig = this.getConfig();
+        const langs = this.$vApp.$store.get(ConfigStore.getRegisteredLangs) as {
+            [key: string]: string;
+        };
 
+        // prevent full map reload if the new language uses the same config
+        if (langs[language] === langs[this.$vApp.$i18n.locale]) {
+            this.$vApp.$i18n.locale = language;
+            return;
+        }
+
+        this.$vApp.$i18n.locale = language;
+
+        const activeConfig = this.getConfig();
         this.$vApp.$iApi.event.emit(GlobalEvents.CONFIG_CHANGE, activeConfig);
 
         // reload the map to apply new config

--- a/src/store/modules/config/config-state.ts
+++ b/src/store/modules/config/config-state.ts
@@ -6,10 +6,11 @@ export class ConfigState {
     activeBasemapConfig: RampBasemapConfig | undefined;
     // change if decide need to support registering multiple configs per lang
     registeredConfigs: { [key: string]: RampConfig };
+    registeredLangs: { [key: string]: string };
 
     constructor(config: any) {
         this.config = config;
-        const lang = config.language;
-        this.registeredConfigs = { [lang]: config };
+        this.registeredConfigs = {};
+        this.registeredLangs = {};
     }
 }

--- a/src/store/modules/config/config-store.ts
+++ b/src/store/modules/config/config-store.ts
@@ -1,6 +1,5 @@
-import type { ActionContext, Action } from 'vuex';
+import type { ActionContext } from 'vuex';
 import { make } from 'vuex-pathify';
-import merge from 'deepmerge';
 import type { RampBasemapConfig, RampMapConfig } from '@/geo/api';
 
 import { ConfigState } from './config-state';
@@ -17,6 +16,10 @@ const getters = {
         state: ConfigState
     ): { [key: string]: RampConfig } => {
         return state.registeredConfigs;
+    },
+
+    getRegisteredLangs: (state: ConfigState): { [key: string]: string } => {
+        return state.registeredLangs;
     },
 
     getActiveConfig:
@@ -67,14 +70,19 @@ const actions = {
         const config = configInfo.config;
         if (langs !== undefined && langs.length > 0) {
             // register config for specified languages
-            langs.forEach(
-                (lang: string) =>
-                    (context.state.registeredConfigs[lang] = config)
-            );
+            langs.forEach((lang: string) => {
+                context.state.registeredConfigs[lang] = config;
+                // add correspondence between language and config
+                context.state.registeredLangs[lang] = lang;
+            });
         } else {
             // register config for all available languages
             for (const lang in i18n.global.messages) {
                 context.state.registeredConfigs[lang] = config;
+                // initially each language corresponds to first config by default
+                context.state.registeredLangs[lang] = Object.keys(
+                    context.state.registeredConfigs
+                )[0];
             }
         }
     },
@@ -160,6 +168,14 @@ export enum ConfigStore {
      * `@returns` <{ [key: string]: RampConfig }> RAMP config for each registered language
      */
     getRegisteredConfigs = 'config/getRegisteredConfigs',
+    /**
+     * Get correspondence from each language to config
+     *
+     * `@remarks` Getter - use `@Get`
+     *
+     * `@returns` <{ [key: string]: string }> RAMP config langauge for each registered language
+     */
+    getRegisteredLangs = 'config/getRegisteredLangs',
     /**
      * Get active config based on the current map language
      *


### PR DESCRIPTION
Closes #1090.

### Summary

This PR changes the behaviour of switching the language of RAMP so that a reload only occurs when languages don't correspond to the same config file. For example, suppose there exist the following registered configs:
```
registeredConfigs = {
    en: enConfig,
    fr: frConfig,
    es: enConfig
}
```

Switching from English to French and back will cause the RAMP instance to reload, since they have different configs. Switching from English to Spanish and back, however, will now simply change the strings in the instance without a full reload.

### [Demo](http://ramp4-app.azureedge.net/demo/users/roryhofland/1090/demos/index.html)
- Since the current demo has only one config (`en`), this should demonstrate language switching without reloading, as all languages correspond with `en`.
- To test a config with both `en` and `fr` configs, copy and run [this snippet](https://gist.github.com/roryhofland/f9d0122e34f717c0bc9a9f34a1d9cd64) in the browser console. This will make so that English and French both have a unique config, and switching the language should cause the instance to reload.

### Changes
- added `getRegisteredLangs` getter to `ConfigStore`, which returns a correspondence between registered languages and configs
- added `registeredLangs` to `ConfigState`, which keeps track of the pairings of languages and configs
- modified `registerConfig` in `ConfigStore` to update `registeredLangs`
- modified `setLanguage` in `instance` to perform a check that prevents reloading when the new language shares a config with the current language
- removed unused imports

### Notes
- Thank you to Sharven. This implements the first option from [his proposed solutions](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1090#issuecomment-1145268757).
- The constructor of `ConfigState` previously had `registeredConfigs` initialized as `this.registeredConfigs = { [lang]: config };`. This appeared to just register an `undefined` config before any others, which seemed unnecessary so I removed it. If it has a reason for existing that I missed, let me know and I'll revert this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1109)
<!-- Reviewable:end -->
