### PR TITLE
Layer Initiation Enhancements

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -91,7 +91,8 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
 | LAYER_RELOAD_START<br>'layer/reloadstart'          | LayerInstance object                                           | The layer started reloading                      |
 | LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |
-| LAYER_STATECHANGE<br>'layer/statechange'           | _state_: new value, layer: LayerInstance object                | The layer state changed                          |
+| LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange'   | _state_: new value, layer: LayerInstance object                | The layer load state changed |
+| LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, layer: LayerInstance object                | The layer layer state changed                 |
 | LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, layer: LayerInstance object           | The layer visibility changed                     |
 | MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | basemapId: string, schemaChanged: boolean                      | The basemap was changed                          |
 | MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                                |

--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -121,7 +121,7 @@ var featureLayer = instanceApi.geo.layer.createLayer(simpleConfig));
 
 The creation of the layer just generates the controlling `Layer` object. To generate an ESRI layer (which the mapping API uses to render stuff on the map), use the `initiate()` method on the layer. To remove/trash the ESRI layer, use `terminate()`. These functions can be used to orchestrate things like layer reloads, projection changes, etc.
 
-The `.initialized` property on the `Layer` will indicate the current state of the layer in this matter.
+The `.initiationState` property on the `Layer` will indicate the current state of the layer in this matter.
 
 ### Waiting For Layer Load
 
@@ -195,10 +195,16 @@ Determine if the layer is in a valid state. Invalid states would be pre-loaded o
 myLayer.isValidState; // true
 ```
 
-Get the state of the layer. This state tracks the loading life cycle (i.e. loading, loaded, error)
+Get the load state of the layer. This state tracks the loading life cycle (i.e. loading, loaded, error)
 
 ```js
-myLayer.state; // 'loaded'
+myLayer.layerState; // 'loaded'
+```
+
+Get the layer state of the layer. This state tracks the initiation life cycle (i.e. initiating, initiated, terminating, terminated)
+
+```js
+myLayer.initiationState; // 'initiated'
 ```
 
 Get the drawing state of the layer. This state tracks the drawing life cycle (i.e. getting or processing spatial data for the current map view)
@@ -286,7 +292,7 @@ Options parameter object:
 }                   // The number represents pixels to buffer by (so 5 would be a 10x10 pixel square around the point at the current map scale level).
 ```
 
-The result object is on the fancy side, as there are a few levels identify acts up. The topmost array of results has an entry for each logical layer involved, including the logical `uid`, a loading flag and promise, and another array of individual hits (called items) for the logical layer. The loading properties here indicate when the items array as been populated, but be aware that individual items still may be downloading their own data. 
+The result object is on the fancy side, as there are a few levels identify acts up. The topmost array of results has an entry for each logical layer involved, including the logical `uid`, a loading flag and promise, and another array of individual hits (called items) for the logical layer. The loading properties here indicate when the items array as been populated, but be aware that individual items still may be downloading their own data.
 The items array contains a loading flag and promise to track the download of its data, a format specification and a property to contain data that aligns to the given format.
 
 TODO flush out formats once things are nailed down.

--- a/schema.json
+++ b/schema.json
@@ -693,7 +693,7 @@
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -759,7 +759,7 @@
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -826,7 +826,7 @@
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -1023,7 +1023,7 @@
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -1125,6 +1125,11 @@
                     "default": "",
                     "description": "Hex code representing the layer symbology colour."
                 },
