### PR TITLE
Scope tailwind to within the app

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -477,7 +477,7 @@ rInstance.$element.component('WFSLayer-Custom', {
 rInstance.$element.component('Water-Quantity-Template', {
     props: ['identifyData'],
     template: `
-        <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
             <div v-html="renderHeader()" />
             <div v-html="createSection('Station ID', 'StationID')" />
             <div v-html="createSection('Province', 'E_Province')" />
@@ -512,19 +512,19 @@ rInstance.$element.component('Water-Quantity-Template', {
         renderHeader() {
             if (!this.identifyData.loaded) {
                 return `
-                <span style="display: flex; font-size: 1.25rem; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
+                <span style="display: flex; font-size: 20px; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
                     Loading...
                 </span>
                 `;
             } else if (this.identifyData.data['Symbol'] === '3') {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
             } else {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
@@ -536,7 +536,7 @@ rInstance.$element.component('Water-Quantity-Template', {
                 : 'Loading...';
 
             return `
-            <div style="display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;">
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
                 <span style="color: #a0aec0; font-weight: bold;">
                     ${title}
                 </span>

--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -1346,7 +1346,7 @@ rInstance.$element.component('WFSLayer-Custom', {
 rInstance.$element.component('Water-Quantity-Template', {
     props: ['identifyData'],
     template: `
-        <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
             <div v-html="renderHeader()" />
             <div v-html="createSection('Station ID', 'StationID')" />
             <div v-html="createSection('Province', 'E_Province')" />
@@ -1381,19 +1381,19 @@ rInstance.$element.component('Water-Quantity-Template', {
         renderHeader() {
             if (!this.identifyData.loaded) {
                 return `
-                <span style="display: flex; font-size: 1.25rem; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
+                <span style="display: flex; font-size: 20px; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
                     Loading...
                 </span>
                 `;
             } else if (this.identifyData.data['Symbol'] === '3') {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
             } else {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
@@ -1405,7 +1405,7 @@ rInstance.$element.component('Water-Quantity-Template', {
                 : 'Loading...';
 
             return `
-            <div style="display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;">
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
                 <span style="color: #a0aec0; font-weight: bold;">
                     ${title}
                 </span>

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -412,7 +412,7 @@ rInstance.$element.component('WFSLayer-Custom', {
 rInstance.$element.component('Water-Quantity-Template', {
     props: ['identifyData'],
     template: `
-        <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
             <div v-html="renderHeader()" />
             <div v-html="createSection('Station ID', 'StationID')" />
             <div v-html="createSection('Province', 'E_Province')" />
@@ -447,19 +447,19 @@ rInstance.$element.component('Water-Quantity-Template', {
         renderHeader() {
             if (!this.identifyData.loaded) {
                 return `
-                <span style="display: flex; font-size: 1.25rem; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
+                <span style="display: flex; font-size: 20px; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
                     Loading...
                 </span>
                 `;
             } else if (this.identifyData.data['Symbol'] === '3') {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
             } else {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
@@ -471,7 +471,7 @@ rInstance.$element.component('Water-Quantity-Template', {
                 : 'Loading...';
 
             return `
-            <div style="display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;">
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
                 <span style="color: #a0aec0; font-weight: bold;">
                     ${title}
                 </span>

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -479,7 +479,7 @@ rInstance.$element.component('WFSLayer-Custom', {
 rInstance.$element.component('Water-Quantity-Template', {
     props: ['identifyData'],
     template: `
-        <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
             <div v-html="renderHeader()" />
             <div v-html="createSection('Station ID', 'StationID')" />
             <div v-html="createSection('Province', 'E_Province')" />
@@ -514,19 +514,19 @@ rInstance.$element.component('Water-Quantity-Template', {
         renderHeader() {
             if (!this.identifyData.loaded) {
                 return `
-                <span style="display: flex; font-size: 1.25rem; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
+                <span style="display: flex; font-size: 20px; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
                     Loading...
                 </span>
                 `;
             } else if (this.identifyData.data['Symbol'] === '3') {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
             } else {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
@@ -538,7 +538,7 @@ rInstance.$element.component('Water-Quantity-Template', {
                 : 'Loading...';
 
             return `
-            <div style="display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;">
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
                 <span style="color: #a0aec0; font-weight: bold;">
                     ${title}
                 </span>

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,9 +1,9 @@
 /* eslint-env node */
 module.exports = {
-    plugins: {
-        'postcss-import': {},
-        'tailwindcss/nesting': {},
-        tailwindcss: {},
-        autoprefixer: {}
-    }
+    plugins: [
+        require('postcss-import'),
+        require('postcss-nested'),
+        require('tailwindcss'),
+        require('autoprefixer')
+    ]
 };

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -484,7 +484,7 @@ rInstance.$element.component('WFSLayer-Custom', {
 rInstance.$element.component('Water-Quantity-Template', {
     props: ['identifyData'],
     template: `
-        <div style="align-items: center; justify-content: center; font-size: .875rem; font-family: Arial, sans-serif;">
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
             <div v-html="renderHeader()" />
             <div v-html="createSection('Station ID', 'StationID')" />
             <div v-html="createSection('Province', 'E_Province')" />
@@ -519,19 +519,19 @@ rInstance.$element.component('Water-Quantity-Template', {
         renderHeader() {
             if (!this.identifyData.loaded) {
                 return `
-                <span style="display: flex; font-size: 1.25rem; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
+                <span style="display: flex; font-size: 20px; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
                     Loading...
                 </span>
                 `;
             } else if (this.identifyData.data['Symbol'] === '3') {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
             } else {
                 return `
-                    <span style="display: flex; font-size: 1.25rem; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                    <span style="display: flex; font-size: 20px; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
                         ${this.identifyData.data['StationName']}
                     </span>
                 `;
@@ -543,7 +543,7 @@ rInstance.$element.component('Water-Quantity-Template', {
                 : 'Loading...';
 
             return `
-            <div style="display: flex; flex-direction: column; font-size: .875rem; padding-top: 5px;">
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
                 <span style="color: #a0aec0; font-weight: bold;">
                     ${title}
                 </span>

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -296,10 +296,11 @@ export class InstanceAPI {
      * @memberof InstanceAPI
      */
     get screenSize(): string | null {
-        if (!this.$element || !this.$element._container) {
+        if (!this.$root || !this.$root.$refs['app-size']) {
             return null;
         }
-        const classList = this.$element._container.children[0].classList;
+
+        const classList = this.$root.$refs['app-size'].classList;
         if (classList.contains('lg')) {
             return 'lg';
         } else if (classList.contains('md')) {

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,6 +1,8 @@
 <template>
     <div class="ramp-app animation-enabled" :lang="$i18n.locale">
-        <shell></shell>
+        <div class="h-full" ref="app-size">
+            <shell></shell>
+        </div>
     </div>
 </template>
 
@@ -18,7 +20,7 @@ export default defineComponent({
     mounted() {
         // let ResizeObserver observe the app div
         // it applies 'xs' 'sm' 'md' and 'lg' classes to the div depending on the size
-        ro.observe(this.$el);
+        ro.observe(this.$refs['app-size']);
         // Set tooltip defaults, theme does not get applied properly in prod builds if setting the defaults using vue-tippy
         // This bypasses the wrapper and sets the defaults at the tippy.js level
         setDefaultProps({
@@ -42,6 +44,7 @@ export default defineComponent({
 $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica,
     Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 @use 'directives/focus-list/focus-list';
+
 .ramp-app {
     @include focus-list.default-focused-styling;
     height: 100%;

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -17,7 +17,7 @@
             class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48 overflow-hidden"
             tabindex="-1"
         >
-            <back class="block sm:hidden" @click="panel.close()"></back>
+            <back class="block sm:display-none" @click="panel.close()"></back>
 
             <h2 class="flex-grow text-lg py-16 pl-8 min-w-0" v-truncate>
                 <slot name="header"></slot>
@@ -27,7 +27,7 @@
                 <slot name="controls"></slot>
             </panel-options-menu>
 
-            <div class="hidden sm:flex">
+            <div class="display-none sm:flex">
                 <pin @click="panel.pin()" :active="panel.isPinned" />
                 <expand
                     v-if="panel.controls && panel.controls.expand"

--- a/src/components/panel-stack/panel-stack.vue
+++ b/src/components/panel-stack/panel-stack.vue
@@ -47,7 +47,7 @@ export default defineComponent({
             // then the screen is too large).
             this.$store.set(
                 'panel/mobileView',
-                !this.$root?.$el.classList.contains('sm')
+                !this.$root.$refs['app-size'].classList.contains('sm')
             );
 
             this.$store.set('panel/stackWidth', entries[0].contentRect.width);

--- a/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/src/fixtures/layer-reorder/components/layer-component.vue
@@ -32,7 +32,7 @@
                     v-focus-container
                 >
                     <!-- TODO: fix this hack that prevents duplicate UI bug on prod (to reproduce: remove this, run prod build and open -> close -> re-open reorder panel) -->
-                    <div class="hidden"></div>
+                    <div class="display-none"></div>
 
                     <div
                         class="flex items-center p-5 ms-5 h-44 cursor-pointer hover:bg-gray-200"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,12 +1,16 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+.ramp-app {
+    @tailwind base;
+    @tailwind components;
+    @tailwind utilities;
+    @tailwind variants;
 
-@layer utilities {
-    .display-none {
-        display: none;
+    @layer utilities {
+        .display-none {
+            display: none;
+        }
     }
 }
+
 .ramp-app {
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
         Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -94,19 +94,11 @@ module.exports = {
         }
     },
     plugins: [
-        plugin(function ({ addVariant, e }) {
-            addVariant('xs', ({ modifySelectors, separator }) => {
-                modifySelectors(({ className }) => {
-                    return `.xs .${e(`xs${separator}${className}`)}`;
-                });
-            });
-        }),
-        plugin(function ({ addVariant, e }) {
-            addVariant('sm', ({ modifySelectors, separator }) => {
-                modifySelectors(({ className }) => {
-                    return `.sm .${e(`sm${separator}${className}`)}`;
-                });
-            });
+        plugin(function ({ addVariant }) {
+            addVariant('xs', '.xs &');
+            addVariant('sm', '.sm &');
+            addVariant('md', '.md &');
+            addVariant('lg', '.lg &');
         }),
         require('@tailwindcss/forms')
     ]


### PR DESCRIPTION
Closes #1190 

Scopes all of tailwinds' output under `.ramp-app`. I also simplified the tailwind plugins that handle our app sizes.

Turns out the big issue was the `tailwindcss/nesting` wrapper around `postcss-nested` wasn't allowing the `@tailwind` rules to be nested. Removing the wrapper and just using `postcss-nested` fixed that... for some reason. There is still a warning in the console about the nesting but it works properly and I could not find a way to just ignore that part of the css file for warnings/errors.

A good place to see this in action is the [WET sample](https://ramp4-pcar4.github.io/ramp4-pcar4/tailwind-scope-fix/demos/index-wet.html) where `.container` from tailwind no longer affects the host page and everything is constrained to the proper width.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1204)
<!-- Reviewable:end -->
