### PR TITLE
Map Caption Coords for Crosshairs

### DIFF
--- a/demos/starter-scripts/custom-renderer.js
+++ b/demos/starter-scripts/custom-renderer.js
@@ -34,7 +34,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -34,7 +34,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {

--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -47,7 +47,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {
@@ -484,7 +484,7 @@ let config2 = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {
@@ -921,7 +921,7 @@ let config3 = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -34,7 +34,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {

--- a/demos/starter-scripts/ramp-basic.js
+++ b/demos/starter-scripts/ramp-basic.js
@@ -34,7 +34,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -34,7 +34,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {

--- a/public/help/default/en.md
+++ b/public/help/default/en.md
@@ -34,7 +34,7 @@ The following navigation controls can be found in the bottom right corner of the
 
 # Navigation Information
 
-The navigation information is located in the lower right corner of the map and includes map scale and mouse cursor positioning coordinates.
+The navigation information is located in the lower right corner of the map and includes map scale and mouse/crosshairs positioning coordinates.
 
 The positioning coordinates can be in degrees minutes seconds (DMS), decimal degrees or meters depending on the projection and configuration used.
 

--- a/public/help/default/fr.md
+++ b/public/help/default/fr.md
@@ -34,7 +34,7 @@
 
 # [fr] Navigation Information
 
-[fr] The navigation information is located in the lower right corner of the map and includes map scale and mouse cursor positioning coordinates.
+[fr] The navigation information is located in the lower right corner of the map and includes map scale and mouse/crosshairs positioning coordinates.
 
 [fr] The positioning coordinates can be in degrees minutes seconds (DMS), decimal degrees or meters depending on the projection and configuration used.
 

--- a/public/starter-scripts/cam.js
+++ b/public/starter-scripts/cam.js
@@ -53,7 +53,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'LAT_LONG_DMS'
                     },
                     scaleBar: {
@@ -438,7 +438,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'LAT_LONG_DMS'
                     },
                     scaleBar: {

--- a/public/starter-scripts/cesi.js
+++ b/public/starter-scripts/cesi.js
@@ -52,7 +52,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'LAT_LONG_DMS'
                     },
                     scaleBar: {

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -32,7 +32,7 @@ let config = {
                     }
                 ],
                 caption: {
-                    mouseCoords: {
+                    mapCoords: {
                         formatter: 'WEB_MERCATOR'
                     },
                     scaleBar: {

--- a/schema.json
+++ b/schema.json
@@ -2092,9 +2092,9 @@
                     "type": "object",
                     "description": "Configuration for the components in the map caption bar",
                     "properties": {
-                        "mouseCoords": {
+                        "mapCoords": {
                             "type": "object",
-                            "description": "Configuration for mouse co-ords",
+                            "description": "Configuration for mouse/crosshairs co-ords",
                             "properties": {
                                 "disabled": {
                                     "type": "boolean",
@@ -2132,7 +2132,7 @@
                             }
                         }
                     },
-                    "required": ["mouseCoords", "scaleBar"]
+                    "required": ["mapCoords", "scaleBar"]
                 },
                 "pointZoomScale": {
                     "type": "number",

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -199,7 +199,7 @@ function mapUpgrader(r2Map: any, r4c: any): void {
         }
         if (r2Map.components.scaleBar && r2Map.components.scaleBar.enabled) {
             r4c.map.caption = {
-                mouseCoords: {
+                mapCoords: {
                     disabled: false,
                     formatter: 'LAT_LONG_DMS'
                 },

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -50,7 +50,7 @@
 
         <div class="flex min-w-fit justify-end">
             <div
-                v-if="!cursorCoords.disabled"
+                v-if="!coords.disabled"
                 class="relative top-2 pl-8 px-14 sm:block display-none"
                 v-truncate="{
                     options: {
@@ -60,7 +60,7 @@
                     }
                 }"
             >
-                {{ cursorCoords.formattedString }}
+                {{ coords.formattedString }}
             </div>
 
             <button
@@ -134,7 +134,7 @@ export default defineComponent({
         return {
             scale: this.get(MapCaptionStore.scale),
             attribution: this.get(MapCaptionStore.attribution),
-            cursorCoords: this.get(MapCaptionStore.cursorCoords),
+            coords: this.get(MapCaptionStore.coords),
             mapConfig: this.get(ConfigStore.getMapConfig),
             lang: [] as Array<string>,
             watchers: [] as Array<Function>

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -442,8 +442,8 @@ export interface ScaleHelper {
     distance: number;
 }
 
-// Contains properties needed to display mouse co-ords on the map-caption bar
-export interface MouseCoords {
+// Contains properties needed to display mouse/crosshairs co-ords on the map-caption bar
+export interface MapCoords {
     disabled?: boolean;
     formattedString?: string;
 }
@@ -631,7 +631,7 @@ export interface RampLodConfig {
 
 // Contains properties for compoents on the map caption bar
 export interface MapCaptionConfig {
-    mouseCoords: { disabled?: boolean; formatter?: string };
+    mapCoords: { disabled?: boolean; formatter?: string };
     scaleBar: { disabled?: boolean; imperialScale?: boolean };
 }
 

--- a/src/geo/map/caption.ts
+++ b/src/geo/map/caption.ts
@@ -44,15 +44,15 @@ export class MapCaptionAPI extends APIScope {
             return;
         }
 
-        // check if mouse coords has been disabled
-        if (captionConfig.mouseCoords.disabled) {
-            this.$iApi.$vApp.$store.set(MapCaptionStore.setCursorCoords, {
+        // check if map coords has been disabled
+        if (captionConfig.mapCoords.disabled) {
+            this.$iApi.$vApp.$store.set(MapCaptionStore.setCoords, {
                 disabled: true
             });
         } else {
             // get formatter specified in the config
             const defaultFormatter: string | undefined =
-                captionConfig.mouseCoords.formatter;
+                captionConfig.mapCoords.formatter;
             if (defaultFormatter !== undefined) {
                 this.setPointFormatter(defaultFormatter);
             }

--- a/src/store/modules/map-caption/map-caption-state.ts
+++ b/src/store/modules/map-caption/map-caption-state.ts
@@ -1,17 +1,13 @@
-import type { Attribution, ScaleBar, MouseCoords } from '@/geo/api';
+import type { Attribution, ScaleBar, MapCoords } from '@/geo/api';
 
 export class MapCaptionState {
     attribution: Attribution;
     scale: ScaleBar;
-    cursorCoords: MouseCoords;
+    coords: MapCoords;
 
-    constructor(
-        attrib: Attribution,
-        scale: ScaleBar,
-        cursorCoords: MouseCoords
-    ) {
+    constructor(attrib: Attribution, scale: ScaleBar, coords: MapCoords) {
         this.attribution = attrib;
         this.scale = scale;
-        this.cursorCoords = cursorCoords;
+        this.coords = coords;
     }
 }

--- a/src/store/modules/map-caption/map-caption-store.ts
+++ b/src/store/modules/map-caption/map-caption-store.ts
@@ -3,7 +3,7 @@ import { make } from 'vuex-pathify';
 
 import { MapCaptionState } from './map-caption-state';
 import type { RootState } from '@/store';
-import type { Attribution, MouseCoords, ScaleBar } from '@/geo/api';
+import type { Attribution, MapCoords, ScaleBar } from '@/geo/api';
 
 type MapCaptionContext = ActionContext<MapCaptionState, RootState>;
 
@@ -13,11 +13,8 @@ const actions = {
     setAttribution: (context: MapCaptionContext, attribution: Attribution) => {
         context.commit('SET_ATTRIBUTION', attribution);
     },
-    setCursorCoords: (
-        context: MapCaptionContext,
-        cursorCoords: MouseCoords
-    ) => {
-        context.commit('SET_CURSOR_COORDS', cursorCoords);
+    setCoords: (context: MapCaptionContext, coords: MapCoords) => {
+        context.commit('SET_COORDS', coords);
     },
     setScale: (context: MapCaptionContext, scale: ScaleBar) => {
         context.commit('SET_SCALE', scale);
@@ -31,8 +28,8 @@ const mutations = {
     SET_ATTRIBUTION: (state: MapCaptionState, value: Attribution) => {
         state.attribution = value;
     },
-    SET_CURSOR_COORDS: (state: MapCaptionState, value: MouseCoords) => {
-        state.cursorCoords = value;
+    SET_COORDS: (state: MapCaptionState, value: MapCoords) => {
+        state.coords = value;
     },
     SET_SCALE: (state: MapCaptionState, value: ScaleBar) => {
         state.scale = value;
@@ -56,13 +53,13 @@ export enum MapCaptionStore {
      */
     setAttribution = 'mapcaption/setAttribution!',
     /**
-     * (State) cursorCoords: MouseCoords
+     * (State) coords: MapCoords
      */
-    cursorCoords = 'mapcaption/cursorCoords',
+    coords = 'mapcaption/coords',
     /**
-     * (Action) setCursorCoords: (cursorCoords: MouseCoords)
+     * (Action) setCoords: (coords: MapCoords)
      */
-    setCursorCoords = 'mapcaption/setCursorCoords!',
+    setCoords = 'mapcaption/setCoords!',
     /**
      * (State) scale: ScaleBar
      */


### PR DESCRIPTION
Closes #1210.

The mouse coordinates on the bottom right of the map caption will now also reflect the position of the center of the crosshairs when panning the map using the keyboard.

A lot of the file changes are simply to do with refactoring `MouseCoords` to `MapCoords` and related terms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1253)
<!-- Reviewable:end -->
