### PR TITLE
Handle appbar/mapnav buttons on fixture removal

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -429,7 +429,16 @@ let config = {
                         'layer-reorder'
                     ]
                 },
-                mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
                 export: {
                     title: {
                         value: 'All Your Base are Belong to Us',

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -1,5 +1,10 @@
 import { TinyEmitter } from 'tiny-emitter';
-import { APIScope, InstanceAPI, LayerInstance } from './internal';
+import {
+    APIScope,
+    InstanceAPI,
+    LayerInstance,
+    PanelInstance
+} from './internal';
 import type { DetailsAPI } from '@/fixtures/details/api/details';
 import type { SettingsAPI } from '@/fixtures/settings/api/settings';
 import type { HelpAPI } from '@/fixtures/help/api/help';
@@ -633,10 +638,9 @@ export class EventAPI extends APIScope {
                 zeHandler = (panel: PanelInstance) => {
                     if (
                         this.$iApi.fixture.get('appbar') &&
-                        !this.$iApi.$vApp.$store
-                            .get('appbar/order')
+                        !(this.$iApi.$vApp.$store.get('appbar/order') as any)
                             .flat()
-                            .find(item => item === panel.id)
+                            .find((item: string) => item === panel.id)
                     ) {
                         this.$iApi.$vApp.$store.dispatch(
                             `appbar/${AppbarAction.ADD_TEMP_BUTTON}`,
@@ -650,13 +654,12 @@ export class EventAPI extends APIScope {
                 zeHandler = (panel: PanelInstance) => {
                     if (
                         this.$iApi.fixture.get('appbar') &&
-                        !this.$iApi.$vApp.$store
-                            .get('appbar/order')
+                        !(this.$iApi.$vApp.$store.get('appbar/order') as any)
                             .flat()
-                            .find(item => item === panel.id)
+                            .find((item: string) => item === panel.id)
                     ) {
                         this.$iApi.$vApp.$store.dispatch(
-                            `appbar/${AppbarAction.REMOVE_TEMP_BUTTON}`,
+                            `appbar/${AppbarAction.REMOVE_BUTTON}`,
                             panel.id
                         );
                     }

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -207,15 +207,6 @@ export class InstanceAPI {
      * @param {RampOptions} options startup options for this R4MP instance
      */
     reload(configs?: RampConfigs, options?: RampOptions): void {
-        // TODO: remove the below step after #882 and appbar/mapnav fixture removal is donethanks
-        // clear appbar and mapnav buttons
-        this.$vApp.$store.set('appbar/items', {});
-        this.$vApp.$store.set('appbar/order', []);
-        this.$vApp.$store.set('appbar/temporary', []);
-        this.$vApp.$store.set('appbar/tempButtonDict', {});
-        this.$vApp.$store.set('mapnav/items', {});
-        this.$vApp.$store.set('mapnav/order', []);
-
         // remove all fixtures
         // get list of all fixture ids currently added
         let addedFixtures: Array<string> = Object.keys(

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -35,7 +35,7 @@
                     :active="panel.expanded"
                 />
                 <minimize
-                    v-if="panel.button && temporary.includes(panel.id)"
+                    v-if="panel.button && temporary?.includes(panel.id)"
                     @click="panel.minimize()"
                 />
                 <close @click="panel.close()" />

--- a/src/fixtures/appbar/store/appbar-state.ts
+++ b/src/fixtures/appbar/store/appbar-state.ts
@@ -10,10 +10,10 @@ export class AppbarState {
     /**
      * An ordered list of fixed appbar item ids.
      *
-     * @type {string[]}
+     * @type {(string | AppbarItemInstance)[][]}
      * @memberof AppbarState
      */
-    order: string[] = [];
+    order: (string | AppbarItemInstance)[][] = [];
 
     /**
      * An ordered list of panel IDs. Used to display the buttons registered to the panels.

--- a/src/fixtures/basemap/index.ts
+++ b/src/fixtures/basemap/index.ts
@@ -28,9 +28,14 @@ class BasemapFixture extends FixtureInstance {
 
     removed() {
         console.log(`[fixture] ${this.id} removed`);
-        // TODO:
-        // - remove mapnav button
-        // - remove appbar button (blocked by #882)
+
+        if (!!this.$iApi.fixture.get('appbar')) {
+            this.$iApi.$vApp.$store.dispatch('appbar/removeButton', 'basemap');
+        }
+        if (!!this.$iApi.fixture.get('mapnav')) {
+            this.$iApi.$vApp.$store.dispatch('mapnav/removeItem', 'basemap');
+        }
+
         this.$iApi.panel.remove('basemap');
     }
 }

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -57,10 +57,20 @@ class DetailsFixture extends DetailsAPI {
         // override the removed method here to get access to scope
         this.removed = () => {
             console.log(`[fixture] ${this.id} removed`);
-            // TODO: remove appbar buttons (blocked by #882)
             unwatch();
             this.$iApi.panel.remove('details-items');
             this.$iApi.panel.remove('details-layers');
+
+            if (!!this.$iApi.fixture.get('appbar')) {
+                this.$iApi.$vApp.$store.dispatch(
+                    'appbar/removeButton',
+                    'details-layers'
+                );
+                this.$iApi.$vApp.$store.dispatch(
+                    'appbar/removeButton',
+                    'details-items'
+                );
+            }
 
             // /*
             //     TODO: Fix this hack!

--- a/src/fixtures/export/index.ts
+++ b/src/fixtures/export/index.ts
@@ -58,7 +58,6 @@ class ExportFixture extends ExportAPI {
 
         this.removed = () => {
             console.log(`[fixture] ${this.id} removed`);
-            // TODO: remove appbar button (blocked by #882)
             unwatch();
             // remove sub fixtures
             this.$iApi.fixture
@@ -74,6 +73,13 @@ class ExportFixture extends ExportAPI {
             this.$iApi.fixture
                 .get<ExportScalebarFixture>('export-scalebar')
                 ?.remove();
+
+            if (!!this.$iApi.fixture.get('appbar')) {
+                this.$iApi.$vApp.$store.dispatch(
+                    'appbar/removeButton',
+                    'export'
+                );
+            }
 
             this.$iApi.panel.remove('export');
             this.$vApp.$store.unregisterModule('export');

--- a/src/fixtures/geosearch/index.ts
+++ b/src/fixtures/geosearch/index.ts
@@ -1,6 +1,7 @@
 import { markRaw } from 'vue';
 import GeosearchScreenV from './screen.vue';
 import { GeosearchAPI } from './api/geosearch';
+import GeosearchNavButtonV from './nav-button.vue';
 import { geosearch } from './store/index';
 
 import messages from './lang/lang.csv?raw';
@@ -10,6 +11,8 @@ class GeosearchFixture extends GeosearchAPI {
         console.log(`[fixture] ${this.id} added`);
 
         this.$vApp.$store.registerModule('geosearch', geosearch(this.config));
+
+        this.$iApi.component('geosearch-nav-button', GeosearchNavButtonV);
 
         this.$iApi.panel.register(
             {
@@ -31,7 +34,18 @@ class GeosearchFixture extends GeosearchAPI {
 
     removed() {
         console.log(`[fixture] ${this.id} removed`);
-        // TODO: remove appbar button (blocked by #882)
+
+        if (!!this.$iApi.fixture.get('appbar')) {
+            this.$iApi.$vApp.$store.dispatch(
+                'appbar/removeButton',
+                'geosearch'
+            );
+        }
+
+        if (!!this.$iApi.fixture.get('mapnav')) {
+            this.$iApi.$vApp.$store.dispatch('mapnav/removeItem', 'geosearch');
+        }
+
         this.$vApp.$store.unregisterModule('geosearch');
         this.$iApi.panel.remove('geosearch');
     }

--- a/src/fixtures/geosearch/nav-button.vue
+++ b/src/fixtures/geosearch/nav-button.vue
@@ -1,17 +1,17 @@
 <template>
     <mapnav-button
         :onClickFunction="togglePanel"
-        :tooltip="$t('basemap.title')"
+        :tooltip="$t('geosearch.title')"
     >
         <svg
             class="fill-current w-32 h-20"
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 24 24"
         >
-            <path d="M0 0h24v24H0z" fill="none" />
             <path
-                d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z"
+                d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
             />
+            <path d="M0 0h24v24H0z" fill="none" />
         </svg>
     </mapnav-button>
 </template>
@@ -20,10 +20,10 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-    name: 'BasemapNavButtonV',
+    name: 'GeosearchNavButtonV',
     methods: {
         togglePanel() {
-            this.$iApi.panel.toggle('basemap');
+            this.$iApi.panel.toggle('geosearch');
         }
     }
 });

--- a/src/fixtures/grid/index.ts
+++ b/src/fixtures/grid/index.ts
@@ -36,7 +36,10 @@ class GridFixture extends GridAPI {
     }
 
     removed() {
-        // TODO: remove appbar button (blocked by #882)
+        if (!!this.$iApi.fixture.get('appbar')) {
+            this.$iApi.$vApp.$store.dispatch('appbar/removeButton', 'grid');
+        }
+
         this.$iApi.panel.remove('grid');
         this.$vApp.$store.unregisterModule('grid');
     }

--- a/src/fixtures/help/index.ts
+++ b/src/fixtures/help/index.ts
@@ -41,8 +41,12 @@ class HelpFixture extends HelpAPI {
         // override the removed method here to get access to scope
         this.removed = () => {
             console.log(`[fixture] ${this.id} removed`);
-            // TODO: remove mapnav button (probably need to discuss how to do this properly)
             unwatch();
+
+            if (!!this.$iApi.fixture.get('mapnav')) {
+                this.$iApi.$vApp.$store.dispatch('mapnav/removeItem', 'help');
+            }
+
             this.$vApp.$store.unregisterModule('help');
             this.$iApi.panel.remove('help');
         };

--- a/src/fixtures/layer-reorder/index.ts
+++ b/src/fixtures/layer-reorder/index.ts
@@ -32,7 +32,12 @@ class LayerReorderFixture extends LayerReorderAPI {
 
     removed() {
         console.log(`[fixture] ${this.id} removed`);
-        // TODO: remove appbar button (blocked by #882)
+        if (!!this.$iApi.fixture.get('appbar')) {
+            this.$iApi.$vApp.$store.dispatch(
+                'appbar/removeButton',
+                'layer-reorder'
+            );
+        }
         this.$iApi.panel.remove('layer-reorder');
     }
 }

--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -18,8 +18,8 @@
                 `"
                 @click="toggleGrid"
                 v-focus-item="'show-truncate'"
-                @mouseover.stop="$event.currentTarget._tippy.show()"
-                @mouseout.self="$event.currentTarget._tippy.hide()"
+                @mouseover.stop="$event.currentTarget._tippy?.show()"
+                @mouseout.self="$event.currentTarget._tippy?.hide()"
                 :content="
                     legendItem.controlAvailable('datatable') &&
                     getDatagridExists()

--- a/src/fixtures/legend/index.ts
+++ b/src/fixtures/legend/index.ts
@@ -1,6 +1,7 @@
 import { markRaw } from 'vue';
 import { LegendAPI } from './api/legend';
 import { legend } from './store/index';
+import LegendNavButtonV from './nav-button.vue';
 import LegendScreenV from './screen.vue';
 
 import messages from './lang/lang.csv?raw';
@@ -8,6 +9,9 @@ import messages from './lang/lang.csv?raw';
 class LegendFixture extends LegendAPI {
     added() {
         console.log(`[fixture] ${this.id} added`);
+
+        this.$iApi.component('legend-nav-button', LegendNavButtonV);
+
         this.$iApi.panel.register(
             {
                 legend: {
@@ -43,8 +47,19 @@ class LegendFixture extends LegendAPI {
         // override the removed method here to get access to scope
         this.removed = () => {
             console.log(`[fixture] ${this.id} removed`);
-            // TODO: remove appbar button (blocked by #882)
             unwatch();
+
+            if (!!this.$iApi.fixture.get('appbar')) {
+                this.$iApi.$vApp.$store.dispatch(
+                    'appbar/removeButton',
+                    'legend'
+                );
+            }
+
+            if (!!this.$iApi.fixture.get('mapnav')) {
+                this.$iApi.$vApp.$store.dispatch('mapnav/removeItem', 'legend');
+            }
+
             this.$iApi.panel.remove('legend');
             this.$vApp.$store.unregisterModule('legend');
         };

--- a/src/fixtures/legend/nav-button.vue
+++ b/src/fixtures/legend/nav-button.vue
@@ -1,8 +1,5 @@
 <template>
-    <mapnav-button
-        :onClickFunction="togglePanel"
-        :tooltip="$t('basemap.title')"
-    >
+    <mapnav-button :onClickFunction="togglePanel" :tooltip="$t('legend.title')">
         <svg
             class="fill-current w-32 h-20"
             xmlns="http://www.w3.org/2000/svg"
@@ -10,7 +7,7 @@
         >
             <path d="M0 0h24v24H0z" fill="none" />
             <path
-                d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z"
+                d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
             />
         </svg>
     </mapnav-button>
@@ -20,10 +17,10 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-    name: 'BasemapNavButtonV',
+    name: 'LegendNavButtonV',
     methods: {
         togglePanel() {
-            this.$iApi.panel.toggle('basemap');
+            this.$iApi.panel.toggle('legend');
         }
     }
 });

--- a/src/fixtures/mapnav/api/mapnav.ts
+++ b/src/fixtures/mapnav/api/mapnav.ts
@@ -58,16 +58,26 @@ export class MapnavAPI extends FixtureInstance {
      * @memberof MapnavAPI
      */
     _validateItems() {
+        // system mapnav controls that are not tied to a fixture
+        const systemControls: string[] = [
+            'geolocator',
+            'zoom',
+            'home',
+            'fullscreen'
+        ];
+
         // get the ordered list of items and see if any of them are registered
         this.$vApp.$store.get<string[]>('mapnav/order')!.forEach(id => {
-            // check components with the literal id and with a `-nav-button` suffix;
-            [`${id}-nav-button`, id].some(v => {
-                // TODO: fix this if needed
-                // if (v in this.$vApp.$options.components!) {
-                // if an item is registered globally, save the name of the registered component
-                this.$vApp.$store.set(`mapnav/items@${id}.componentId`, v);
-                // }
-            });
+            // can't check if the nav button component is registered
+            // so we make the assumption that it will always have the `-nav-button` prefix
+
+            // check if fixture exists, or if control is a system control
+            if (this.$iApi.fixture.get(id) || systemControls.includes(id)) {
+                this.$vApp.$store.set(
+                    `mapnav/items@${id}.componentId`,
+                    `${id}-nav-button`
+                );
+            }
         });
     }
 }

--- a/src/fixtures/mapnav/store/mapnav-store.ts
+++ b/src/fixtures/mapnav/store/mapnav-store.ts
@@ -7,9 +7,6 @@ import type { RootState } from '@/store/state';
 
 type MapnavContext = ActionContext<MapnavState, RootState>;
 
-type StoreActions = { [key: string]: Action<MapnavState, RootState> };
-type StoreMutations = { [key: string]: Mutation<MapnavState> };
-
 export enum MapnavAction {
     REMOVE_ITEM = 'removeItem'
 }
@@ -34,16 +31,15 @@ const getters = {
 
 const actions = {
     [MapnavAction.REMOVE_ITEM](context: MapnavContext, value: string) {
-        const item = context.state.items[value];
-        if (item) {
-            context.commit(MapnavMutation.REMOVE_ITEM, item);
-        }
+        context.commit(MapnavMutation.REMOVE_ITEM, value);
     }
 };
 
 const mutations = {
     [MapnavMutation.REMOVE_ITEM](state: MapnavState, value: string) {
-        delete state.items[value];
+        if (value in state.items) {
+            delete state.items[value];
+        }
         let index = state.order.indexOf(value);
         if (index !== -1) {
             state.order.splice(index, 1);

--- a/src/fixtures/metadata/index.ts
+++ b/src/fixtures/metadata/index.ts
@@ -38,7 +38,12 @@ class MetadataFixture extends MetadataAPI {
 
         this.removed = () => {
             console.log(`[fixture] ${this.id} removed`);
-            // TODO: remove appbar button (blocked by #882)
+            if (!!this.$iApi.fixture.get('appbar')) {
+                this.$iApi.$vApp.$store.dispatch(
+                    'appbar/removeButton',
+                    'metadata'
+                );
+            }
             this.$iApi.event.off(handler);
             this.$iApi.panel.remove('metadata');
         };

--- a/src/fixtures/settings/index.ts
+++ b/src/fixtures/settings/index.ts
@@ -30,7 +30,9 @@ class SettingsFixture extends SettingsAPI {
 
     removed() {
         console.log(`[fixture] ${this.id} removed`);
-        // TODO: handle appbar button (blocked by #882)
+        if (!!this.$iApi.fixture.get('appbar')) {
+            this.$iApi.$vApp.$store.dispatch('appbar/removeButton', 'settings');
+        }
         this.$iApi.panel.remove('settings');
     }
 }

--- a/src/fixtures/wizard/index.ts
+++ b/src/fixtures/wizard/index.ts
@@ -34,7 +34,6 @@ class WizardFixture extends WizardAPI {
         // override the removed method here to get access to scope
         this.removed = () => {
             console.log(`[fixture] ${this.id} removed`);
-            // TODO: handle appbar button (blocked by #882)
             this.$iApi.panel.remove('wizard');
             this.$vApp.$store.unregisterModule('wizard');
             layerSource = undefined; // will be cleaned up by JS garbage collector


### PR DESCRIPTION
## Closes #1107 

## Changes
- Added appbar/mapnav buttons will be removed on fixture removal
    - Buttons will also be automatically added if fixture is re-added (only if fixture button is specified in the appbar/mapnav config) 
- Fully implemented appbar/mapnav fixture removal
- Added mapnav buttons for legend and geosearch
- Fixed bug where `entry.vue` will sometimes throw `undefined` errors when `_tippy` is undefined

## Testing

- Fixtures can be removed through the console with `window.debugInstance.fixture.remove('<fixture name>')`
- Fixtures can be added with `window.debugInstance.fixture.add('<fixture name>')`


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1131)
<!-- Reviewable:end -->
