### PR TITLE
Fixed tooltip text in legend

### DIFF
--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -6,8 +6,8 @@
             :aria-label="
                 $t(
                     checked
-                        ? 'legend.visibility.hide'
-                        : 'legend.visibility.show'
+                        ? `legend.visibility.hide${label}`
+                        : `legend.visibility.show${label}`
                 )
             "
             :checked="checked && initialChecked"
@@ -23,8 +23,8 @@
             :content="
                 $t(
                     checked
-                        ? 'legend.visibility.hide'
-                        : 'legend.visibility.show'
+                        ? `legend.visibility.hide${label}`
+                        : `legend.visibility.show${label}`
                 )
             "
             v-tippy="{ placement: 'top-end', hideOnClick: false }"
@@ -48,6 +48,7 @@ export default defineComponent({
         },
         legendItem: { type: Object as PropType<LegendEntry>, required: true },
         checked: { type: Boolean },
+        label: { type: String },
         isRadio: { type: Boolean },
         disabled: { type: Boolean }
     },

--- a/src/fixtures/legend/components/entry.vue
+++ b/src/fixtures/legend/components/entry.vue
@@ -88,6 +88,7 @@
                     "
                     :legendItem="legendItem"
                     :disabled="!legendItem.controlAvailable('visibility')"
+                    label="Layer"
                 />
             </div>
         </div>
@@ -138,6 +139,7 @@
                             :disabled="
                                 !legendItem.controlAvailable('visibility')
                             "
+                            label="Symbol"
                         />
                     </div>
                 </div>

--- a/src/fixtures/legend/components/group.vue
+++ b/src/fixtures/legend/components/group.vue
@@ -48,6 +48,7 @@
                     "
                     :legendItem="legendItem"
                     :disabled="!legendItem.controlAvailable('visibility')"
+                    label="Group"
                 />
             </div>
         </div>

--- a/src/fixtures/legend/lang/lang.csv
+++ b/src/fixtures/legend/lang/lang.csv
@@ -10,8 +10,12 @@ legend.header.visible.show,Show All,1,Montrer tout,1
 legend.header.visible.hide,Hide All,1,Cacher tout,1
 legend.group.expand,Expand Group,1,Développer un groupe,1
 legend.group.collapse,Collapse Group,1,Réduire un groupe,1
-legend.visibility.show,Show layer,1,Afficher la couche,1
-legend.visibility.hide,Hide layer,1,Masquer la couche,1
+legend.visibility.showLayer,Show layer,1,Afficher la couche,1
+legend.visibility.hideLayer,Hide layer,1,Masquer la couche,1
+legend.visibility.showSymbol,Show symbol,1,Afficher le symbole,0
+legend.visibility.hideSymbol,Hide symbol,1,Masquer le symbole,0
+legend.visibility.showGroup,Show group,1,Afficher le groupe,0
+legend.visibility.hideGroup,Hide group,1,Masquer le groupe,0
 legend.symbology.expand,Expand legend,1,Développer la légende,1
 legend.symbology.hide,Hide legend,1,Masquer la légende,1
 legend.symbology.loading,Loading...,1,Chargement en cours...,1


### PR DESCRIPTION
Closes #1232.

Previously, the legend checkbox tooltip would show "Show layer" and "Hide layer" regardless of whether the checkbox was for a layer, a group, or a symbol. This is now fixed so that each checkbox shows its appropriate text in the tooltip.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1258)
<!-- Reviewable:end -->
