### PR TITLE
Hybrid Identify and Layer Draw Order

### DIFF
--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -279,6 +279,20 @@ myLayer.isRemoved; // false
 myLayer.supportsIdentify; // true
 ```
 
+Layers also have method `.canIdentify()` which indicates if the layer would partipate in an identify at the current moment. This method takes into account things like layer visibility, the value of the `.identify` toggle, if the layer is in a loading or error state, etc.
+
+```js
+myLayer.canIdentify(); // true
+```
+
+Layers also have the property `.identifyMode`. This can be `'geometric'` (using intersection against feature geometry), `'symbolic'` (using intersection against layer symbols), or `'hybrid'` (combining both types of intersections). Raster based layers (Map Image, WMS) are always in `geometric` mode since there is no client side renderers to leverage. Vector based layers can choose any of the modes.
+
+```js
+myLayer.identifyMode; // 'hybrid'
+```
+
+The typical identify process is run from the map, using `MapAPI.runIdentify()`. This will execute the identify across all valid layers and collate the results. However, the following goes into the guts of how each layer contributes to that process. Custom modules are allowed to run identifies directly off layers if it is advantageous.
+
 The `.runIdentify()` method will execute an identify request on the layer. Identify is not directly called on logical sublayers. RAMP's sublayer filter can be overridden using the below options parameter object.
 
 Options parameter object:
@@ -348,6 +362,12 @@ Get the geometry type of the logical layer.
 
 ```js
 myLayer.geomType; // "polygon"
