### PR TITLE
Add CORS info and error messages to wizard

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -124,6 +124,12 @@
                     >
                         {{ validationMessages.invalid }}
                     </div>
+                    <div
+                        v-if="validation && failureError"
+                        class="text-red-900 text-xs"
+                    >
+                        {{ validationMessages.failure }}
+                    </div>
                 </div>
             </div>
         </div>
@@ -151,6 +157,7 @@ import type { PropType } from 'vue';
 interface ValidationMsgs {
     required: string;
     invalid: string;
+    failure: string;
 }
 
 interface SelectionOption {
@@ -166,6 +173,10 @@ export default defineComponent({
             default: false
         },
         formatError: {
+            type: Boolean,
+            default: false
+        },
+        failureError: {
             type: Boolean,
             default: false
         },

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -13,6 +13,9 @@ wizard.format.type.service,Service type,1,Type de service,1
 wizard.format.type.file,File format,1,Format du fichier,1
 wizard.format.type.error.required,Service or file type is required,1,Le service ou le type de fichier est requis,1
 wizard.format.type.error.invalid,Invalid file or service type,1,Type de fichier ou de service non valide,1
+wizard.format.type.error.failure,Failed to load data from file/service,1,Failed to load data from file/service,0
+wizard.format.info.cors,Service needs to be CORS enabled,1,Service needs to be CORS enabled,0
+wizard.format.warn.cors,Service may not support CORS,1,Service may not support CORS,0
 wizard.fileType.csv,CSV,1,CSV,1
 wizard.fileType.shapefile,zipped Shapefile,1,Shapefile zippé,1
 wizard.fileType.geojson,GeoJSON,1,GeoJSON,1


### PR DESCRIPTION
## Closes #1132

## Changes
- Added info message that conditionally displays when the service is expected to be CORS enabled
    - This condition is determined based on the scenarios highlighted in the issue
- Added new error message that displays when the wizard fails to load data
    -   If CORS is expected, an additional message is appended indicating that the service may not be CORS enabled 

## Testing

*Note: there is no proxy set in the demo page

- Enter a URL in the wizard
    - Select any layer type - wizard will display the CORS info message
    - Set proxy to some value with `debugInstance.geo.proxy = 'www.google.ca'` - now only selecting the WFS layer type will display the message (since CORS is always expected for this layer type)
-  Go back and enter this [url](http://ramp4-app.azureedge.net/legacy/assets/sample_data/canada.json) (CORS is not enabled on this file service)
    - Select any of the file types - the CORS info message will always be displayed (regardless of whether proxy is defined)
    - Click continue - the wizard should display an error which indicates CORS may not be enabled on the service
- Go back and upload a file instead of providing a url
    - Select any of the file types - the CORS info message should not appear

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1148)
<!-- Reviewable:end -->
