### PR TITLE
Update schema and config interfaces

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -348,7 +348,6 @@
                 "type": "string",
                 "enum": [
                     "boundaryZoom",
-                    "boundingBox",
                     "datatable",
                     "identify",
                     "metadata",
@@ -690,10 +689,8 @@
                     "default": 4000,
                     "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
-                "metadataUrl": {
-                    "type": "string",
-                    "default": null,
-                    "description": "Metadata url of the layer service."
+                "metadata": {
+                    "$ref": "#/$defs/layerMetadata"
                 },
                 "catalogueUrl": {
                     "type": "string",
@@ -714,7 +711,6 @@
                         "datatable",
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -759,10 +755,8 @@
                     "default": 4000,
                     "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
-                "metadataUrl": {
-                    "type": "string",
-                    "default": null,
-                    "description": "Metadata url of the layer service."
+                "metadata": {
+                    "$ref": "#/$defs/layerMetadata"
                 },
                 "layerType": {
                     "type": "string",
@@ -777,7 +771,6 @@
                     "default": [
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "metadata",
                         "boundaryZoom",
                         "reload",
@@ -829,10 +822,8 @@
                     "default": 4000,
                     "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
-                "metadataUrl": {
-                    "type": "string",
-                    "default": null,
-                    "description": "Metadata url of the layer service."
+                "metadata": {
+                    "$ref": "#/$defs/layerMetadata"
                 },
                 "catalogueUrl": {
                     "type": "string",
@@ -871,7 +862,6 @@
                     "default": [
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -939,7 +929,6 @@
                         "datatable",
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -961,6 +950,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "A flag indicating this entry is only for state tracking (i.e. it should not be displayed on the UI and all of the controls will be ignored, but the layer itself will be displayed on the map with the given state settings)."
+                },
+                "customRenderer": {
+                    "type": "object",
+                    "description": "Optional renderer object to apply to the layer. Follows ESRI ArcGIS Server json convention.",
+                    "additionalProperties": true
                 },
                 "fieldMetadata": {
                     "type": "object",
@@ -1025,10 +1019,8 @@
                     "default": 4000,
                     "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
-                "metadataUrl": {
-                    "type": "string",
-                    "default": null,
-                    "description": "Metadata url of the layer service."
+                "metadata": {
+                    "$ref": "#/$defs/layerMetadata"
                 },
                 "catalogueUrl": {
                     "type": "string",
@@ -1054,7 +1046,6 @@
                         "datatable",
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -1083,6 +1074,10 @@
                     "items": {
                         "$ref": "#/$defs/fieldMetadataEntry"
                     }
+                },
+                "initialFilteredQuery": {
+                    "type": "string",
+                    "description": "Initial filter query to be applied to the layer."
                 },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"
@@ -1151,7 +1146,6 @@
                         "datatable",
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -1240,7 +1234,6 @@
                         "datatable",
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -1310,10 +1303,8 @@
                     "default": 4000,
                     "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
                 },
-                "metadataUrl": {
-                    "type": "string",
-                    "default": null,
-                    "description": "Metadata url of the layer service."
+                "metadata": {
+                    "$ref": "#/$defs/layerMetadata"
                 },
                 "catalogueUrl": {
                     "type": "string",
@@ -1347,7 +1338,6 @@
                     "default": [
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -1409,7 +1399,6 @@
                     "default": [
                         "opacity",
                         "visibility",
-                        "boundingBox",
                         "identify",
                         "metadata",
                         "boundaryZoom",
@@ -1439,7 +1428,7 @@
                     "$ref": "#/$defs/details"
                 },
                 "grid": {
-                    "$ref": "#/$defs/table"
+                    "$ref": "#/$defs/grid"
                 },
                 "legend": {
                     "type": "object",
@@ -1466,6 +1455,22 @@
                     }
                 }
             }
+        },
+        "layerMetadata": {
+            "type": "object",
+            "description": "Metadata link and name of the layer service.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Metadata url of the layer service."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name to be displayed as the header of the metadata panel."
+                }
+            },
+            "required": ["url"],
+            "additionalProperties": false
         },
         "fieldMetadataEntry": {
             "type": "object",
@@ -1497,11 +1502,6 @@
                     "default": true,
                     "description": "Initial visibility of layer on map."
                 },
-                "boundingBox": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Specifies whether or not to display a bounding box."
-                },
                 "identify": {
                     "type": "boolean",
                     "default": true,
@@ -1515,7 +1515,7 @@
             },
             "additionalProperties": false
         },
-        "table": {
+        "grid": {
             "type": "object",
             "description": "Configuration for the datatable.",
             "properties": {
@@ -1647,10 +1647,6 @@
                     "type": "string",
                     "description": "A unique id identifying a tile schema (combination of an extent set and a zoom scale)."
                 },
-                "default": {
-                    "type": "string",
-                    "description": "Default name that can be traced to a value containing extent set and lod set hardcoded data."
-                },
                 "name": {
                     "type": "string",
                     "default": "",
@@ -1658,11 +1654,11 @@
                 },
                 "extentSetId": {
                     "type": "string",
-                    "description": "Link to extent set data defined in map.extentSets. This should be provided when no hardcoded default value exists or if the default value needs to be overridden."
+                    "description": "Identification link to extent set data defined in map.extentSets."
                 },
                 "lodSetId": {
                     "type": "string",
-                    "description": "Optional identification link to lod set data defined in map.lodSets. This can be used to override hardcoded default value."
+                    "description": "Identification link to lod set data defined in map.lodSets."
                 },
                 "thumbnailTileUrls": {
                     "type": "array",
@@ -1671,9 +1667,13 @@
                         "type": "string"
                     },
                     "minItems": 2
+                },
+                "hasNorthPole": {
+                    "type": "boolean",
+                    "description": "Indicates if this tile schema shows the north pole."
                 }
             },
-            "required": ["id", "name", "default"],
+            "required": ["id", "name", "default", "extentSetId", "lodSetId"],
             "additionalProperties": false
         },
         "basemap": {

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -565,7 +565,6 @@ function legendEntryUpgrader(r2legendEntry: any) {
     const r4legendEntry: any = r2legendEntry; // mostly a 1:1 mapping
     const allowedControls = [
         'boundaryZoom',
-        'boundingBox',
         'datatable',
         'identify',
         'metadata',
@@ -656,7 +655,9 @@ function layerUpgrader(r2layer: any): any {
         );
     }
     if (r2layer.metadataUrl) {
-        r4layer.metadataUrl = r2layer.metadataUrl;
+        r4layer.metadata = {
+            url: r2layer.metadataUrl
+        };
     }
     if (r2layer.catalogueUrl) {
         r4layer.catalogueUrl = r2layer.catalogueUrl;
@@ -821,7 +822,6 @@ function layerCommonPropertiesUpgrader(r2layer: any) {
     }
     const allowedControls: string[] = [
         'boundaryZoom',
-        'boundingBox',
         'datatable',
         'identify',
         'metadata',
@@ -848,13 +848,17 @@ function layerCommonPropertiesUpgrader(r2layer: any) {
         r4layer.state = {
             opacity: r2layer.state.opacity ?? 1,
             visibility: r2layer.state.visibility ?? true,
-            boundingBox: r2layer.state.boundingBox ?? false,
             identify: r2layer.state.query ?? true,
             hovertips: r2layer.state.hovertips ?? true
         };
         if (typeof r2layer.state.snapshot !== 'undefined') {
             console.warn(
                 `snapshot property provided in initialLayer settings in layer ${r2layer.id} cannot be mapped and will be skipped.`
+            );
+        }
+        if (typeof r2layer.state.boundingBox !== 'undefined') {
+            console.warn(
+                `boundingBox property provided in initialLayer settings in layer ${r2layer.id} cannot be mapped and will be skipped.`
             );
         }
     }

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -47,7 +47,8 @@
 
                     <div class="rv-settings-divider"></div>
 
-                    <settings-component
+                    <!-- Revist this in #194 -->
+                    <!-- <settings-component
                         class="rv-subsection"
                         type="toggle"
                         :name="$t('settings.label.boundingBox')"
@@ -60,8 +61,7 @@
                             )
                         }"
                     ></settings-component>
-
-                    <div class="rv-settings-divider"></div>
+                    <div class="rv-settings-divider"></div> -->
                 </div>
 
                 <div class="flex flex-col justify-center">

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -273,21 +273,6 @@ export enum IdentifyResultFormat {
     UNKNOWN = 'unknown'
 }
 
-export enum LayerControls {
-    BoundaryZoom = 'boundaryZoom',
-    Boundingbox = 'boundingBox',
-    Datatable = 'datatable',
-    Identify = 'identify',
-    Metadata = 'metadata',
-    Opacity = 'opacity',
-    Refresh = 'refresh',
-    Reload = 'reload',
-    Remove = 'remove',
-    Settings = 'settings',
-    Symbology = 'symbology',
-    Visibility = 'visibility'
-}
-
 // TODO since MapClick and MapMove are payloads on public events, is there a proper
 //      way they should be exposed from the main app as well (like, exported? in one of those .d.ts files?)?
 //      same question probably applies to a number of other interfaces here.
@@ -450,30 +435,11 @@ export enum CoreFilter {
     API = 'api' // this would be a default api key. e.g. if someone just does an API filter set with no key parameter, it would use this.
 }
 
-// Attribution interface that contains all the core attributes of the attribution node
-export interface Attribution {
-    text: { disabled?: boolean; value?: string };
-    logo: {
-        disabled?: boolean;
-        altText?: string;
-        value?: string;
-        link?: string;
-    };
-}
-
 export interface ScaleHelper {
     units: string;
     isImperialScale: boolean;
     pixels: number;
     distance: number;
-}
-
-// Contains properties needed to display scale on the map-caption bar
-export interface ScaleBar {
-    disabled?: boolean;
-    label?: string;
-    width?: string;
-    isImperialScale?: boolean;
 }
 
 // Contains properties needed to display mouse co-ords on the map-caption bar
@@ -490,6 +456,39 @@ export interface UrlQueryMap {
 
 // TODO migrate these to /geo/api/geo-common ? if we need config interfaces before creating an instance,
 //      having them defined here might cause circular reference.
+
+export enum LayerControls {
+    BoundaryZoom = 'boundaryZoom',
+    Datatable = 'datatable',
+    Identify = 'identify',
+    Metadata = 'metadata',
+    Opacity = 'opacity',
+    Refresh = 'refresh',
+    Reload = 'reload',
+    Remove = 'remove',
+    Settings = 'settings',
+    Symbology = 'symbology',
+    Visibility = 'visibility'
+}
+
+// Attribution interface that contains all the core attributes of the attribution node
+export interface Attribution {
+    text: { disabled?: boolean; value?: string };
+    logo: {
+        disabled?: boolean;
+        altText?: string;
+        value?: string;
+        link?: string;
+    };
+}
+
+// Contains properties needed to display scale on the map-caption bar
+export interface ScaleBar {
+    disabled?: boolean;
+    label?: string;
+    width?: string;
+    isImperialScale?: boolean;
+}
 
 export interface RampSpatialReference {
     wkid?: number;
@@ -517,17 +516,16 @@ export interface RampLayerFieldMetadataConfig {
 // i.e. a dynamic layer child
 export interface RampLayerMapImageSublayerConfig {
     // A+ name
-    index?: number;
+    index: number;
     name?: string;
     nameField?: string;
     // outfields?: string; // TODO tbd if we keep this
     state?: RampLayerStateConfig;
     // following items need to be flushed out
-    extent?: any;
+    extent?: RampExtentConfig;
     controls?: Array<LayerControls>;
     disabledControls?: Array<LayerControls>;
-    stateOnly?: any;
-    table?: any;
+    stateOnly?: boolean;
     fieldMetadata?: RampLayerFieldMetadataConfig;
     customRenderer?: any;
     fixtures?: any; // layer-based fixture config
@@ -535,7 +533,7 @@ export interface RampLayerMapImageSublayerConfig {
 
 // i.e. a wms layer child
 export interface RampLayerWmsSublayerConfig {
-    id?: string; // this is the "name" on the service
+    id: string; // this is the "name" on the service
     name?: string; // this is display name in ramp. would override "title" on the service
     state?: RampLayerStateConfig;
     // following items need to be flushed out
@@ -544,37 +542,38 @@ export interface RampLayerWmsSublayerConfig {
     currentStyle?: string; // style to be used
     styleLegends?: Array<{ name: string; url: string }>; // map of styles to legend graphic url. overrides service urls.
     fixtures?: any; // layer-based fixture config
-    // more...
 }
 
 // TODO investigate if we want to make a fancy interface heirarchy instead of pile-of-?-properties
 export interface RampLayerConfig {
     id: string;
     layerType: LayerType;
-    url?: string;
+    url: string;
     name?: string;
     state?: RampLayerStateConfig;
-    customRenderer?: any; // TODO expand, if worth it. fairly complex object
+    customRenderer?: any;
     // TODO revisit issue #1019 after v1.0.0
     // refreshInterval?: number;
-    initialFilteredQuery?: string;
     fieldMetadata?: RampLayerFieldMetadataConfig;
     nameField?: string;
     tooltipField?: string;
-    featureInfoMimeType?: string;
+    featureInfoMimeType?: string; // used by WMS layer
     controls?: Array<LayerControls>;
     disabledControls?: Array<LayerControls>;
     sublayers?:
         | Array<RampLayerMapImageSublayerConfig>
         | Array<RampLayerWmsSublayerConfig>;
-    rawData?: any; // used for static data, like geojson string, shapefile guts
+    extent?: RampExtentConfig;
     latField?: string; // csv coord field
     longField?: string; // csv coord field
     tolerance?: number; // click tolerance
     metadata?: { url: string; name?: string };
+    catalogueUrl?: string;
     fixtures?: any; // layer-based fixture config
     cosmetic?: boolean;
     colour?: string;
+    initialFilteredQuery?: string;
+    rawData?: any; // used for static data, like geojson string, shapefile guts
 }
 
 export interface RampExtentConfig {
@@ -593,7 +592,7 @@ export interface RampExtentSetConfig {
 }
 
 export interface RampBasemapLayerConfig {
-    id?: string;
+    id: string;
     layerType: LayerType;
     url: string;
     opacity?: number;
@@ -601,13 +600,13 @@ export interface RampBasemapLayerConfig {
 
 export interface RampBasemapConfig {
     id: string;
-    tileSchemaId: string;
-    name?: string;
-    description?: string;
-    altText?: string;
+    name: string;
+    description: string;
+    altText: string;
     thumbnailUrl?: string;
-    attribution?: Attribution;
+    tileSchemaId: string;
     layers: Array<RampBasemapLayerConfig>;
+    attribution?: Attribution;
 }
 
 export interface RampTileSchemaConfig {


### PR DESCRIPTION
## Closes #204

## Changes
- Removed references to `boundingBox` (kept the config property in `RampLayerStateConfig`)
- Updated layer `metadata` config schema
- Added `initialFilteredQuery` to feature layer schema
- Added `catalogueUrl` to layer config interface
- Added `default` to tile schema config and also implemented defaulting
- Various other minor changes to config interfaces


## Further work
- Other layer types should support `initialFilteredQuery` as well
    - #1215 

## Testing
- No changes to functionality - RAMP should work the same as before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1214)
<!-- Reviewable:end -->
