### PR TITLE
Add colour picker to wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
                 "tiny-emitter": "^2.1.0",
                 "tippy.js": "next",
                 "vue": "^3.2.31",
+                "vue-accessible-color-picker": "^4.0.3",
                 "vue-i18n": "^9.1.7",
                 "vue-tippy": "next",
                 "vuedraggable": "next",
@@ -20663,6 +20664,14 @@
                 "@vue/shared": "3.2.31"
             }
         },
+        "node_modules/vue-accessible-color-picker": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vue-accessible-color-picker/-/vue-accessible-color-picker-4.0.3.tgz",
+            "integrity": "sha512-L+HCLerK4ECJoX3Yzt1gaUArPMgudz8h2OJzR3dtdGHwMxGiLcrXMzQN4VDirAwAGLPd3RW/O8cwy1+0zW295g==",
+            "peerDependencies": {
+                "vue": "^3.2.x"
+            }
+        },
         "node_modules/vue-class-component": {
             "version": "8.0.0-rc.1",
             "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-8.0.0-rc.1.tgz",
@@ -38287,6 +38296,12 @@
                 "@vue/server-renderer": "3.2.31",
                 "@vue/shared": "3.2.31"
             }
+        },
+        "vue-accessible-color-picker": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vue-accessible-color-picker/-/vue-accessible-color-picker-4.0.3.tgz",
+            "integrity": "sha512-L+HCLerK4ECJoX3Yzt1gaUArPMgudz8h2OJzR3dtdGHwMxGiLcrXMzQN4VDirAwAGLPd3RW/O8cwy1+0zW295g==",
+            "requires": {}
         },
         "vue-class-component": {
             "version": "8.0.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "tiny-emitter": "^2.1.0",
         "tippy.js": "next",
         "vue": "^3.2.31",
+        "vue-accessible-color-picker": "^4.0.3",
         "vue-i18n": "^9.1.7",
         "vue-tippy": "next",
         "vuedraggable": "next",

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -35,5 +35,9 @@ wizard.configure.longField.label,Longitude Field,1,Champ longitude,1
 wizard.configure.sublayers.error.required,Sublayers are required,1,Le sous-couche est obligatoire,0
 wizard.configure.sublayers.label,Layers,1,Couches,1
 wizard.configure.sublayers.help,Hold Ctrl to select multiple layers,1,Maintenez la touche CTRL enfoncée pour sélectionner plusieurs couches,1
+wizard.configure.colour.label,Colour,1,Couleur,0
+wizard.configure.colour.hue,Hue,1,Hue,0
+wizard.configure.colour.copy,Copy colour,1,Copier la couleur,0
+wizard.configure.colour.hex,Hex,1,Hex,0
 wizard.step.cancel,Cancel,1,Annuler,1
 wizard.step.continue,Continue,1,Continuer,1

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -165,7 +165,7 @@ export class LayerSource extends APIScope {
         return {
             config,
             fields: response.data.fields,
-            configOptions: ['name', 'nameField', 'tooltipField', 'colour']
+            configOptions: ['name', 'nameField', 'tooltipField']
         };
     }
 

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -77,7 +77,7 @@ export class LayerSource extends APIScope {
             fields: [{ name: 'OBJECTID', type: 'oid' }].concat(
                 this.$iApi.geo.layer.files.extractGeoJsonFields(fileData)
             ),
-            configOptions: ['name', 'nameField', 'tooltipField']
+            configOptions: ['name', 'nameField', 'tooltipField', 'colour']
         };
     }
 
@@ -105,7 +105,8 @@ export class LayerSource extends APIScope {
                 'nameField',
                 'tooltipField',
                 'latField',
-                'longField'
+                'longField',
+                'colour'
             ]
         };
     }
@@ -164,7 +165,7 @@ export class LayerSource extends APIScope {
         return {
             config,
             fields: response.data.fields,
-            configOptions: ['name', 'nameField', 'tooltipField']
+            configOptions: ['name', 'nameField', 'tooltipField', 'colour']
         };
     }
 


### PR DESCRIPTION
Closes #440 

Adds https://github.com/kleinfreund/vue-accessible-color-picker

- Had to label the hex input myself as there was no slot like the other controls.
- Generates a random colour each time
- Generates a random ID prefix to avoid multi-ramp conflicts

Testing:
Add layers, colour picker should appear on layers that can use it, a new colour should be generated each time you try to add a layer.
Also attempt to use the colour picker with keyboard only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1254)
<!-- Reviewable:end -->
