### PR TITLE
Fix discrepancy between appbar schema and code

### DIFF
--- a/src/fixtures/appbar/api/appbar.ts
+++ b/src/fixtures/appbar/api/appbar.ts
@@ -70,7 +70,6 @@ export class AppbarAPI extends FixtureInstance {
 
     /**
      * Checks if components specified as appbar items are registered or not.
-     * Will check the literal id values, and id values with `-appbar-button` suffixes appended.
      *
      * @memberof AppbarAPI
      */
@@ -86,7 +85,7 @@ export class AppbarAPI extends FixtureInstance {
                 ) {
                     return;
                 }
-                // appbar check components with the literal id and with a `-appbar-button` suffix;
+                // check for components with the id
                 [id].some(v => {
                     if (this.$iApi.fixture.get(v)) {
                         // if an item is registered globally, save the name of the registered component

--- a/src/fixtures/appbar/appbar.vue
+++ b/src/fixtures/appbar/appbar.vue
@@ -14,7 +14,7 @@
                 ></default-button>
                 <component
                     v-else
-                    :is="addComponentIdSuffix(item.componentId)"
+                    :is="item.componentId"
                     :key="`${item}-${index2}`"
                     :options="item.options"
                     :id="item.id"
@@ -141,18 +141,6 @@ export default defineComponent({
                 if (dropdown.childElementCount == 0) this.overflow = false;
             }
         });
-    },
-    methods: {
-        /**
-         * Checks if the component id has the "-appbar-button" suffix
-         * Returns the component id with the suffix added
-         */
-        addComponentIdSuffix(componentId: string): string {
-            if (componentId.includes('-appbar-button')) {
-                return componentId;
-            }
-            return `${componentId}-appbar-button`;
-        }
     }
 });
 </script>


### PR DESCRIPTION
As detailed in #610 this removes a discrepancy where `-appbar-button` was still being appended to all appbar item configs' ids. I had meant to remove this in the refactor anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1196)
<!-- Reviewable:end -->
