### PR TITLE
Services and Geosearch schema

### DIFF
--- a/demos/starter-scripts/cam.js
+++ b/demos/starter-scripts/cam.js
@@ -379,8 +379,6 @@ let config = {
                             'https://geogratis.gc.ca/services/geoname/en/geonames.json',
                         geoLocation:
                             'https://geogratis.gc.ca/services/geolocation/en/locate?q=',
-                        geoSuggest:
-                            'https://geogratis.gc.ca/services/geolocation/en/suggest?q=',
                         provinces:
                             'https://geogratis.gc.ca/services/geoname/en/codes/province.json',
                         types: 'https://geogratis.gc.ca/services/geoname/en/codes/concise.json'
@@ -961,8 +959,6 @@ let config = {
                             'https://geogratis.gc.ca/services/geoname/en/geonames.json',
                         geoLocation:
                             'https://geogratis.gc.ca/services/geolocation/en/locate?q=',
-                        geoSuggest:
-                            'https://geogratis.gc.ca/services/geolocation/en/suggest?q=',
                         provinces:
                             'https://geogratis.gc.ca/services/geoname/en/codes/province.json',
                         types: 'https://geogratis.gc.ca/services/geoname/en/codes/concise.json'

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -442,14 +442,16 @@ let config = {
                     fileName: 'ramp-pcar-4-map-carte'
                 },
                 geosearch: {
-                    geoNames:
-                        'https://geogratis.gc.ca/services/geoname/@{language}/geonames.json',
-                    geoLocation:
-                        'https://geogratis.gc.ca/services/geolocation/@{language}/locate',
-                    geoTypes:
-                        'https://geogratis.gc.ca/services/geoname/@{language}/codes/concise.json',
-                    geoProvince:
-                        'https://geogratis.gc.ca/services/geoname/@{language}/codes/province.json'
+                    serviceUrls: {
+                        geoNames:
+                            'https://geogratis.gc.ca/services/geoname/@{language}/geonames.json',
+                        geoLocation:
+                            'https://geogratis.gc.ca/services/geolocation/@{language}/locate',
+                        geoTypes:
+                            'https://geogratis.gc.ca/services/geoname/@{language}/codes/concise.json',
+                        geoProvince:
+                            'https://geogratis.gc.ca/services/geoname/@{language}/codes/province.json'
+                    }
                 }
             },
             system: { animate: true }

--- a/schema.json
+++ b/schema.json
@@ -163,12 +163,12 @@
                     "properties": {
                         "geoNames": {
                             "type": "string",
-                            "default": "",
+                            "default": "https://geogratis.gc.ca/services/geoname/@{language}/geonames.json",
                             "description": "Endpoint url for geoNames service."
                         },
                         "geoLocation": {
                             "type": "string",
-                            "default": "",
+                            "default": "https://geogratis.gc.ca/services/geolocation/@{language}/locate",
                             "description": "Endpoint url for geoLocation service."
                         },
                         "geoProvince": {
@@ -180,45 +180,40 @@
                             "type": "string",
                             "default": "https://geogratis.gc.ca/services/geoname/@{language}/codes/concise.json",
                             "description": "Endpoint url for types service."
-                        },
-                        "settings": {
-                            "type": "object",
-                            "properties": {
-                                "categories": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": [],
-                                    "description": "Filter the search results based on the type of the geographical names. Allowed values can be found here (if using the Canadian GeoNames Search Service API): http://geogratis.gc.ca/services/geoname/en/codes/concise."
-                                },
-                                "sortOrder": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": [],
-                                    "description": "The sort order of the defined 'categories'. Any missing categories are appended to the bottom of the sorted list. The results can still be sorted through this option even if there are no categories being filtered."
-                                },
-                                "maxResults": {
-                                    "type": "number",
-                                    "default": 100,
-                                    "description": "The maximum number of results to return per request. The Canadian GeoNames Search Service API has a 1000 search limit which will be used as an upper limit of results returned unless another service is being used with a higher limit. The default is 100 results."
-                                },
-                                "officialOnly": {
-                                    "type": "boolean",
-                                    "default": false,
-                                    "description": "Whether to return only official names for the geographic names. Default is false which will return both official names and formerly official names."
-                                }
-                            }
                         }
                     },
-                    "required": [
-                        "geoNames",
-                        "geoLocation",
-                        "geoProvince",
-                        "geoTypes"
-                    ]
+                    "description": "Set of urls for lookup services. Aligns with GeoGratis APIs."
+                },
+                "settings": {
+                    "type": "object",
+                    "properties": {
+                        "categories": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [],
+                            "description": "Filter the search results based on the type of the geographical names. Allowed values can be found here (if using the Canadian GeoNames Search Service API): http://geogratis.gc.ca/services/geoname/en/codes/concise."
+                        },
+                        "sortOrder": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [],
+                            "description": "The sort order of the defined 'categories'. Any missing categories are appended to the bottom of the sorted list. The results can still be sorted through this option even if there are no categories being filtered."
+                        },
+                        "maxResults": {
+                            "type": "number",
+                            "default": 100,
+                            "description": "The maximum number of results to return per request. The Canadian GeoNames Search Service API has a 1000 search limit which will be used as an upper limit of results returned unless another service is being used with a higher limit. The default is 100 results."
+                        },
+                        "officialOnly": {
+                            "type": "boolean",
+                            "default": false,
+                            "description": "Whether to return only official names for the geographic names. Default is false which will return both official names and formerly official names."
+                        }
+                    }
                 }
             },
             "unevaluatedProperties": false
