### PR TITLE
Change greedy mode behavior for long loading identify requests

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -49,12 +49,6 @@ export enum GlobalEvents {
     CONFIG_CHANGE = 'config/configchanged',
 
     /**
-     * Fires when details panel is closed.
-     * Payload: none
-     */
-    DETAILS_CLOSED = 'details/closed',
-
-    /**
      * Fires when a request is issued to show the details of an identify result.
      * Payload: `({ identifyItem: IdentifyItem, uid: string })`
      */

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -4,7 +4,7 @@
             {{ $t('details.items.title') }}
         </template>
         <template #content>
-            <div v-if="result.loaded">
+            <div v-if="result.loaded && activeGreedy === 0">
                 <div
                     class="flex flex-col justify-between py-8 px-8 mb-8 bg-gray-100"
                     v-if="layerExists"
@@ -132,24 +132,26 @@
                 </div>
             </div>
             <!-- result is loading -->
-            <div v-else class="flex justify-center py-10 items-center">
+            <div
+                v-else-if="slowLoadingFlag"
+                class="flex justify-center py-10 items-center"
+            >
                 <span class="animate-spin spinner h-20 w-20 px-5 mr-8"></span>
                 {{ $t('details.item.loading') }}
             </div>
+            <!-- clear panel when new identify request came in -->
+            <div v-else></div>
         </template>
     </panel-screen>
 </template>
 
 <script lang="ts">
 import { defineComponent, type PropType } from 'vue';
-
 import { DetailsStore } from './store';
-
-import type { LayerInstance, PanelInstance } from '@/api/internal';
 import { GlobalEvents } from '@/api';
 import { IdentifyResultFormat } from '@/geo/api';
-
 import type { FieldDefinition, IdentifyResult, IdentifyItem } from '@/geo/api';
+import type { LayerInstance, PanelInstance } from '@/api/internal';
 
 import ESRIDefaultV from './templates/esri-default.vue';
 import HTMLDefaultV from './templates/html-default.vue';
@@ -179,6 +181,8 @@ export default defineComponent({
         return {
             defaultTemplates: this.get(DetailsStore.defaultTemplates),
             detailProperties: this.get(DetailsStore.properties),
+            activeGreedy: this.get(DetailsStore.activeGreedy),
+            slowLoadingFlag: this.get(DetailsStore.slowLoadingFlag),
             identifyTypes: IdentifyResultFormat.UNKNOWN,
             icon: '' as string,
             currentIdx: 0,
@@ -294,14 +298,6 @@ export default defineComponent({
         }
     },
     methods: {
-        /**
-         * Close details screen
-         */
-        close() {
-            this.panel.close();
-            this.$iApi.event.emit(GlobalEvents.DETAILS_CLOSED);
-        },
-
         /**
          * Initialize the details screen
          */

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -80,9 +80,23 @@ export class DetailsState {
     properties: { [id: string]: DetailsItemInstance } = {};
 
     /**
-     * Details default templates indexed by the identify result format
+     * Details default templates indexed by the identify result format.
      *
      * @memberof DetailsState
      */
     defaultTemplates: { [type: string]: string } = {};
+
+    /**
+     * Indicates whether greedy mode is still loading for current identify request after 500ms delay.
+     *
+     * @memberof DetailsState
+     */
+    slowLoadingFlag: boolean = false;
+
+    /**
+     * Indicates whether greedy mode is off (0), or currently running for the last request timestamp.
+     *
+     * @memberof DetailsState
+     */
+    activeGreedy: number = 0;
 }

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -61,6 +61,14 @@ export enum DetailsStore {
      */
     defaultTemplates = 'details/defaultTemplates',
     /**
+     * (State) slowLoadingFlag: boolean
+     */
+    slowLoadingFlag = 'details/slowLoadingFlag',
+    /**
+     * (State) activeGreedy: number
+     */
+    activeGreedy = 'details/activeGreedy',
+    /**
      * (Action) setPayload: (payload: ItemResult[])
      */
     setPayload = 'details/setPayload!',


### PR DESCRIPTION
Closes #1102 

**Changes**: 

Modified behavior of details greedy mode based on the discussion post to resolve issues of out of sync details panels for slow-loading identify requests. On new identify clicks, first all open details panels are cleared to indicate a new request has come in. If the greedy mode is still running for the request after 500ms, a loading spinner animation is displayed on each screen. The details content is shown whenever the greedy mode has completed or aborted. Also fixed regression cases where abort cases were not going off when closing details panel before request resolves. 

If clearing the screen creates unnecessary flickering (since most requests resolve fast), we can remove this behavior and keep the old results for this 500ms duration instead. 

**Testing**: 

Added a delay to running MIL identify requests for demo purposes. Test out greedy mode behavior on map clicks and abort cases and comment on any behavior that looks off.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1238)
<!-- Reviewable:end -->
