### PR TITLE
Grid column error fix

### DIFF
--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -160,7 +160,7 @@ export default defineComponent({
                         [index].querySelector('.move-left') as HTMLElement
                 ).focus();
 
-                this.params.gridApi.ensureColumnVisible(allColumns[index]);
+                this.params.api.ensureColumnVisible(allColumns[index]);
             }
         },
 
@@ -175,7 +175,7 @@ export default defineComponent({
 
             if (this.canMoveRight) {
                 this.columnApi.moveColumn(this.params.column, index);
-                this.params.gridApi.ensureColumnVisible(allColumns[index]);
+                this.params.api.ensureColumnVisible(allColumns[index]);
             }
         },
 


### PR DESCRIPTION
Closes #1122.

Moving columns left and right in the grid panel no longer throws an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1129)
<!-- Reviewable:end -->
