### PR TITLE
Esri attribution for mobile view

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -341,6 +341,7 @@ enum DefEH {
     MAP_BASEMAPCHANGE_ATTRIBUTION = 'updates_map_caption_attribution_basemap',
     CONFIG_CHANGE_ATTRIBUTION = 'updates_map_caption_attribution_config',
     MAP_CREATED_ATTRIBUTION = 'updates_map_caption_attribution_map_created',
+    MAP_RESIZED_SCALEBAR = 'resizes_map_caption_scale',
     MAP_SCALECHANGE_SCALEBAR = 'updates_map_caption_scale',
     MOUSE_MOVE_MAPTIP_CHECK = 'checks_maptip_mouse_move',
     EXTENT_CHANGE_MAPTIP_CHECK = 'checks_maptip_extent_change',
@@ -617,6 +618,7 @@ export class EventAPI extends APIScope {
                 DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION,
                 DefEH.CONFIG_CHANGE_ATTRIBUTION,
                 DefEH.MAP_CREATED_ATTRIBUTION,
+                DefEH.MAP_RESIZED_SCALEBAR,
                 DefEH.MAP_SCALECHANGE_SCALEBAR,
                 DefEH.MOUSE_MOVE_MAPTIP_CHECK,
                 DefEH.EXTENT_CHANGE_MAPTIP_CHECK,
@@ -932,6 +934,16 @@ export class EventAPI extends APIScope {
                 this.$iApi.event.on(
                     GlobalEvents.MAP_CREATED,
                     zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_RESIZED_SCALEBAR:
+                // update the map scale caption when the window is resized
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_RESIZED,
+                    debounce(100, () =>
+                        this.$iApi.geo.map.caption.updateScale()
+                    ),
                     handlerName
                 );
                 break;

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -12,7 +12,7 @@
         ></notifications-caption-button>
 
         <span
-            class="relative top-1 sm:block display-none shrink-0"
+            class="relative top-2 sm:top-1 ml-4 sm:ml-0 shrink-0"
             v-if="!attribution.logo.disabled"
         >
             <a
@@ -22,7 +22,7 @@
                 :aria-label="attribution.logo.altText"
             >
                 <img
-                    class="object-contain h-26"
+                    class="object-contain h-18 sm:h-26"
                     :src="attribution.logo.value"
                     :alt="attribution.logo.altText"
                 />
@@ -30,15 +30,14 @@
         </span>
 
         <span
-            class="relative ml-10 top-2 sm:block display-none"
+            class="relative ml-10 top-2 text-sm sm:text-base"
             v-if="!attribution.text.disabled"
             v-truncate="{
                 options: {
                     placement: 'top',
                     hideOnClick: false,
                     theme: 'ramp4',
-                    animation: 'scale',
-                    appendTo: 'parent'
+                    animation: 'scale'
                 }
             }"
         >
@@ -49,10 +48,10 @@
 
         <!-- TODO: find out if any ARIA attributes are needed for the map scale -->
 
-        <div class="flex min-w-0 sm:min-w-fit justify-end">
+        <div class="flex min-w-fit justify-end">
             <div
                 v-if="!cursorCoords.disabled"
-                class="relative top-2 pl-8 sm:px-14 text-sm sm:text-base"
+                class="relative top-2 pl-8 px-14 sm:block display-none"
                 v-truncate="{
                     options: {
                         hideOnClick: false,
@@ -66,7 +65,7 @@
 
             <button
                 v-if="!scale.disabled"
-                class="flex-shrink-0 mx-10 px-4 pointer-events-auto cursor-pointer border-none"
+                class="flex-shrink-0 mx-2 sm:mx-10 px-4 pointer-events-auto cursor-pointer border-none"
                 @click="onScaleClick"
                 :aria-pressed="scale.isImperialScale"
                 :aria-label="$t('map.toggleScaleUnits')"


### PR DESCRIPTION
Closes #1154.

### Changes
This PR adjusts the map caption at lower resolutions so that the Esri logo and basemap attribution text are always at least partially visible, in accordance with Esri guidelines. These elements replace the mouse coordinates, which are pretty useless when using a touchscreen device.

Also, the scalebar resizes when the map is resized, so resizing the window from full width to mobile view no longer leaves an unnecessarily wide scalebar in the map caption.

### Notes
- The basemap attribution text gets truncated when overflowing, which is inevitable considering the length of the string for some of the basemaps (look at World Street Map). At least part of the text is always showing, and the full string can be seen in a tooltip. However, Esri guidelines state "Do not overlap with another logo or visual component (excluding elements of the map.)". Is this being violated? If it is, some attributions are truncated even at full resolution, so I'm not sure how to interpret this rule.

### Testing
Resize the RAMP instance to your mobile resolution of choice, and observe that the Esri logo and attribution text are preserved in the map caption. Clicking/tapping on the text brings up the full string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1206)
<!-- Reviewable:end -->
