### PR TITLE
Multi-Ramp Composition API Sample

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -25,8 +25,12 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app" style="height: 100vh"></div>
+        <div id="top-row" style="display: flex; height: 50vh">
+            <div id="app" style="flex-grow: 1"></div>
+            <div id="app2" style="width: 390px"></div>
+        </div>
+        <div id="app3" style="height: 50vh"></div>
 
-        <script type="module" src="./starter-scripts/main.js"></script>
+        <script type="module" src="./starter-scripts/multi-ramp.js"></script>
     </body>
 </html>

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -484,6 +484,10 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
     vueElement.config.globalProperties.$store = thisStore;
     vueElement.config.globalProperties.$iApi = iApi;
 
+    // Add the iApi instance to Vue component with provide/inject
+    vueElement.provide('iApi', iApi);
+    vueElement.provide('thisStore', thisStore);
+
     const app = vueElement.mount(element);
 
     return { element: vueElement, app };

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="ramp-app animation-enabled" :lang="$i18n.locale">
-        <shell></shell>
+    <div ref="el" class="ramp-app animation-enabled" :lang="$i18n.locale">
+        <shell />
     </div>
 </template>
 
 <script lang="ts">
 import '@/styles/main.css';
-import { defineComponent } from 'vue';
+import { defineComponent, ref, onMounted } from 'vue';
 import Shell from '@/components/shell.vue';
 
 import ro from '@/scripts/resize-observer.js';
