### PR TITLE
add panelWidth property to fixtures

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -439,6 +439,12 @@ let config = {
                         'geosearch'
                     ]
                 },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
                 export: {
                     title: {
                         value: 'All Your Base are Belong to Us',

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -431,6 +431,12 @@ let config = {
                     ]
                 },
                 mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
                 export: {
                     title: {
                         value: 'All Your Base are Belong to Us',

--- a/schema.json
+++ b/schema.json
@@ -241,12 +241,19 @@
                     "default": true,
                     "description": "Specifies whether legend panel is pinned by default."
                 },
+                "panelWidth": {
+                    "$ref": "#/$defs/panelWidth"
+                },
                 "root": {
                     "$ref": "#/$defs/entryGroup"
                 }
             },
             "required": ["root"],
             "unevaluatedProperties": false
+        },
+        "panelWidth": {
+            "type": ["number", "object"],
+            "description": "Determines the width of provided panels. If a number, then defaults all panels for the fixture to the number."
         },
         "entryGroup": {
             "type": "object",
@@ -611,6 +618,9 @@
                 "fileName": {
                     "type": "string",
                     "description": "The filename of the exported image."
+                },
+                "panelWidth": {
+                    "$ref": "#/$defs/panelWidth"
                 }
             }
         },
@@ -1549,6 +1559,9 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Specifies if the table should filter rows by extent by default."
+                },
+                "panelWidth": {
+                    "$ref": "#/$defs/panelWidth"
                 }
             },
             "unevaluatedProperties": false
@@ -1976,6 +1989,9 @@
                             "additionalProperties": {
                                 "type": "string"
                             }
+                        },
+                        "panelWidth": {
+                            "$ref": "#/$defs/panelWidth"
                         }
                     },
                     "required": ["templates"]
@@ -1984,7 +2000,9 @@
                     "$ref": "#/$defs/help",
                     "default": {
                         "folderName": "default",
-                        "panelWidth": 350
+                        "panelWidth": {
+                            "$ref": "#/$defs/panelWidth"
+                        }
                     },
                     "description": "Specifies details for the Help section"
                 },

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -420,4 +420,46 @@ export class FixtureInstance extends APIScope implements FixtureBase {
 
         return fixtureConfigs;
     }
+
+    /**
+     * If the `panelWidth` property is provided, handle default and specified panel widths for the given fixture.
+     *
+     * @param {Array<string>} panels list of panel names for the calling fixture
+     */
+    handlePanelWidths(panels: Array<string>): void {
+        if (this.config?.panelWidth) {
+            const panelWidths: any = {};
+
+            // If only a number was provided, use it as the `default` value.
+            if (typeof this.config?.panelWidth == 'number') {
+                this.config.panelWidth = {
+                    default: this.config?.panelWidth
+                };
+            }
+
+            // If the `default` attribute is provided, set all panels owned by this fixture to the provided width.
+            if (this.config.panelWidth.default) {
+                panels.forEach((item: string) => {
+                    panelWidths[item] = (this.config.panelWidth as any).default;
+                });
+            }
+
+            // Handle other panels, if they have a specific width set.
+            for (const item in this.config.panelWidth) {
+                if (item == 'default') continue;
+                panelWidths[item] = this.config.panelWidth[item];
+            }
+
+            // Update the width for each specified panel.
+            for (const item in panelWidths) {
+                // Set new panel widths.
+                const panel = this.$iApi.panel.get(item);
+                this.$iApi.panel.setStyle(
+                    panel,
+                    { width: `${panelWidths[item]}px` },
+                    true
+                );
+            }
+        }
+    }
 }

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -467,3 +467,21 @@ export type PanelRegistrationOptions = {
      */
     i18n?: I18nComponentOptions;
 };
+
+export interface PanelWidthObject {
+    /**
+     * The default panel width for this fixtures panels.
+     *
+     * @type number
+     * @memberof PanelWidthObject
+     */
+    default?: number;
+
+    /**
+     * Used for setting a specific panel width.
+     *
+     * @type number
+     * @memberof PanelWidthObject
+     */
+    [panel: string]: number | any;
+}

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -94,6 +94,8 @@ export class DetailsAPI extends FixtureInstance {
             );
         }
 
+        this.handlePanelWidths(['details-items', 'details-layers']);
+
         // get all layer fixture configs
         let layerDetailsConfigs: any = this.getLayerFixtureConfigs();
         let detailsConfigItems: DetailsConfigItem[] = [];

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -1,4 +1,5 @@
 import type { IdentifyResult } from '@/geo/api';
+import type { PanelWidthObject } from '@/api';
 
 export type DetailsItemSet = { [name: string]: DetailsItemInstance };
 
