### PR TITLE
Add colour support for file layers

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -334,6 +334,7 @@ let config = {
                     layerType: 'ogc-wfs',
                     url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
                     xyInAttribs: true,
+                    colour: '#FF5555',
                     state: {
                         visibility: true
                     },

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -574,6 +574,7 @@ export interface RampLayerConfig {
     metadata?: { url: string; name?: string };
     fixtures?: any; // layer-based fixture config
     cosmetic?: boolean;
+    colour?: string;
 }
 
 export interface RampExtentConfig {

--- a/src/geo/api/graphic/style/colour.ts
+++ b/src/geo/api/graphic/style/colour.ts
@@ -86,6 +86,11 @@ export class Colour {
         return new EsriColour(this.rgba);
     }
 
+    toArcServer(): Array<number> {
+        // map (0-1) alpha to (0-255) alpha
+        return [this.c[0], this.c[1], this.c[2], 255 * this.c[3]];
+    }
+
     static hexToInt(twoCharHex: string): number {
         return twoCharHex.length === 0 ? 255 : parseInt(twoCharHex, 16);
     }

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -106,7 +106,6 @@ export class FileLayer extends AttribLayer {
 
         // TODO figure out options parameter.
         // TODO look into supporting renderer from rampConfig. dont we already have something like this?
-        // TODO should be a colour option. figure out where that comes from. will our ramp config have that? or is it sys option for wizard trickery?
         // TODO figure out how a sourceProjection option would work. who is supplying this? an API caller? RAMP UI / Config really doesnt support it.
         const opts = {
             layerId: this.origRampConfig.id || '',
@@ -116,7 +115,8 @@ export class FileLayer extends AttribLayer {
             }),
             ...(this.origRampConfig.longField && {
                 lonField: this.origRampConfig.longField
-            })
+            }),
+            colour: this.origRampConfig.colour
         };
 
         this.esriJson = await this.$iApi.geo.layer.files.geoJsonToEsriJson(

--- a/src/geo/layer/file-utils.ts
+++ b/src/geo/layer/file-utils.ts
@@ -9,7 +9,7 @@ import {
     EsriSimpleRenderer,
     EsriSpatialReference
 } from '@/geo/esri';
-import { FieldType } from '@/geo/api';
+import { Colour, FieldType } from '@/geo/api';
 
 /**
  * Maps GeoJSON geometry types to a set of default renders defined in GlobalStorage.DefaultRenders
@@ -239,8 +239,12 @@ export class FileUtils extends APIScope {
 
         // @ts-ignore
         const value = featureTypeToRenderer[geoJson.features[0].geometry.type];
-        // @ts-ignore
-        const defRender: any = defaultRenderers[value];
+        // clone the default renderer so changes don't persist
+        // also note that this default renderer object is in ArcGIS Server object format
+        const defRender: any = JSON.parse(
+            // @ts-ignore
+            JSON.stringify(defaultRenderers[value])
+        );
 
         // attempt to get spatial reference from geoJson
         if (geoJson.crs && geoJson.crs.type === 'name') {
@@ -267,11 +271,10 @@ export class FileUtils extends APIScope {
                 layerId = this.$iApi.geo.shared.generateUUID();
             }
 
-            // due to grousyness of esri typescript, we mangle the colour pre-fromJSON
             if (options.colour) {
-                defRender.renderer.symbol.color = new EsriColour(
+                defRender.renderer.symbol.color = new Colour(
                     options.colour
-                ).toRgba();
+                ).toArcServer();
             }
 
             // TODO add support for renderer option, or drop the option


### PR DESCRIPTION
## Changes
- Added support for `colour` config prop for file layers
- Added `toArcServer` method to `Colour` class that returns rgba where alpha is set between 0-255 (as per ESRI ArcServer specification)

## Testing
- The [main demo sample](https://ramp4-pcar4.github.io/ramp4-pcar4/file-layer-colour/demos/index.html) should use a red colour for `WFSLayer` points

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1207)
<!-- Reviewable:end -->
