### PR TITLE
Fix metadata remove layer case + event parameter changes

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -126,11 +126,11 @@ TODO add stuff as we make events that core fixtures raise
 | Event Name                           | Payload                                                 | Event Announces                                                |
 | ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------- |
 | DETAILS_OPEN<br>'details/open'       | { data: any, uid: string, format: string }              | A feature's details was requested                              |
-| GRID_TOGGLE<br>'grid/toggle'         | _uid_: layer uid<br>_open_: boolean (optional)          | Grid panel toggle was requested with optional force open/close |
+| GRID_TOGGLE<br>'grid/toggle'         | layer: LayerInstance, _open_: boolean (optional)        | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |
 | METADATA_OPEN<br>'metadata/open'     | { type: string, layerName: string, url: string, layer: LayerInstance }         | A metadata view was requested                                  |
 | REORDER_OPEN<br>'reorder/open'       | none                                                    | The reorder panel was requested                                |
-| SETTINGS_TOGGLE<br>'settings/toggle' | layer uid                                               | Settings panel toggle was requested for a layer                |
+| SETTINGS_TOGGLE<br>'settings/toggle' | layer: LayerInstance                                    | Settings panel toggle was requested for a layer                |
 | WIZARD_OPEN<br>'wizard/open'         | none                                                    | A request was made to add a layer                              |
 
 ## Default Events Handlers

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -692,11 +692,11 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.TOGGLE_SETTINGS:
                 // opens or closes the settings panel and hooks it up to the requested layer.
-                zeHandler = (payload: any) => {
+                zeHandler = (layer: LayerInstance) => {
                     const settingsFixture: SettingsAPI =
                         this.$iApi.fixture.get('settings');
                     if (settingsFixture) {
-                        settingsFixture.toggleSettings(payload);
+                        settingsFixture.toggleSettings(layer);
                     }
                 };
                 this.$iApi.event.on(
@@ -740,10 +740,10 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.TOGGLE_GRID:
                 // opens or closes the standard grid panel when a toggle grid event happens
-                zeHandler = (uid: string, open?: boolean) => {
+                zeHandler = (layer: LayerInstance, open?: boolean) => {
                     const gridFixture: GridAPI = this.$iApi.fixture.get('grid');
                     if (gridFixture) {
-                        gridFixture.toggleGrid(uid, open);
+                        gridFixture.toggleGrid(layer.uid, open);
                     }
                 };
                 this.$iApi.event.on(

--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -271,7 +271,7 @@ export default defineComponent({
             ) {
                 this.$iApi.event.emit(
                     GlobalEvents.GRID_TOGGLE,
-                    this.legendItem!.layerUID
+                    this.legendItem!.layer
                 );
             }
         },

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -24,7 +24,7 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem.controlAvailable(`metadata`) ||
+                        !legendItem!.controlAvailable(LayerControls.Metadata) ||
                         !getFixtureExists('metadata')
                 }"
                 @click="toggleMetadata"
@@ -45,7 +45,7 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem.controlAvailable(`settings`) ||
+                        !legendItem!.controlAvailable(LayerControls.Settings) ||
                         !getFixtureExists('settings')
                 }"
                 @click="toggleSettings"
@@ -68,7 +68,7 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem.controlAvailable(`datatable`) ||
+                        !legendItem!.controlAvailable(LayerControls.Datatable) ||
                         !getFixtureExists('grid')
                 }"
                 @click="toggleGrid"
@@ -88,7 +88,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem.controlAvailable(`symbology`)
+                    disabled: !legendItem!.controlAvailable(LayerControls.Symbology)
                 }"
                 @click="toggleSymbology"
             >
@@ -107,7 +107,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem.controlAvailable(`boundaryZoom`)
+                    disabled: !legendItem!.controlAvailable(LayerControls.BoundaryZoom)
                 }"
                 @click="zoomToLayerBoundary"
             >
