### PR TITLE
Geolocation Service

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -420,6 +420,7 @@ let config = {
                 mapnav: {
                     items: [
                         'fullscreen',
+                        'geolocator',
                         'help',
                         'home',
                         'basemap',

--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -428,7 +428,15 @@ let config = {
                         'layer-reorder'
                     ]
                 },
-                mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap'
+                    ]
+                },
                 export: {
                     title: {
                         value: 'All Your Base are Belong to Us',
@@ -857,7 +865,15 @@ let config2 = {
                         'layer-reorder'
                     ]
                 },
-                mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap'
+                    ]
+                },
                 export: {
                     title: {
                         value: 'All Your Base are Belong to Us',
@@ -1286,7 +1302,15 @@ let config3 = {
                         'layer-reorder'
                     ]
                 },
-                mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap'
+                    ]
+                },
                 export: {
                     title: {
                         value: 'All Your Base are Belong to Us',

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -419,6 +419,7 @@ let config = {
                 mapnav: {
                     items: [
                         'fullscreen',
+                        'geolocator',
                         'help',
                         'home',
                         'basemap',

--- a/public/help/default/en.md
+++ b/public/help/default/en.md
@@ -26,7 +26,9 @@ The following navigation controls can be found in the bottom right corner of the
 |--|--|
 | Zoom in - Plus (+) | Zoom in one level on the map to see more detailed content |
 | Zoom out - Minus (-) | Zoom out one level on the map to see less detailed content |
-| Fullscreen | Full screen presents map content using the entire page. Full screen option is only available when the map is embedded into another page | Home / Initial extent | Zoom and pan map such that initial extent is visible |
+| Fullscreen | Full screen presents map content using the entire page. Full screen option is only available when the map is embedded into another page |
+| Geolocate | Zoom and pan map over the current location of the device |
+| Home / Initial extent | Zoom and pan map such that initial extent is visible |
 | Help | Toggle open or closed the help dialog |
 
 

--- a/public/help/default/fr.md
+++ b/public/help/default/fr.md
@@ -26,7 +26,9 @@
 |--|--|
 | [fr] Zoom in - Plus (+) | [fr] Zoom in one level on the map to see more detailed content |
 | [fr] Zoom out - Minus (-) | [fr] Zoom out one level on the map to see less detailed content |
-| [fr] Fullscreen | [fr] Full screen presents map content using the entire page. Full screen option is only available when the map is embedded into another page | [fr] Home / Initial extent | [fr] Zoom and pan map such that initial extent is visible |
+| [fr] Fullscreen | [fr] Full screen presents map content using the entire page. Full screen option is only available when the map is embedded into another page |
+| [fr] Geolocate | [fr] Zoom and pan map over the current location of the device |
+| [fr] Home / Initial extent | [fr] Zoom and pan map such that initial extent is visible |
 | [fr] Help | [fr] Toggle open or closed the help dialog |
 
 

--- a/public/starter-scripts/cam.js
+++ b/public/starter-scripts/cam.js
@@ -352,7 +352,7 @@ let config = {
                 appbar: {
                     items: ['legend', 'geosearch', 'export']
                 },
-                mapnav: { items: ['fullscreen', 'geoLocator', 'home', 'help'] },
+                mapnav: { items: ['fullscreen', 'geolocator', 'home', 'help'] },
                 export: {
                     title: {
                         value: 'Climate action map'
@@ -747,7 +747,7 @@ let config = {
                 appbar: {
                     items: ['legend', 'geosearch', 'export']
                 },
-                mapnav: { items: ['fullscreen', 'geoLocator', 'home', 'help'] },
+                mapnav: { items: ['fullscreen', 'geolocator', 'home', 'help'] },
                 export: {
                     title: {
                         value: 'Climate action map'

--- a/public/starter-scripts/cesi.js
+++ b/public/starter-scripts/cesi.js
@@ -668,7 +668,7 @@ let config = {
                 appbar: {
                     items: ['legend', 'geosearch', 'basemap', 'export']
                 },
-                mapnav: { items: ['fullscreen', 'geoLocator', 'home', 'help'] },
+                mapnav: { items: ['fullscreen', 'geolocator', 'home', 'help'] },
                 export: {
                     title: {
                         value: 'Canadian Environmental Sustainability Indicators (CESI)'

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -417,7 +417,15 @@ let config = {
                         'layer-reorder'
                     ]
                 },
-                mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'help',
+                        'home',
+                        'geolocator',
+                        'basemap'
+                    ]
+                },
                 details: {
                     panelWidth: {
                         default: 350,

--- a/schema.json
+++ b/schema.json
@@ -517,7 +517,13 @@
                 },
                 "items": {
                     "type": "array",
-                    "default": ["fullscreen", "help", "home", "basemap"],
+                    "default": [
+                        "fullscreen",
+                        "help",
+                        "home",
+                        "geolocator",
+                        "basemap"
+                    ],
                     "description": "Map navigation buttons displayed on mapnav.",
                     "items": {
                         "type": "string",
@@ -1961,7 +1967,13 @@
                     "$ref": "#/$defs/mapnav",
                     "default": {
                         "zoom": "buttons",
-                        "items": ["fullscreen", "home", "help", "basemap"]
+                        "items": [
+                            "fullscreen",
+                            "home",
+                            "geolocator",
+                            "help",
+                            "basemap"
+                        ]
                     },
                     "description": "Provides configuration to the appbar. If not supplied, default appbar controls are displayed."
                 },

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -37,6 +37,7 @@ import PanelOptionsMenuV from '@/components/panel-stack/controls/panel-options-m
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
 import FullscreenNavV from '@/fixtures/mapnav/buttons/fullscreen-nav.vue';
+import GeolocatorNavV from '@/fixtures/mapnav/buttons/geolocator-nav.vue';
 import HomeNavV from '@/fixtures/mapnav/buttons/home-nav.vue';
 import MapnavButtonV from '@/fixtures/mapnav/button.vue';
 
@@ -483,6 +484,7 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
 
     // ported from mapnav.vue
     vueElement.component('fullscreen-nav-button', FullscreenNavV);
+    vueElement.component('geolocator-nav-button', GeolocatorNavV);
     vueElement.component('home-nav-button', HomeNavV);
     vueElement.component('mapnav-button', MapnavButtonV);
 

--- a/src/fixtures/mapnav/buttons/geolocator-nav.vue
+++ b/src/fixtures/mapnav/buttons/geolocator-nav.vue
@@ -1,0 +1,83 @@
+<template>
+    <mapnav-button
+        :onClickFunction="geolocate"
+        :tooltip="$t('mapnav.geolocator')"
+    >
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class="fill-current w-32 h-20"
+        >
+            <path
+                d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 3c-.46-4.17-3.77-7.48-7.94-7.94V1h-2v2.06C6.83 3.52 3.52 6.83 3.06 11H1v2h2.06c.46 4.17 3.77 7.48 7.94 7.94V23h2v-2.06c4.17-.46 7.48-3.77 7.94-7.94H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z"
+            ></path>
+        </svg>
+    </mapnav-button>
+</template>
+
+<script lang="ts">
+import { NotificationType } from '@/api';
+import { Point, SpatialReference } from '@/geo/api';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'GeolocatorNavV',
+    data() {
+        return {
+            geolocation: [] as Array<number>
+        };
+    },
+    methods: {
+        async geolocate() {
+            // use cached location
+            if (!this.geolocation.length) {
+                // request current location from browser
+                const position = await this.browserLocate({
+                    maximumAge: Infinity,
+                    timeout: 5000
+                }).catch((error: GeolocationPositionError) => {
+                    // send an error message if user accepts location access but something goes wrong with the navigator
+                    if (error.code > 1) {
+                        this.$iApi.notify.show(
+                            NotificationType.ERROR,
+                            this.$iApi.$vApp.$t('mapnav.geolocator.error')
+                        );
+                    }
+                });
+                if (position) {
+                    // store geolocation as array for speedy zoomIn
+                    this.geolocation = [
+                        position.coords.longitude,
+                        position.coords.latitude
+                    ];
+                    this.zoomIn(this.geolocation);
+                }
+            } else {
+                this.zoomIn(this.geolocation);
+            }
+        },
+        // zoom to point
+        zoomIn(coords: Array<number>): void {
+            let zoomTarget = new Point(
+                'geolocation',
+                coords,
+                SpatialReference.latLongSR(),
+                true
+            );
+            this.$iApi.geo.map.zoomMapTo(zoomTarget);
+        },
+        // prompt user to geolocate via browser
+        browserLocate(options: PositionOptions): Promise<GeolocationPosition> {
+            return new Promise((resolve, reject) =>
+                navigator.geolocation.getCurrentPosition(
+                    resolve,
+                    reject,
+                    options
+                )
+            );
+        }
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/fixtures/mapnav/lang/lang.csv
+++ b/src/fixtures/mapnav/lang/lang.csv
@@ -3,3 +3,5 @@ mapnav.zoomIn,Zoom In,1,Zoom avant,1
 mapnav.zoomOut,Zoom Out,1,Zoom arrière,1
 mapnav.home,Home,1,Accueil,1
 mapnav.fullscreen,Full Screen,1,Plein Écran,1
+mapnav.geolocator,Your Location,1,Votre position,1
+mapnav.geolocator.error,Your location could not be found.,1,Votre emplacement n'a pu être trouvé.,1

--- a/src/fixtures/mapnav/store/mapnav-store.ts
+++ b/src/fixtures/mapnav/store/mapnav-store.ts
@@ -1,4 +1,4 @@
-import type { ActionContext, Action, Mutation } from 'vuex';
+import type { ActionContext } from 'vuex';
 import { make } from 'vuex-pathify';
 
 import { MapnavState } from './mapnav-state';


### PR DESCRIPTION
Closes #1164.

### Summary

This PR adds a geolocation service that previously existed in RAMP2. This is a common map feature that allows the user to zoom in to the current location of their device. The current location is accessed via the browser.

### Changes
- added `geolocator` feature to RAMP4
- added `geolocator-nav-button` to `mapnav` fixture
- added geolocator description in help panel

### Notes
- Since RAMP4 no longer uses the `toast` component for notifications, internal/timeout errors are now sent to the notifications panel.
- There is currently no loading indicator for the initial fetch of geolocation data, like RAMP2. The longest I experienced waiting for the map to zoom was ~2 seconds, but this has the potential to wait up to 5 seconds before timing out. I think it's okay in it's current implementation with cached results, but maybe there's a desire to add some kind of loading icon somewhere.
- The RAMP2 service used Google's geolocation API as a fallback when the browser geolocation failed for whatever reason. Since the team is undecided on using Google API and handling CORS stuff, I decided not to carry this over to RAMP4. If these issues are decided upon later, it wouldn't be much of a hassle to add this on. The feature currently works fine without it.

### Testing
- Click the geolocator button in the mapnav and give permission to the browser to access your location.
- You can also spoof your location in your browser. A simple way is to use method 1 in [this guide](https://beebom.com/fake-geo-location-google-chrome-mozilla-firefox-microsoft-edge/). Doing this and then using the geolocation service will zoom into whatever location you provided.
- An easy way to get an error is to load the RAMP instance, then disconnect from wifi and attempt to geolocate.
    - You might have to close and reopen your browser to clear the cache

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1220)
<!-- Reviewable:end -->
