### PR TITLE
Update the way shpjs library is being used

### DIFF
--- a/demos/index-multi.html
+++ b/demos/index-multi.html
@@ -5,10 +5,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
-        <script
-            type="src"
-            src="https://unpkg.com/shpjs@latest/dist/shp.js"
-        ></script>
     </head>
     <body style="margin: 0">
         <style>

--- a/demos/index.html
+++ b/demos/index.html
@@ -5,10 +5,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
-        <script
-            type="src"
-            src="https://unpkg.com/shpjs@latest/dist/shp.js"
-        ></script>
     </head>
     <body style="margin: 0">
         <style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "pinia": "^2.0.13",
                 "proj4": "2.6.0",
                 "screenfull": "~5.0.2",
+                "shpjs": "^4.0.2",
                 "svg.js": "2.7.1",
                 "terraformer": "1.0.9",
                 "terraformer-arcgis-parser": "1.1.0",
@@ -12910,6 +12911,49 @@
                 "verror": "1.10.0"
             }
         },
+        "node_modules/jszip": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.0.tgz",
+            "integrity": "sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==",
+            "dependencies": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            }
+        },
+        "node_modules/jszip/node_modules/process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+        },
+        "node_modules/jszip/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/jszip/node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/jszip/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
         "node_modules/keyv": {
             "version": "3.1.0",
             "dev": true,
@@ -12973,6 +13017,19 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dependencies": {
+                "immediate": "~3.0.5"
+            }
+        },
+        "node_modules/lie/node_modules/immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
         },
         "node_modules/lilconfig": {
             "version": "2.0.5",
@@ -14582,8 +14639,7 @@
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-            "dev": true
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
         },
         "node_modules/parallel-transform": {
             "version": "1.2.0",
@@ -14686,6 +14742,26 @@
             "version": "5.1.0",
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/parsedbf": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-1.1.1.tgz",
+            "integrity": "sha512-jndFmhcrzSAGCMccM4za+3bIRxqV6L2doQjYN8Xgz0kZUpyBT5I8Gs6Y6hL5GcO2rih9OBkPcLlx2uBoLi8R8Q==",
+            "dependencies": {
+                "iconv-lite": "^0.4.15",
+                "text-encoding-polyfill": "^0.6.7"
+            }
+        },
+        "node_modules/parsedbf/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
@@ -17752,7 +17828,6 @@
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
-            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/sass": {
@@ -18071,8 +18146,7 @@
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -18121,6 +18195,23 @@
                 "vscode-oniguruma": "^1.6.1",
                 "vscode-textmate": "5.2.0"
             }
+        },
+        "node_modules/shpjs": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-4.0.2.tgz",
+            "integrity": "sha512-yiyc7FyOCnVeF6UiJmKMxg5P/x0MQIUnH3m+OhFb2eic39WZo40b7jxh+zkhj309kA2Hh2t5La+kFv8Im94C3g==",
+            "dependencies": {
+                "jszip": "^3.5.0",
+                "lie": "^3.0.1",
+                "lru-cache": "^2.7.0",
+                "parsedbf": "^1.1.0",
+                "proj4": "^2.1.4"
+            }
+        },
+        "node_modules/shpjs/node_modules/lru-cache": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+            "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
         },
         "node_modules/side-channel": {
             "version": "1.0.4",
@@ -19442,6 +19533,11 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
+        },
+        "node_modules/text-encoding-polyfill": {
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
+            "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -32215,6 +32311,51 @@
                 "verror": "1.10.0"
             }
         },
