### PR TITLE
remove overflow CSS property from main app container

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -34,8 +34,6 @@ export default defineComponent({
             // needed to have tooltips in fullscreen, by default it appends to document.body
             appendTo: this.$el
         });
-        let parent = this.$el.parentElement;
-        parent?.style.setProperty('overflow', 'hidden');
     }
 });
 </script>

--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         name="esriMap"
-        class="h-full"
+        class="h-full overflow-hidden"
         v-tippy="{
             allowHTML: true,
             zIndex: 5,


### PR DESCRIPTION
Closes #594

This PR includes a more issue-specific fix for the problem specified in #594. Instead of adding the `overflow: hidden;` CSS property to the entire app container, it is added to just the ESRI map container (which seems to be the source of the issue).

To test this PR, open the demo link and ensure that no whitespace appears when hovering the language change button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1216)
<!-- Reviewable:end -->
