### PR TITLE
Fix blank legend bug

### DIFF
--- a/demos/index-wet.html
+++ b/demos/index-wet.html
@@ -352,7 +352,7 @@
                 });
             </script>
 
-            <script type="module" src="./starter-scripts/main.js"></script>
+            <script type="module" src="./starter-scripts/wet.js"></script>
         </main>
 
         <div id="def-footer">

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -441,6 +441,9 @@ let config = {
                         selected: false
                     },
                     fileName: 'ramp-pcar-4-map-carte'
+                },
+                scrollguard: {
+                    enabled: true
                 }
             },
             system: { animate: true }
@@ -461,7 +464,6 @@ const rInstance = createInstance(
 );
 rInstance.fixture.addDefaultFixtures().then(() => {
     rInstance.panel.open('legend');
-    rInstance.panel.pin('legend');
 });
 
 rInstance.$element.component('WFSLayer-Custom', {

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -468,6 +468,7 @@ window.debugInstance = rInstance;
 
 rInstance.fixture.addDefaultFixtures().then(() => {
     rInstance.panel.open('legend');
+    rInstance.panel.pin('legend');
 });
 
 rInstance.$element.component('WFSLayer-Custom', {

--- a/src/fixtures/legend/index.ts
+++ b/src/fixtures/legend/index.ts
@@ -35,9 +35,6 @@ class LegendFixture extends LegendAPI {
         );
 
         this.$vApp.$store.registerModule('legend', legend());
-        if (super.config?.isPinned !== false) {
-            this.$iApi.panel.pin('legend');
-        }
 
         // parse legend section of config and store information in legend store
         // here we create a copy of the config because the config parser will mutate the layer ids in the config


### PR DESCRIPTION
## Closes #1189 

## Changes
- Fixed bug where legend panel will sometimes be blank when RAMP loads
    - This was due to the legend fixture code trying to pin the legend panel before it opens
    - I added an additional check where the panel is pinned only if it is currently open
    - This will properly handled in #1166
- Added scrollguard to WET template sample

## Testing
- The [CAM](https://ramp4-pcar4.github.io/ramp4-pcar4/1189/index-cam.html) and [ CESI](https://ramp4-pcar4.github.io/ramp4-pcar4/1189/index-cesi.html) samples should no longer display a blank legend panel
- The [WET template](https://ramp4-pcar4.github.io/ramp4-pcar4/1189/demos/index-wet.html) sample should now have scrollguard enabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1200)
<!-- Reviewable:end -->