+        "jszip": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.0.tgz",
+            "integrity": "sha512-LDfVtOLtOxb9RXkYOwPyNBTQDL4eUbqahtoY6x07GiDJHwSYvn8sHHIw8wINImV3MqbMNve2gSuM1DDqEKk09Q==",
+            "requires": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "setimmediate": "^1.0.5"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+                    "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
         "keyv": {
             "version": "3.1.0",
             "dev": true,
@@ -32261,6 +32402,21 @@
             "requires": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
+            }
+        },
+        "lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "requires": {
+                "immediate": "~3.0.5"
+            },
+            "dependencies": {
+                "immediate": {
+                    "version": "3.0.6",
+                    "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+                    "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+                }
             }
         },
         "lilconfig": {
@@ -33487,8 +33643,7 @@
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-            "dev": true
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
         },
         "parallel-transform": {
             "version": "1.2.0",
@@ -33581,6 +33736,25 @@
         "parse5": {
             "version": "5.1.0",
             "optional": true
+        },
+        "parsedbf": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/parsedbf/-/parsedbf-1.1.1.tgz",
+            "integrity": "sha512-jndFmhcrzSAGCMccM4za+3bIRxqV6L2doQjYN8Xgz0kZUpyBT5I8Gs6Y6hL5GcO2rih9OBkPcLlx2uBoLi8R8Q==",
+            "requires": {
+                "iconv-lite": "^0.4.15",
+                "text-encoding-polyfill": "^0.6.7"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.4.24",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                }
+            }
         },
         "parseurl": {
             "version": "1.3.3",
@@ -35869,8 +36043,7 @@
             }
         },
         "safer-buffer": {
-            "version": "2.1.2",
-            "devOptional": true
+            "version": "2.1.2"
         },
         "sass": {
             "version": "1.50.0",
@@ -36124,8 +36297,7 @@
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-            "dev": true
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
         "setprototypeof": {
             "version": "1.2.0",
@@ -36161,6 +36333,25 @@
                 "jsonc-parser": "^3.0.0",
                 "vscode-oniguruma": "^1.6.1",
                 "vscode-textmate": "5.2.0"
+            }
+        },
+        "shpjs": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-4.0.2.tgz",
+            "integrity": "sha512-yiyc7FyOCnVeF6UiJmKMxg5P/x0MQIUnH3m+OhFb2eic39WZo40b7jxh+zkhj309kA2Hh2t5La+kFv8Im94C3g==",
+            "requires": {
+                "jszip": "^3.5.0",
+                "lie": "^3.0.1",
+                "lru-cache": "^2.7.0",
+                "parsedbf": "^1.1.0",
+                "proj4": "^2.1.4"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "2.7.3",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                    "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
+                }
             }
         },
         "side-channel": {
@@ -37181,6 +37372,11 @@
                     "dev": true
                 }
             }
+        },
+        "text-encoding-polyfill": {
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/text-encoding-polyfill/-/text-encoding-polyfill-0.6.7.tgz",
+            "integrity": "sha512-/DZ1XJqhbqRkCop6s9ZFu8JrFRwmVuHg4quIRm+ziFkR3N3ec6ck6yBvJ1GYeEQZhLVwRW0rZE+C3SSJpy0RTg=="
         },
         "text-table": {
             "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "pinia": "^2.0.13",
         "proj4": "2.6.0",
         "screenfull": "~5.0.2",
+        "shpjs": "^4.0.2",
         "svg.js": "2.7.1",
         "terraformer": "1.0.9",
         "terraformer-arcgis-parser": "1.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -6,10 +6,6 @@
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
         <link rel="stylesheet" href="./lib/style.css" />
-        <script
-            type="src"
-            src="https://unpkg.com/shpjs@latest/dist/shp.js"
-        ></script>
     </head>
     <body style="margin: 0">
         <style>

--- a/src/geo/layer/file-utils.ts
+++ b/src/geo/layer/file-utils.ts
@@ -2,6 +2,7 @@ import { APIScope } from '@/api/internal';
 import defaultRenderers from './defaultRenderers.json';
 import ArcGIS from 'terraformer-arcgis-parser';
 import { csv2geojson, dsv } from 'csv2geojson';
+import shp from 'shpjs/dist/shp.min.js';
 
 import {
     EsriColour,
@@ -428,7 +429,7 @@ export class FileUtils extends APIScope {
      * @returns {Promise} a promise resolving with geojson
      */
     async shapefileToGeoJson(shapeData: ArrayBuffer): Promise<any> {
-        return (<any>window).shp(shapeData);
+        return shp(shapeData);
     }
 
     /**

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -39,3 +39,6 @@ declare class ResizeObserver {
     unobserve(target: Element): void;
     disconnect(): void;
 }
+
+declare module 'shpjs/dist/shp.min.js';
+declare module 'csv2geojson';


### PR DESCRIPTION
The shpjs library is now imported instead of being a global window object. The `shpjs/dist/shp.min.js` file is used instead of the default one defined in shpjs package.json since that version fails in the browser (it thinks it's in a nodejs environment).


I used [citiesx020.zip](https://github.com/ramp4-pcar4/ramp4-pcar4/files/8928850/citiesx020.zip) in the import wizard for testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1161)
<!-- Reviewable:end -->
