### PR TITLE
build: fix Vite dev errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
                 "tailwindcss": "^3.0.23",
                 "typedoc": "^0.22.14",
                 "typescript": "~4.6.3",
-                "vite": "^2.9.1",
+                "vite": "^2.9.12",
                 "vue-tsc": "^0.33.9",
                 "vuepress": "~1.9.7"
             },
@@ -13801,8 +13801,9 @@
             "optional": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.2",
-            "license": "MIT",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -14965,7 +14966,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.12",
+            "version": "8.4.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -14976,9 +14979,8 @@
                     "url": "https://tidelift.com/funding/github/npm/postcss"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.1",
+                "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             },
@@ -20451,12 +20453,13 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "2.9.1",
+            "version": "2.9.12",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
+            "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.14.27",
-                "postcss": "^8.4.12",
+                "postcss": "^8.4.13",
                 "resolve": "^1.22.0",
                 "rollup": "^2.59.0"
             },
@@ -24625,7 +24628,7 @@
                 "@types/highlight.js": "^9.7.0",
                 "@types/linkify-it": "*",
                 "@types/mdurl": "*",
-                "highlight.js": "^9.7.0"
+                "highlight.js": ">10.4.0"
             }
         },
         "@types/marked": {
@@ -25404,7 +25407,7 @@
                         "async-each": "^1.0.1",
                         "braces": "^2.3.2",
                         "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
+                        "glob-parent": ">=5.1.3",
                         "inherits": "^2.0.3",
                         "is-binary-path": "^1.0.0",
                         "is-glob": "^4.0.0",
@@ -25720,7 +25723,7 @@
             "dev": true,
             "requires": {
                 "@vuepress/shared-utils": "1.9.7",
-                "markdown-it": "^8.4.1",
+                "markdown-it": ">=12.3.2",
                 "markdown-it-anchor": "^5.0.2",
                 "markdown-it-chain": "^1.3.0",
                 "markdown-it-emoji": "^1.4.0",
@@ -25974,7 +25977,7 @@
                     "requires": {
                         "@mrmlnc/readdir-enhanced": "^2.2.1",
                         "@nodelib/fs.stat": "^1.1.2",
-                        "glob-parent": "^3.1.0",
+                        "glob-parent": ">=5.1.3",
                         "is-glob": "^4.0.0",
                         "merge2": "^1.2.3",
                         "micromatch": "^3.1.10"
@@ -27401,7 +27404,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 },
                 "rimraf": {
@@ -27498,7 +27501,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 },
                 "p-locate": {
@@ -27704,7 +27707,7 @@
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
                 "fsevents": "~2.3.2",
-                "glob-parent": "~5.1.2",
+                "glob-parent": ">=5.1.3",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
@@ -28188,7 +28191,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 },
                 "rimraf": {
@@ -28216,7 +28219,7 @@
             "requires": {
                 "cacache": "^12.0.3",
                 "find-cache-dir": "^2.1.0",
-                "glob-parent": "^3.1.0",
+                "glob-parent": ">=5.1.3",
                 "globby": "^7.1.1",
                 "is-glob": "^4.0.1",
                 "loader-utils": "^1.2.3",
@@ -28610,7 +28613,7 @@
                 "boolbase": "^1.0.0",
                 "css-what": "^3.2.1",
                 "domutils": "^1.7.0",
-                "nth-check": "^1.0.2"
+                "nth-check": ">=2.0.1"
             }
         },
         "css-select-base-adapter": {
@@ -29287,7 +29290,7 @@
             "requires": {
                 "acorn-node": "^1.6.1",
                 "defined": "^1.0.0",
-                "minimist": "^1.1.1"
+                "minimist": ">=1.2.6"
             }
         },
         "didyoumean": {
@@ -30464,7 +30467,7 @@
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
+                "glob-parent": ">=5.1.3",
                 "merge2": "^1.3.0",
                 "micromatch": "^4.0.4"
             }
@@ -31199,7 +31202,8 @@
             "dev": true
         },
         "highlight.js": {
-            "version": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.5.1.tgz",
             "integrity": "sha512-LKzHqnxr4CrD2YsNoIf/o5nJ09j4yi/GcH5BnYz9UnVpZdS4ucMgvP61TDty5xJcFGRjnH4DpujkS9bHT3hq0Q==",
             "dev": true
         },
@@ -32326,7 +32330,7 @@
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.0"
+                        "minimist": ">=1.2.6"
                     }
                 }
             }
