### PR TITLE
fix broken text in keyboard instructions menu

### DIFF
--- a/src/lang/index.ts
+++ b/src/lang/index.ts
@@ -5,7 +5,7 @@ import type {
     LocaleMessages,
     VueMessageType
 } from 'vue-i18n';
-import messages from './lang.csv?raw';
+import messages from './lang.csv';
 
 export type I18nComponentOptions = {
     messages?: LocaleMessages<VueMessageType> | VueMessageType;


### PR DESCRIPTION
Closes #1183 

This PR fixes the cut-off text in the keyboard instructions menu. 

You can test this PR by loading up the demo and opening the keyboard instructions menu. The text should appear properly now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1205)
<!-- Reviewable:end -->
