### PR TITLE
Fix Help Panel at lower resolution

### DIFF
--- a/public/help/default/en.md
+++ b/public/help/default/en.md
@@ -4,14 +4,20 @@ Navigation controls are used for changing the viewing extent of the map.
 
 The following navigation controls can be found in the bottom right corner of the map:
 
-|Symbol|Name|Key Binding|Description|
-|----|----|----|----|
-|![](navigation/zoomin.png)| Zoom in | Plus (+) | Zoom in one level on the map to see more detailed content |
-|![](navigation/zoomout.png)| Zoom out | Minus (-) | Zoom out one level on the map to see less detailed content  |
-|![](navigation/fullscreen.png)| Fullscreen | | Full screen presents map content using the entire page. Full screen option is only available when the map is embedded into another page  |
-|![](navigation/help.png)| Help | | Open the help panel |
-|![](navigation/home.png)| Home | | Zoom and pan map such that initial extent is visible |
-|![](navigation/basemaps.png)| Basemap | | Opens the basemap selection panel |
+- ![](navigation/zoomin.png) **Zoom in** 
+    - *Key Binding:* plus (+)
+    - Zoom in one level on the map to see more detailed content.
+- ![](navigation/zoomout.png) **Zoom out** 
+    - *Key Binding:* minus (-)
+    - Zoom out one level on the map to see less detailed content.
+- ![](navigation/fullscreen.png) **Fullscreen**
+    - Full screen presents map content using the entire page. Full screen option is only available when the map is embedded into another page.
+- ![](navigation/help.png) **Help**
+    - Open the help panel.
+- ![](navigation/home.png) **Home**
+    - Zoom and pan map such that initial extent is visible.
+- ![](navigation/basemaps.png) **Basemap**
+    - Opens the basemap selection panel.
 
 You can also pan the map by using your left, right, up and down arrow keys, or by click-holding on the map and dragging. Holding CTRL and using the mouse scroll wheel while hovering over the map will zoom the map in/out.
 

--- a/public/help/default/fr.md
+++ b/public/help/default/fr.md
@@ -4,14 +4,20 @@ Les contrôles de navigation servent à modifier la taille de l’affichage de l
 
 Les commandes de navigation suivantes se trouvent dans le coin inférieur droit de la carte:
 
-|Symbol|Nom|Touche clavier|Description|
-|----|----|----|----|
-|![](navigation/zoomin.png)| Zoom avant | Plus (+) | Zoom avant d'un niveau sur la carte pour afficher un contenu plus détaillé |
-|![](navigation/zoomout.png)| Zoom arrière | Moins (-) | Zoom arrière d'un niveau sur la carte pour afficher un contenu moins  |
-|![](navigation/fullscreen.png)| Plein écran | | Le plein écran présente le contenu de la carte en utilisant la page entière. L'option « Plein écran » n'est disponible que lorsque la carte est incorporée dans une autre page  |
-|![](navigation/help.png)| Aide | | Ouvre le panneau d'aide |
-|![](navigation/home.png)| Étendue initiale | | Zoom et déplace la carte afin que l'étendue initiale soit visible |
-|![](navigation/basemaps.png)| Cartes de base | | Ouvre le panneau de sélection des cartes de base |
+- ![](navigation/zoomin.png) **Zoom avant**
+    - *Touche Clavier:* plus (+)
+    - Zoom avant d'un niveau sur la carte pour afficher un contenu plus détaillé.
+- ![](navigation/zoomout.png) **Zoom arrière**
+    - *Touche Clavier:* moins (-)
+    - Zoom arrière d'un niveau sur la carte pour afficher un contenu moins.
+- ![](navigation/fullscreen.png) **Plein écran** 
+    - Le plein écran présente le contenu de la carte en utilisant la page entière. L'option « Plein écran » n'est disponible que lorsque la carte est incorporée dans une autre page.
+- ![](navigation/help.png) **Aide**
+    - Ouvre le panneau d'aide.
+- ![](navigation/home.png) **Étendue initiale**
+    - Zoom et déplace la carte afin que l'étendue initiale soit visible.
+- ![](navigation/basemaps.png) **Cartes de base**
+    - Ouvre le panneau de sélection des cartes de base.
 
 Vous pouvez également parcourir la carte en utilisant les touches fléchées gauche, droite, haut et bas ou en cliquant sur la carte et en la faisant glisser. Tenir la touche CTRL enfoncée et en utilisant la roulette de défilement de la souris pendant que le curseur de la souris sur la carte sera zoom de la carte de sortie.
 

--- a/src/fixtures/help/section.vue
+++ b/src/fixtures/help/section.vue
@@ -75,13 +75,11 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 :deep(.section-body) {
-    table,
     p {
         @apply mb-15;
     }
-    th,
-    td {
-        @apply px-5;
+    li {
+        @apply pb-10;
     }
     img {
         @apply inline;


### PR DESCRIPTION
Closes #1137.

This fixes the formatting of the help panel at low horizontal resolution by using a markdown list instead of a table in the navigation controls section. I also added the help panel resource files to the `demos` folder, so that the changes can be observed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1160)
<!-- Reviewable:end -->