@@ -2123,7 +2118,7 @@
             "properties": {
                 "proxyUrl": {
                     "type": "string",
-                    "description": "An optional proxy to be used for dealing with same-origin issues.  URL must either be a relative path on the same server or an absolute path on a server which sets CORS headers."
+                    "description": "An optional proxy to be used for dealing with same-origin issues.  URL must either be a relative path on the same server or an absolute path on a server which sets CORS headers. Applies only to map services."
                 },
                 "animate": {
                     "type": "boolean",

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -704,8 +704,7 @@ function servicesUpgrader(r2Services: any, r4c: any): void {
         };
 
         if (r2Services.search.settings) {
-            r4c.fixtures.geosearch.serviceUrls.settings =
-                r2Services.search.settings;
+            r4c.fixtures.geosearch.settings = r2Services.search.settings;
         }
 
         r4c.fixturesEnabled.push('geosearch');

--- a/src/fixtures/geosearch/definitions.ts
+++ b/src/fixtures/geosearch/definitions.ts
@@ -1,9 +1,10 @@
-export interface GenericObjectType {
+export interface IGenericObjectType {
     [key: string]: string;
 }
 
 // config object is used by all query classes
-export interface GeosearchConfig {
+// this is a flattened version from the actual RAMP config. Easier to bind to.
+export interface IGeosearchConfig {
     geoNameUrl: string;
     geoLocateUrl: string;
     categories: string[];
@@ -11,11 +12,11 @@ export interface GeosearchConfig {
     maxResults: number;
     officialOnly: boolean;
     language: string;
-    types: Types;
-    provinces: Provinces;
+    types: ITypes;
+    provinces: IProvinces;
 }
 
-export interface NameResponse {
+export interface INameResponse {
     name: string;
     location: string;
     province: { code: string };
@@ -25,72 +26,72 @@ export interface NameResponse {
     bbox: number[];
 }
 
-export interface Types {
-    allTypes: GenericObjectType;
-    validTypes: GenericObjectType;
-    filterValidTypes(exclude?: string | string[]): GenericObjectType;
+export interface ITypes {
+    allTypes: IGenericObjectType;
+    validTypes: IGenericObjectType;
+    filterValidTypes(exclude?: string | string[]): IGenericObjectType;
 }
 
-export interface Provinces {
-    list: GenericObjectType;
-    fsaToProvinces(fsa: string): GenericObjectType;
+export interface IProvinces {
+    list: IGenericObjectType;
+    fsaToProvinces(fsa: string): IGenericObjectType;
 }
 
-export interface LatLon {
+export interface ILatLon {
     lat: number;
     lon: number;
 }
 
-export interface RawNameResult {
-    items: NameResponse[];
+export interface IRawNameResult {
+    items: INameResponse[];
 }
 
-export interface FSAResult {
+export interface IFSAResult {
     fsa: string; // "H0H"
     code: string; // "FSA"
     desc: string; // "Forward Sortation Area"
     province: string; // Ontario
-    _provinces: GenericObjectType; // {ON: "Ontario"} or {ON: "Ontario", MB: "Manitoba"}
-    LatLon: LatLon;
+    _provinces: IGenericObjectType; // {ON: "Ontario"} or {ON: "Ontario", MB: "Manitoba"}
+    LatLon: ILatLon;
 }
 
-export interface NTSResult {
+export interface INTSResult {
     nts: string; // 064D or 064D06
     location: string; // "NUMABIN BAY"
     code: string; // "NTS"
     desc: string; // "National Topographic System"
-    LatLon: LatLon;
+    LatLon: ILatLon;
     bbox: number[];
 }
 
-export interface LatLongResult {
+export interface ILatLongResult {
     latlong: string; // "54.54,-91.45"
     desc: string; // "Latitude/Longitude",
-    LatLon: LatLon;
+    LatLon: ILatLon;
     bbox: number[];
 }
 
 // defines results from a geoNames search
-export interface NameResult {
+export interface INameResult {
     name: string;
     location: string;
     province: string; // "Ontario"
     type: string; // "Lake"
-    LatLon: LatLon;
+    LatLon: ILatLon;
     bbox: number[];
 }
 
-export interface LocateResponse {
+export interface ILocateResponse {
     title: string;
     bbox?: number[];
     geometry: { coordinates: number[] };
 }
 
-export type LocateResponseList = LocateResponse[];
-export type NameResultList = NameResult[];
-export type NTSResultList = NTSResult[];
+export type LocateResponseList = ILocateResponse[];
+export type NameResultList = INameResult[];
+export type NTSResultList = INTSResult[];
 export type queryFeatureResults =
-    | FSAResult
-    | NTSResult
-    | LatLongResult
+    | IFSAResult
+    | INTSResult
+    | ILatLongResult
     | undefined;

--- a/src/fixtures/geosearch/store/geosearch-state.ts
+++ b/src/fixtures/geosearch/store/geosearch-state.ts
@@ -1,4 +1,3 @@
-import type { GeosearchConfig } from '../definitions';
 import { GeoSearchUI } from './geosearch.feature';
 
 export class GeosearchState {
@@ -11,7 +10,8 @@ export class GeosearchState {
     resultsVisible: boolean;
     loadingResults: boolean;
 
-    constructor(geosearchConfig: GeosearchConfig) {
+    // param is the fixture config from config file
+    constructor(geosearchConfig: any) {
         // initialize geosearch feature service that contains all key geosearch functionality - running queries, fetch initial filters, update filters, etc.
         const language = 'en';
         this.GSservice = new GeoSearchUI(language, geosearchConfig);

--- a/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/src/fixtures/geosearch/store/geosearch-store.ts
@@ -3,7 +3,6 @@ import { make } from 'vuex-pathify';
 
 import { GeosearchState } from './geosearch-state';
 import type { RootState } from '@/store/state';
-import type { GeosearchConfig } from '../definitions';
 
 type GeosearchContext = ActionContext<GeosearchState, RootState>;
 
@@ -255,7 +254,7 @@ export enum GeosearchStore {
     setMapExtent = 'geosearch/setMapExtent'
 }
 
-export function geosearch(config: GeosearchConfig) {
+export function geosearch(config: any) {
     const state = new GeosearchState(config);
 
     return {

--- a/src/fixtures/geosearch/store/provinces.ts
+++ b/src/fixtures/geosearch/store/provinces.ts
@@ -1,7 +1,6 @@
-import type * as defs from '../definitions';
+import type { IGenericObjectType, IProvinces } from '../definitions';
 import axios from 'axios';
 
-const provinceObj: { [key: string]: Provinces } = {};
 const fsaToProv = <any>{
     A: 10,
     B: 12,
@@ -29,10 +28,10 @@ const provs: any = {
 };
 
 class Provinces {
-    list: defs.GenericObjectType = {};
+    list: IGenericObjectType = {};
 
     constructor(language: string, url: string) {
-        const fetchProvinces = axios.get(url).then((res: any) => {
+        axios.get(url).then((res: any) => {
             // Update the provinces array.
             res.data.definitions.forEach(
                 (type: any) => (provs[language][type.code] = type.description)
@@ -45,8 +44,8 @@ class Provinces {
     }
 
     // return list of province codes based on FSA search input query
-    fsaToProvinces(fsa: string): defs.GenericObjectType {
-        const genericObj: defs.GenericObjectType = {};
+    fsaToProvinces(fsa: string): IGenericObjectType {
+        const genericObj: IGenericObjectType = {};
         // either a provincial code, or an array of them
         let provCodes = <number[] | number>(
             fsaToProv[fsa.substring(0, 1).toUpperCase()]
@@ -61,6 +60,6 @@ class Provinces {
     }
 }
 
-export default function (language: string, url: string): defs.Provinces {
+export default function (language: string, url: string): IProvinces {
     return new Provinces(language, url);
 }

--- a/src/fixtures/geosearch/store/types.ts
+++ b/src/fixtures/geosearch/store/types.ts
@@ -1,6 +1,7 @@
-import type * as defs from '../definitions';
+import type { IGenericObjectType, ITypes } from '../definitions';
 import axios from 'axios';
 
+// TODO should these strings be in an i18n csv instead?
 const types: any = {
     en: {
         FSA: 'Forward Sortation Area',
@@ -17,8 +18,8 @@ const types: any = {
 };
 
 class Types {
-    allTypes: defs.GenericObjectType = {};
-    validTypes: defs.GenericObjectType = {};
+    allTypes: IGenericObjectType = {};
+    validTypes: IGenericObjectType = {};
     filterComplete = false;
 
     constructor(language: string, url: string) {
@@ -38,7 +39,7 @@ class Types {
     }
 
     // remove any excluded types indicated by config
-    filterValidTypes(exclude?: string | string[]): defs.GenericObjectType {
+    filterValidTypes(exclude?: string | string[]): IGenericObjectType {
         if (this.filterComplete) {
             return this.validTypes;
         }
@@ -53,6 +54,6 @@ class Types {
     }
 }
 
-export default function (language: string, url: string): defs.Types {
+export default function (language: string, url: string): ITypes {
     return new Types(language, url);
 }


### PR DESCRIPTION
Donethankses #645

- schema updates for services
- corrections to geosearch schema - moved `settings` nugget out of `serviceUrls` nugget
- making geosearch fixture obey the schema instead of being disrespectful
- fixed import issues and duplicate name fun in geosearch (interfaces vs classes)
- fixed geosearch settings defaulting edge case

Can test that geosearch works, nothing really changed, just got pushed around.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1167)
<!-- Reviewable:end -->
