### PR TITLE
Export Panel and Notifications Fixes

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -436,7 +436,7 @@ let config = {
                 },
                 export: {
                     title: {
-                        value: 'All Your Base are Belong to Us',
+                        value: 'All Your Base are Belong to Us All Your Base are Belong to Us All Your Base are Belong to Us',
                         selectable: false
                     },
                     legend: {

--- a/src/components/notification-center/notification-item.vue
+++ b/src/components/notification-center/notification-item.vue
@@ -12,7 +12,7 @@
         @click="open = !open"
         :class="notification.messageList ? 'cursor-pointer' : ''"
     >
-        <div class="flex items-center h-32">
+        <div class="flex items-center text-left">
             <span
                 >{{ icons[notification.type] }} {{ notification.message }}</span
             >

--- a/src/fixtures/export-title/index.ts
+++ b/src/fixtures/export-title/index.ts
@@ -32,7 +32,7 @@ class ExportTitleFixture extends FixtureInstance implements ExportSubFixture {
         }
 
         const config: any = merge(fabricTextConfig, options || {});
-        const fbTitle = new fabric.Text(config.text, config);
+        const fbTitle = new fabric.Textbox(config.text, config);
         return Promise.resolve(fbTitle);
     }
 }

--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -121,7 +121,9 @@ export class ExportAPI extends FixtureInstance {
                 /* text: '😸🤖🧙‍♂️🤦‍♀️🎶', */
                 top: this.options.runningHeight,
                 left: 0,
-                originX: 'left'
+                originX: 'left',
+                width: panelWidth,
+                textAlign: 'center'
             });
             this.options.runningHeight += fbTitle.height! + 40;
             selectedExportComponents.push(fbTitle);
@@ -140,6 +142,11 @@ export class ExportAPI extends FixtureInstance {
 
             this.options.runningHeight += fbMap.height! + 40;
             selectedExportComponents.push(fbMap);
+        }
+
+        // title should spread to length of canvas if map isn't rendered
+        if (!fbMap && fbTitle) {
+            fbTitle.width = DEFAULT_WIDTH;
         }
 
         this.options.scale =

--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -12,7 +12,7 @@
             <div class="flex">
                 <button
                     @click="fixture?.export()"
-                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-16 mr-16"
+                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-8 sm:px-16 mr-8 sm:mr-16"
                     :aria-label="$t('export.download')"
                 >
                     {{ $t('export.download') }}
@@ -20,7 +20,7 @@
 
                 <button
                     @click="make()"
-                    class="py-8 px-16"
+                    class="py-8 px-4 sm:px-16"
                     :aria-label="$t('export.refresh')"
                 >
                     {{ $t('export.refresh') }}
@@ -29,7 +29,7 @@
                 <export-settings
                     :componentSelectedState="selectedComponents"
                     :onComponentToggle="make()"
-                    class="ml-auto flex px-8"
+                    class="ml-auto flex px-4 sm:px-8"
                 ></export-settings>
             </div>
         </template>

--- a/src/fixtures/export/settings-button.vue
+++ b/src/fixtures/export/settings-button.vue
@@ -1,13 +1,13 @@
 <template>
     <dropdown-menu
         v-focus-item
-        position="left-end"
+        :position="dropdownPlacement"
         :tooltip="$t('export.menu')"
         tooltip-placement="top"
     >
         <template #header>
             <div
-                class="flex items-center text-gray-400 w-full h-full hover:text-black p-8"
+                class="flex items-center text-gray-400 w-full h-full hover:text-black p-4 sm:p-8"
             >
                 <svg
                     class="fill-current w-24 h-24 m-auto"
@@ -70,6 +70,15 @@ import { ExportStore } from './store';
 
 export default defineComponent({
     name: 'ExportSettingsButtonV',
+    data() {
+        return {
+            dropdownPlacement: !this.$root.$refs['app-size'].classList.contains(
+                'sm'
+            )
+                ? 'top-end'
+                : 'left-end'
+        };
+    },
     props: {
         componentSelectedState: {
             type: Object,


### PR DESCRIPTION
Closes #1235, #1262.

### Changes
- map title now wraps to new lines when too long to prevent overflow
- export settings button no longer gets pushed off screen at low resolutions
- export settings dropdown positions better at low resolutions
- long notifications are formatted correctly

### Testing
For the export panel, you can observe the changes by opening it at low resolutions. I made the map title longer on the [main demo sample](https://ramp4-pcar4.github.io/ramp4-pcar4/1235/demos/index.html) to demonstrate the text wrapping.

For the notifications, you can run the command below in the console to fire a notification with a long string.
`debugInstance.notify.show("error", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")`


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1263)
<!-- Reviewable:end -->
