### PR TITLE
fix cut-off panguard text

### DIFF
--- a/src/fixtures/panguard/map-panguard.vue
+++ b/src/fixtures/panguard/map-panguard.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="pan-guard" ref="panGuard">
-        <p class="label">{{ $t('panguard.instructions') }}</p>
+    <div class="pg" ref="panGuard">
+        <p class="pg-label">{{ $t('panguard.instructions') }}</p>
     </div>
 </template>
 
@@ -92,14 +92,14 @@ export default defineComponent({
                         if (distance < 20) return;
 
                         // show the text on screen and remove after 2 seconds of no movement
-                        this.$el.classList.add('active');
+                        this.$el.classList.add('pg-active');
 
                         if (this.timeoutID !== -1) {
                             clearTimeout(this.timeoutID);
                         }
 
                         this.timeoutID = window.setTimeout(() => {
-                            this.$el.classList.remove('active');
+                            this.$el.classList.remove('pg-active');
                         }, 2000);
 
                         // manually scroll the page since scrolling doesn't work when moving over the map
@@ -113,7 +113,7 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.pan-guard {
+.pg {
     transition: opacity ease-in-out;
     background-color: rgba(0, 0, 0, 0.45);
     text-align: center;
@@ -130,15 +130,15 @@ export default defineComponent({
     transition-duration: 0.8s;
 
     opacity: 0;
-    z-index: 100;
     pointer-events: none !important;
+    z-index: 100;
 
-    &.active {
+    &.pg-active {
         opacity: 1;
         transition-duration: 0.3s;
     }
 
-    .label {
+    .pg-label {
         font-size: 1em * 1.5;
         color: white;
         position: relative;


### PR DESCRIPTION
Closes #1240 

This PR changes ensures that the panguard fixture text is not cut-off on smaller devices. Also made some small CSS class name changes to have more consistency between the panguard and scrollguard fixtures.

To test this PR, open the demo link to the [`index-wet.html` page](https://ramp4-pcar4.github.io/ramp4-pcar4/fix-1240/demos/index-wet.html) on a mobile device or use the Chrome emulator. Try to pan the screen. The text should no longer be cut off when the panguard overlay appears.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1260)
<!-- Reviewable:end -->
