### PR TITLE
Config Layer Names

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -144,8 +144,12 @@
         },
         "details": {
             "type": "object",
-            "description": "Provides configuration to the details fixture.",
+            "description": "Provides layer-specific configuration to the details fixture.",
             "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Display name of the identified layer"
+                },
                 "template": {
                     "type": "string",
                     "description": "Custom Vue component to render as details template"

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -104,6 +104,7 @@ export class DetailsAPI extends FixtureInstance {
         Object.keys(layerDetailsConfigs).forEach((layerId: string) => {
             detailsConfigItems.push({
                 id: layerId,
+                name: layerDetailsConfigs[layerId].name,
                 template: layerDetailsConfigs[layerId].template
             });
         });
@@ -114,7 +115,7 @@ export class DetailsAPI extends FixtureInstance {
 
         // save the items in the store
         this.$vApp.$store.set(
-            DetailsStore.templates,
+            DetailsStore.properties,
             detailsItems.reduce<DetailsItemSet>((map, item) => {
                 map[item.id] = item;
                 return map;
@@ -132,12 +133,12 @@ export class DetailsAPI extends FixtureInstance {
     _validateItems() {
         Object.values(
             this.$vApp.$store.get<DetailsItemInstance[]>(
-                DetailsStore.templates
+                DetailsStore.properties
             )!
         ).forEach(item => {
             if (item.template in this.$vApp.$options.components!) {
                 this.$vApp.$store.set(
-                    `${DetailsStore.templates}@${item.id}.componentId`,
+                    `${DetailsStore.properties}@${item.id}.componentId`,
                     item.template
                 );
             }

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -178,7 +178,7 @@ export default defineComponent({
     data() {
         return {
             defaultTemplates: this.get(DetailsStore.defaultTemplates),
-            templateBindings: this.get(DetailsStore.templates),
+            detailProperties: this.get(DetailsStore.properties),
             identifyTypes: IdentifyResultFormat.UNKNOWN,
             icon: '' as string,
             currentIdx: 0,
@@ -229,6 +229,13 @@ export default defineComponent({
         layerName(): string {
             const layer: LayerInstance | undefined =
                 this.$iApi.geo.layer.getLayer(this.result.uid);
+            if (
+                layer &&
+                this.detailProperties[layer.id] &&
+                this.detailProperties[layer.id].name
+            ) {
+                return this.detailProperties[layer.id].name;
+            }
             return layer?.name ?? '';
         },
 
@@ -264,10 +271,10 @@ export default defineComponent({
             // return its name.
             if (
                 layer &&
-                this.templateBindings[layer.id] &&
-                this.templateBindings[layer.id].template
+                this.detailProperties[layer.id] &&
+                this.detailProperties[layer.id].template
             ) {
-                return this.templateBindings[layer.id].template;
+                return this.detailProperties[layer.id].template;
             }
 
             // If nothing is found, use a default template from config

--- a/src/fixtures/details/layers-screen.vue
+++ b/src/fixtures/details/layers-screen.vue
@@ -56,6 +56,7 @@ export default defineComponent({
             lastLayerUid: '' as string,
             activeGreedy: 0 as number, // 0 = turn greedy mode off, some timestamp = greedy mode running with last request timestamp
             payload: this.get(DetailsStore.payload),
+            detailProperties: this.get(DetailsStore.properties),
             getLayerByUid: this.get('layer/getLayerByUid'),
             layers: this.get('layer/layers'),
             mobileMode: this.get('panel/mobileView'),
@@ -313,12 +314,17 @@ export default defineComponent({
          */
         layerName(idx: number) {
             const layerInfo = this.payload[idx];
-            let item: LayerInstance | undefined = this.getLayerByUid(
+            let layer: LayerInstance | undefined = this.getLayerByUid(
                 layerInfo.uid
             );
-            if (!item) return '';
-
-            return item.name;
+            if (
+                layer &&
+                this.detailProperties[layer.id] &&
+                this.detailProperties[layer.id].name
+            ) {
+                return this.detailProperties[layer.id].name;
+            }
+            return layer?.name ?? '';
         }
     }
 });

--- a/src/fixtures/details/result-screen.vue
+++ b/src/fixtures/details/result-screen.vue
@@ -64,6 +64,8 @@ import { defineComponent, type PropType } from 'vue';
 import { GlobalEvents, type LayerInstance, type PanelInstance } from '@/api';
 import type { IdentifyResult } from '@/geo/api';
 
+import { DetailsStore } from './store';
+
 export default defineComponent({
     name: 'DetailsResultScreenV',
     props: {
@@ -85,6 +87,7 @@ export default defineComponent({
         return {
             icon: [] as string[],
             layerExists: false, // tracks whether the layer still exists
+            detailProperties: this.get(DetailsStore.properties),
             handlers: [] as Array<string>
         };
     },
@@ -104,6 +107,13 @@ export default defineComponent({
         layerName(): string {
             const layer: LayerInstance | undefined =
                 this.$iApi.geo.layer.getLayer(this.result.uid);
+            if (
+                layer &&
+                this.detailProperties[layer.id] &&
+                this.detailProperties[layer.id].name
+            ) {
+                return this.detailProperties[layer.id].name;
+            }
             return layer?.name ?? '';
         }
     },

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -28,6 +28,14 @@ export interface DetailsConfigItem {
     id: string;
 
     /**
+     * The optional display name of the layer.
+     *
+     * @type {string}
+     * @memberof DetailsConfigItem
+     */
+    name: string;
+
+    /**
      * The component that we would like to use as a template.
      *
      * @type {string}
@@ -39,15 +47,19 @@ export interface DetailsConfigItem {
 export class DetailsItemInstance implements DetailsConfigItem {
     id: string;
 
+    name: string;
+
     template: string;
 
     componentId?: string;
 
     constructor(value: string | DetailsConfigItem) {
         const params = {
-            ...(typeof value === 'string' ? { id: value, template: '' } : value)
+            ...(typeof value === 'string'
+                ? { id: value, template: '', name: '' }
+                : value)
         };
-        ({ template: this.template, id: this.id } = params);
+        ({ template: this.template, id: this.id, name: this.name } = params);
     }
 }
 
@@ -61,11 +73,11 @@ export class DetailsState {
     payload: IdentifyResult[] = [];
 
     /**
-     * Details config templates
+     * Details config properties
      *
      * @memberof DetailsState
      */
-    templates: { [id: string]: DetailsItemInstance } = {};
+    properties: { [id: string]: DetailsItemInstance } = {};
 
     /**
      * Details default templates indexed by the identify result format

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -53,9 +53,9 @@ export enum DetailsStore {
      */
     payload = 'details/payload',
     /**
-     * (State) templates:  { [id: string]: DetailsItemInstance }
+     * (State) properties:  { [id: string]: DetailsItemInstance }
      */
-    templates = 'details/templates',
+    properties = 'details/properties',
     /**
      * (State) defaultTemplates:  { [type: string]: string }
      */


### PR DESCRIPTION
Closes #1191.

This PR adds the `name` property to the `layer.fixture.details` nugget in the config. The name of a layer in the details panel can now be optionally overridden, and uses the ESRI layer name as a default value.

To test this change, copy and run [this snippet](https://gist.github.com/roryhofland/bc17d7a338f9f8d835b39f3afb995018) in the console. Then observe that the Water Quantity layer now has a custom name, while the other layers retain the name of their ESRI layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1202)
<!-- Reviewable:end -->