@@ -15,28 +15,68 @@ import { setDefaultProps } from 'vue-tippy';
 
 export default defineComponent({
     components: { Shell },
-    mounted() {
-        // let ResizeObserver observe the app div
-        // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
-        ro.observe(this.$el);
-        // Set tooltip defaults, theme does not get applied properly in prod builds if setting the defaults using vue-tippy
-        // This bypasses the wrapper and sets the defaults at the tippy.js level
-        setDefaultProps({
-            aria: {
-                content: 'labelledby'
-            },
-            theme: 'ramp4',
-            animation: 'scale',
-            inertia: true,
-            trigger: 'mouseenter manual focus',
-            // needed to have tooltips in fullscreen, by default it appends to document.body
-            appendTo: this.$el
+    setup() {
+        const el = ref();
+
+        onMounted(() => {
+            // let ResizeObserver observe the app div
+            // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
+            ro.observe(el.value);
+            // Set tooltip defaults, theme does not get applied properly in prod builds if setting the defaults using vue-tippy
+            // This bypasses the wrapper and sets the defaults at the tippy.js level
+            setDefaultProps({
+                aria: {
+                    content: 'labelledby'
+                },
+                theme: 'ramp4',
+                animation: 'scale',
+                inertia: true,
+                trigger: 'mouseenter manual focus',
+                // needed to have tooltips in fullscreen, by default it appends to document.body
+                appendTo: el.value
+            });
+            // TODO not sure this is needed anymore? from issue #594
+            let parent = el.value.parentElement;
+            parent?.style.setProperty('overflow', 'hidden');
         });
-        let parent = this.$el.parentElement;
-        parent?.style.setProperty('overflow', 'hidden');
+
+        return { el };
     }
 });
 </script>
+
+<!-- <script setup lang="ts">
+import '@/styles/main.css';
+import { ref, onMounted } from 'vue';
+import Shell from '@/components/shell.vue';
+
+import ro from '@/scripts/resize-observer.js';
+import 'tippy.js/animations/scale.css';
+import { setDefaultProps } from 'vue-tippy';
+
+const el = ref();
+
+onMounted(() => {
+    // let ResizeObserver observe the app div
+    // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
+    ro.observe(el.value);
+    // Set tooltip defaults, theme does not get applied properly in prod builds if setting the defaults using vue-tippy
+    // This bypasses the wrapper and sets the defaults at the tippy.js level
+    setDefaultProps({
+        aria: {
+            content: 'labelledby'
+        },
+        theme: 'ramp4',
+        animation: 'scale',
+        inertia: true,
+        trigger: 'mouseenter manual focus',
+        // needed to have tooltips in fullscreen, by default it appends to document.body
+        appendTo: el.value
+    });
+    let parent = el.value.parentElement;
+    parent?.style.setProperty('overflow', 'hidden');
+});
+</script> -->
 
 <style lang="scss">
 $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica,

--- a/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/src/components/about-ramp/about-ramp-dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <dropdown-menu
+    <dropdown-menu-v
         class="pointer-events-auto sm:flex"
         :aria-label="$t('ramp.about')"
         :position="position"
@@ -62,67 +62,57 @@
                 </div>
             </div>
         </template>
-    </dropdown-menu>
+    </dropdown-menu-v>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
-import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
+<script setup lang="ts">
+import { computed } from 'vue';
 import { version } from '@/main';
 
-export default defineComponent({
-    name: 'AboutRampDropdownV',
+import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
-    props: {
-        position: {
-            type: String,
-            default: 'top-start'
-        }
-    },
+defineProps({
+    position: {
+        type: String,
+        default: 'top-start'
+    }
+});
+/**
+ * Get RAMP's version string
+ */
+const versionString = computed<string>(() => {
+    return `${version.major}.${version.minor}.${version.patch}`;
+});
 
-    components: {
-        'dropdown-menu': DropdownMenuV
-    },
+/**
+ * Get RAMP build version hash
+ */
+const versionHash = computed<string>(() => {
+    return version.hash.slice(0, 9);
+});
 
-    computed: {
-        /**
-         * Get RAMP's version string
-         */
-        versionString(): string {
-            return `${version.major}.${version.minor}.${version.patch}`;
-        },
-
-        /**
-         * Get RAMP build version hash
-         */
-        versionHash(): string {
-            return version.hash.slice(0, 9);
-        },
-
-        /**
-         * Get RAMP build date
-         */
-        buildDate(): string {
-            let timestamp = new Date(version.timestamp);
-            if (isNaN(<any>timestamp)) {
-                // this appears to be broken in dev serve mode (but not always).
-                // likely the vite `git log -1 --format=%cd` command isnt working in that context
-                return 'dev mode, no date';
+/**
+ * Get RAMP build date
+ */
+const buildDate = computed<string>(() => {
+    let timestamp = new Date(version.timestamp);
+    if (isNaN(<any>timestamp)) {
+        // this appears to be broken in dev serve mode (but not always).
+        // likely the vite `git log -1 --format=%cd` command isnt working in that context
+        return 'dev mode, no date';
+    } else {
+        const padZero = (num: number): string => {
+            if (num < 10) {
+                return '0' + num.toString();
             } else {
-                const padZero = (num: number): string => {
-                    if (num < 10) {
-                        return '0' + num.toString();
-                    } else {
-                        return num.toString();
-                    }
-                };
-                return `${timestamp.getFullYear()}-${
-                    timestamp.getMonth() + 1
-                }-${timestamp.getDate()} ${timestamp.getHours()}:${padZero(
-                    timestamp.getMinutes()
-                )}:${padZero(timestamp.getSeconds())}`;
+                return num.toString();
             }
-        }
+        };
+        return `${timestamp.getFullYear()}-${
+            timestamp.getMonth() + 1
+        }-${timestamp.getDate()} ${timestamp.getHours()}:${padZero(
+            timestamp.getMinutes()
+        )}:${padZero(timestamp.getSeconds())}`;
     }
 });
 </script>

--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -10,7 +10,7 @@
                 animation: tooltipAnimation,
                 appendTo: 'parent'
             }"
-            ref="dropdown-trigger"
+            ref="dropdownTrigger"
         >
             <slot name="header"></slot>
         </button>
@@ -26,105 +26,88 @@
     </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { onMounted, ref, nextTick, onBeforeUnmount, watch } from 'vue';
 import { createPopper } from '@popperjs/core';
 import type { Placement } from '@popperjs/core';
-export default defineComponent({
-    name: 'DropdownMenuV',
-    props: {
-        position: {
-            type: String,
-            default: 'bottom'
-        },
-        popperOptions: {
-            type: Object,
-            default: {}
-        },
-        tooltip: { type: String },
-        tooltipPlacement: { type: String, default: 'bottom' },
-        tooltipTheme: { type: String, default: 'ramp4' },
-        tooltipAnimation: { type: String, default: 'scale' },
-        centered: { type: Boolean, default: true }
+
+const open = ref(false);
+const popper = ref<any>(null) as any;
+const watchers = ref<Array<Function>>([]);
+const el = ref();
+const dropdown = ref();
+const dropdownTrigger = ref();
+
+const props = defineProps({
+    position: {
+        type: String,
+        default: 'bottom'
     },
-    data() {
-        return {
-            open: false,
-            popper: null as any,
-            watchers: [] as Array<Function>
-        };
-    },
+    tooltip: { type: String },
+    tooltipPlacement: { type: String, default: 'bottom' },
+    tooltipTheme: { type: String, default: 'ramp4' },
+    tooltipAnimation: { type: String, default: 'scale' },
+    centered: { type: Boolean, default: true }
+});
 
-    created() {
-        this.watchers.push(
-            this.$watch('open', () => {
-                this.popper.update();
-            })
-        );
-    },
+watchers.value.push(
+    watch(open, () => {
+        popper.value.update();
+    })
+);
 
-    mounted() {
-        window.addEventListener(
-            'click',
-            event => {
-                if (!this.$el.contains(event.target)) {
-                    this.open = false;
-                }
-            },
-            { capture: true }
-        );
-
-        window.addEventListener('blur', () => {
-            this.open = false;
-        });
-
-        window.addEventListener('focusin', event => {
-            if (!this.$el.contains(event.target)) {
-                this.open = false;
+onMounted(() => {
+    window.addEventListener(
+        'click',
+        event => {
+            if (!el.value.contains(event.target)) {
+                open.value = false;
             }
-        });
+        },
+        { capture: true }
+    );
 
-        // $nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
-        this.$nextTick(() => {
-            this.popper = createPopper(
-                this.$refs['dropdown-trigger'] as Element,
-                this.$refs['dropdown'] as HTMLElement,
-                {
-                    placement: (this.position || 'bottom') as Placement,
-                    modifiers: [
-                        {
-                            name: 'offset',
-                            options: {
-                                offset: [0, 5]
-                            }
+    window.addEventListener('blur', () => {
+        open.value = false;
+    });
+    window.addEventListener('focusin', event => {
+        if (!el.contains(event.target)) {
+            open.value = false;
+        }
+    });
+
+    // nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
+    nextTick(() => {
+        popper.value = createPopper(
+            dropdownTrigger.value as Element,
+            dropdown.value as HTMLElement,
+            {
+                placement: (props.position || 'bottom') as Placement,
+                modifiers: [
+                    {
+                        name: 'offset',
+                        options: {
+                            offset: [0, 5]
                         }
-                    ],
-                    ...this.popperOptions
-                }
-            );
-        });
-    },
-    beforeUnmount() {
-        this.watchers.forEach(unwatch => unwatch());
-        window.removeEventListener(
-            'click',
-            event => {
-                if (!this.$el.contains(event.target)) {
-                    this.open = false;
-                }
-            },
-            { capture: true }
-        );
-        window.removeEventListener('blur', () => {
-            this.open = false;
-        });
-        window.removeEventListener('focusin', event => {
-            if (!this.$el.contains(event.target)) {
-                this.open = false;
+                    }
+                ]
             }
-        });
-        this.open = false;
-    }
+        );
+    });
+});
+
+onBeforeUnmount(() => {
+    watchers.value.forEach(unwatch => unwatch());
+    window.removeEventListener(
+        'click',
+        event => {
+            if (!el.value.contains(event.target)) {
+                open.value = false;
+            }
+        },
+        { capture: true }
+    );
+    open.value = false;
 });
 </script>
 

--- a/src/components/shell.vue
+++ b/src/components/shell.vue
@@ -13,65 +13,51 @@
                     {{ $t('keyboardInstructions.open') }}
                 </button>
             </div>
-            <keyboard-instructions-modal></keyboard-instructions-modal>
-            <panel-stack
-                class="panel-stack sm:flex absolute inset-0 overflow-hidden sm:p-12 z-10 sm:pl-80 xs:pl-40 sm:pb-48 xs:pb-28 xs:pr-0 sm:pr-40"
-            ></panel-stack>
-            <notification-floating-button
-                v-if="!appbarFixture"
-            ></notification-floating-button>
-            <map-caption class="z-10"></map-caption>
+            <keyboard-instructions-modal-v />
+            <panel-stack-v
+                class="panel-stack sm:flex absolute inset-0 overflow-hidden xs:pl-40 sm:p-12 sm:pl-80 z-10 sm:pb-48 xs:pb-28"
+            />
+            <notifications-floating-button-v v-if="!appbarFixture" />
+            <map-caption-v class="z-10" />
         </div>
 
-        <esri-map v-if="start"></esri-map>
+        <esri-map-v v-if="start" />
         <div v-else class="w-full h-full">
             <div class="spinner relative inset-x-1/2 inset-y-9/20"></div>
         </div>
     </div>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue';
+<script setup lang="ts">
+import { ref, inject } from 'vue';
 import EsriMapV from '@/components/map/esri-map.vue';
 import PanelStackV from '@/components/panel-stack/panel-stack.vue';
 import MapCaptionV from '@/components/map/map-caption.vue';
 import NotificationsFloatingButtonV from '@/components/notification-center/floating-button.vue';
 import KeyboardInstructionsModalV from './keyboard-instructions.vue';
 import { GlobalEvents } from '@/api';
+import type { InstanceAPI } from '@/api';
+import type { storeType } from '@/store';
 
-export default defineComponent({
-    name: 'Shell',
-    components: {
-        'esri-map': EsriMapV,
-        'panel-stack': PanelStackV,
-        'map-caption': MapCaptionV,
-        'notification-floating-button': NotificationsFloatingButtonV,
-        'keyboard-instructions-modal': KeyboardInstructionsModalV
-    },
-    data() {
-        return {
-            appbarFixture: this.get(`fixture/items@appbar`),
-            start: false
-        };
-    },
-    created() {
-        // the start property is used to prevent the esri-map component from instantiating
-        // until the property turns true. trickery!
-        if (this.$iApi.startRequired) {
-            this.$iApi.event.once(GlobalEvents.MAP_START, () => {
-                this.start = true;
-            });
-        } else {
-            this.$iApi.event.emit(GlobalEvents.MAP_START);
-            this.start = true;
-        }
-    },
-    methods: {
-        openKeyboardInstructions() {
-            this.$iApi.event.emit('openKeyboardInstructions');
-        }
-    }
-});
+const iApi = inject('iApi') as InstanceAPI;
+const store = inject('thisStore') as storeType;
+const appbarFixture = ref(store.get(`fixture/items@appbar`));
+const start = ref(false);
+
+// the start property is used to prevent the esri-map component from instantiating
+// until the property turns true. trickery!
+if (iApi.startRequired) {
+    iApi.event.once(GlobalEvents.MAP_START, () => {
+        start.value = true;
+    });
+} else {
+    iApi.event.emit(GlobalEvents.MAP_START);
+    start.value = true;
+}
+
+const openKeyboardInstructions = () => {
+    iApi.event.emit('openKeyboardInstructions');
+};
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
**Not for pulling.**
PR is for investigation and analysis of multi-ramp page conflicts for composition API.

**Update:** This PR has been updated to include Spencer's Multi-Ramp fix. Upon first examination, it appears that providing/inject the instance API and store do not break Multi-Ramp instances, but leaving this here for examination for if/when we revisit the conversion to composition API.

The following files were converted from options to composition API:

* `src/app.vue`
* `src/components/keyboard-instructions.vue`
* `src/components/shell.vue`
* `src/components/about-ramp/about-ramp-dropdown.vue`
* `src/components/controls/dropdown-menu.vue`
* `src/components/panel-stack/panel-container.vue`
