### PR TITLE
fix closing details panel on small resolutions

### DIFF
--- a/src/fixtures/details/layers-screen.vue
+++ b/src/fixtures/details/layers-screen.vue
@@ -58,6 +58,8 @@ export default defineComponent({
             payload: this.get(DetailsStore.payload),
             getLayerByUid: this.get('layer/getLayerByUid'),
             layers: this.get('layer/layers'),
+            mobileMode: this.get('panel/mobileView'),
+            remainingWidth: this.get('panel/getRemainingWidth'),
             watchers: [] as Array<Function>
         };
     },
@@ -126,9 +128,17 @@ export default defineComponent({
                 return;
             }
 
-            // track last identify request timestamp and add to payload items
+            // track last identify request timestamp and add to payload items. If no new results, app is in mobile mode, or if
+            // there is not enough space available to open the detail items panel, then disable the greedy identify.
+            const detailsPanel = this.$iApi.panel.get('details-items');
+            const detailsWidth = detailsPanel.width || 350;
+
             this.activeGreedy =
-                newPayload.length === 0 ? 0 : newPayload[0].requestTime;
+                this.mobileMode ||
+                (this.remainingWidth < detailsWidth && !detailsPanel.isOpen) ||
+                newPayload.length === 0
+                    ? 0
+                    : newPayload[0].requestTime;
 
             this.layerResults = newPayload;
 

--- a/src/store/modules/panel/panel-state.ts
+++ b/src/store/modules/panel/panel-state.ts
@@ -55,12 +55,20 @@ export class PanelState {
     stackWidth = 0;
 
     /**
+     * The remaining screen width that non-opened panels are allowed to take up.
+     *
+     * @type {number}
+     * @memberof PanelState
+     */
+    remainingWidth = 0;
+
+    /**
      * True if the app contains the `xs` class, indicating that panels have no extra margin.
      *
      * @type {boolean}
      * @memberof PanelState
      */
-     mobileView = false;
+    mobileView = false;
 }
 
 // this should have been `AsyncComponentPromise` type, but something is off there

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -29,7 +29,8 @@ export enum PanelMutation {
     SET_ORDERED_ITEMS = 'SET_ORDERED_ITEMS',
     SET_PRIORITY = 'SET_PRIORITY',
     SET_VISIBLE = 'SET_VISIBLE',
-    SET_WIDTH = 'SET_WIDTH'
+    SET_WIDTH = 'SET_WIDTH',
+    SET_REMAINING_WIDTH = 'SET_REMAINING_WIDTH'
 }
 
 const getters = {
@@ -47,7 +48,16 @@ const getters = {
             }
 
             return state.visible;
-        }
+        },
+
+    /**
+     * Returns `remainingWidth` from the state. Displays how much space is left for panels to be displayed on the map.
+     *
+     * @returns {number}
+     */
+    getRemainingWidth: (state: PanelState): number => {
+        return state.remainingWidth;
+    }
 };
 
 const actions = {
@@ -174,6 +184,7 @@ const actions = {
             context.commit(PanelMutation.SET_PRIORITY, null);
         }
 
+        context.commit(PanelMutation.SET_REMAINING_WIDTH, remainingWidth);
         context.commit(PanelMutation.SET_VISIBLE, nowVisible);
     }
 };


### PR DESCRIPTION
Closes #1080

Closing the details item panel when on smaller resolutions should no longer result in the panel re-opening immediately. This PR makes it so if there is not enough room on the screen to open the details item panel, only the result panel will open (as proposed in the original issue). 

To test this PR, ensure the greedy identify still works if there's room for the panel to open, and then test smaller resolutions to ensure that the panel does not open and can be closed without immediately popping back up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1147)
<!-- Reviewable:end -->