+                "expectedResponseTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
+                },
                 "layerType": {
                     "type": "string",
                     "enum": ["file-geojson", "file-csv", "file-shape"],
@@ -1215,6 +1220,11 @@
                     "type": "string",
                     "default": "",
                     "description": "The service endpoint of the layer. It should match the type provided in layerType."
+                },
+                "expectedResponseTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
                 },
                 "colour": {
                     "type": "string",
@@ -1307,7 +1317,7 @@
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
-                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer. Currently not supported."
+                    "description": "The time span after which a 'slow-to-respond' notification is shown for any loading or refreshing layer."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -17,6 +17,7 @@ import type { MetadataPayload } from '@/fixtures/metadata/store';
 import { AppbarAction } from '@/fixtures/appbar/store';
 import { LegendStore } from '@/fixtures/legend/store';
 import { GridStore, GridAction } from '@/fixtures/grid/store';
+import { LayerState } from '@/geo/api';
 import type {
     MapClick,
     MapMove,
@@ -127,10 +128,16 @@ export enum GlobalEvents {
     LAYER_REMOVE = 'layer/remove',
 
     /**
-     * Fires when the state of a layer changes.
+     * Fires when the load state of a layer changes.
      * Payload: `({ layer: LayerInstance, state: string })`
      */
-    LAYER_STATECHANGE = 'layer/statechange',
+    LAYER_LAYERSTATECHANGE = 'layer/layerstatechange',
+
+    /**
+     * Fires when the layer state of a layer changes.
+     * Payload: `({ layer: LayerInstance, state: string})`
+     */
+    LAYER_INITIATIONSTATECHANGE = 'layer/initiationStatechange',
 
     /**
      * Fires when the visibility of a layer changes.
@@ -336,6 +343,7 @@ enum DefEH {
     OPEN_LAYER_REORDER = 'opens_layer_reorder_panel',
     OPEN_METADATA = 'opens_metadata_panel',
     UPDATE_LEGEND_LAYER_REGISTER = 'updates_legend_layer_register',
+    UPDATE_LEGEND_LAYER_ERROR = 'updates_legend_layer_error',
     UPDATE_LEGEND_WIZARD_ADDED = 'updates_legend_wizard_added',
     UPDATE_LEGEND_LAYER_RELOAD = 'updates_legend_layer_reload',
     MAP_BASEMAPCHANGE_ATTRIBUTION = 'updates_map_caption_attribution_basemap',
@@ -613,6 +621,7 @@ export class EventAPI extends APIScope {
                 DefEH.OPEN_LAYER_REORDER,
                 DefEH.OPEN_METADATA,
                 DefEH.UPDATE_LEGEND_LAYER_REGISTER,
+                DefEH.UPDATE_LEGEND_LAYER_ERROR,
                 DefEH.UPDATE_LEGEND_WIZARD_ADDED,
                 DefEH.UPDATE_LEGEND_LAYER_RELOAD,
                 DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION,
@@ -816,6 +825,26 @@ export class EventAPI extends APIScope {
                 };
                 this.$iApi.event.on(
                     GlobalEvents.LAYER_REGISTERED,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.UPDATE_LEGEND_LAYER_ERROR:
+                // when a layer errors, have the standard legend update in accordance to the layer
+                zeHandler = (payload: {
+                    state: String;
+                    layer: LayerInstance;
+                }) => {
+                    if (payload.layer.layerState === LayerState.ERROR) {
+                        const legendFixture: LegendAPI =
+                            this.$iApi.fixture.get('legend');
+                        if (legendFixture) {
+                            legendFixture.updateLegend(payload.layer);
+                        }
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.LAYER_LAYERSTATECHANGE,
                     zeHandler,
                     handlerName
                 );

--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -138,19 +138,12 @@ export default defineComponent({
                                     this.$iApi.geo.layer.createLayer(
                                         layerConfig
                                     );
-
-                                // TODO call the new layer load method.
-                                //      might need to wait on that (think file layers that are making asynch calls prior to creating esri layer)
-                                //      see if layers are going to expose an "esri layer exists" promise, leverage that if they do
                                 const [initiateErr] = await to(
-                                    layer!.initiate()
+                                    this.map.addLayer(layer!)
                                 );
                                 if (initiateErr) {
                                     console.error(initiateErr);
-                                } else {
-                                    this.map.addLayer(layer!);
                                 }
-
                                 resolve(layer!);
                             }
                         );
@@ -163,14 +156,19 @@ export default defineComponent({
                 .filter(Boolean)
                 .forEach((layer: LayerInstance | null, index: number) => {
                     // wait on layer load to check for valid state
-                    layer?.isLayerLoaded().then(() => {
-                        if (layer?.isValidState) {
-                            this.$iApi.geo.map.reorder(
-                                layer!,
-                                oldValue ? oldValue.length + index : index
-                            );
-                        }
-                    });
+                    layer
+                        ?.isLayerLoaded()
+                        .then(() => {
+                            if (layer?.isValidState) {
+                                this.$iApi.geo.map.reorder(
+                                    layer!,
+                                    oldValue ? oldValue.length + index : index
+                                );
+                            }
+                        })
+                        .catch(() =>
+                            console.log(`Unable to reorder ${layer.id}.`)
+                        );
                 });
         },
         onMapConfigChange(newValue: RampMapConfig) {

--- a/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/src/fixtures/layer-reorder/components/layer-component.vue
@@ -161,6 +161,7 @@ import { GlobalEvents, LayerInstance } from '@/api';
 import type { LayerModel } from '../definitions';
 import LayerReorderButtonV from './reorder-button.vue';
 import draggable from 'vuedraggable';
+import { LayerState } from '@/geo/api';
 
 export default defineComponent({
     name: 'LayerReorderComponentV',
@@ -228,7 +229,11 @@ export default defineComponent({
             this.layersModel = [];
 
             this.layersModel = [...toRaw(this.layers)]
-                .filter((layer: LayerInstance) => !layer.isCosmetic) // filter out cosmetic layers
+                .filter(
+                    (layer: LayerInstance) =>
+                        !layer.isCosmetic &&
+                        layer.layerState !== LayerState.ERROR
+                ) // filter out cosmetic layers
                 .reverse() // needs to be reverse because map-stack is in reverse order of layer list
                 .map((layer: LayerInstance) => {
                     // get the true index of this layer in the layers list
@@ -249,9 +254,12 @@ export default defineComponent({
 
             // add load promise listeners to update models
             this.layers.forEach((layer: LayerInstance) => {
-                layer.isLayerLoaded().then(() => {
-                    this.loadLayerData(layer);
-                });
+                layer
+                    .isLayerLoaded()
+                    .then(() => {
+                        this.loadLayerData(layer);
+                    })
+                    .catch(() => 1); // make the console stop complaining
             });
 
             // calculate the min and max boundary indices

--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -162,7 +162,8 @@
 import { defineComponent, toRaw } from 'vue';
 import type { PropType } from 'vue';
 import { GlobalEvents, LayerInstance } from '@/api';
-import { LayerControls, LayerState, type LegendSymbology } from '@/geo/api';
+import { LayerControls, LayerState } from '@/geo/api';
+import type { LegendSymbology } from '@/geo/api';
 
 import type { LegendEntry } from '../store/legend-defs';
 import LegendCheckboxV from './checkbox.vue';
@@ -218,7 +219,7 @@ export default defineComponent({
         // watch for when layer state turns to ERROR
         this.handlers.push(
             this.$iApi.event.on(
-                GlobalEvents.LAYER_STATECHANGE,
+                GlobalEvents.LAYER_LAYERSTATECHANGE,
                 (payload: { layer: LayerInstance; state: string }) => {
                     // sync legend item state with layer state if errors
                     if (

--- a/src/fixtures/northarrow/northarrow.vue
+++ b/src/fixtures/northarrow/northarrow.vue
@@ -155,7 +155,7 @@ export default defineComponent({
                             layerType: LayerType.GRAPHIC,
                             cosmetic: true // mark this layer as a cosmetic layer
                         });
-                        await poleLayer.initiate();
+                        await this.$iApi.geo.map.addLayer(poleLayer);
 
                         const poleGraphic = new Graphic(projPole, 'northpole');
                         const poleStyle = new PointStyle(
@@ -168,7 +168,6 @@ export default defineComponent({
                         (poleLayer as CommonGraphicLayer).addGraphic(
                             poleGraphic
                         );
-                        this.$iApi.geo.map.addLayer(poleLayer);
                     }
                 }
             }

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -467,15 +467,11 @@ export default defineComponent({
             const config = Object.assign(this.layerInfo!.config, data);
 
             const layer = this.$iApi.geo.layer.createLayer(config);
-            await layer.initiate();
+            await this.$iApi.geo.map.addLayer(layer);
             layer.userAdded = true;
 
             // notify the legend to prepare a legend item
             this.$iApi.event.emit(GlobalEvents.USER_LAYER_ADDED, layer);
-
-            // add layer to map
-            this.$iApi.geo.map.addLayer(layer);
-
             this.goNext = false;
             this.goToStep(WizardStep.UPLOAD);
         },

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -250,6 +250,14 @@ export interface EpsgLookup {
     (code: string | number): Promise<string>;
 }
 
+export enum InitiationState {
+    NEW = 'new',
+    INITIATING = 'initiating',
+    INITIATED = 'initiated',
+    TERMINATING = 'terminating',
+    TERMINATED = 'terminated'
+}
+
 export enum LayerState {
     NEW = 'new', // this means ramp layer class exists but needs to be initialized()
     LOADING = 'loading',
@@ -554,6 +562,7 @@ export interface RampLayerConfig {
     customRenderer?: any;
     // TODO revisit issue #1019 after v1.0.0
     // refreshInterval?: number;
+    expectedResponseTime?: number;
     fieldMetadata?: RampLayerFieldMetadataConfig;
     nameField?: string;
     tooltipField?: string;

--- a/src/geo/layer/csv-layer.ts
+++ b/src/geo/layer/csv-layer.ts
@@ -9,7 +9,7 @@ export class CsvLayer extends FileLayer {
         this.layerType = LayerType.CSV;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         // TODO check if .sourceGeoJson is already populated?
         //      if this initiate is a reload, do we want to re-use it, or re-download? decide.
 
@@ -52,6 +52,6 @@ export class CsvLayer extends FileLayer {
             }
         );
 
-        await super.initiate();
+        await super.onInitiate();
     }
 }

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -32,13 +32,13 @@ export class FeatureLayer extends AttribLayer {
         this.layerFormat = LayerFormat.FEATURE;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         markRaw(
             (this.esriLayer = new EsriFeatureLayer(
                 this.makeEsriLayerConfig(this.origRampConfig)
             ))
         );
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -88,10 +88,10 @@ export class FileLayer extends AttribLayer {
         this.tooltipField = '';
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         // NOTE subclasses of FileLayer should do all their file data processing first,
         //      drop it in this.sourceGeoJson,
-        //      then call super.initiate() as final step.
+        //      then call super.onInitiate() as final step.
 
         // TODO figure out how the geojson is supplied.
         // another protected property? a permananent property to support reloads? part of rampConfig?
@@ -130,7 +130,7 @@ export class FileLayer extends AttribLayer {
 
         this.esriJson = undefined;
 
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**

--- a/src/geo/layer/geojson-layer.ts
+++ b/src/geo/layer/geojson-layer.ts
@@ -9,7 +9,7 @@ export class GeoJsonLayer extends FileLayer {
         this.layerType = LayerType.GEOJSON;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         // TODO check if .sourceGeoJson is already populated?
         //      if this initiate is a reload, do we want to re-use it, or re-download? decide.
 
@@ -63,6 +63,6 @@ export class GeoJsonLayer extends FileLayer {
             throw new Error('GeoJson layer config contains no raw data or url');
         }
 
-        await super.initiate();
+        await super.onInitiate();
     }
 }

--- a/src/geo/layer/graphic-layer.ts
+++ b/src/geo/layer/graphic-layer.ts
@@ -14,11 +14,11 @@ export class GraphicLayer extends CommonGraphicLayer {
         this.layerType = LayerType.GRAPHIC;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         this.esriLayer = markRaw(
             new EsriGraphicsLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**

--- a/src/geo/layer/imagery-layer.ts
+++ b/src/geo/layer/imagery-layer.ts
@@ -17,11 +17,11 @@ export class ImageryLayer extends CommonLayer {
         this.dataFormat = DataFormat.ESRI_RASTER;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         this.esriLayer = markRaw(
             new EsriImageryLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -4,6 +4,7 @@ import {
     DrawState,
     Extent,
     Graphic,
+    InitiationState,
     LayerControls,
     LayerFormat,
     LayerState,
@@ -44,9 +45,8 @@ export class LayerInstance extends APIScope {
      */
     id: string;
     uid: string;
-
-    initialized: boolean;
-    state: LayerState;
+    layerState: LayerState;
+    initiationState: InitiationState;
     drawState: DrawState;
 
     layerIdx: number;
@@ -86,11 +86,9 @@ export class LayerInstance extends APIScope {
 
         this.id = ''; // take from config here?
         this.uid = ''; // shutting up typescript. will get set somewhere else. // TODO verify setting, move here if that is smarter.
-
-        this.initialized = false;
-        this.state = LayerState.NEW;
+        this.layerState = LayerState.NEW;
         this.drawState = DrawState.NOT_LOADED;
-
+        this.initiationState = InitiationState.NEW;
         this.layerIdx = -1; // default value
         this.layerFormat = LayerFormat.UNKNOWN;
         this.layerType = LayerType.UNKNOWN;
@@ -547,16 +545,28 @@ export class LayerInstance extends APIScope {
     onLoad(): void {}
 
     /**
-     * Updates layer state and raises events.
+     * Initiates actions after layer load error.
      * Should generally only be called internally by the RAMP core.
      */
-    updateState(newState: LayerState): void {}
+    onError(): void {}
+
+    /**
+     * Updates layer load state and raises events.
+     * Should generally only be called internally by the RAMP core.
+     */
+    updateLayerState(newState: LayerState): void {}
 
     /**
      * Updates layer draw state and raises events.
      * Should generally only be called internally by the RAMP core.
      */
     updateDrawState(newState: DrawState): void {}
+
+    /**
+     * Updates layer layer state and raises events.
+     * Should generally only be called internally by the RAMP core.
+     */
+    updateInitiationState(newState: InitiationState): void {}
 
     /**
      * Finds an sublayer index corresponding to the given uid.

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -35,7 +35,7 @@ export class LayerAPI extends APIScope {
      * Will generate a RAMP Layer based on the supplied config object.
      *
      * @param {Object} config a valid layer configuration object
-     * @returns {LayerInstance} Layer in uninitialized state
+     * @returns {LayerInstance} Layer in uninitialized load state
      */
     createLayer(config: RampLayerConfig): LayerInstance {
         let closs: new (config: any, iApi: InstanceAPI) => LayerInstance;
@@ -111,6 +111,16 @@ export class LayerAPI extends APIScope {
      */
     allLayers(): Array<LayerInstance> {
         return this.$vApp.$store.get<LayerInstance[]>(LayerStore.layers) || [];
+    }
+
+    /**
+     * Return all error layers.
+     * @returns {Array<LayerInstance>} all error layers
+     */
+    allErrorLayers(): Array<LayerInstance> {
+        return (
+            this.$vApp.$store.get<LayerInstance[]>(LayerStore.penaltyBox) || []
+        );
     }
 
     /**

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -12,9 +12,10 @@ import {
     GeometryType,
     Graphic,
     IdentifyResultFormat,
+    InitiationState,
     LayerFormat,
-    LayerType,
     LayerState,
+    LayerType,
     NoGeometry,
     TreeNode
 } from '@/geo/api';
@@ -56,11 +57,11 @@ export class MapImageLayer extends AttribLayer {
         this.layerTree.layerIdx = -1;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         this.esriLayer = markRaw(
             new EsriMapImageLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**
@@ -235,7 +236,7 @@ export class MapImageLayer extends AttribLayer {
                     !parentTreeNode.children
                         .map(node => node.layerIdx)
                         .includes(sid) ||
-                    !_sublayer.initialized
+                    _sublayer.initiationState !== InitiationState.INITIATED
                 ) {
                     const treeLeaf = new TreeNode(
                         sid,
@@ -389,10 +390,10 @@ export class MapImageLayer extends AttribLayer {
         return loadPromises;
     }
 
-    updateState(newState: LayerState): void {
+    updateLayerState(newState: LayerState): void {
         // force any sublayers to also update their state and raise events
-        super.updateState(newState);
-        this.sublayers.forEach(sublayer => sublayer.updateState(newState));
+        super.updateLayerState(newState);
+        this.sublayers.forEach(sublayer => sublayer.updateLayerState(newState));
     }
 
     updateDrawState(newState: DrawState): void {

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -4,7 +4,7 @@ import {
     InstanceAPI,
     type MapImageLayer
 } from '@/api/internal';
-import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
+import { DataFormat, InitiationState, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { markRaw } from 'vue';
 
@@ -83,9 +83,9 @@ export class MapImageSublayer extends AttribLayer {
      *
      * This is called after the parent layer is initiated
      */
-    async initiate(): Promise<void> {
-        // For now we just set initialized to true
-        this.initialized = true;
+    protected async onInitiate(): Promise<void> {
+        // For now we just set initiation state to initiated
+        this.initiationState = InitiationState.INITIATED; // hardcoding this one because we don't want event API to fire here
     }
 
     async reload(): Promise<void> {

--- a/src/geo/layer/osm-tile-layer.ts
+++ b/src/geo/layer/osm-tile-layer.ts
@@ -21,13 +21,13 @@ export class OsmTileLayer extends CommonLayer {
         this.hovertips = false;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         this.esriLayer = markRaw(
             new EsriOpenStreetMapLayer(
                 this.makeEsriLayerConfig(this.origRampConfig)
             )
         );
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**

--- a/src/geo/layer/shapefile-layer.ts
+++ b/src/geo/layer/shapefile-layer.ts
@@ -7,7 +7,7 @@ export class ShapefileLayer extends FileLayer {
         this.layerType = LayerType.SHAPEFILE;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         // TODO check if .sourceGeoJson is already populated?
         //      if this initiate is a reload, do we want to re-use it, or re-download? decide.
 
@@ -56,6 +56,6 @@ export class ShapefileLayer extends FileLayer {
         this.sourceGeoJson =
             await this.$iApi.geo.layer.files.shapefileToGeoJson(shapefileData);
 
-        await super.initiate();
+        await super.onInitiate();
     }
 }

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -18,11 +18,11 @@ export class TileLayer extends CommonLayer {
         this.dataFormat = DataFormat.ESRI_TILE;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         this.esriLayer = markRaw(
             new EsriTileLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**

--- a/src/geo/layer/wfs-layer.ts
+++ b/src/geo/layer/wfs-layer.ts
@@ -9,7 +9,7 @@ export class WfsLayer extends FileLayer {
         this.layerType = LayerType.WFS;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         const wrapper = new UrlWrapper(this.config.url);
 
         // get start index and limit set on the url
@@ -25,7 +25,6 @@ export class WfsLayer extends FileLayer {
         );
 
         // TODO error handling? set layer state to error if above call fails?
-
-        await super.initiate();
+        await super.onInitiate();
     }
 }

--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -38,11 +38,11 @@ export class WmsLayer extends CommonLayer {
         this.dataFormat = DataFormat.OGC_RASTER;
     }
 
-    async initiate(): Promise<void> {
+    protected async onInitiate(): Promise<void> {
         this.esriLayer = markRaw(
             new EsriWMSLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
-        await super.initiate();
+        await super.onInitiate();
     }
 
     /**

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -42,3 +42,4 @@ panels.controls.collapse,Collapse,1,Réduire,1
 panels.alert.open,{name} panel opened,1,Panneau de {name} ouvert,0
 panels.alert.close,{name} panel closed,1,Panneau de {name} fermé,0
 panels.alert.minimize,{name} panel minimized,1,Panneau de {name} minimisé,0
+layer.longload,{id} is taking longer than expected to load,1,{id} prend plus longtemps que prévu,0

--- a/src/store/modules/layer/layer-state.ts
+++ b/src/store/modules/layer/layer-state.ts
@@ -2,11 +2,16 @@ import type { RampLayerConfig } from '@/geo/api';
 import type { LayerInstance } from '@/api/internal';
 
 export class LayerState {
+    /** @property {LayerInstance[]} layers the layers that were initiated successfully */
     layers: LayerInstance[];
+    /** @property {LayerInstance[]} penaltyBox the layers in an error state */
+    penaltyBox: LayerInstance[];
+    /** @property {LayerInstance[]} layerConfigs configs for layers */
     layerConfigs: RampLayerConfig[];
 
     constructor(layers: LayerInstance[], configs: RampLayerConfig[]) {
         this.layers = layers;
+        this.penaltyBox = [];
         this.layerConfigs = configs;
     }
 }

--- a/src/store/modules/layer/layer-store.ts
+++ b/src/store/modules/layer/layer-store.ts
@@ -131,8 +131,19 @@ const actions = {
         });
         */
     },
+    addErrorLayers: (context: LayerContext, layers: LayerInstance[]) => {
+        if (!Array.isArray(layers)) {
+            return;
+        }
+        layers.forEach(l => {
+            context.commit('ADD_ERROR_LAYER', l);
+        });
+    },
     removeLayer: (context: LayerContext, layer: LayerInstance) => {
         context.commit('REMOVE_LAYER', layer);
+    },
+    removeErrorLayer: (context: LayerContext, layer: LayerInstance) => {
+        context.commit('REMOVE_ERROR_LAYER', layer);
     },
     removeLayerConfig: (context: LayerContext, layerId: string) => {
         context.commit('REMOVE_LAYER_CONFIG', layerId);
@@ -147,6 +158,9 @@ const mutations = {
     ADD_LAYER: (state: LayerState, value: LayerInstance) => {
         // copy to new array so watchers will have a reference to the old value
         state.layers = [...state.layers, value];
+    },
+    ADD_ERROR_LAYER: (state: LayerState, value: LayerInstance) => {
+        state.penaltyBox = [...state.penaltyBox, value];
     },
     REORDER_LAYER: (
         state: LayerState,
@@ -171,6 +185,13 @@ const mutations = {
         });
         state.layers = filteredLayers;
     },
+    REMOVE_ERROR_LAYER: (state: LayerState, value: LayerInstance) => {
+        // copy to new array so watchers will have a reference to the old value
+        const filteredLayers = state.penaltyBox.filter(layer => {
+            return layer.id !== value.id || layer.uid !== value.uid;
+        });
+        state.penaltyBox = filteredLayers;
+    },
     REMOVE_LAYER_CONFIG: (state: LayerState, layerId: string) => {
         // copy to new array so watchers will have a reference to the old value
         const filteredLayerConfigs = state.layerConfigs.filter(layerConfig => {
@@ -193,6 +214,12 @@ export enum LayerStore {
      * (State) layers: LayerInstance[]
      */
     layers = 'layer/layers',
+
+    /**
+     * (State) penaltyBox: LayerInstance[]
+     */
+    penaltyBox = 'layer/penaltyBox',
+
     /**
      * (Action) reorderLayer: ({ layer: LayerInstance, index: number })
      */
@@ -202,9 +229,17 @@ export enum LayerStore {
      */
     addLayers = 'layer/addLayers!',
     /**
+     * (Action) addErrorLayers: (layers: LayerInstance[])
+     */
+    addErrorLayers = 'layer/addErrorLayers!',
+    /**
      * (Action) removeLayer: (layer: LayerInstance)
      */
     removeLayer = 'layer/removeLayer!',
+    /**
+     * (Action) removeLayer: (layer: LayerInstance)
+     */
+    removeErrorLayer = 'layer/removeErrorLayer!',
     /**
      * (State) layerConfigs: RampLayerConfig[]
      */


### PR DESCRIPTION
Closes #1208, #1020.
This PR aims to improve layer initiation and error handling.

### Changes
* Implemented the second state found in discussion #992. A layer now has two states: ~~`loadState`~~ `layerState` is the `state` we already have and represents the lifecycle of the ESRI layer, whereas the new ~~`layerState`~~ `initiationState` represents the lifecycle of the layer in RAMP and is used for initiation purposes.
* Implemented `expectedResponseTime` - a slow to load notification is shown via the notification API for slow loading layers (will also trigger on reload). In its current design, the timer will be disabled if a value `<= 0` is passed in the config, it will resort to the default value (4 seconds, copied from RAMP2) if nothing is specified, and will take the value specified in the config otherwise. Note that the timer currently only times the layer's "server handshake" - it would be nice to also have another `expectedDrawTime` timer that times the drawing on the map.
* Improved error handling on layer initiation. The legend will now react to layer error and error instantly instead of going to an error state on timeout. Note that in the current RAMP design, the `LayerStore` only stores layers that are not in an error state. To avoid making changes all across RAMP, a new `penaltyBox` array has been added to the `LayerStore state` which stores layers in error state, but perhaps we may want to come up with a better solution. 

### Testing
* Ensure that all the layer magic works correctly as before.
* For the `expectedResponseTime`, I have temporarily changed the WFS layer to have an `expectedResponseTime` of 10 milliseconds so that the notification appears for testing purposes.
* For error handling, I have temporarily broken the layer on the CAM sample. Notice how the layer goes into error rather than loading for a while. Feel free to test this by passing in a config with broken layers into RAMP as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1252)
<!-- Reviewable:end -->