@@ -128,7 +128,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem.controlAvailable(`remove`)
+                    disabled: !legendItem!.controlAvailable(LayerControls.Remove)
                 }"
                 @click="removeLayer"
             >
@@ -147,7 +147,7 @@
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem.controlAvailable(`reload`)
+                    disabled: !legendItem!.controlAvailable(LayerControls.Reload)
                 }"
                 @click="reloadLayer"
             >
@@ -176,6 +176,11 @@ export default defineComponent({
     props: {
         legendItem: LegendEntry
     },
+    data() {
+        return {
+            LayerControls
+        };
+    },
     methods: {
         /**
          * Display symbology stack for the layer.
@@ -196,7 +201,7 @@ export default defineComponent({
             ) {
                 this.$iApi.event.emit(
                     GlobalEvents.GRID_TOGGLE,
-                    this.legendItem!.layerUID
+                    this.legendItem!.layer
                 );
             }
         },
@@ -211,7 +216,7 @@ export default defineComponent({
             ) {
                 this.$iApi.event.emit(
                     GlobalEvents.SETTINGS_TOGGLE,
-                    this.legendItem!.layerUID
+                    this.legendItem!.layer
                 );
             }
         },

--- a/src/fixtures/metadata/api/metadata.ts
+++ b/src/fixtures/metadata/api/metadata.ts
@@ -16,7 +16,7 @@ export class MetadataAPI extends FixtureInstance {
             });
         } else {
             // otherwise refresh with new layer info or close if it is the same layer
-            const currentUid = (panel.route.props! as any).payload.uid;
+            const currentUid = (panel.route.props! as any).payload.layer.uid;
             if (currentUid !== payload?.layer?.uid) {
                 panel.show({
                     screen: 'metadata-screen-content',

--- a/src/fixtures/settings/api/settings.ts
+++ b/src/fixtures/settings/api/settings.ts
@@ -6,11 +6,7 @@ export class SettingsAPI extends FixtureInstance {
      * Opens the settings panel. Passes the provided LayerInstance object to the panel.
      * @param layer
      */
-    toggleSettings(uid: string): void {
-        const layer: LayerInstance | undefined = this.$iApi.$vApp.$store.get(
-            'layer/getLayerByUid',
-            uid
-        );
+    toggleSettings(layer: LayerInstance): void {
         const panel = this.$iApi.panel.get('settings');
         const legendItem = this.$iApi.$vApp.$store.get(
             LegendStore.getChildById,
@@ -19,14 +15,17 @@ export class SettingsAPI extends FixtureInstance {
         if (!panel.isOpen) {
             this.$iApi.panel.open({
                 id: 'settings',
-                props: { layer: layer, uid: uid, legendItem: legendItem }
+                props: { layer: layer, legendItem: legendItem }
             });
         } else {
-            const currentUid = (panel.route.props! as any).uid;
-            if (currentUid !== uid) {
+            const currentUid = (panel.route.props! as any).layer.uid;
+            if (currentUid !== layer.uid) {
                 panel.show({
                     screen: 'settings-screen-content',
-                    props: { layer: layer, uid: uid, legendItem: legendItem }
+                    props: {
+                        layer: layer,
+                        legendItem: legendItem
+                    }
                 });
             } else {
                 panel.close();


### PR DESCRIPTION
Closes #1156 

**Changes**: 
- fixes case of metadata panel not updating its screen content when an existing panel is already open 
- fixes minimize and remove layer case mentioned in original issue and add error message to panel when layer doesn't exist
- normalizes some fixture event parameters to use `LayerInstance` as opposed to `uid` for `TOGGLE_GRID` and `TOGGLE_SETTINGS`
- remove some template TS errors

**Testing**:
- ensure removing a layer after minimizing the metadata panel and then re-opening the panel will display proper no metadata message 
- check that opening new settings/metadata panel properly re-renders updated content 
- test that all other settings/grid/metadata functionality remains the same

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1185)
<!-- Reviewable:end -->
