### PR TITLE
WCAG: Input field description and unique element IDs

### DIFF
--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -3,6 +3,13 @@
         <!-- TODO: see if getting this to use v-model works; children wouldnt update properly on initial try -->
         <input
             :type="isRadio ? 'radio' : 'checkbox'"
+            :aria-label="
+                $t(
+                    checked
+                        ? 'legend.visibility.hide'
+                        : 'legend.visibility.show'
+                )
+            "
             :checked="checked && initialChecked"
             @click.stop="toggleVisibility(value)"
             @keyup.enter.stop="toggleVisibility(value)"

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -54,7 +54,7 @@
                     class="inline-block fill-current w-18 h-18 mr-10"
                     viewBox="0 0 23 21"
                 >
-                    <g id="tune">
+                    <g>
                         <path
                             d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "
                         />


### PR DESCRIPTION
Closes #1172, #1174.

* For #1172, the checkboxes and radio buttons in the legend panel now have a description. One thing to note is that because the tippy for the button gets read by a screen reader, we technically already had a description for the buttons, but I'm guessing that's not good enough from a WCAG perspective?
* For #1174, there were 5 elements with `id` of tune. Fixed by removing the tune `id` as it was not being used anywhere/not changing anything.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1180)
<!-- Reviewable:end -->