### PR TITLE
Restored easy language switching

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -142,17 +142,12 @@ export class InstanceAPI {
                 langConfigs[Object.keys(langConfigs)[0]];
             this.$vApp.$store.set(ConfigStore.newConfig, langConfig);
 
-            // register first config for all available languages and then overwrite configs per language as needed
+            // register configs and languages in the store
             this.$vApp.$store.set(ConfigStore.registerConfig, {
                 config: langConfig,
-                langs: Object.keys(this.$vApp.$i18n.messages)
+                configLangs: Object.keys(langConfigs),
+                allLangs: Object.keys(this.$vApp.$i18n.messages)
             });
-            for (let lang in langConfigs) {
-                this.$vApp.$store.set(ConfigStore.registerConfig, {
-                    config: langConfigs[lang],
-                    langs: [lang]
-                });
-            }
 
             // set the initial basemap
             this.$vApp.$store.set(

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -142,12 +142,19 @@ export class InstanceAPI {
                 langConfigs[Object.keys(langConfigs)[0]];
             this.$vApp.$store.set(ConfigStore.newConfig, langConfig);
 
-            // register configs and languages in the store
+            // register first config for all available languages and then overwrite configs per language as needed
             this.$vApp.$store.set(ConfigStore.registerConfig, {
                 config: langConfig,
                 configLangs: Object.keys(langConfigs),
                 allLangs: Object.keys(this.$vApp.$i18n.messages)
             });
+
+            for (let lang in langConfigs) {
+                this.$vApp.$store.set(ConfigStore.registerConfig, {
+                    config: langConfigs[lang],
+                    configLangs: [lang]
+                });
+            }
 
             // set the initial basemap
             this.$vApp.$store.set(

--- a/src/store/modules/config/config-store.ts
+++ b/src/store/modules/config/config-store.ts
@@ -73,7 +73,6 @@ const actions = {
         if (allLangs !== undefined && allLangs.length > 0) {
             // register config for all available languages
             allLangs.forEach((lang: string) => {
-                console.log(lang);
                 context.state.registeredConfigs[lang] = config;
                 // initially each language corresponds to first config by default
                 context.state.registeredLangs[lang] = Object.keys(

--- a/src/store/modules/config/config-store.ts
+++ b/src/store/modules/config/config-store.ts
@@ -6,7 +6,6 @@ import { ConfigState } from './config-state';
 import type { RootState } from '@/store';
 import { LayerStore } from '../layer';
 import type { RampConfig } from '@/types';
-import { i18n } from '@/lang';
 
 // use for actions
 type ConfigContext = ActionContext<ConfigState, RootState>;
@@ -66,11 +65,26 @@ const actions = {
         context: ConfigContext,
         configInfo: any
     ): void {
-        const langs = configInfo.langs;
+        // configLangs are languages with a given config, whereas allLangs include languages without their own config
+        const configLangs = configInfo.configLangs;
         const config = configInfo.config;
-        if (langs !== undefined && langs.length > 0) {
+        const allLangs = configInfo.allLangs;
+
+        if (allLangs !== undefined && allLangs.length > 0) {
+            // register config for all available languages
+            allLangs.forEach((lang: string) => {
+                console.log(lang);
+                context.state.registeredConfigs[lang] = config;
+                // initially each language corresponds to first config by default
+                context.state.registeredLangs[lang] = Object.keys(
+                    context.state.registeredConfigs
+                )[0];
+            });
+        }
+
+        if (configLangs !== undefined && configLangs.length > 0) {
             // register config for specified languages
-            langs.forEach((lang: string) => {
+            configLangs.forEach((lang: string) => {
                 context.state.registeredConfigs[lang] = config;
                 // add correspondence between language and config
                 context.state.registeredLangs[lang] = lang;


### PR DESCRIPTION
Closes #1124.

### Summary

This PR restores the behaviour of switching the language of RAMP to that of #1109.

**TL;DR** when switching language, the RAMP instance will only reload when necessary, otherwise a simple string update will occur. 

### Testing
- the current demo has only one config, so switching language should not reload the page
- copy and run [this snippet](https://gist.github.com/roryhofland/f9d0122e34f717c0bc9a9f34a1d9cd64) in the console to test a config with separate English and French configs to witness page reloading. The French config should load without layers on the map.

### Changes
- restored `registerConfig` behaviour
- modified `registerConfig` in `ConfigStore` to include new `allLangs` parameter
- removed unused import

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1130)
<!-- Reviewable:end -->