@@ -7,6 +8,14 @@ export interface DetailsConfig {
      * The dictionary of default templates indexed by identify result format with value as the template component id.
      */
     templates: { [type: string]: string };
+
+    /**
+     * The width of the details panel in pixels.
+     *
+     * @type {number}
+     * @interface GridConfig
+     */
+    panelWidth: PanelWidthObject | number;
 }
 
 export interface DetailsConfigItem {

--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -59,6 +59,8 @@ export class ExportAPI extends FixtureInstance {
             ExportStore.fileName,
             exportConfig.fileName || ''
         );
+
+        this.handlePanelWidths(['export']);
     }
 
     /**

--- a/src/fixtures/export/store/export-state.ts
+++ b/src/fixtures/export/store/export-state.ts
@@ -1,3 +1,5 @@
+import type { PanelWidthObject } from '@/api';
+
 export class ExportState {
     componentSelectedState: any = {
         title: true,
@@ -29,4 +31,5 @@ export interface ExportConfig {
     footnote?: ExportComponentConfig;
     timestamp?: ExportComponentConfig;
     fileName?: string;
+    panelWidth: PanelWidthObject | number;
 }

--- a/src/fixtures/grid/api/grid.ts
+++ b/src/fixtures/grid/api/grid.ts
@@ -52,4 +52,16 @@ export class GridAPI extends FixtureInstance {
             panel.close();
         }
     }
+
+    /**
+     * Parses the grid config JSON snippet from the config file.
+     *
+     * @param {GridConfig} [gridConfig]
+     * @memberof GridAPI
+     */
+    _parseConfig(gridConfig?: GridConfig) {
+        if (!gridConfig) return;
+
+        this.handlePanelWidths(['grid']);
+    }
 }

--- a/src/fixtures/grid/index.ts
+++ b/src/fixtures/grid/index.ts
@@ -32,6 +32,7 @@ class GridFixture extends GridAPI {
             { i18n: { messages } }
         );
 
+        this._parseConfig(this.config);
         this.$vApp.$store.registerModule('grid', grid());
     }
 

--- a/src/fixtures/grid/store/grid-state.ts
+++ b/src/fixtures/grid/store/grid-state.ts
@@ -1,5 +1,6 @@
 import type TableStateManager from './table-state-manager';
 import type { PanelConfig } from '@/store/modules/panel';
+import type { PanelWidthObject } from '@/api';
 
 export class GridState {
     /**
@@ -43,4 +44,12 @@ export interface GridConfig {
      * @memberof GridItemConfig
      */
     state: TableStateManager;
+
+    /**
+     * The width of the grid panel in pixels.
+     *
+     * @type {number}
+     * @interface GridConfig
+     */
+    panelWidth: PanelWidthObject | number;
 }

--- a/src/fixtures/help/api/help.ts
+++ b/src/fixtures/help/api/help.ts
@@ -40,13 +40,7 @@ export class HelpAPI extends FixtureInstance {
     _parseConfig(helpConfig?: HelpConfig) {
         if (!helpConfig) return;
         this.$vApp.$store.set(HelpStore.folderName, helpConfig.folderName);
-        if (helpConfig.panelWidth) {
-            const panel = this.$iApi.panel.get('help');
-            this.$iApi.panel.setStyle(
-                panel,
-                { width: `${helpConfig.panelWidth}px` },
-                true
-            );
-        }
+
+        this.handlePanelWidths(['help']);
     }
 }

--- a/src/fixtures/help/store/help-state.ts
+++ b/src/fixtures/help/store/help-state.ts
@@ -1,3 +1,5 @@
+import type { PanelWidthObject } from '@/api';
+
 export class HelpState {
     /**
      * name of help source folder
@@ -10,5 +12,5 @@ export class HelpState {
 
 export interface HelpConfig {
     folderName: string;
-    panelWidth: number;
+    panelWidth: PanelWidthObject | number;
 }

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -40,6 +40,8 @@ export class LegendAPI extends FixtureInstance {
             return;
         }
 
+        this.handlePanelWidths(['legend']);
+
         let legendEntries: Array<LegendItem> = [];
         let stack: Array<any> = [];
         // initialize stack with all legend elements listed in config

--- a/src/fixtures/legend/store/legend-state.ts
+++ b/src/fixtures/legend/store/legend-state.ts
@@ -1,3 +1,4 @@
+import type { PanelWidthObject } from '@/api';
 import type { LegendEntry, LegendGroup } from './legend-defs';
 
 export class LegendState {
@@ -11,4 +12,5 @@ export interface LegendConfig {
     isPinned: boolean;
     root: { name: string; children: Array<any> };
     headerControls: Array<string>;
+    panelWidth: PanelWidthObject | number;
 }


### PR DESCRIPTION
Closes #964 

This PR adds a new property to the fixtures specified in the issue. The property basically works as specified in [this discussion](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/984), but also just supports a single number that acts as a default. All of the following examples are valid uses:

```
grid: {
    panelWidth: 500 // all panels owned by this fixture will have a width of 500.
},
help: {
    panelWidth: {
        default: 500 // same as above.
    }
},
details: {
    panelWidth: {
         default: 350, // all panels except for the `details-items` panel will have a width of 350.
         'details-items': 500 // `details-items` will have a width of 500.
    }
}
```

To test this PR, you can open the demo link and click on a feature on the map. When the two details panels open, notice that the `details-items` panel is slightly wider than the `details-list` panel. You can also test other variations locally with the configs provided above.

---

Note: I don't love that I had to provide the panel names for each fixture as a parameter to the function call (`this.handlePanelWidths(['help'])`), but as far as I can tell there's no way to find registered panels for a fixture. Did I just miss something, or is this something we can't do (and would it be useful to have if we don't have it?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1195)
<!-- Reviewable:end -->
