### PR TITLE
Map Caption fixes for lower res

### DIFF
--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="map-caption absolute bottom-0 flex justify-center pointer-events-auto cursor-default select-none text-gray-400 bg-black-75 left-0 right-0 py-2 sm:py-6"
+        class="map-caption absolute bottom-0 flex justify-end pointer-events-auto cursor-default select-none text-gray-400 bg-black-75 left-0 right-0 py-2 sm:py-6"
     >
         <about-ramp-dropdown
             class="sm:block display-none ml-8 mr-4"
@@ -12,7 +12,7 @@
         ></notifications-caption-button>
 
         <span
-            class="relative truncate top-1 sm:block display-none"
+            class="relative truncate top-1 sm:block display-none shrink-0"
             v-if="!attribution.logo.disabled"
         >
             <a
@@ -30,8 +30,17 @@
         </span>
 
         <span
-            class="relative ml-10 truncate top-2 sm:block display-none"
+            class="relative ml-10 top-2 sm:block display-none"
             v-if="!attribution.text.disabled"
+            v-truncate="{
+                options: {
+                    placement: 'top',
+                    hideOnClick: false,
+                    theme: 'ramp4',
+                    animation: 'scale',
+                    appendTo: 'parent'
+                }
+            }"
         >
             {{ attribution.text.value }}
         </span>
@@ -40,64 +49,75 @@
 
         <!-- TODO: find out if any ARIA attributes are needed for the map scale -->
 
-        <span
-            v-if="!cursorCoords.disabled"
-            class="flex-shrink-0 relative top-2 pr-14 pl-14 text-sm sm:text-base"
-        >
-            {{ cursorCoords.formattedString }}
-        </span>
-
-        <button
-            v-if="!scale.disabled"
-            class="flex-shrink-0 mx-10 px-4 pointer-events-auto cursor-pointer border-none"
-            @click="onScaleClick"
-            :aria-pressed="scale.isImperialScale"
-            :aria-label="$t('map.toggleScaleUnits')"
-            v-tippy="{
-                placement: 'top',
-                hideOnClick: false,
-                theme: 'ramp4',
-                animation: 'scale',
-                appendTo: 'parent'
-            }"
-            :content="$t('map.toggleScaleUnits')"
-        >
-            <span
-                class="border-solid border-2 border-white border-t-0 h-5 mr-4 inline-block"
-                :style="{ width: scale.width }"
-            ></span>
-            <span class="relative text-sm sm:text-base">
-                {{ scale.label }}
-            </span>
-        </button>
-
-        <dropdown-menu
-            class="flex-shrink-0 pointer-events-auto focus:outline-none px-4 mr-4"
-            position="top-end"
-            :tooltip="$t('map.changeLanguage')"
-            tooltip-placement="top-end"
-        >
-            <template #header>
-                <span
-                    class="text-gray-400 hover:text-white text-sm sm:text-base pb-5"
-                >
-                    {{ $t('map.language.short') }}
-                </span>
-            </template>
-            <a
-                v-for="(item, index) in lang"
-                :key="`${item}-${index}`"
-                class="flex-auto items-center text-sm sm:text-base cursor-pointer"
-                :class="{ 'font-bold': item === $iApi.$vApp.$i18n.locale }"
-                href="javascript:;"
-                @click="changeLang(item)"
+        <div class="flex min-w-0 sm:min-w-fit relative justify-end">
+            <div
+                v-if="!cursorCoords.disabled"
+                class="relative top-2 pl-8 sm:px-14 text-sm sm:text-base"
+                v-truncate="{
+                    options: {
+                        hideOnClick: false,
+                        theme: 'ramp4',
+                        animation: 'scale'
+                    }
+                }"
             >
