### PR TITLE
Export options alignment + grid spacing

### DIFF
--- a/src/components/notification-center/screen.vue
+++ b/src/components/notification-center/screen.vue
@@ -63,7 +63,6 @@ export default defineComponent({
             clearAll: call('notification/clearAll')
         };
     },
-
     methods: {
         isPinned(): boolean {
             return this.panel.isPinned;

--- a/src/fixtures/export/settings-button.vue
+++ b/src/fixtures/export/settings-button.vue
@@ -6,7 +6,9 @@
         tooltip-placement="top"
     >
         <template #header>
-            <div class="text-gray-400 w-full h-full hover:text-black p-8">
+            <div
+                class="flex items-center text-gray-400 w-full h-full hover:text-black p-8"
+            >
                 <svg
                     class="fill-current w-24 h-24 m-auto"
                     xmlns="http://www.w3.org/2000/svg"

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1,48 +1,50 @@
 <template>
     <div class="flex flex-col w-full h-full bg-white">
-        <div class="flex items-center pl-8 pb-8">
-            <input
-                @keyup="updateQuickSearch()"
-                v-model="quicksearch"
-                class="rv-global-search rv-input pr-32"
-                aria-invalid="false"
-                :aria-label="$t('grid.filters.label.global')"
-                :placeholder="$t('grid.filters.label.global')"
-            />
-            <div class="-ml-32">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fit=""
-                    preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 24 24"
-                    focusable="false"
-                    class="fill-current w-24 h-24 flex-shrink-0"
-                    v-if="quicksearch.length < 3"
-                >
-                    <g id="search_cache224">
-                        <path
-                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                        ></path>
-                    </g>
-                </svg>
-                <svg
-                    data-v-486a0302=""
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 352 512"
-                    class="fill-current w-18 h-18 ml-6 cursor-pointer"
-                    @click="resetQuickSearch()"
-                    v-else
-                >
-                    <path
+        <div class="flex items-center justify-between pl-8 pb-8">
+            <div class="flex items-center pb-4 mr-8 min-w-0">
+                <input
+                    @keyup="updateQuickSearch()"
+                    v-model="quicksearch"
+                    class="rv-global-search rv-input pr-32 min-w-0"
+                    aria-invalid="false"
+                    :aria-label="$t('grid.filters.label.global')"
+                    :placeholder="$t('grid.filters.label.global')"
+                />
+                <div class="-ml-30">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fit=""
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 24 24"
+                        focusable="false"
+                        class="fill-current w-24 h-24 flex-shrink-0"
+                        v-if="quicksearch.length < 3"
+                    >
+                        <g id="search_cache224">
+                            <path
+                                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                            ></path>
+                        </g>
+                    </svg>
+                    <svg
                         data-v-486a0302=""
-                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
-                    ></path>
-                </svg>
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 352 512"
+                        class="fill-current w-18 h-18 ml-6 cursor-pointer"
+                        @click="resetQuickSearch()"
+                        v-else
+                    >
+                        <path
+                            data-v-486a0302=""
+                            d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                        ></path>
+                    </svg>
+                </div>
             </div>
 
             <div class="pb-2 flex ml-auto">
                 <button
-                    class="p-8 h-40 disabled:opacity-30 disabled:cursor-default text-gray-500 hover:text-black"
+                    class="p-4 h-40 disabled:opacity-30 disabled:cursor-default text-gray-500 hover:text-black"
                     @click="applyFiltersToMap"
                     :content="$t('grid.label.filters.apply')"
                     v-tippy="{ placement: 'bottom', hideOnClick: false }"
@@ -83,7 +85,7 @@
 
                 <!-- toggle column filters -->
                 <button
-                    class="p-8 h-40 text-gray-500 hover:text-black"
+                    class="p-4 h-40 text-gray-500 hover:text-black"
                     @click="toggleShowFilters()"
                     :content="
                         gridOptions.floatingFilter


### PR DESCRIPTION
Closes #1105, closes #1116.

### Summary

This PR fixes the alignment of the options button in the export panel at lower resolutions. Also, the grid panel no longer has extra space on the right hand side at lower resolutions.

To test these changes, resize your RAMP instance to a lower resolution (mobile resolution).

### [Demo](http://ramp4-app.azureedge.net/demo/users/roryhofland/1090/demos/index.html)