+```
+
+Get the draw order of the layer. Not supported by Map Image Layers. Can only be set via layer configuration. ESRI currently only supports ordering by one field.
+
+```js
+myLayer.drawOrder; // [{ field: 'name', ascending: true }]
 ```
 
 Request the set of attributes for the logical layer. The first request will incur the server hit. Subsequent requests will use the cached result.

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare const __VERSION__: {
+declare const __RAMP_VERSION__: {
     major: string;
     minor: string;
     patch: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "ramp",
             "version": "4.0.0-alpha",
             "dependencies": {
-                "@arcgis/core": "4.22.2",
+                "@arcgis/core": "4.24.7",
                 "@braid/vue-formulate": "~2.5.2",
                 "@ecgc/vue-slider-component": "4.0.0-beta.7",
                 "@popperjs/core": "~2.9.2",
@@ -90,7 +90,8 @@
         },
         "node_modules/@a11y/focus-trap": {
             "version": "1.0.5",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
+            "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
         },
         "node_modules/@actions/core": {
             "version": "1.6.0",
@@ -151,26 +152,32 @@
             }
         },
         "node_modules/@arcgis/core": {
-            "version": "4.22.2",
-            "license": "SEE LICENSE IN copyright.txt",
+            "version": "4.24.7",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.24.7.tgz",
+            "integrity": "sha512-uDkF4/3zOOFDzFEXxAaENhtz7hhkmOw71R96rfVPjqIfRxd2HxgrpNlrjXI8xYC2ub8rRpBZ6WmxlvaCn/zu7Q==",
             "dependencies": {
-                "@esri/arcgis-html-sanitizer": "~2.9.0-next.1",
+                "@esri/arcgis-html-sanitizer": "~2.10.0",
                 "@esri/calcite-colors": "~6.0.1",
-                "@esri/calcite-components": "1.0.0-beta.69",
-                "@popperjs/core": "~2.10.2",
-                "focus-trap": "~6.7.1",
-                "luxon": "~2.1.1",
-                "moment": "~2.29.1",
-                "sortablejs": "~1.14.0"
+                "@esri/calcite-components": "1.0.0-beta.82",
+                "@popperjs/core": "~2.11.5",
+                "focus-trap": "~6.9.4",
+                "luxon": "~2.4.0",
+                "sortablejs": "~1.15.0"
             }
         },
         "node_modules/@arcgis/core/node_modules/@popperjs/core": {
-            "version": "2.10.2",
-            "license": "MIT",
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
+        },
+        "node_modules/@arcgis/core/node_modules/sortablejs": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.16.7",
@@ -2072,11 +2079,12 @@
             }
         },
         "node_modules/@esri/arcgis-html-sanitizer": {
-            "version": "2.9.0",
-            "license": "Apache-2.0",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.10.0.tgz",
+            "integrity": "sha512-OGrczx3sbszMVQESGdZf2BaZL/oGMm+wuFgF6od50ff0WThjiJDTxi5SXIleRF6QQVFywsab3sFbQ77Q/gSzsg==",
             "dependencies": {
                 "lodash.isplainobject": "^4.0.6",
-                "xss": "^1.0.10"
+                "xss": "^1.0.11"
             }
         },
         "node_modules/@esri/calcite-colors": {
@@ -2084,25 +2092,33 @@
             "license": "SEE LICENSE IN README.md"
         },
         "node_modules/@esri/calcite-components": {
-            "version": "1.0.0-beta.69",
-            "license": "SEE LICENSE IN copyright.txt",
+            "version": "1.0.0-beta.82",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.82.tgz",
+            "integrity": "sha512-wAJeEZ4g/TiJ4J6z/GO9YQFSFubQERCWEo71jr2xLmegxEQIYHL3AvJaLmp0IBsr2tVzRG1TN2PVuew4ljp8WA==",
             "dependencies": {
                 "@a11y/focus-trap": "1.0.5",
-                "@popperjs/core": "2.10.2",
-                "@stencil/core": "2.10.0",
-                "@types/color": "3.0.2",
-                "color": "4.0.1",
+                "@popperjs/core": "2.11.5",
+                "@stencil/core": "2.15.1",
+                "@types/color": "3.0.3",
+                "color": "4.2.3",
+                "form-request-submit-polyfill": "2.0.0",
                 "lodash-es": "4.17.21",
-                "sortablejs": "1.14.0"
+                "sortablejs": "1.15.0"
             }
         },
         "node_modules/@esri/calcite-components/node_modules/@popperjs/core": {
-            "version": "2.10.2",
-            "license": "MIT",
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
+        },
+        "node_modules/@esri/calcite-components/node_modules/sortablejs": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
         },
         "node_modules/@hapi/hoek": {
             "version": "9.2.1",
@@ -2506,8 +2522,9 @@
             }
         },
         "node_modules/@stencil/core": {
-            "version": "2.10.0",
-            "license": "MIT",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.1.tgz",
+            "integrity": "sha512-NYjRwQnjzscyFfqK+iIwRdr/dgYn33u6KE7kyQWdi7xsCkqMHalXYgJlN/QBQ9PN3qXmXKeBrJNG8EkNdCbK5g==",
             "bin": {
                 "stencil": "bin/stencil"
             },
@@ -2559,22 +2576,25 @@
             "license": "MIT"
         },
         "node_modules/@types/color": {
-            "version": "3.0.2",
-            "license": "MIT",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
+            "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
             "dependencies": {
                 "@types/color-convert": "*"
             }
         },
         "node_modules/@types/color-convert": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
+            "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
             "dependencies": {
                 "@types/color-name": "*"
             }
         },
         "node_modules/@types/color-name": {
             "version": "1.1.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "node_modules/@types/connect": {
             "version": "3.4.35",
@@ -7005,11 +7025,15 @@
             }
         },
         "node_modules/color": {
-            "version": "4.0.1",
-            "license": "MIT",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "dependencies": {
                 "color-convert": "^2.0.1",
-                "color-string": "^1.6.0"
+                "color-string": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=12.5.0"
             }
         },
         "node_modules/color-convert": {
@@ -7871,7 +7895,8 @@
         },
         "node_modules/cssfilter": {
             "version": "0.0.10",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
         },
         "node_modules/cssnano": {
             "version": "4.1.11",
@@ -10747,10 +10772,11 @@
             }
         },
         "node_modules/focus-trap": {
-            "version": "6.7.3",
-            "license": "MIT",
+            "version": "6.9.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+            "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
             "dependencies": {
-                "tabbable": "^5.2.1"
+                "tabbable": "^5.3.3"
             }
         },
         "node_modules/follow-redirects": {
@@ -10806,6 +10832,11 @@
             "engines": {
                 "node": ">= 0.12"
             }
+        },
+        "node_modules/form-request-submit-polyfill": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
+            "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
         },
         "node_modules/forwarded": {
             "version": "0.2.0",
@@ -13150,7 +13181,8 @@
         },
         "node_modules/lodash-es": {
             "version": "4.17.21",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash._reinterpolate": {
             "version": "3.0.0",
@@ -13172,7 +13204,8 @@
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "node_modules/lodash.kebabcase": {
             "version": "4.1.1",
@@ -13328,8 +13361,9 @@
             "license": "MIT"
         },
         "node_modules/luxon": {
-            "version": "2.1.1",
-            "license": "MIT",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
+            "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==",
             "engines": {
                 "node": ">=12"
             }
@@ -13779,13 +13813,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/moment": {
-            "version": "2.29.2",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/move-concurrently": {
@@ -19291,8 +19318,9 @@
             "optional": true
         },
         "node_modules/tabbable": {
-            "version": "5.2.1",
-            "license": "MIT"
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
         },
         "node_modules/tailwindcss": {
             "version": "3.0.23",
@@ -22613,8 +22641,9 @@
             "optional": true
         },
         "node_modules/xss": {
-            "version": "1.0.11",
-            "license": "MIT",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
+            "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
             "dependencies": {
                 "commander": "^2.20.3",
                 "cssfilter": "0.0.10"
@@ -22628,7 +22657,8 @@
         },
         "node_modules/xss/node_modules/commander": {
             "version": "2.20.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/xtend": {
             "version": "4.0.2",
@@ -22800,7 +22830,9 @@
     },
     "dependencies": {
         "@a11y/focus-trap": {
-            "version": "1.0.5"
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
+            "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
         },
         "@actions/core": {
             "version": "1.6.0",
@@ -22858,20 +22890,28 @@
             }
         },
         "@arcgis/core": {
-            "version": "4.22.2",
+            "version": "4.24.7",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.24.7.tgz",
+            "integrity": "sha512-uDkF4/3zOOFDzFEXxAaENhtz7hhkmOw71R96rfVPjqIfRxd2HxgrpNlrjXI8xYC2ub8rRpBZ6WmxlvaCn/zu7Q==",
             "requires": {
-                "@esri/arcgis-html-sanitizer": "~2.9.0-next.1",
+                "@esri/arcgis-html-sanitizer": "~2.10.0",
                 "@esri/calcite-colors": "~6.0.1",
-                "@esri/calcite-components": "1.0.0-beta.69",
-                "@popperjs/core": "~2.10.2",
-                "focus-trap": "~6.7.1",
-                "luxon": "~2.1.1",
-                "moment": "~2.29.1",
-                "sortablejs": "~1.14.0"
+                "@esri/calcite-components": "1.0.0-beta.82",
+                "@popperjs/core": "~2.11.5",
+                "focus-trap": "~6.9.4",
+                "luxon": "~2.4.0",
+                "sortablejs": "~1.15.0"
             },
             "dependencies": {
                 "@popperjs/core": {
-                    "version": "2.10.2"
+                    "version": "2.11.5",
+                    "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+                    "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+                },
+                "sortablejs": {
+                    "version": "1.15.0",
+                    "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+                    "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
                 }
             }
         },
@@ -24207,29 +24247,41 @@
             }
         },
         "@esri/arcgis-html-sanitizer": {
-            "version": "2.9.0",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.10.0.tgz",
+            "integrity": "sha512-OGrczx3sbszMVQESGdZf2BaZL/oGMm+wuFgF6od50ff0WThjiJDTxi5SXIleRF6QQVFywsab3sFbQ77Q/gSzsg==",
             "requires": {
                 "lodash.isplainobject": "^4.0.6",
-                "xss": "^1.0.10"
+                "xss": "^1.0.11"
             }
         },
         "@esri/calcite-colors": {
             "version": "6.0.1"
         },
         "@esri/calcite-components": {
-            "version": "1.0.0-beta.69",
+            "version": "1.0.0-beta.82",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.82.tgz",
+            "integrity": "sha512-wAJeEZ4g/TiJ4J6z/GO9YQFSFubQERCWEo71jr2xLmegxEQIYHL3AvJaLmp0IBsr2tVzRG1TN2PVuew4ljp8WA==",
             "requires": {
                 "@a11y/focus-trap": "1.0.5",
-                "@popperjs/core": "2.10.2",
-                "@stencil/core": "2.10.0",
-                "@types/color": "3.0.2",
-                "color": "4.0.1",
+                "@popperjs/core": "2.11.5",
+                "@stencil/core": "2.15.1",
+                "@types/color": "3.0.3",
+                "color": "4.2.3",
+                "form-request-submit-polyfill": "2.0.0",
                 "lodash-es": "4.17.21",
-                "sortablejs": "1.14.0"
+                "sortablejs": "1.15.0"
             },
             "dependencies": {
                 "@popperjs/core": {
-                    "version": "2.10.2"
+                    "version": "2.11.5",
+                    "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+                    "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+                },
+                "sortablejs": {
+                    "version": "1.15.0",
+                    "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+                    "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
                 }
             }
         },
@@ -24544,7 +24596,9 @@
             "dev": true
         },
         "@stencil/core": {
-            "version": "2.10.0"
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.1.tgz",
+            "integrity": "sha512-NYjRwQnjzscyFfqK+iIwRdr/dgYn33u6KE7kyQWdi7xsCkqMHalXYgJlN/QBQ9PN3qXmXKeBrJNG8EkNdCbK5g=="
         },
         "@szmarczak/http-timer": {
             "version": "1.1.2",
@@ -24579,19 +24633,25 @@
             "dev": true
         },
         "@types/color": {
-            "version": "3.0.2",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
+            "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
             "requires": {
                 "@types/color-convert": "*"
             }
         },
         "@types/color-convert": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
+            "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
             "requires": {
                 "@types/color-name": "*"
             }
         },
         "@types/color-name": {
-            "version": "1.1.1"
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "@types/connect": {
             "version": "3.4.35",
@@ -28061,10 +28121,12 @@
             }
         },
         "color": {
-            "version": "4.0.1",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "requires": {
                 "color-convert": "^2.0.1",
-                "color-string": "^1.6.0"
+                "color-string": "^1.9.0"
             }
         },
         "color-convert": {
@@ -28743,7 +28805,9 @@
             "dev": true
         },
         "cssfilter": {
-            "version": "0.0.10"
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
         },
         "cssnano": {
             "version": "4.1.11",
@@ -30782,9 +30846,11 @@
             }
         },
         "focus-trap": {
-            "version": "6.7.3",
+            "version": "6.9.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+            "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
             "requires": {
-                "tabbable": "^5.2.1"
+                "tabbable": "^5.3.3"
             }
         },
         "follow-redirects": {
@@ -30814,6 +30880,11 @@
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
+        },
+        "form-request-submit-polyfill": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
+            "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
         },
         "forwarded": {
             "version": "0.2.0",
@@ -32505,7 +32576,9 @@
             "devOptional": true
         },
         "lodash-es": {
-            "version": "4.17.21"
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
@@ -32526,7 +32599,9 @@
             "dev": true
         },
         "lodash.isplainobject": {
-            "version": "4.0.6"
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "lodash.kebabcase": {
             "version": "4.1.1",
@@ -32640,7 +32715,9 @@
             "dev": true
         },
         "luxon": {
-            "version": "2.1.1"
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
+            "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA=="
         },
         "magic-string": {
             "version": "0.25.9",
@@ -32981,9 +33058,6 @@
         "mkdirp": {
             "version": "1.0.4",
             "dev": true
-        },
-        "moment": {
-            "version": "2.29.2"
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -37196,7 +37270,9 @@
             "optional": true
         },
         "tabbable": {
-            "version": "5.2.1"
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
         },
         "tailwindcss": {
             "version": "3.0.23",
@@ -39747,14 +39823,18 @@
             "optional": true
         },
         "xss": {
-            "version": "1.0.11",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
+            "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
             "requires": {
                 "commander": "^2.20.3",
                 "cssfilter": "0.0.10"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.20.3"
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "format": "prettier .  --write"
     },
     "dependencies": {
-        "@arcgis/core": "4.22.2",
+        "@arcgis/core": "4.24.7",
         "@braid/vue-formulate": "~2.5.2",
         "@ecgc/vue-slider-component": "4.0.0-beta.7",
         "@popperjs/core": "~2.9.2",

--- a/public/starter-scripts/cam.js
+++ b/public/starter-scripts/cam.js
@@ -264,71 +264,65 @@ let config = {
                 {
                     id: 'climateActionMap',
                     name: 'Climate action map',
-                    layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer',
-                    sublayers: [
-                        {
-                            index: 0,
-                            name: 'Keyword search',
-                            state: {
-                                opacity: 1,
-                                visibility: true
-                            },
-                            table: {
-                                lazyFilter: true,
-                                search: { enabled: false },
-                                columns: [
-                                    {
-                                        name: 'Category'
-                                    },
-                                    {
-                                        name: 'Recipient_type'
-                                    },
-                                    {
-                                        name: 'Department___Agency___Crown_Corporation'
-                                    },
-                                    {
-                                        name: 'Province_Territory'
-                                    },
-                                    {
-                                        name: 'Municipality___Community'
-                                    },
-                                    {
-                                        name: 'Program_name'
-                                    },
-                                    {
-                                        name: 'Project_name'
-                                    },
-                                    {
-                                        name: 'Project_description'
-                                    },
-                                    {
-                                        name: 'Ultimate_recipient_name'
-                                    },
-                                    {
-                                        name: 'Funding_date___estimated_start_date'
-                                    },
-                                    {
-                                        name: 'Program_contribution'
-                                    },
-                                    {
-                                        name: 'Estimated_total_project_cost'
-                                    },
-                                    {
-                                        name: 'Additional_information'
-                                    },
-                                    {
-                                        name: 'Icon',
-                                        visible: false
-                                    },
-                                    {
-                                        name: 'OBJECTID'
-                                    }
-                                ]
-                            }
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer/0',
+                    fixtures: {
+                        grid: {
+                            lazyFilter: true,
+                            search: { enabled: false },
+                            columns: [
+                                {
+                                    name: 'Category'
+                                },
+                                {
+                                    name: 'Recipient_type'
+                                },
+                                {
+                                    name: 'Department___Agency___Crown_Corporation'
+                                },
+                                {
+                                    name: 'Province_Territory'
+                                },
+                                {
+                                    name: 'Municipality___Community'
+                                },
+                                {
+                                    name: 'Program_name'
+                                },
+                                {
+                                    name: 'Project_name'
+                                },
+                                {
+                                    name: 'Project_description'
+                                },
+                                {
+                                    name: 'Ultimate_recipient_name'
+                                },
+                                {
+                                    name: 'Funding_date___estimated_start_date'
+                                },
+                                {
+                                    name: 'Program_contribution'
+                                },
+                                {
+                                    name: 'Estimated_total_project_cost'
+                                },
+                                {
+                                    name: 'Additional_information'
+                                },
+                                {
+                                    name: 'Icon',
+                                    visible: false
+                                },
+                                {
+                                    name: 'OBJECTID'
+                                }
+                            ]
                         }
-                    ],
-                    tolerance: 20,
+                    },
+                    tolerance: 5,
+                    identifyMode: 'hybrid',
+                    drawOrder: [{ field: 'Program_name', ascending: true }],
                     state: {
                         opacity: 1,
                         visibility: true
@@ -343,8 +337,7 @@ let config = {
                             {
                                 name: 'Keyword search',
                                 layerId: 'climateActionMap',
-                                symbologyExpanded: true,
-                                sublayerIndex: 0
+                                symbologyExpanded: true
                             }
                         ]
                     }

--- a/schema.json
+++ b/schema.json
@@ -682,7 +682,9 @@
                         "type": "boolean",
                         "description": "Direction to order in. True means smaller values are on top of larger values. False is the opposite."
                     }
-                }
+                },
+                "additionalProperties": false,
+                "required": ["field", "ascending"]
             }
         },
         "basicLayer": {

--- a/schema.json
+++ b/schema.json
@@ -1113,7 +1113,7 @@
                 "identifyMode": {
                     "type": "string",
                     "description": "Determines how features should be identified. By geometry, by symbol, or both.",
-                    "default": "geometric",
+                    "default": "hybrid",
                     "enum": ["geometric", "symbolic", "hybrid"]
                 }
             },
@@ -1224,7 +1224,7 @@
                 "identifyMode": {
                     "type": "string",
                     "description": "Determines how features should be identified. By geometry, by symbol, or both.",
-                    "default": "geometric",
+                    "default": "hybrid",
                     "enum": ["geometric", "symbolic", "hybrid"]
                 }
             },
@@ -1332,7 +1332,7 @@
                 "identifyMode": {
                     "type": "string",
                     "description": "Determines how features should be identified. By geometry, by symbol, or both.",
-                    "default": "geometric",
+                    "default": "hybrid",
                     "enum": ["geometric", "symbolic", "hybrid"]
                 }
             },

--- a/schema.json
+++ b/schema.json
@@ -1109,6 +1109,12 @@
                 "drawOrder": {
                     "$ref": "#/$defs/drawOrder",
                     "default": []
+                },
+                "identifyMode": {
+                    "type": "string",
+                    "description": "Determines how features should be identified. By geometry, by symbol, or both.",
+                    "default": "geometric",
+                    "enum": ["geometric", "symbolic", "hybrid"]
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1214,6 +1220,12 @@
                 "drawOrder": {
                     "$ref": "#/$defs/drawOrder",
                     "default": []
+                },
+                "identifyMode": {
+                    "type": "string",
+                    "description": "Determines how features should be identified. By geometry, by symbol, or both.",
+                    "default": "geometric",
+                    "enum": ["geometric", "symbolic", "hybrid"]
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1316,6 +1328,12 @@
                 "drawOrder": {
                     "$ref": "#/$defs/drawOrder",
                     "default": []
+                },
+                "identifyMode": {
+                    "type": "string",
+                    "description": "Determines how features should be identified. By geometry, by symbol, or both.",
+                    "default": "geometric",
+                    "enum": ["geometric", "symbolic", "hybrid"]
                 }
             },
             "required": ["id", "layerType", "url"],

--- a/schema.json
+++ b/schema.json
@@ -667,6 +667,24 @@
             },
             "minItems": 0
         },
+        "drawOrder": {
+            "type": "array",
+            "description": "Attribute fields used to control drawing order on the map for vector features. Note ESRI currently only supports one field.",
+            "items": {
+                "type": "object",
+                "description": "Draw order for one attribute field.",
+                "properties": {
+                    "field": {
+                        "type": "string",
+                        "description": "Layer field name contianing the value to order by."
+                    },
+                    "ascending": {
+                        "type": "boolean",
+                        "description": "Direction to order in. True means smaller values are on top of larger values. False is the opposite."
+                    }
+                }
+            }
+        },
         "basicLayer": {
             "type": "object",
             "description": "Properties describing a generic layer type that can represent an ESRI tile/image layer.",
@@ -1087,6 +1105,10 @@
                 },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"
+                },
+                "drawOrder": {
+                    "$ref": "#/$defs/drawOrder",
+                    "default": []
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1188,6 +1210,10 @@
                 },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"
+                },
+                "drawOrder": {
+                    "$ref": "#/$defs/drawOrder",
+                    "default": []
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1286,6 +1312,10 @@
                 },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"
+                },
+                "drawOrder": {
+                    "$ref": "#/$defs/drawOrder",
+                    "default": []
                 }
             },
             "required": ["id", "layerType", "url"],

--- a/scripts/vite-plugin-version.ts
+++ b/scripts/vite-plugin-version.ts
@@ -14,7 +14,7 @@ export default (): Plugin => {
             const [major, minor, patch] = pkg.version.split('.');
 
             config.define
-                ? (config.define.__VERSION__ = {
+                ? (config.define.__RAMP_VERSION__ = {
                       major,
                       minor,
                       patch,

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -8,7 +8,7 @@ import type { FixtureBase, FixtureBaseSet } from '@/store/modules/fixture';
 import type { RampConfig } from '@/types';
 
 const fixtureModules = import.meta.glob<{ default: typeof FixtureInstance }>(
-    `@/fixtures/*/index.ts`
+    '@/fixtures/*/index.ts'
 );
 
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -77,10 +77,10 @@ export class InstanceAPI {
         options?: RampOptions
     ) {
         console.log(
-            `RAMP v${__VERSION__.major}.${__VERSION__.minor}.${
-                __VERSION__.patch
-            } [${__VERSION__.hash.slice(0, 9)}] (Built on ${new Date(
-                __VERSION__.timestamp.toString()
+            `RAMP v${__RAMP_VERSION__.major}.${__RAMP_VERSION__.minor}.${
+                __RAMP_VERSION__.patch
+            } [${__RAMP_VERSION__.hash.slice(0, 9)}] (Built on ${new Date(
+                __RAMP_VERSION__.timestamp.toString()
             ).toLocaleString()})`
         );
 

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -19,7 +19,7 @@ import type {
 } from '@/store/modules/panel';
 
 import ScreenSpinnerV from '@/components/panel-stack/screen-spinner.vue';
-const screenModules = import.meta.glob<Component>(`@/fixtures/*/screen.vue`);
+const screenModules = import.meta.glob<Component>('../fixtures/*/screen.vue');
 
 export class PanelInstance extends APIScope {
     /**

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -246,6 +246,13 @@ export enum GeoJsonGeomType {
 //    Haze = 'haze'
 //}
 
+export enum LayerIdentifyMode {
+    GEOMETRIC = 'geometric', // uses geometric intersection; feature symbology is not considered
+    SYMBOLIC = 'symbolic', // uses symbol intersection; not applicable for raster layers
+    HYBRID = 'hybrid', // combines geometric and symbolic results
+    NONE = 'none' // value for layers that don't support identify
+}
+
 export interface EpsgLookup {
     (code: string | number): Promise<string>;
 }
@@ -396,6 +403,7 @@ export interface IdentifyParameters {
     tolerance?: number;
     returnGeometry?: boolean; // TODO revisit this. might make more sense to offload geom to a followup request. if we keep, we may need to add property to IdentifyItem for the geom to live in
     sublayerIds?: Array<string | number>; // Optional array of sublayer uids or server indices. When defined, the given sublayers are queried for instead of the default (visible, queryable, on-scale sublayers)
+    hitTest?: Promise<Array<GraphicHitResult>>; // Optional results of local hits to incorporate in the identify
 }
 
 export interface IdentifyItem {
@@ -588,6 +596,7 @@ export interface RampLayerConfig {
     colour?: string;
     initialFilteredQuery?: string;
     drawOrder?: Array<DrawOrder>; // feature drawing order
+    identifyMode?: LayerIdentifyMode;
     rawData?: any; // used for static data, like geojson string, shapefile guts
 }
 

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -271,6 +271,11 @@ export enum DrawState {
     UP_TO_DATE = 'up-to-date'
 }
 
+export interface DrawOrder {
+    field: string;
+    ascending: boolean; // true means smaller values are drawn ON TOP of larger values. false is the opposite
+}
+
 export enum IdentifyResultFormat {
     ESRI = 'esri',
     TEXT = 'text',
@@ -582,6 +587,7 @@ export interface RampLayerConfig {
     cosmetic?: boolean;
     colour?: string;
     initialFilteredQuery?: string;
+    drawOrder?: Array<DrawOrder>; // feature drawing order
     rawData?: any; // used for static data, like geojson string, shapefile guts
 }
 

--- a/src/geo/api/graphic/geometry/geometry.ts
+++ b/src/geo/api/graphic/geometry/geometry.ts
@@ -304,6 +304,7 @@ export class GeometryAPI {
     serverGeomTypeToRampGeomType(serverType: string): GeometryType {
         if (!serverType) {
             // falsy case, pass it on thru
+            // this would handle a MIL raster sublayer
             return GeometryType.NONE;
         }
         switch (serverType) {

--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -25,7 +25,6 @@ import EsriOpenStreetMapLayer from '@arcgis/core/layers/OpenStreetMapLayer';
 import EsriTileLayer from '@arcgis/core/layers/TileLayer';
 import EsriWMSLayer from '@arcgis/core/layers/WMSLayer';
 import EsriField from '@arcgis/core/layers/support/Field';
-import EsriImageParameters from '@arcgis/core/layers/support/ImageParameters';
 import EsriLOD from '@arcgis/core/layers/support/LOD';
 import EsriSublayer from '@arcgis/core/layers/support/Sublayer';
 import EsriWMSSublayer from '@arcgis/core/layers/support/WMSSublayer';
@@ -38,13 +37,7 @@ import EsriClassBreakInfo from '@arcgis/core/renderers/support/ClassBreakInfo';
 import { fromJSON as EsriRendererFromJson } from '@arcgis/core/renderers/support/jsonUtils';
 import EsriUniqueValueInfo from '@arcgis/core/renderers/support/UniqueValueInfo';
 import EsriRequest from '@arcgis/core/request';
-// import EsriIdentify from '@arcgis/core/rest/identify';
-// import EsriPrint from '@arcgis/core/rest/print';
 import { executeForIds as EsriQueryByIds } from '@arcgis/core/rest/query';
-// import EsriIdentifyParameters from '@arcgis/core/rest/support/IdentifyParameters';
-// import EsriPrintParameters from '@arcgis/core/rest/support/PrintParameters';
-// import EsriPrintTemplate from '@arcgis/core/rest/support/PrintTemplate';
-// import EsriProjectParameters from '@arcgis/core/rest/support/ProjectParameters';
 import EsriQuery from '@arcgis/core/rest/support/Query';
 import EsriPictureMarkerSymbol from '@arcgis/core/symbols/PictureMarkerSymbol';
 import EsriSimpleFillSymbol from '@arcgis/core/symbols/SimpleFillSymbol';
@@ -52,7 +45,6 @@ import EsriSimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import EsriSimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
 import EsriSymbol from '@arcgis/core/symbols/Symbol';
 import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jsonUtils';
-import EsriGeometryService from '@arcgis/core/tasks/GeometryService';
 import EsriFeatureFilter from '@arcgis/core/layers/support/FeatureFilter';
 import EsriMapView from '@arcgis/core/views/MapView';
 import EsriBasemapGallery from '@arcgis/core/widgets/BasemapGallery';
@@ -72,12 +64,8 @@ export {
     EsriField,
     EsriGeometry,
     EsriGeometryFromJson,
-    EsriGeometryService,
     EsriGraphic,
     EsriGraphicsLayer,
-    // EsriIdentifyParameters,
-    // EsriIdentify,
-    EsriImageParameters,
     EsriImageryLayer,
     EsriLOD,
     EsriMap,
@@ -86,10 +74,6 @@ export {
     EsriMultipoint,
     EsriOpenStreetMapLayer,
     EsriPictureMarkerSymbol,
-    // EsriPrintParameters,
-    // EsriPrint,
-    // EsriPrintTemplate,
-    // EsriProjectParameters,
     EsriPoint,
     EsriPolygon,
     EsriPolyline,

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -172,6 +172,17 @@ export class AttribLayer extends CommonLayer {
                     })();
             }
 
+            // drawOrder field check
+            this.drawOrder.forEach(d => {
+                if (
+                    this.esriFields.findIndex(ef => ef.name === d.field) === -1
+                ) {
+                    console.error(
+                        `Draw order for layer ${this.id} references invalid field ${d.field}`
+                    );
+                }
+            });
+
             // add renderer and legend
             const renderer =
                 options && options.customRenderer && options.customRenderer.type

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -129,8 +129,6 @@ export class AttribLayer extends CommonLayer {
         const sData: any = serviceResult.data;
 
         // properties for all endpoints
-
-        // TODO need to decide what propert default is. Raster Layer has null gt.
         this.geomType = this.$iApi.geo.geom.serverGeomTypeToRampGeomType(
             sData.geometryType
         );
@@ -147,7 +145,7 @@ export class AttribLayer extends CommonLayer {
             this.dataFormat = DataFormat.ESRI_FEATURE;
             this.esriFields = markRaw(
                 sData.fields.map((f: any) => EsriField.fromJSON(f))
-            ); // TODO need to use Field.fromJSON() to make things correct
+            );
             this.nameField = sData.displayField;
 
             // find object id field
@@ -166,6 +164,7 @@ export class AttribLayer extends CommonLayer {
                 this.oidField =
                     sData.objectIdField ||
                     (() => {
+                        // TODO worth pinging the notification api, or pushing layer into error state?
                         console.error(
                             `Encountered service with no OID defined: ${this.serviceUrl}`
                         );
@@ -173,7 +172,6 @@ export class AttribLayer extends CommonLayer {
                     })();
             }
 
-            // TODO add in renderer and legend magic
             // add renderer and legend
             const renderer =
                 options && options.customRenderer && options.customRenderer.type
@@ -496,9 +494,7 @@ export class AttribLayer extends CommonLayer {
             if (aCache) {
                 // value is already cached. use it
                 resultAttribs = aCache;
-            } else if (this.attLoader.isLoaded || this.isFile!) {
-                // NOTE: the above line has a habit of showing as an error in VSCode. The compiler will not be as dumb.
-
+            } else if (this.attLoader.isLoaded() || this.isFile!) {
                 // all attributes have been loaded (or is a file and are local). use that store.
                 // since attributes come from a promise, reset the wait promise to the attribute promise
                 const atSet = await this.attLoader.getAttribs();

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -12,6 +12,7 @@ import {
     DefPromise,
     DrawState,
     Extent,
+    GeometryType,
     Graphic,
     InitiationState,
     LayerFormat,
@@ -42,7 +43,6 @@ export class CommonLayer extends LayerInstance {
     _clickTolerance: number;
     _featureCount: number;
     _fields: Array<FieldDefinition>;
-    _geomType: string;
     _nameField: string;
     _oidField: string;
     _drawOrder: Array<DrawOrder>;
@@ -76,7 +76,7 @@ export class CommonLayer extends LayerInstance {
         this._clickTolerance =
             rampConfig.tolerance != undefined ? rampConfig.tolerance : 5; // use default value of 5 if tolerance is undefined
         this._fields = [];
-        this._geomType = 'error';
+        this.geomType = GeometryType.NONE;
         this._nameField = 'error';
         this._oidField = 'error';
         this.dataFormat = DataFormat.UNKNOWN;
@@ -665,26 +665,7 @@ export class CommonLayer extends LayerInstance {
     }
 
     /**
-     * Returns the geometry type of the given sublayer.
-     *
-     * @returns {Array} list of field definitions
-     */
-    get geomType(): string {
-        // this.stubError();
-        return this._geomType;
-    }
-
-    /**
-     * Sets the geometry type of the layer
-     *
-     * @param {string} type the new the geometry type
-     */
-    set geomType(type: string) {
-        this._geomType = type;
-    }
-
-    /**
-     * Returns the name field of the given sublayer.
+     * Returns the name field of the layer.
      *
      * @returns {string} name field
      */
@@ -703,7 +684,7 @@ export class CommonLayer extends LayerInstance {
     }
 
     /**
-     * Returns the OID field of the given sublayer.
+     * Returns the OID field of the layer.
      *
      * @returns {string} OID field
      */

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -24,6 +24,7 @@ import {
 
 import type {
     AttributeSet,
+    DrawOrder,
     FieldDefinition,
     GetGraphicParams,
     LegendSymbology,
@@ -43,6 +44,7 @@ export class CommonLayer extends LayerInstance {
     _geomType: string;
     _nameField: string;
     _oidField: string;
+    _drawOrder: Array<DrawOrder>;
     // used to manage debouncing when applying filter updates against a layer. Private! but needs to be seen by FCs.
     _lastFilterUpdate = '';
 
@@ -79,6 +81,7 @@ export class CommonLayer extends LayerInstance {
         this.dataFormat = DataFormat.UNKNOWN;
         this.layerType = LayerType.UNKNOWN;
         this.layerFormat = LayerFormat.UNKNOWN;
+        this._drawOrder = [];
 
         this.origRampConfig = rampConfig;
         this.id = rampConfig.id || '';
@@ -618,6 +621,13 @@ export class CommonLayer extends LayerInstance {
         }
 
         this._clickTolerance = tolerance;
+    }
+
+    /**
+     * Returns an array describing the draw order of features. Raster layers will have empty arrays
+     */
+    get drawOrder(): Array<DrawOrder> {
+        return this._drawOrder;
     }
 
     /**

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -15,6 +15,7 @@ import {
     Graphic,
     InitiationState,
     LayerFormat,
+    LayerIdentifyMode,
     LayerState,
     LayerType,
     NoGeometry,
@@ -89,6 +90,7 @@ export class CommonLayer extends LayerInstance {
         this.isRemoved = false;
         this.isSublayer = false;
         this.supportsIdentify = false; // default state.
+        this.identifyMode = LayerIdentifyMode.NONE;
         this.supportsFeatures = false; // default state. featurish layers should set to true when the load
         this.supportsSublayers = false; // by default layers do not support sublayers
         this.isFile = false; // default state.
@@ -523,6 +525,19 @@ export class CommonLayer extends LayerInstance {
     }
 
     /**
+     * Indicates if layer should participate in an identify request.
+     */
+    canIdentify(): boolean {
+        return (
+            this.supportsIdentify &&
+            this.isValidState &&
+            this.visibility &&
+            this.identify &&
+            !this.scaleSet.isOffScale(this.$iApi.geo.map.getScale()).offScale
+        );
+    }
+
+    /**
      * Cause the map to zoom to a scale level where the layer is visible.
      *
      * @returns {Promise} resolves when map has finished zooming
@@ -860,12 +875,11 @@ export class CommonLayer extends LayerInstance {
         });
     }
 
-    // TODO think about this name. using getGraphic for consistency.
     /**
      * Gets information on a graphic in the most efficient way possible. Options object properties:
      * - getGeom ; a boolean to indicate if the result should include graphic geometry
      * - getAttribs ; a boolean to indicate if the result should include graphic attributes
-     * - unboundMap ; an optional RampMap reference. Only required if geometry was requested and the layer has not been added to a map.
+     * - getStyle ; a boolean to indicate if the result should include symbol styling information
      *
      * @param {Integer} objectId the object id of the graphic to find
      * @param {Object} options options object for the request, see above

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -38,7 +38,7 @@ export class FeatureLayer extends AttribLayer {
         ) {
             this.identifyMode = rampConfig.identifyMode;
         } else {
-            this.identifyMode = LayerIdentifyMode.GEOMETRIC;
+            this.identifyMode = LayerIdentifyMode.HYBRID;
         }
     }
 

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -92,7 +92,7 @@ export class FileLayer extends AttribLayer {
         ) {
             this.identifyMode = rampConfig.identifyMode;
         } else {
-            this.identifyMode = LayerIdentifyMode.GEOMETRIC;
+            this.identifyMode = LayerIdentifyMode.HYBRID;
         }
     }
 

--- a/src/geo/layer/file-utils.ts
+++ b/src/geo/layer/file-utils.ts
@@ -4,11 +4,7 @@ import ArcGIS from 'terraformer-arcgis-parser';
 import { csv2geojson, dsv } from 'csv2geojson';
 import shp from 'shpjs/dist/shp.min.js';
 
-import {
-    EsriColour,
-    EsriSimpleRenderer,
-    EsriSpatialReference
-} from '@/geo/esri';
+import { EsriSimpleRenderer, EsriSpatialReference } from '@/geo/esri';
 import { Colour, FieldType } from '@/geo/api';
 
 /**

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -3,6 +3,7 @@ import {
     DataFormat,
     DrawState,
     Extent,
+    GeometryType,
     Graphic,
     InitiationState,
     LayerControls,
@@ -144,6 +145,11 @@ export class LayerInstance extends APIScope {
     hovertips: boolean;
 
     /**
+     * The geometry type of the layer.
+     */
+    geomType: GeometryType;
+
+    /**
      *  The internal ESRI API layer
      */
     esriLayer: __esri.Layer | undefined;
@@ -198,6 +204,7 @@ export class LayerInstance extends APIScope {
         this.userAdded = false;
         this.identify = false; // will be updated later based on config/supportsIdentify value
         this.hovertips = config.state?.hovertips ?? true;
+        this.geomType = GeometryType.UNKNOWN;
         this._sublayers = [];
     }
 
@@ -389,22 +396,6 @@ export class LayerInstance extends APIScope {
      * @param {Array<FieldDefinition>} fields the list of field definitions
      */
     set fields(fields: Array<FieldDefinition>) {}
-
-    /**
-     * Returns the geometry type of the given layer.
-     *
-     * @returns {Array} list of field definitions
-     */
-    get geomType(): string {
-        return 'error';
-    }
-
-    /**
-     * Sets the geometry type of the layer
-     *
-     * @param {string} type the new the geometry type
-     */
-    set geomType(type: string) {}
 
     /**
      * Returns the name field of the given layer.

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -7,6 +7,7 @@ import {
     InitiationState,
     LayerControls,
     LayerFormat,
+    LayerIdentifyMode,
     LayerState,
     LayerType,
     NoGeometry,
@@ -45,29 +46,121 @@ export class LayerInstance extends APIScope {
      * @memberof LayerInstance
      */
     id: string;
+
+    /**
+     * Unique identifier for this layer. Randomly generated at runtime.
+     */
     uid: string;
+
+    /**
+     * State of the actual layer on the map, such as loading, loaded, error'd.
+     */
     layerState: LayerState;
+
+    /**
+     * State of the initiation / termination process of the layer
+     */
     initiationState: InitiationState;
+
+    /**
+     * State of drawing / refreshing data for a layer
+     */
     drawState: DrawState;
 
+    /**
+     * Index of the layer. Aligns to index of arcgis server, or defaults to 0 on other layers
+     */
     layerIdx: number;
+
+    /**
+     * Type of layer this is (describes the overall layer)
+     */
     layerType: LayerType;
+
+    /**
+     * How the layer is instantiated in the map stack
+     */
     layerFormat: LayerFormat;
+
+    /**
+     * The type of spatial data used to generate layer content
+     */
     dataFormat: DataFormat;
+
+    /**
+     * If the layer type can support an identify request
+     */
     supportsIdentify: boolean;
+
+    /**
+     * If the layer type can support Feature type requests and operations
+     */
     supportsFeatures: boolean;
+
+    /**
+     * If the layer has Sublayers
+     */
     supportsSublayers: boolean;
+
+    /**
+     * If the layer is a Sublayer
+     */
     isSublayer: boolean;
-    isRemoved: boolean; // used to track if layer is removed from map. Is false during the period "before" the layer gets added to map.
+
+    /**
+     * Tracks if layer is removed from map. Is false during the period "before" the layer gets added to map.
+     */
+    isRemoved: boolean;
+
+    // TODO verify if WFS has isFile === true, update the comment
+    /**
+     * If the layer was sourced from a file / no server.
+     */
     isFile: boolean;
+
+    /**
+     * If the layer is non-interactive and only displays content on the map
+     */
     isCosmetic: boolean;
+
+    /**
+     * If the layer was added by user interaction during the session
+     */
     userAdded: boolean;
+
+    /**
+     * If the layer is set to participate in identify requests
+     */
     identify: boolean;
+
+    /**
+     * The type of logic used to identify items on the layer
+     */
+    identifyMode: LayerIdentifyMode;
+
+    /**
+     * If the layer should show hovertips on the map
+     */
     hovertips: boolean;
 
+    /**
+     *  The internal ESRI API layer
+     */
     esriLayer: __esri.Layer | undefined;
-    esriSubLayer: __esri.Sublayer | undefined; // used only by sublayers
+
+    /**
+     *  The internal ESRI API sublayer. Valid only by sublayers
+     */
+    esriSubLayer: __esri.Sublayer | undefined;
+
+    /**
+     * The internal ESRI API layer view
+     */
     esriView: __esri.LayerView | undefined;
+
+    /**
+     * The extent of the layer on the map
+     */
     extent: Extent | undefined; // layer extent
 
     protected _parentLayer: LayerInstance | undefined;
@@ -95,6 +188,7 @@ export class LayerInstance extends APIScope {
         this.layerType = LayerType.UNKNOWN;
         this.dataFormat = DataFormat.UNKNOWN;
         this.supportsIdentify = false; // this is updated by subclasses as they will know the real deal.
+        this.identifyMode = LayerIdentifyMode.NONE;
         this.supportsFeatures = false;
         this.supportsSublayers = false;
         this.isSublayer = false;
@@ -381,6 +475,13 @@ export class LayerInstance extends APIScope {
      */
     get drawOrder(): Array<DrawOrder> {
         return [];
+    }
+
+    /**
+     * Indicates if layer should participate in an identify request.
+     */
+    canIdentify(): boolean {
+        return false;
     }
 
     /**

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -15,6 +15,7 @@ import {
 } from '@/geo/api';
 import type {
     AttributeSet,
+    DrawOrder,
     FieldDefinition,
     GetGraphicParams,
     IdentifyParameters,
@@ -374,6 +375,13 @@ export class LayerInstance extends APIScope {
      * @param {Integer} tolerance the new click tolerance
      */
     set clickTolerance(tolerance: number) {}
+
+    /**
+     * Return the draw order for the layer, if applicable
+     */
+    get drawOrder(): Array<DrawOrder> {
+        return [];
+    }
 
     /**
      * Baseline identify function for layers that do not support identify.

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -14,6 +14,7 @@ import {
     IdentifyResultFormat,
     InitiationState,
     LayerFormat,
+    LayerIdentifyMode,
     LayerState,
     LayerType,
     NoGeometry,
@@ -55,6 +56,7 @@ export class MapImageLayer extends AttribLayer {
         this.isDynamic = false; // will get updated after layer load.
         this.hovertips = false;
         this.layerTree.layerIdx = -1;
+        this.identifyMode = LayerIdentifyMode.GEOMETRIC;
     }
 
     protected async onInitiate(): Promise<void> {
@@ -414,7 +416,7 @@ export class MapImageLayer extends AttribLayer {
         //         also, if the grid has been opened, the identify can utilize the local attribute set.
 
         // early kickout check. not loaded/error
-        if (!this.isValidState || !this.visibility) {
+        if (!this.canIdentify()) {
             // return empty result.
             return [];
         }
@@ -443,12 +445,7 @@ export class MapImageLayer extends AttribLayer {
             : (<Array<MapImageSublayer>>this._sublayers).filter(
                   (sublayer: MapImageSublayer) => {
                       // query for visible, identifiable, on-scale sublayers
-                      return (
-                          sublayer.visibility &&
-                          sublayer.supportsFeatures &&
-                          sublayer.identify &&
-                          !sublayer.scaleSet.isOffScale(map.getScale()).offScale
-                      );
+                      return sublayer.canIdentify();
                   }
               );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { configUpgrade2to4, InstanceAPI } from '@/api/internal';
 import type { RampOptions } from '@/api/instance';
 import type { RampConfigs } from './types';
 
-export const version = __VERSION__;
+export const version = __RAMP_VERSION__;
 export function configUpgrade(ramp2Config: any | Array<any>): any {
     return configUpgrade2to4(ramp2Config);
 }


### PR DESCRIPTION
Donethankses #897


- Implements identify modes on layers. Allows vector layers to leverage symbol hits as well as geometry hits
- Implements symbol draw order for vector layers. Can use one field to control order things are drawn on the map.
- Upgrades ESRI API to 4.24
- Adapts to changes in the ESRI `hitTest`, finds topmost feature to know what hovertip to trigger
- Doc party and helper functions
- Fix to ESRI library colliding with version environment variable (code by @milespetrov )

There are some edge cases that may break our hovertips at the moment. ESRI's `hitTest` results come back in a random order, but they have hinted that future versions of the API will be sorted by drawing order. This will let us remove the big nasty "top-most" algorithm and solve the edge cases as well (e.g. layer is ordered by a field that does not have unique values).

CAM sample has been edited to be feature layer, and also has draw order based on Program Name (A will draw on top of Z).
https://ramp4-pcar4.github.io/ramp4-pcar4/jamesparty/index-cam.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1264)
<!-- Reviewable:end -->