@@ -32845,7 +32849,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 },
                 "rimraf": {
@@ -32887,7 +32891,9 @@
             "optional": true
         },
         "nanoid": {
-            "version": "3.3.2"
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -33042,7 +33048,8 @@
             }
         },
         "node-forge": {
-            "version": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
             "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
             "dev": true
         },
@@ -33746,7 +33753,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 }
             }
@@ -33758,9 +33765,11 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.4.12",
+            "version": "8.4.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
             "requires": {
-                "nanoid": "^3.3.1",
+                "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             }
@@ -35328,7 +35337,7 @@
             "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
-                "minimist": "^1.2.0",
+                "minimist": ">=1.2.6",
                 "strip-json-comments": "~2.0.1"
             },
             "dependencies": {
@@ -35557,7 +35566,7 @@
                         "css-what": "^6.0.1",
                         "domhandler": "^4.3.1",
                         "domutils": "^2.8.0",
-                        "nth-check": "^2.0.1"
+                        "nth-check": ">=2.0.1"
                     }
                 },
                 "css-what": {
@@ -35919,7 +35928,7 @@
             "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
             "dev": true,
             "requires": {
-                "node-forge": "^0.10.0"
+                "node-forge": ">=1.2.2"
             }
         },
         "semver": {
@@ -36977,7 +36986,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 },
                 "supports-color": {
@@ -37955,12 +37964,14 @@
             }
         },
         "vite": {
-            "version": "2.9.1",
+            "version": "2.9.12",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
+            "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
             "dev": true,
             "requires": {
                 "esbuild": "^0.14.27",
                 "fsevents": "~2.3.2",
-                "postcss": "^8.4.12",
+                "postcss": "^8.4.13",
                 "resolve": "^1.22.0",
                 "rollup": "^2.59.0"
             }
@@ -38414,7 +38425,7 @@
                         "async-each": "^1.0.1",
                         "braces": "^2.3.2",
                         "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
+                        "glob-parent": ">=5.1.3",
                         "inherits": "^2.0.3",
                         "is-binary-path": "^1.0.0",
                         "is-glob": "^4.0.0",
@@ -38816,7 +38827,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 },
                 "schema-utils": {
@@ -38879,7 +38890,7 @@
                     "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "^1.2.6"
+                        "minimist": ">=1.2.6"
                     }
                 }
             }
@@ -38986,7 +38997,7 @@
                         "async-each": "^1.0.1",
                         "braces": "^2.3.2",
                         "fsevents": "^1.2.7",
-                        "glob-parent": "^3.1.0",
+                        "glob-parent": ">=5.1.3",
                         "inherits": "^2.0.3",
                         "is-binary-path": "^1.0.0",
                         "is-glob": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "tailwindcss": "^3.0.23",
         "typedoc": "^0.22.14",
         "typescript": "~4.6.3",
-        "vite": "^2.9.1",
+        "vite": "^2.9.12",
         "vue-tsc": "^0.33.9",
         "vuepress": "~1.9.7"
     }


### PR DESCRIPTION
This PR updates Vite to the latest version which contains a fix for the `Vite Error ... optimized info should be defined` errors randomly disrespecting us.

The root cause was an i/o race condition, reported in the console as `[vite] error while updating dependencies: Error: EPERM: operation not permitted`. The fix is available for Vite >= v2.9.10. See the [Vite release notes](https://github.com/vitejs/vite/blob/v2.9.12/packages/vite/CHANGELOG.md#2910-2022-06-06) for more info.

> fix: EPERM error on Windows when processing dependencies (#8235) (dfe4307), closes #8235

Closes #1039

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1153)
<!-- Reviewable:end -->
