### PR TITLE
WCAG: Focus visibility

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -94,7 +94,8 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | LAYER_STATECHANGE<br>'layer/statechange'           | _state_: new value, layer: LayerInstance object                | The layer state changed                          |
 | LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, layer: LayerInstance object           | The layer visibility changed                     |
 | MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | basemapId: string, schemaChanged: boolean                      | The basemap was changed                          |
-| MAP_BLUR<br>'map/blur'                             | FocusEvent object                                              | The map lost focus                               |
+| MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                                |
+| MAP_BLUR<br>'map/blur'                             | KeyboardEvent object                                           | The map lost focus                               |
 | MAP_CLICK<br>'map/click'                           | MapClick object                                                | The map was clicked                              |
 | MAP_CREATED<br>'map/created'                       | none                                                           | The map was created                              |
 | MAP_DESTROYED<br>'map/destroyed'                   | none                                                           | The map was destroyed                            |

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -145,6 +145,12 @@ export enum GlobalEvents {
     MAP_BASEMAPCHANGE = 'map/basemapchanged',
 
     /**
+     * Fires when the map gains focus.
+     * Payload: `(params: KeyboardEvent)` (DOM Event)
+     */
+    MAP_FOCUS = 'map/focus',
+
+    /**
      * Fires when the map loses focus.
      * Payload: `(params: KeyboardEvent)` (DOM Event)
      */
@@ -866,7 +872,7 @@ export class EventAPI extends APIScope {
                 break;
             case DefEH.MAP_BLUR:
                 // processes loss of focus from the map view
-                zeHandler = (payload: FocusEvent) => {
+                zeHandler = (payload: KeyboardEvent) => {
                     this.$iApi.geo.map.stopKeyPan();
                 };
                 this.$iApi.event.on(

--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -12,6 +12,7 @@
             delay: 200,
             duration: [200, 200]
         }"
+        @mousedown="mouseFocus"
     ></div>
 </template>
 
@@ -198,6 +199,10 @@ export default defineComponent({
             // TODO see if we still need this. map config should trigger the array watcher due to the store.
             //      possibly layer config is processed before map config is done creating map?
             this.onLayerConfigArrayChange(this.layerConfigs.value, []);
+        },
+        mouseFocus() {
+            // focused the map using the mouse, as opposed to keyboard controls
+            this.$iApi.geo.map.setMouseFocus();
         }
     }
 });

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -12,7 +12,7 @@
         ></notifications-caption-button>
 
         <span
-            class="relative truncate top-1 sm:block display-none shrink-0"
+            class="relative top-1 sm:block display-none shrink-0"
             v-if="!attribution.logo.disabled"
         >
             <a

--- a/src/fixtures/crosshairs/crosshairs.vue
+++ b/src/fixtures/crosshairs/crosshairs.vue
@@ -70,6 +70,15 @@ export default defineComponent({
         );
 
         this.handlers.push(
+            this.$iApi.event.on(GlobalEvents.MAP_FOCUS, () => {
+                // display crosshairs only when focused with keyboard controls
+                if (!this.$iApi.geo.map.mouseFocus) {
+                    this.visible = true;
+                }
+            })
+        );
+
+        this.handlers.push(
             this.$iApi.event.on(GlobalEvents.MAP_MOUSEDOWN, () => {
                 this.visible = false;
             })

--- a/src/fixtures/crosshairs/index.ts
+++ b/src/fixtures/crosshairs/index.ts
@@ -5,7 +5,7 @@ import { FixtureInstance } from '@/api';
 class CrosshairsFixture extends FixtureInstance {
     added(): void {
         console.log(`[fixture] ${this.id} added`);
-        const { vNode, destroy, el } = this.mount(CrosshairsV, {
+        const { destroy, el } = this.mount(CrosshairsV, {
             app: this.$element
         });
 

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -306,6 +306,14 @@ export class MapAPI extends CommonMapAPI {
         });
 
         this.handlers.push({
+            type: 'focus',
+            handler: this.esriView.on('focus', esriFocus => {
+                // .native is a DOM keyboard event
+                this.$iApi.event.emit(GlobalEvents.MAP_FOCUS, esriFocus.native);
+            })
+        });
+
+        this.handlers.push({
             type: 'blur',
             handler: this.esriView.on('blur', esriBlur => {
                 // .native is a DOM keyboard event
@@ -997,6 +1005,9 @@ export class MapAPI extends CommonMapAPI {
     // ID of pan interval
     private _panInterval: any;
 
+    // true if map is focused using mouse click
+    private _mouseFocus: boolean = false;
+
     /**
      * Processes keydown event on map and initiates panning/zooming
      *
@@ -1057,6 +1068,15 @@ export class MapAPI extends CommonMapAPI {
     }
 
     /**
+     * Sets the map focus source from the mouse
+     *
+     * @memberof MapAPI
+     */
+    setMouseFocus() {
+        this._mouseFocus = true;
+    }
+
+    /**
      * Stops panning and deactivates all keys
      *
      * @memberof MapAPI
@@ -1064,6 +1084,7 @@ export class MapAPI extends CommonMapAPI {
     stopKeyPan() {
         this._activeKeys = [];
         clearInterval(this._panInterval);
+        this._mouseFocus = false;
     }
 
     /**
@@ -1077,6 +1098,16 @@ export class MapAPI extends CommonMapAPI {
             this._activeKeys.filter(k => !['Control', 'Shift'].includes(k))
                 .length !== 0
         );
+    }
+
+    /**
+     * Returns if map focus is caused by mouse click
+     *
+     * @memberof MapAPI
+     * @returns {boolean}
+     */
+    get mouseFocus(): boolean {
+        return this._mouseFocus;
     }
 
     /**


### PR DESCRIPTION
Closes #1171.

This PR adds highlighting to the ESRI attribution label, and displays the crosshairs when focusing on the map using keyboard controls.

The legend panel and minimap already have focus indicators, so they weren't changed.

### Changes
- added ESRI logo highlight on focus
- added `MAP_FOCUS` event
- added check on `esri_map.vue` component to distinguish between mouse/keyboard focus
- the crosshair appearing with keyboard controls works better now


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1194)
<!-- Reviewable:end -->
