### PR TITLE
fix remaining grid prop warnings

### DIFF
--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -30,13 +30,9 @@ import { directive as tippyDirective } from 'vue-tippy';
 
 export default defineComponent({
     name: 'DetailsButtonRendererV',
+    props: ['params'],
     directives: {
         tippy: tippyDirective
-    },
-    data(props) {
-        return {
-            params: props.params as any
-        };
     },
     mounted() {
         // need to hoist events to top level cell wrapper to be keyboard accessible


### PR DESCRIPTION
Closes #1027 

This PR should remove the remaining `prop` warnings that show up when you open the grid.

You can find a demo for this PR [here](http://ramp4-app.azureedge.net/demo/users/RyanCoulsonCA/fix-1027/demos/index.html).

To test this PR, go to the demo link above and open a grid. You should notice that no more errors pop up when scrolling through the grid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1120)
<!-- Reviewable:end -->
