### PR TITLE
Language Menu Colour Fix

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -130,9 +130,10 @@ export default defineComponent({
 
 <style lang="scss">
 .rv-dropdown > * {
-    display: block;
     padding: 0.5rem 1rem;
-    color: #2d3748;
+    display: block !important;
+    color: #2d3748 !important;
+    text-decoration: none !important;
 }
 .rv-dropdown > *:hover:not(.disabled) {
     background-color: #eee;

--- a/src/fixtures/grid/column-dropdown.vue
+++ b/src/fixtures/grid/column-dropdown.vue
@@ -38,10 +38,15 @@
             href="#"
             class="flex leading-snug items-center w-256"
         >
-            {{ col.headerName }}
-            <div class="flex-auto"></div>
-            <div class="md-icon-small inline" v-if="!col.hide">
-                <svg height="18" width="18" viewBox="0 0 24 24" class="inline">
+            <div class="md-icon-small inline">
+                {{ col.headerName }}
+                <svg
+                    height="18"
+                    width="18"
+                    viewBox="0 0 24 24"
+                    class="inline float-right"
+                    v-if="!col.hide"
+                >
                     <g id="done">
                         <path
                             d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"


### PR DESCRIPTION
Closes #1221.

This PR fixes the colouring of the language menu. Also, the link styling of the column dropdown menu in the grid fixture is fixed, so the options no longer appear as web URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1257)
<!-- Reviewable:end -->
