### PR TITLE
Rename layerEntry to sublayer

### DIFF
--- a/demos/starter-scripts/custom-renderer.js
+++ b/demos/starter-scripts/custom-renderer.js
@@ -526,7 +526,7 @@ let config = {
                     id: 'MILSimple',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 18,
                             state: {
@@ -573,7 +573,7 @@ let config = {
                     id: 'MILUniqueValue',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 18,
                             state: {
@@ -635,7 +635,7 @@ let config = {
                     id: 'MILClassBreaks',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 18,
                             state: {
@@ -740,24 +740,24 @@ let config = {
                                             {
                                                 layerId: 'MILSimple',
                                                 name: 'Sulfur Oxide Emissions',
-                                                entryIndex: 18
+                                                sublayerIndex: 18
                                             },
                                             {
                                                 layerId: 'MILSimple',
                                                 name: 'Water Quantity',
-                                                entryIndex: 1
+                                                sublayerIndex: 1
                                             }
                                         ]
                                     },
                                     {
                                         layerId: 'MILUniqueValue',
                                         name: 'Unique Value',
-                                        entryIndex: 18
+                                        sublayerIndex: 18
                                     },
                                     {
                                         layerId: 'MILClassBreaks',
                                         name: 'Class Breaks',
-                                        entryIndex: 18
+                                        sublayerIndex: 18
                                     }
                                 ]
                             }

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -264,7 +264,7 @@ let config = {
                     id: 'WaterQuantity',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 1,
                             name: 'Water quantity child',
@@ -305,7 +305,7 @@ let config = {
                     id: 'WaterQuality',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 5,
                             state: {}
@@ -366,7 +366,7 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'Water Quantity in Nested Group',
-                                                entryIndex: 1,
+                                                sublayerIndex: 1,
                                                 controls: [
                                                     'datatable',
                                                     'metadata',
@@ -379,12 +379,12 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'CO2 in Nested Group',
-                                                entryIndex: 9
+                                                sublayerIndex: 9
                                             },
                                             {
                                                 layerId: 'WaterQuality',
                                                 name: 'Water Quality in Nested Group',
-                                                entryIndex: 5
+                                                sublayerIndex: 5
                                             }
                                         ]
                                     }

--- a/demos/starter-scripts/map-image-layer.js
+++ b/demos/starter-scripts/map-image-layer.js
@@ -55,7 +55,7 @@ let config = {
                     id: 'AirEmissions',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 9,
                             state: {
@@ -99,12 +99,12 @@ let config = {
                                     {
                                         layerId: 'AirEmissions',
                                         name: 'Carbon monoxide emissions by facility',
-                                        entryIndex: 9
+                                        sublayerIndex: 9
                                     },
                                     {
                                         layerId: 'AirEmissions',
                                         name: 'Sulphur oxide emissions by facility',
-                                        entryIndex: 18
+                                        sublayerIndex: 18
                                     }
                                 ]
                             },

--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -276,7 +276,7 @@ let config = {
                     id: 'WaterQuantity',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 1,
                             name: 'Water quantity child',
@@ -317,7 +317,7 @@ let config = {
                     id: 'WaterQuality',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 5,
                             state: {}
@@ -378,7 +378,7 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'Water Quantity in Nested Group',
-                                                entryIndex: 1,
+                                                sublayerIndex: 1,
                                                 controls: [
                                                     'datatable',
                                                     'metadata',
@@ -391,12 +391,12 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'CO2 in Nested Group',
-                                                entryIndex: 9
+                                                sublayerIndex: 9
                                             },
                                             {
                                                 layerId: 'WaterQuality',
                                                 name: 'Water Quality in Nested Group',
-                                                entryIndex: 5
+                                                sublayerIndex: 5
                                             }
                                         ]
                                     }
@@ -705,7 +705,7 @@ let config2 = {
                     id: 'WaterQuantity',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 1,
                             name: 'Water quantity child',
@@ -746,7 +746,7 @@ let config2 = {
                     id: 'WaterQuality',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 5,
                             state: {}
@@ -807,7 +807,7 @@ let config2 = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'Water Quantity in Nested Group',
-                                                entryIndex: 1,
+                                                sublayerIndex: 1,
                                                 controls: [
                                                     'datatable',
                                                     'metadata',
@@ -820,12 +820,12 @@ let config2 = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'CO2 in Nested Group',
-                                                entryIndex: 9
+                                                sublayerIndex: 9
                                             },
                                             {
                                                 layerId: 'WaterQuality',
                                                 name: 'Water Quality in Nested Group',
-                                                entryIndex: 5
+                                                sublayerIndex: 5
                                             }
                                         ]
                                     }
@@ -1134,7 +1134,7 @@ let config3 = {
                     id: 'WaterQuantity',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 1,
                             name: 'Water quantity child',
@@ -1175,7 +1175,7 @@ let config3 = {
                     id: 'WaterQuality',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 5,
                             state: {}
@@ -1236,7 +1236,7 @@ let config3 = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'Water Quantity in Nested Group',
-                                                entryIndex: 1,
+                                                sublayerIndex: 1,
                                                 controls: [
                                                     'datatable',
                                                     'metadata',
@@ -1249,12 +1249,12 @@ let config3 = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'CO2 in Nested Group',
-                                                entryIndex: 9
+                                                sublayerIndex: 9
                                             },
                                             {
                                                 layerId: 'WaterQuality',
                                                 name: 'Water Quality in Nested Group',
-                                                entryIndex: 5
+                                                sublayerIndex: 5
                                             }
                                         ]
                                     }

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -248,7 +248,7 @@ let config = {
                     name: 'Water quantity parent',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 1,
                             name: 'Water quantity child',
@@ -273,7 +273,7 @@ let config = {
                     id: 'WaterQuality',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 5,
                             state: {
@@ -330,12 +330,12 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'Water Quantity in Nested Group',
-                                                entryIndex: 1
+                                                sublayerIndex: 1
                                             },
                                             {
                                                 layerId: 'WaterQuality',
                                                 name: 'Water Quality in Nested Group',
-                                                entryIndex: 5
+                                                sublayerIndex: 5
                                             }
                                         ]
                                     }

--- a/demos/starter-scripts/wms-layer.js
+++ b/demos/starter-scripts/wms-layer.js
@@ -100,7 +100,7 @@ let config = {
                     state: {
                         visibility: true
                     },
-                    layerEntries: [
+                    sublayers: [
                         {
                             id: 'ne:ne'
                         }
@@ -114,7 +114,7 @@ let config = {
                     state: {
                         visibility: true
                     },
-                    layerEntries: [
+                    sublayers: [
                         { id: 'railway', name: 'Railway' },
                         { id: 'railway.structure.line' },
                         { id: 'railway.structure.point' },
@@ -135,7 +135,7 @@ let config = {
                         visibility: true,
                         opacity: 0.5
                     },
-                    layerEntries: [
+                    sublayers: [
                         {
                             id: 'RDPA.24F_PR',
                             currentStyle: 'PRECIPMM'

--- a/public/starter-scripts/cam.js
+++ b/public/starter-scripts/cam.js
@@ -266,7 +266,7 @@ let config = {
                     name: 'Climate action map',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 0,
                             name: 'Keyword search',
@@ -344,7 +344,7 @@ let config = {
                                 name: 'Keyword search',
                                 layerId: 'climateActionMap',
                                 symbologyExpanded: true,
-                                entryIndex: 0
+                                sublayerIndex: 0
                             }
                         ]
                     }
@@ -659,7 +659,7 @@ let config = {
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer',
                     tolerance: 20,
                     symbologyExpanded: true,
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 1,
                             name: 'Recherche de mot cl?',
@@ -739,7 +739,7 @@ let config = {
                                 name: 'Recherche de mot cl?',
                                 layerId: 'climateActionMap',
                                 symbologyExpanded: true,
-                                entryIndex: 1
+                                sublayerIndex: 1
                             }
                         ]
                     }

--- a/public/starter-scripts/cesi.js
+++ b/public/starter-scripts/cesi.js
@@ -272,7 +272,7 @@ let config = {
                         visibility: true,
                         opacity: 1
                     },
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 10,
                             state: {
@@ -480,7 +480,7 @@ let config = {
                         visibility: false,
                         opacity: 1
                     },
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 32,
                             state: {
@@ -572,7 +572,7 @@ let config = {
                         visibility: true,
                         opacity: 1
                     },
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 33,
                             state: {
@@ -615,12 +615,12 @@ let config = {
                                     {
                                         layerId: 'EZ',
                                         name: 'Ecozone',
-                                        entryIndex: 33
+                                        sublayerIndex: 33
                                     },
                                     {
                                         layerId: 'EZ',
                                         name: 'Ecozone boundary',
-                                        entryIndex: 34
+                                        sublayerIndex: 34
                                     }
                                 ]
                             },
@@ -635,7 +635,7 @@ let config = {
                             {
                                 name: 'Conserved areas',
                                 layerId: 'Conserved_Areas',
-                                entryIndex: 32
+                                sublayerIndex: 32
                             },
                             {
                                 name: 'Releases of lead to water by facility',
@@ -660,7 +660,7 @@ let config = {
                             {
                                 name: 'Greenhouse gas emissions from large facilities',
                                 layerId: 'AirEmissions_GHG',
-                                entryIndex: 10
+                                sublayerIndex: 10
                             }
                         ]
                     }

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -265,7 +265,7 @@ let config = {
                     id: 'WaterQuantity',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 1,
                             name: 'Water quantity child',
@@ -302,7 +302,7 @@ let config = {
                     id: 'WaterQuality',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    layerEntries: [
+                    sublayers: [
                         {
                             index: 5,
                             state: {
@@ -365,7 +365,7 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'Water Quantity in Nested Group',
-                                                entryIndex: 1,
+                                                sublayerIndex: 1,
                                                 controls: [
                                                     'metadata',
                                                     'boundaryZoom',
@@ -380,12 +380,12 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'CO2 in Nested Group',
-                                                entryIndex: 9
+                                                sublayerIndex: 9
                                             },
                                             {
                                                 layerId: 'WaterQuality',
                                                 name: 'Water Quality in Nested Group',
-                                                entryIndex: 5
+                                                sublayerIndex: 5
                                             }
                                         ]
                                     }

--- a/schema.json
+++ b/schema.json
@@ -377,12 +377,12 @@
                         "type": "string"
                     }
                 },
-                "entryIndex": {
+                "sublayerIndex": {
                     "type": "integer",
                     "default": 0,
                     "description": "Index of the 'sublayer' in the case of a map image layer."
                 },
-                "entryId": {
+                "sublayerId": {
                     "type": "string",
                     "default": 0,
                     "description": "Id of the 'sublayer' in the case of an OGC WMS layer."
@@ -836,11 +836,11 @@
                     "default": false,
                     "description": "Indicates that the map image layer with a single layer entry should be rendered without the root group."
                 },
-                "layerEntries": {
+                "sublayers": {
                     "type": "array",
                     "description": "Layer entries rendered as part of the map image layer group.",
                     "items": {
-                        "$ref": "#/$defs/mapImageLayerEntry"
+                        "$ref": "#/$defs/mapImageSublayer"
                     },
                     "minItems": 1
                 },
@@ -895,10 +895,10 @@
                     "$ref": "#/$defs/layerFixtureConfig"
                 }
             },
-            "required": ["id", "layerType", "layerEntries", "url"],
+            "required": ["id", "layerType", "sublayers", "url"],
             "unevaluatedProperties": false
         },
-        "mapImageLayerEntry": {
+        "mapImageSublayer": {
             "type": "object",
             "description": "A child entry of a map image layer.",
             "properties": {
@@ -1306,11 +1306,11 @@
                     "default": null,
                     "description": "Catalogue url of the layer service."
                 },
-                "layerEntries": {
+                "sublayers": {
                     "type": "array",
                     "description": "Layer entries rendered as part of the WMS legend block.",
                     "items": {
-                        "$ref": "#/$defs/wmsLayerEntry"
+                        "$ref": "#/$defs/wmsSublayer"
                     },
                     "minItems": 1
                 },
@@ -1352,10 +1352,10 @@
                     "$ref": "#/$defs/initialLayerSettings"
                 }
             },
-            "required": ["id", "layerType", "layerEntries", "url"],
+            "required": ["id", "layerType", "sublayers", "url"],
             "unevaluatedProperties": false
         },
-        "wmsLayerEntry": {
+        "wmsSublayer": {
             "type": "object",
             "description": "A child entry of a WMS layer.",
             "properties": {

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -394,26 +394,26 @@ function mapUpgrader(r2Map: any, r4c: any): void {
                             name: r4layer.name ?? `${r4layer.id} Group`,
                             children: []
                         };
-                        r4layer.layerEntries.forEach((r4layerEntry: any) => {
+                        r4layer.sublayers.forEach((r4Sublayer: any) => {
                             const entry: any = {
                                 layerId: r4layer.id
                             };
-                            if (r4layerEntry.name) {
-                                entry.name = r4layerEntry.name;
+                            if (r4Sublayer.name) {
+                                entry.name = r4Sublayer.name;
                             }
-                            if (r4layerEntry.controls) {
-                                entry.controls = r4layerEntry.controls;
+                            if (r4Sublayer.controls) {
+                                entry.controls = r4Sublayer.controls;
                             }
-                            if (r4layerEntry.disabledControls) {
+                            if (r4Sublayer.disabledControls) {
                                 entry.disabledControls =
-                                    r4layerEntry.disabledControls;
+                                    r4Sublayer.disabledControls;
                             }
                             if (r4layer.type === 'esri-map-image') {
-                                entry.entryIndex = r4layerEntry.index;
+                                entry.sublayerIndex = r4Sublayer.index;
                             } else {
-                                entry.entryId = r4layerEntry.id;
+                                entry.sublayerId = r4Sublayer.id;
                                 console.warn(
-                                    `entryId property defined in legend entry ${entry.layerId} is currently not supported.`
+                                    `sublayerId property defined in legend entry ${entry.layerId} is currently not supported.`
                                 );
                             }
                             entryGroup.children.push(entry);
@@ -598,9 +598,9 @@ function legendEntryUpgrader(r2legendEntry: any) {
             `controlledIds property defined in legend entry ${r2legendEntry.layerId} is currently not supported.`
         );
     }
-    if (r2legendEntry.entryId) {
+    if (r2legendEntry.sublayerId) {
         console.warn(
-            `entryId property defined in legend entry ${r2legendEntry.layerId} is currently not supported.`
+            `sublayerId property defined in legend entry ${r2legendEntry.layerId} is currently not supported.`
         );
     }
     if (r2legendEntry.coverIcon) {
@@ -681,18 +681,18 @@ function layerUpgrader(r2layer: any): any {
             if (r2layer.imageFormat) {
                 r4layer.imageFormat = r2layer.imageFormat;
             }
-            if (r2layer.layerEntries) {
-                r4layer.layerEntries = [];
-                r2layer.layerEntries.forEach((r2layerEntry: any) => {
-                    const r4layerEntry: any =
-                        layerCommonPropertiesUpgrader(r2layerEntry);
-                    r4layerEntry.index = r2layerEntry.index;
-                    if (r2layerEntry.outfields) {
+            if (r2layer.sublayers) {
+                r4layer.sublayers = [];
+                r2layer.sublayers.forEach((r2Sublayer: any) => {
+                    const r4Sublayer: any =
+                        layerCommonPropertiesUpgrader(r2Sublayer);
+                    r4Sublayer.index = r2Sublayer.index;
+                    if (r2Sublayer.outfields) {
                         console.warn(
-                            `outfields property provided in layer entry ${r2layerEntry.index} of layer ${r2layer.id} cannot be mapped and will be skipped.`
+                            `outfields property provided in layer entry ${r2Sublayer.index} of layer ${r2layer.id} cannot be mapped and will be skipped.`
                         );
                     }
-                    r2layer.layerEntries.push(r4layerEntry);
+                    r2layer.sublayers.push(r4Sublayer);
                 });
             }
             break;
@@ -751,24 +751,24 @@ function layerUpgrader(r2layer: any): any {
                     `legendMimeType property provided in layer ${r2layer.id} cannot be mapped and will be skipped.`
                 );
             }
-            if (r2layer.layerEntries) {
-                r4layer.layerEntries = [];
-                r2layer.layerEntries.forEach((r2layerEntry: any) => {
-                    const r4layerEntry: any =
-                        layerCommonPropertiesUpgrader(r2layerEntry);
-                    r4layerEntry.id = r2layerEntry.id;
-                    if (r2layerEntry.currentStyle) {
-                        r4layerEntry.currentStyle = r2layerEntry.currentStyle;
+            if (r2layer.sublayers) {
+                r4layer.sublayers = [];
+                r2layer.sublayers.forEach((r2Sublayer: any) => {
+                    const r4Sublayer: any =
+                        layerCommonPropertiesUpgrader(r2Sublayer);
+                    r4Sublayer.id = r2Sublayer.id;
+                    if (r2Sublayer.currentStyle) {
+                        r4Sublayer.currentStyle = r2Sublayer.currentStyle;
                         console.warn(
-                            `currentStyle property provided in layer entry ${r2layerEntry.id} of layer ${r2layer.id} is currently not supported.`
+                            `currentStyle property provided in layer entry ${r2Sublayer.id} of layer ${r2layer.id} is currently not supported.`
                         );
                     }
-                    if (r2layerEntry.allStyles) {
+                    if (r2Sublayer.allStyles) {
                         console.warn(
-                            `allStyles property provided in layer entry ${r2layerEntry.id} of layer ${r2layer.id} cannot be mapped and will be skipped.`
+                            `allStyles property provided in layer entry ${r2Sublayer.id} of layer ${r2layer.id} cannot be mapped and will be skipped.`
                         );
                     }
-                    r4layer.layerEntries.push(r4layerEntry);
+                    r4layer.sublayers.push(r4Sublayer);
                 });
             }
             break;

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -409,8 +409,8 @@ export class FixtureInstance extends APIScope implements FixtureBase {
             }
 
             // process child layer entries
-            if (layer.layerEntries) {
-                layer.layerEntries.forEach((sublayer: any) =>
+            if (layer.sublayers) {
+                layer.sublayers.forEach((sublayer: any) =>
                     layerCrawler(sublayer, layer)
                 );
             }

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -67,9 +67,9 @@ export class LegendAPI extends FixtureInstance {
             } else if (lastEntry.layerId !== undefined) {
                 // create a wrapper legend object for single legend entry
                 // if the entry is a sublayer, override the entry id to the sublayers id
-                if (lastEntry.entryIndex !== undefined) {
+                if (lastEntry.sublayerIndex !== undefined) {
                     lastEntry.layerParentId = lastEntry.layerId;
-                    lastEntry.layerId = `${lastEntry.layerId}-${lastEntry.entryIndex}`;
+                    lastEntry.layerId = `${lastEntry.layerId}-${lastEntry.sublayerIndex}`;
                 }
                 const legendEntry = new LegendEntry(
                     lastEntry,

--- a/src/fixtures/legend/store/legend-defs.ts
+++ b/src/fixtures/legend/store/legend-defs.ts
@@ -131,7 +131,7 @@ export class LegendEntry extends LegendItem {
         this._type = LegendTypes.Placeholder; // entry will be in a placeholder state by default
 
         this._layerParentId = legendEntry.layerParentId; // will only be defined for sublayers
-        this._layerIdx = legendEntry.entryIndex; // will only be defined for sublayers
+        this._layerIdx = legendEntry.sublayerIndex; // will only be defined for sublayers
         this._symbologyExpanded = legendEntry.symbologyExpanded || false;
 
         // read the toggleSymbology from the layer fixture config
@@ -160,7 +160,7 @@ export class LegendEntry extends LegendItem {
     }
 
     /** Returns the entry index of the layer */
-    get entryIndex(): number | undefined {
+    get sublayerIndex(): number | undefined {
         return this._layerIdx;
     }
 
@@ -254,7 +254,7 @@ export class LegendEntry extends LegendItem {
             ) {
                 this._type = LegendTypes.Error;
                 console.error(
-                    `MapImageLayer has no entryIndex defined - ${this._itemConfig.layerId} (${this._itemConfig.name})`
+                    `MapImageLayer has no sublayerIndex defined - ${this._itemConfig.layerId} (${this._itemConfig.name})`
                 );
                 this._loadPromise.rejectMe();
             } else {
@@ -463,7 +463,7 @@ export class LegendGroup extends LegendItem {
                                   layer: layer,
                                   layerId: layer.id,
                                   name: layer.name,
-                                  entryIndex:
+                                  sublayerIndex:
                                       layer.layerIdx === -1
                                           ? undefined
                                           : layer.layerIdx
@@ -518,9 +518,9 @@ export class LegendGroup extends LegendItem {
                     this._children.push(new LegendGroup(entry, this));
                 } else {
                     // if the entry is a sublayer, set the entry id to the sublayers id
-                    if (entry.entryIndex !== undefined) {
+                    if (entry.sublayerIndex !== undefined) {
                         entry.layerParentId = entry.layerId;
-                        entry.layerId = `${entry.layerId}-${entry.entryIndex}`;
+                        entry.layerId = `${entry.layerId}-${entry.sublayerIndex}`;
                     }
                     this._children.push(new LegendEntry(entry, this));
                 }

--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -88,7 +88,7 @@
                     </select>
                     <div class="text-gray-400 text-xs mb-1">{{ help }}</div>
                     <div
-                        v-if="validation && layerEntriesError"
+                        v-if="validation && sublayersError"
                         class="text-red-900 text-xs"
                     >
                         {{ validationMessages.required }}
@@ -255,7 +255,7 @@ export default defineComponent({
         return {
             valid: false,
             urlError: false,
-            layerEntriesError: false,
+            sublayersError: false,
             selected: []
         };
     },
@@ -277,8 +277,8 @@ export default defineComponent({
 
         checkMultiSelectError(selected: Array<any>) {
             selected && selected.length > 0
-                ? (this.layerEntriesError = false)
-                : (this.layerEntriesError = true);
+                ? (this.sublayersError = false)
+                : (this.sublayersError = true);
         }
     }
 });

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -32,8 +32,8 @@ wizard.configure.nameField.label,Primary Field,1,Champ clé,1
 wizard.configure.tooltipField.label,Tooltip Field,1,Champ infobulle,1
 wizard.configure.latField.label,Latitude Field,1,Champ latitude,1
 wizard.configure.longField.label,Longitude Field,1,Champ longitude,1
-wizard.configure.layerEntries.error.required,LayerEntries is required,1,Le champ LayerEntries est obligatoire,1
-wizard.configure.layerEntries.label,Layers,1,Couches,1
-wizard.configure.layerEntries.help,Hold Ctrl to select multiple layers,1,Maintenez la touche CTRL enfoncée pour sélectionner plusieurs couches,1
+wizard.configure.sublayers.error.required,Sublayers are required,1,Le sous-couche est obligatoire,0
+wizard.configure.sublayers.label,Layers,1,Couches,1
+wizard.configure.sublayers.help,Hold Ctrl to select multiple layers,1,Maintenez la touche CTRL enfoncée pour sélectionner plusieurs couches,1
 wizard.step.cancel,Cancel,1,Annuler,1
 wizard.step.continue,Continue,1,Continuer,1

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -194,21 +194,19 @@
                         </wizard-input>
                         <!-- For map image layers -->
                         <wizard-input
-                            v-if="
-                                layerInfo.configOptions.includes(`layerEntries`)
-                            "
+                            v-if="layerInfo.configOptions.includes(`sublayers`)"
                             type="select"
-                            name="layerEntries"
-                            v-model="layerInfo.config.layerEntries"
-                            @select="updateLayerEntries"
-                            :label="$t('wizard.configure.layerEntries.label')"
-                            :help="$t('wizard.configure.layerEntries.help')"
+                            name="sublayers"
+                            v-model="layerInfo.config.sublayers"
+                            @select="updateSublayers"
+                            :label="$t('wizard.configure.sublayers.label')"
+                            :help="$t('wizard.configure.sublayers.help')"
                             :options="sublayerOptions()"
                             :multiple="true"
                             :validation="true"
                             :validation-messages="{
                                 required: $t(
-                                    'wizard.configure.layerEntries.error.required'
+                                    'wizard.configure.sublayers.error.required'
                                 )
                             }"
                             @keydown.stop
@@ -460,7 +458,7 @@ export default defineComponent({
             }
 
             this.goToStep(WizardStep.CONFIGURE);
-            this.layerInfo.configOptions.includes(`layerEntries`)
+            this.layerInfo.configOptions.includes(`sublayers`)
                 ? (this.finishStep = false)
                 : (this.finishStep = true);
         },
@@ -552,14 +550,14 @@ export default defineComponent({
 
         updateLayerName(name: string) {
             this.layerInfo.config.name = name;
-            const le = this.layerInfo.config.layerEntries;
-            const canFinish = le ? name && le.length > 0 : name;
+            const sublayers = this.layerInfo.config.sublayers;
+            const canFinish = sublayers ? name && sublayers.length > 0 : name;
             canFinish ? (this.finishStep = true) : (this.finishStep = false);
         },
 
-        updateLayerEntries(le: Array<any>) {
-            this.layerInfo.config.layerEntries = le;
-            le.length > 0 && this.layerInfo.config.name
+        updateSublayers(sublayer: Array<any>) {
+            this.layerInfo.config.sublayers = sublayer;
+            sublayer.length > 0 && this.layerInfo.config.name
                 ? (this.finishStep = true)
                 : (this.finishStep = false);
         }

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -176,14 +176,14 @@ export class LayerSource extends APIScope {
             url: url,
             layerType: LayerType.MAPIMAGE,
             name: response.data.mapName,
-            layerEntries: [],
+            sublayers: [],
             state: { opacity: 1, visibility: true }
         };
 
         return {
             config,
             layers: flattenMapImageLayerList(response.data.layers),
-            configOptions: ['name', 'layerEntries']
+            configOptions: ['name', 'sublayers']
         };
 
         function flattenMapImageLayerList(layers: any) {
@@ -277,7 +277,7 @@ export class LayerSource extends APIScope {
         return {
             config,
             layers: flattenWmsLayerList(capabilities.layers),
-            configOptions: ['name', 'layerEntries']
+            configOptions: ['name', 'sublayers']
         };
 
         function flattenWmsLayerList(layers: any, level = 0) {

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -515,7 +515,7 @@ export interface RampLayerFieldMetadataConfig {
 }
 
 // i.e. a dynamic layer child
-export interface RampLayerMapImageLayerEntryConfig {
+export interface RampLayerMapImageSublayerConfig {
     // A+ name
     index?: number;
     name?: string;
@@ -534,7 +534,7 @@ export interface RampLayerMapImageLayerEntryConfig {
 }
 
 // i.e. a wms layer child
-export interface RampLayerWmsLayerEntryConfig {
+export interface RampLayerWmsSublayerConfig {
     id?: string; // this is the "name" on the service
     name?: string; // this is display name in ramp. would override "title" on the service
     state?: RampLayerStateConfig;
@@ -564,9 +564,9 @@ export interface RampLayerConfig {
     featureInfoMimeType?: string;
     controls?: Array<LayerControls>;
     disabledControls?: Array<LayerControls>;
-    layerEntries?:
-        | Array<RampLayerMapImageLayerEntryConfig>
-        | Array<RampLayerWmsLayerEntryConfig>;
+    sublayers?:
+        | Array<RampLayerMapImageSublayerConfig>
+        | Array<RampLayerWmsSublayerConfig>;
     rawData?: any; // used for static data, like geojson string, shapefile guts
     latField?: string; // csv coord field
     longField?: string; // csv coord field

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -28,7 +28,7 @@ import type {
     Point,
     QueryFeaturesParams,
     RampLayerConfig,
-    RampLayerMapImageLayerEntryConfig,
+    RampLayerMapImageSublayerConfig,
     TabularAttributeSet
 } from '@/geo/api';
 
@@ -91,16 +91,16 @@ export class MapImageLayer extends AttribLayer {
         //                 prior to running this function. essentially do tree traversal before this instead
         //                 of on onLoadActions like we currently do.
         /*
-        if (rampLayerConfig.layerEntries) {
+        if (rampLayerConfig.sublayers) {
             // NOTE: important not to set esriConfig property to empty array, as that will request no sublayers
             // TODO documentation isn't clear if we should be using .sublayers or .allSublayers ; if .sublayers can it be flat array?
             //      play with their online sandbox using a nested service if cant figure it out.
             // let us all stop to appreciate this line of code.
-            esriConfig.sublayers = (<Array<RampLayerMapImageLayerEntryConfig>>rampLayerConfig.layerEntries).map((le: RampLayerMapImageLayerEntryConfig) => {
+            esriConfig.sublayers = (<Array<RampLayerMapImageSublayerConfig>>rampLayerConfig.sublayers).map((sublayer: RampLayerMapImageSublayerConfig) => {
                 // the super call will set up the basics/common stuff like vis, opacity, def identify
                 // works because the sublayer property scheme is nearly identical to a normal layer
-                const subby: esri.SublayerProperties = super.makeEsriLayerConfig(le);
-                subby.id = le.index;
+                const subby: esri.SublayerProperties = super.makeEsriLayerConfig(sublayer);
+                subby.id = sublayer.index;
 
                 // TODO process the other options
                 return subby;
@@ -157,14 +157,14 @@ export class MapImageLayer extends AttribLayer {
 
         // collate any relevant overrides from the config.
         const subConfigs: {
-            [key: number]: RampLayerMapImageLayerEntryConfig;
+            [key: number]: RampLayerMapImageSublayerConfig;
         } = {};
 
-        (<Array<RampLayerMapImageLayerEntryConfig>>(
-            this.origRampConfig.layerEntries
-        )).forEach((le: RampLayerMapImageLayerEntryConfig) => {
+        (<Array<RampLayerMapImageSublayerConfig>>(
+            this.origRampConfig.sublayers
+        )).forEach((sublayer: RampLayerMapImageSublayerConfig) => {
             // TODO the || 0 is there to handle missing index. probably will never happen. add an error check?
-            subConfigs[le.index || 0] = le;
+            subConfigs[sublayer.index || 0] = sublayer;
         });
 
         // shortcut var to track all leafs that need attention
@@ -271,12 +271,12 @@ export class MapImageLayer extends AttribLayer {
         };
 
         // process the child layers our config is insested in, and all their children.
-        (<Array<RampLayerMapImageLayerEntryConfig>>(
-            this.origRampConfig.layerEntries
-        )).forEach(le => {
-            if (!le.stateOnly) {
+        (<Array<RampLayerMapImageSublayerConfig>>(
+            this.origRampConfig.sublayers
+        )).forEach(sublayer => {
+            if (!sublayer.stateOnly) {
                 // TODO add a check instead of 0 default on the index?
-                const rootSub = findSublayer(le.index || 0);
+                const rootSub = findSublayer(sublayer.index || 0);
                 // TODO would need to validate layer tree every loop to shut up typescript. shutting it up with comment instead.
                 // @ts-ignore
                 processSublayer(rootSub, this.layerTree);


### PR DESCRIPTION
## Closes #920

## Changes
- Renamed all references of `layerEntry` to `sublayer`
- Renamed all references of `entryIndex/entryId` to `sublayerIndex/sublayerId`

## Testing
- Functionality should remain the same since things were only renamed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1193)
<!-- Reviewable:end -->
