### PR TITLE
Details Loading Spinner

### DIFF
--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -107,24 +107,30 @@
                             :fields="fieldsList"
                         ></component>
                     </div>
-                    <div
-                        v-else
-                        class="animate-spin spinner h-20 w-20 px-5"
-                    ></div>
+                    <!-- identified item is loading -->
+                    <div v-else class="flex justify-center py-10 items-center">
+                        <span
+                            class="animate-spin spinner h-20 w-20 px-5 mr-8"
+                        ></span>
+                        {{ $t('details.item.loading') }}
+                    </div>
                 </div>
                 <!-- layer does not exist anymore, show no data text -->
                 <div v-else class="p-5">
                     {{ $t('details.item.no.data') }}
                 </div>
             </div>
-            <div v-else class="animate-spin spinner h-20 w-20 px-5"></div>
+            <!-- result is loading -->
+            <div v-else class="flex justify-center py-10 items-center">
+                <span class="animate-spin spinner h-20 w-20 px-5 mr-8"></span>
+                {{ $t('details.item.loading') }}
+            </div>
         </template>
     </panel-screen>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import type { PropType } from 'vue';
+import { defineComponent, type PropType } from 'vue';
 
 import { DetailsStore } from './store';
 

--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -10,6 +10,7 @@ details.item.zoom,Zoom to feature,1,Zoom à l'élément,1
 details.item.previous.item,Previous item,1,Point précédent,0
 details.item.next.item,Next item,1,Prochain article,0
 details.item.count,{0} of {1},1,{0} de {1},0
+details.item.loading,Loading results...,1,Loading results...,0
 details.item.no.data,No data to show because the layer has been removed,1,No data to show because the layer has been removed,0
 details.item.alert.zoom,Zoomed into feature,1,Zoomed into feature,0
 details.item.alert.show.item,Showing result {itemName},1,Showing result {itemName},0

--- a/src/fixtures/details/result-screen.vue
+++ b/src/fixtures/details/result-screen.vue
@@ -4,9 +4,9 @@
         <template #content>
             <div v-if="layerExists">
                 <div v-if="result.items.length > 0">
-                    <span class="flex font-bold p-8 w-full" v-truncate>{{
-                        layerName
-                    }}</span>
+                    <span class="flex font-bold p-8 w-full" v-truncate>
+                        {{ layerName }}
+                    </span>
                     <button
                         class="w-full flex px-16 py-10 text-md hover:bg-gray-200 cursor-pointer"
                         v-for="(item, idx) in result.items"
@@ -28,8 +28,11 @@
                             v-if="item.loaded"
                         >
                             {{
-                                item.data[nameField] ||
-                                $t('details.result.default.name', [idx + 1])
+                                nameField
+                                    ? item.data[nameField]
+                                    : $t('details.result.default.name', [
+                                          idx + 1
+                                      ])
                             }}
                         </span>
                         <span
@@ -49,9 +52,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import type { PropType } from 'vue';
-
+import { defineComponent, type PropType } from 'vue';
 import { GlobalEvents, type LayerInstance, type PanelInstance } from '@/api';
 import type { IdentifyResult } from '@/geo/api';
 

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -504,9 +504,12 @@ export class MapImageLayer extends AttribLayer {
                         loaded: false,
                         loading: new Promise(resolve => {
                             dgr.graphic.then(g => {
-                                item.data = g.attributes;
-                                item.loaded = true;
-                                resolve();
+                                // temporary loading buffer for demo
+                                setTimeout(() => {
+                                    item.data = g.attributes;
+                                    item.loaded = true;
+                                    resolve();
+                                }, 5000);
                             });
                         })
                     });


### PR DESCRIPTION
Closes #950.

This PR fixes the formatting of the loading spinner in the details panel, and adds loading text. `map-image-layer.ts` has been modified so that the spinner will be visible for longer on the demo page. This change will be reversed before pulling.

To test this change just click on a layer to see the detail panel loading.

