### PR TITLE
Debounce overview map updates

### DIFF
--- a/src/fixtures/geosearch/bottom-filters.vue
+++ b/src/fixtures/geosearch/bottom-filters.vue
@@ -47,6 +47,7 @@ export default defineComponent({
         //      going default means the handler function needs to be public / on the geosearch api.
         //      ^ not entirely true. a person can still unhook the event, however our public documentation will
         //        have no mention of the event handler name. A person would need to discover it.
+        // TODO also consider if this handler requires debounce because MAP_EXTENTCHANGE fires at a high rate
         this.$iApi.event.on(
             GlobalEvents.MAP_EXTENTCHANGE,
             this.onMapExtentChange,

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -246,17 +246,24 @@ export class OverviewMapAPI extends CommonMapAPI {
      * Updates overviewmap extent and graphic based on main map extent
      *
      * @param {Extent} newExtent new main map extent
+     * @returns {Promise<void>} A promise that resolves when the overviewmap has finished updating
      */
-    updateOverview(newExtent: Extent) {
+    updateOverview(newExtent: Extent): Promise<void> {
         const expandFactor: number = this.$iApi.$vApp.$store.get(
             OverviewmapStore.expandFactor
         ) as number;
 
-        this.zoomMapTo(newExtent.expand(expandFactor), undefined, false);
+        let zoomPromise = this.zoomMapTo(
+            newExtent.expand(expandFactor),
+            undefined,
+            false
+        );
 
         // this draws the outline of the main map extent
         this.esriView!.graphics.getItemAt(0).geometry =
             this.$iApi.geo.map.esriView!.extent;
+
+        return zoomPromise;
     }
 
     /**


### PR DESCRIPTION
## Closes #1213

## Changes
- Added debounce to the overview map `MAP_EXTENTCHANGE` change listener so it only updates after the extent stops changing
- Added `Promise<void>` return value for overview map's `updateOverview` method

## Testing
- The "go to interrupted" should no longer appear in the console
- Overview map should only update extent when the main map's extent stops updating
