### PR TITLE
Keyboard controls for embedded RAMP

### DIFF
--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -13,6 +13,7 @@
             duration: [200, 200]
         }"
         @mousedown="mouseFocus"
+        @keydown.up.down.left.right.prevent
     ></div>
 </template>
 

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -1042,6 +1042,9 @@ export class MapAPI extends CommonMapAPI {
             this.keyZoom(payload);
         } else if (payload.key === 'Enter') {
             this.runIdentify(this.getExtent().center());
+        } else if (payload.key === 'Tab') {
+            // used to distinguish keyboard/mouse focus
+            this._activeKeys.push(payload.key);
         }
     }
 
@@ -1082,9 +1085,12 @@ export class MapAPI extends CommonMapAPI {
      * @memberof MapAPI
      */
     stopKeyPan() {
+        // prevents crosshairs appearing when reentering tab/window when mouse focused
+        if (this._activeKeys.includes('Tab')) {
+            this._mouseFocus = false;
+        }
         this._activeKeys = [];
         clearInterval(this._panInterval);
-        this._mouseFocus = false;
     }
 
     /**


### PR DESCRIPTION
Closes #1203.

This PR makes it so that using keyboard controls on an embedded RAMP instance no longer controls the page's scrollbar. It also fixes a bug where being focused on the map with the mouse, then exiting and entering the tab/window causes the crosshairs to appear as if keyboard controls were being used.

You can test the change on the [WET demo page](https://ramp4-pcar4.github.io/ramp4-pcar4/1203/demos/index-wet.html).

~~EDIT: seems like the demo link is not working, looking for a fix
Github Actions says `Error:  The source text contains invalid characters for the used encoding UTF-8` from `develop/help/default/en.md`. I think this might have to do with Dan's PR, as it modifies that file and the demo for the PR has the same name as the main build. There might be some build conflict going on.~~

Demo works again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1211)
<!-- Reviewable:end -->
