### PR TITLE
Fixed notification popup closing when dismissing a notification

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div @focusout="closeDropdown">
+    <div>
         <button
             class="text-gray-500 hover:text-black dropdown-button"
             @click="open = !open"
@@ -21,7 +21,7 @@
             :class="{ 'text-center': centered }"
             ref="dropdown"
         >
-            <slot v-bind:close="closeDropdown"></slot>
+            <slot v-bind:close="() => (open = !open)"></slot>
         </div>
     </div>
 </template>
@@ -74,6 +74,16 @@ export default defineComponent({
             { capture: true }
         );
 
+        window.addEventListener('blur', () => {
+            this.open = false;
+        });
+
+        window.addEventListener('focusin', event => {
+            if (!this.$el.contains(event.target)) {
+                this.open = false;
+            }
+        });
+
         // $nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
         this.$nextTick(() => {
             this.popper = createPopper(
@@ -105,15 +115,15 @@ export default defineComponent({
             },
             { capture: true }
         );
-        this.open = false;
-    },
-
-    methods: {
-        closeDropdown(e: Event) {
-            if (!e.currentTarget.contains(e.relatedTarget)) {
+        window.removeEventListener('blur', () => {
+            this.open = false;
+        });
+        window.removeEventListener('focusin', event => {
+            if (!this.$el.contains(event.target)) {
                 this.open = false;
             }
-        }
+        });
+        this.open = false;
     }
 });
 </script>


### PR DESCRIPTION
Closes #1128.

* Previously, removing a notification would cause the dropdown menu to lose focus, which would result in the dropdown menu (the notification popup) closing.
* Now, when a notification is removed, focus is given to the root `div` element in the notification list, so that the popup doesn't close and clicking away from the screen still closes the popup as before.
* To test this, in the demo, paste the snippet below in the console:
```
debugInstance.notify.show("info", "Here is some info")
debugInstance.notify.show("warning", "Here is a warning")
debugInstance.notify.show("error", "Here is an error")
```
Then, dismiss the notifications individually and notice that the popup will not close.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1136)
<!-- Reviewable:end -->
