### PR TITLE
Schema Mapping for Legend and Map

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -360,6 +360,10 @@
                     "type": "string",
                     "description": "Link to a layer defined in the layers section of config."
                 },
+                "name": {
+                    "type": "string",
+                    "description": "Title of the legend entry."
+                },
                 "hidden": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
Closes #617, #640.

### Map
* Most of the map was already mapped thanks to previous PRs.
* The legend was mapped according to the details given below.
* The only other things that were mapped were the `geoSearch`, `mouseInfo`, `scaleBar`, and `basemap` properties in the `components` property in the RAMP2 map config. If a corresponding place was found in RAMP4, the properties were mapped there. Otherwise, a warning was displayed saying that the property could not be mapped. Additionally, the `enabled` flag was used to the `geoSearch` and `basemap` properties to the `fixturesEnabled` array. 

### Legend
* **Note**: Many parts of the legend from RAMP2 are currently not supported in RAMP4. The way this is handled is that the unsupported properties are mapped, but a warning is displayed saying that they are currently not supported. When issues are created to add support for these properties. we would also need to delete the respective warning from the config upgrader. Alternatively, we may choose to not close #617 for the time being and wait until more of the legend has been implemented. 
* There are 2 "modes" for the legend in RAMP2: `autopulate` and `structured`.
*  The `autopopulate` mode was mapped by taking all the layers and adding a legend entry for each layer. The exception to this is map image and WMS layers - for these layers, a legend entry group was created, and a legend entry was added to the group for each layer entry. This is based on how RAMP2 seems to handle the `autopopulate` legend.
* The `structured` mode was mapped by directly converting the RAMP2 config to the RAMP4 config. As with other config upgrades, properties in common were mapped directly, and warnings were shown from properties that could not be mapped or were not supported.

### Other
* Added a `name` property to legend entry as it is present in the config but missing from the schema, as per #616.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1176)
<!-- Reviewable:end -->