-                {{ $t('map.language.' + item) }}
-                <span class="sr-only" v-if="item === $iApi.$vApp.$i18n.locale">
-                    {{ $t('map.language.curr') }}
+                {{ cursorCoords.formattedString }}
+            </div>
+
+            <button
+                v-if="!scale.disabled"
+                class="flex-shrink-0 mx-10 px-4 pointer-events-auto cursor-pointer border-none"
+                @click="onScaleClick"
+                :aria-pressed="scale.isImperialScale"
+                :aria-label="$t('map.toggleScaleUnits')"
+                v-tippy="{
+                    placement: 'top',
+                    hideOnClick: false,
+                    theme: 'ramp4',
+                    animation: 'scale'
+                }"
+                :content="$t('map.toggleScaleUnits')"
+            >
+                <span
+                    class="border-solid border-2 border-white border-t-0 h-5 mr-4 inline-block"
+                    :style="{ width: scale.width }"
+                ></span>
+                <span class="relative text-sm sm:text-base">
+                    {{ scale.label }}
                 </span>
-            </a>
-        </dropdown-menu>
+            </button>
+
+            <dropdown-menu
+                class="flex-shrink-0 pointer-events-auto focus:outline-none px-4 mr-4"
+                position="top-end"
+                :tooltip="$t('map.changeLanguage')"
+                tooltip-placement="top-end"
+            >
+                <template #header>
+                    <span
+                        class="text-gray-400 hover:text-white text-sm sm:text-base pb-5"
+                    >
+                        {{ $t('map.language.short') }}
+                    </span>
+                </template>
+                <a
+                    v-for="(item, index) in lang"
+                    :key="`${item}-${index}`"
+                    class="flex-auto items-center text-sm sm:text-base cursor-pointer"
+                    :class="{ 'font-bold': item === $iApi.$vApp.$i18n.locale }"
+                    href="javascript:;"
+                    @click="changeLang(item)"
+                >
+                    {{ $t('map.language.' + item) }}
+                    <span
+                        class="sr-only"
+                        v-if="item === $iApi.$vApp.$i18n.locale"
+                    >
+                        {{ $t('map.language.curr') }}
+                    </span>
+                </a>
+            </dropdown-menu>
+        </div>
     </div>
 </template>
 

--- a/src/directives/truncate/truncate.ts
+++ b/src/directives/truncate/truncate.ts
@@ -41,19 +41,16 @@ export const Truncate: Directive = {
             placement: 'bottom-start',
             //flip: false, // can't find a replacement for Vue3
             //boundary: 'window',
-            triggerTarget: triggerElement
+            triggerTarget: triggerElement,
+            ...(binding.value?.options || {})
         });
-
-        // if (binding.value && binding.value.options) {
-        //     (el as any)._tippy.set(binding.value.options);
-        // }
     },
     updated(el: HTMLElement, binding: DirectiveBinding) {
         // update content and options
         if ((el as any)._tippy) {
             (el as any)._tippy.setContent(el.textContent);
             if (binding.value && binding.value.options) {
-                (el as any)._tippy.set(binding.value.options);
+                (el as any)._tippy.setProps(binding.value.options);
             }
         }
     },

--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -164,7 +164,7 @@ import type { PropType } from 'vue';
 import { GlobalEvents, LayerInstance } from '@/api';
 import { LayerControls, LayerState, type LegendSymbology } from '@/geo/api';
 
-import { LegendTypes, type LegendEntry } from '../store/legend-defs';
+import type { LegendEntry } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
 import LegendSymbologyStackV from './symbology-stack.vue';
 import LegendOptionsV from './legend-options.vue';


### PR DESCRIPTION
Closes #1091.

This PR makes changes to the map caption, mostly at lower resolutions.

### Changes
- The ESRI icon no longer shrinks
- The attribution string now has an available tooltip when truncated
- The mouse coordinate string and language switching menu no longer clip out of the screen at mobile resolutions
    - Instead, the screen favours the language menu, since it is an interactive menu and the coordinates are just a string
    - The coordinate string will truncate and have an available tooltip
- Fixed the `truncate` directive to allow passing in `v-tippy` options (thanks Spencer)
- Tooltips for elements in the map caption are no longer covered by the appbar at low resolutions
- Removed an unused import
 

### Testing
- Try out the map caption at various resolutions. The smallest horizontal resolution I tested against was 280px, which is the Galaxy Fold preset on Chrome

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1146)
<!-- Reviewable:end -->
