### PR TITLE
fix build error when esri version is upgraded

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare const __VERSION__: {
+declare const __RAMP_VERSION__: {
     major: string;
     minor: string;
     patch: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "ramp",
             "version": "4.0.0-alpha",
             "dependencies": {
-                "@arcgis/core": "4.22.2",
+                "@arcgis/core": "4.24.7",
                 "@braid/vue-formulate": "~2.5.2",
                 "@ecgc/vue-slider-component": "4.0.0-beta.7",
                 "@popperjs/core": "~2.9.2",
@@ -90,7 +90,8 @@
         },
         "node_modules/@a11y/focus-trap": {
             "version": "1.0.5",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
+            "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
         },
         "node_modules/@actions/core": {
             "version": "1.6.0",
@@ -151,26 +152,32 @@
             }
         },
         "node_modules/@arcgis/core": {
-            "version": "4.22.2",
-            "license": "SEE LICENSE IN copyright.txt",
+            "version": "4.24.7",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.24.7.tgz",
+            "integrity": "sha512-uDkF4/3zOOFDzFEXxAaENhtz7hhkmOw71R96rfVPjqIfRxd2HxgrpNlrjXI8xYC2ub8rRpBZ6WmxlvaCn/zu7Q==",
             "dependencies": {
-                "@esri/arcgis-html-sanitizer": "~2.9.0-next.1",
+                "@esri/arcgis-html-sanitizer": "~2.10.0",
                 "@esri/calcite-colors": "~6.0.1",
-                "@esri/calcite-components": "1.0.0-beta.69",
-                "@popperjs/core": "~2.10.2",
-                "focus-trap": "~6.7.1",
-                "luxon": "~2.1.1",
-                "moment": "~2.29.1",
-                "sortablejs": "~1.14.0"
+                "@esri/calcite-components": "1.0.0-beta.82",
+                "@popperjs/core": "~2.11.5",
+                "focus-trap": "~6.9.4",
+                "luxon": "~2.4.0",
+                "sortablejs": "~1.15.0"
             }
         },
         "node_modules/@arcgis/core/node_modules/@popperjs/core": {
-            "version": "2.10.2",
-            "license": "MIT",
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
+        },
+        "node_modules/@arcgis/core/node_modules/sortablejs": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.16.7",
@@ -2072,11 +2079,12 @@
             }
         },
         "node_modules/@esri/arcgis-html-sanitizer": {
-            "version": "2.9.0",
-            "license": "Apache-2.0",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.10.0.tgz",
+            "integrity": "sha512-OGrczx3sbszMVQESGdZf2BaZL/oGMm+wuFgF6od50ff0WThjiJDTxi5SXIleRF6QQVFywsab3sFbQ77Q/gSzsg==",
             "dependencies": {
                 "lodash.isplainobject": "^4.0.6",
-                "xss": "^1.0.10"
+                "xss": "^1.0.11"
             }
         },
         "node_modules/@esri/calcite-colors": {
@@ -2084,25 +2092,33 @@
             "license": "SEE LICENSE IN README.md"
         },
         "node_modules/@esri/calcite-components": {
-            "version": "1.0.0-beta.69",
-            "license": "SEE LICENSE IN copyright.txt",
+            "version": "1.0.0-beta.82",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.82.tgz",
+            "integrity": "sha512-wAJeEZ4g/TiJ4J6z/GO9YQFSFubQERCWEo71jr2xLmegxEQIYHL3AvJaLmp0IBsr2tVzRG1TN2PVuew4ljp8WA==",
             "dependencies": {
                 "@a11y/focus-trap": "1.0.5",
-                "@popperjs/core": "2.10.2",
-                "@stencil/core": "2.10.0",
-                "@types/color": "3.0.2",
-                "color": "4.0.1",
+                "@popperjs/core": "2.11.5",
+                "@stencil/core": "2.15.1",
+                "@types/color": "3.0.3",
+                "color": "4.2.3",
+                "form-request-submit-polyfill": "2.0.0",
                 "lodash-es": "4.17.21",
-                "sortablejs": "1.14.0"
+                "sortablejs": "1.15.0"
             }
         },
         "node_modules/@esri/calcite-components/node_modules/@popperjs/core": {
-            "version": "2.10.2",
-            "license": "MIT",
+            "version": "2.11.5",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+            "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
+        },
+        "node_modules/@esri/calcite-components/node_modules/sortablejs": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
         },
         "node_modules/@hapi/hoek": {
             "version": "9.2.1",
@@ -2506,8 +2522,9 @@
             }
         },
         "node_modules/@stencil/core": {
-            "version": "2.10.0",
-            "license": "MIT",
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.1.tgz",
+            "integrity": "sha512-NYjRwQnjzscyFfqK+iIwRdr/dgYn33u6KE7kyQWdi7xsCkqMHalXYgJlN/QBQ9PN3qXmXKeBrJNG8EkNdCbK5g==",
             "bin": {
                 "stencil": "bin/stencil"
             },
@@ -2559,22 +2576,25 @@
             "license": "MIT"
         },
         "node_modules/@types/color": {
-            "version": "3.0.2",
-            "license": "MIT",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
+            "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
             "dependencies": {
                 "@types/color-convert": "*"
             }
         },
         "node_modules/@types/color-convert": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
+            "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
             "dependencies": {
                 "@types/color-name": "*"
             }
         },
         "node_modules/@types/color-name": {
             "version": "1.1.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "node_modules/@types/connect": {
             "version": "3.4.35",
@@ -3068,9 +3088,10 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "2.3.1",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz",
+            "integrity": "sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -7005,11 +7026,15 @@
             }
         },
         "node_modules/color": {
-            "version": "4.0.1",
-            "license": "MIT",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "dependencies": {
                 "color-convert": "^2.0.1",
-                "color-string": "^1.6.0"
+                "color-string": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=12.5.0"
             }
         },
         "node_modules/color-convert": {
@@ -7871,7 +7896,8 @@
         },
         "node_modules/cssfilter": {
             "version": "0.0.10",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
         },
         "node_modules/cssnano": {
             "version": "4.1.11",
@@ -9199,10 +9225,11 @@
             "dev": true
         },
         "node_modules/esbuild": {
-            "version": "0.14.34",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.49.tgz",
+            "integrity": "sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -9210,32 +9237,32 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "esbuild-android-64": "0.14.34",
-                "esbuild-android-arm64": "0.14.34",
-                "esbuild-darwin-64": "0.14.34",
-                "esbuild-darwin-arm64": "0.14.34",
-                "esbuild-freebsd-64": "0.14.34",
-                "esbuild-freebsd-arm64": "0.14.34",
-                "esbuild-linux-32": "0.14.34",
-                "esbuild-linux-64": "0.14.34",
-                "esbuild-linux-arm": "0.14.34",
-                "esbuild-linux-arm64": "0.14.34",
-                "esbuild-linux-mips64le": "0.14.34",
-                "esbuild-linux-ppc64le": "0.14.34",
-                "esbuild-linux-riscv64": "0.14.34",
-                "esbuild-linux-s390x": "0.14.34",
-                "esbuild-netbsd-64": "0.14.34",
-                "esbuild-openbsd-64": "0.14.34",
-                "esbuild-sunos-64": "0.14.34",
-                "esbuild-windows-32": "0.14.34",
-                "esbuild-windows-64": "0.14.34",
-                "esbuild-windows-arm64": "0.14.34"
+                "esbuild-android-64": "0.14.49",
+                "esbuild-android-arm64": "0.14.49",
+                "esbuild-darwin-64": "0.14.49",
+                "esbuild-darwin-arm64": "0.14.49",
+                "esbuild-freebsd-64": "0.14.49",
+                "esbuild-freebsd-arm64": "0.14.49",
+                "esbuild-linux-32": "0.14.49",
+                "esbuild-linux-64": "0.14.49",
+                "esbuild-linux-arm": "0.14.49",
+                "esbuild-linux-arm64": "0.14.49",
+                "esbuild-linux-mips64le": "0.14.49",
+                "esbuild-linux-ppc64le": "0.14.49",
+                "esbuild-linux-riscv64": "0.14.49",
+                "esbuild-linux-s390x": "0.14.49",
+                "esbuild-netbsd-64": "0.14.49",
+                "esbuild-openbsd-64": "0.14.49",
+                "esbuild-sunos-64": "0.14.49",
+                "esbuild-windows-32": "0.14.49",
+                "esbuild-windows-64": "0.14.49",
+                "esbuild-windows-arm64": "0.14.49"
             }
         },
         "node_modules/esbuild-android-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-            "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.49.tgz",
+            "integrity": "sha512-vYsdOTD+yi+kquhBiFWl3tyxnj2qZJsl4tAqwhT90ktUdnyTizgle7TjNx6Ar1bN7wcwWqZ9QInfdk2WVagSww==",
             "cpu": [
                 "x64"
             ],
@@ -9275,12 +9302,13 @@
             ]
         },
         "node_modules/esbuild-darwin-arm64": {
-            "version": "0.14.34",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.49.tgz",
+            "integrity": "sha512-XMaqDxO846srnGlUSJnwbijV29MTKUATmOLyQSfswbK/2X5Uv28M9tTLUJcKKxzoo9lnkYPsx2o8EJcTYwCs/A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
-            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -9394,9 +9422,9 @@
             ]
         },
         "node_modules/esbuild-linux-riscv64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-            "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.49.tgz",
+            "integrity": "sha512-h66ORBz+Dg+1KgLvzTVQEA1LX4XBd1SK0Fgbhhw4akpG/YkN8pS6OzYI/7SGENiN6ao5hETRDSkVcvU9NRtkMQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -9410,9 +9438,9 @@
             }
         },
         "node_modules/esbuild-linux-s390x": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-            "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.49.tgz",
+            "integrity": "sha512-DhrUoFVWD+XmKO1y7e4kNCqQHPs6twz6VV6Uezl/XHYGzM60rBewBF5jlZjG0nCk5W/Xy6y1xWeopkrhFFM0sQ==",
             "cpu": [
                 "s390x"
             ],
@@ -9504,9 +9532,9 @@
             ]
         },
         "node_modules/esbuild/node_modules/esbuild-android-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-            "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.49.tgz",
+            "integrity": "sha512-g2HGr/hjOXCgSsvQZ1nK4nW/ei8JUx04Li74qub9qWrStlysaVmadRyTVuW32FGIpLQyc5sUjjZopj49eGGM2g==",
             "cpu": [
                 "arm64"
             ],
@@ -9520,9 +9548,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-darwin-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-            "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.49.tgz",
+            "integrity": "sha512-3rvqnBCtX9ywso5fCHixt2GBCUsogNp9DjGmvbBohh31Ces34BVzFltMSxJpacNki96+WIcX5s/vum+ckXiLYg==",
             "cpu": [
                 "x64"
             ],
@@ -9536,9 +9564,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-            "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.49.tgz",
+            "integrity": "sha512-NJ5Q6AjV879mOHFri+5lZLTp5XsO2hQ+KSJYLbfY9DgCu8s6/Zl2prWXVANYTeCDLlrIlNNYw8y34xqyLDKOmQ==",
             "cpu": [
                 "x64"
             ],
@@ -9552,9 +9580,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-            "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.49.tgz",
+            "integrity": "sha512-lFLtgXnAc3eXYqj5koPlBZvEbBSOSUbWO3gyY/0+4lBdRqELyz4bAuamHvmvHW5swJYL7kngzIZw6kdu25KGOA==",
             "cpu": [
                 "arm64"
             ],
@@ -9568,9 +9596,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-linux-32": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-            "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.49.tgz",
+            "integrity": "sha512-zTTH4gr2Kb8u4QcOpTDVn7Z8q7QEIvFl/+vHrI3cF6XOJS7iEI1FWslTo3uofB2+mn6sIJEQD9PrNZKoAAMDiA==",
             "cpu": [
                 "ia32"
             ],
@@ -9584,9 +9612,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-linux-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-            "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.49.tgz",
+            "integrity": "sha512-hYmzRIDzFfLrB5c1SknkxzM8LdEUOusp6M2TnuQZJLRtxTgyPnZZVtyMeCLki0wKgYPXkFsAVhi8vzo2mBNeTg==",
             "cpu": [
                 "x64"
             ],
@@ -9600,9 +9628,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-linux-arm": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-            "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.49.tgz",
+            "integrity": "sha512-iE3e+ZVv1Qz1Sy0gifIsarJMQ89Rpm9mtLSRtG3AH0FPgAzQ5Z5oU6vYzhc/3gSPi2UxdCOfRhw2onXuFw/0lg==",
             "cpu": [
                 "arm"
             ],
@@ -9616,9 +9644,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-            "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.49.tgz",
+            "integrity": "sha512-KLQ+WpeuY+7bxukxLz5VgkAAVQxUv67Ft4DmHIPIW+2w3ObBPQhqNoeQUHxopoW/aiOn3m99NSmSV+bs4BSsdA==",
             "cpu": [
                 "arm64"
             ],
@@ -9632,9 +9660,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-            "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.49.tgz",
+            "integrity": "sha512-n+rGODfm8RSum5pFIqFQVQpYBw+AztL8s6o9kfx7tjfK0yIGF6tm5HlG6aRjodiiKkH2xAiIM+U4xtQVZYU4rA==",
             "cpu": [
                 "mips64el"
             ],
@@ -9648,9 +9676,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-            "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.49.tgz",
+            "integrity": "sha512-WP9zR4HX6iCBmMFH+XHHng2LmdoIeUmBpL4aL2TR8ruzXyT4dWrJ5BSbT8iNo6THN8lod6GOmYDLq/dgZLalGw==",
             "cpu": [
                 "ppc64"
             ],
@@ -9664,9 +9692,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-            "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.49.tgz",
+            "integrity": "sha512-BXaUwFOfCy2T+hABtiPUIpWjAeWK9P8O41gR4Pg73hpzoygVGnj0nI3YK4SJhe52ELgtdgWP/ckIkbn2XaTxjQ==",
             "cpu": [
                 "x64"
             ],
@@ -9680,9 +9708,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-            "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.49.tgz",
+            "integrity": "sha512-lP06UQeLDGmVPw9Rg437Btu6J9/BmyhdoefnQ4gDEJTtJvKtQaUcOQrhjTq455ouZN4EHFH1h28WOJVANK41kA==",
             "cpu": [
                 "x64"
             ],
@@ -9696,9 +9724,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-sunos-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-            "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.49.tgz",
+            "integrity": "sha512-4c8Zowp+V3zIWje329BeLbGh6XI9c/rqARNaj5yPHdC61pHI9UNdDxT3rePPJeWcEZVKjkiAS6AP6kiITp7FSw==",
             "cpu": [
                 "x64"
             ],
@@ -9712,9 +9740,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-windows-32": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-            "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.49.tgz",
+            "integrity": "sha512-q7Rb+J9yHTeKr9QTPDYkqfkEj8/kcKz9lOabDuvEXpXuIcosWCJgo5Z7h/L4r7rbtTH4a8U2FGKb6s1eeOHmJA==",
             "cpu": [
                 "ia32"
             ],
@@ -9728,9 +9756,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-windows-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-            "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.49.tgz",
+            "integrity": "sha512-+Cme7Ongv0UIUTniPqfTX6mJ8Deo7VXw9xN0yJEN1lQMHDppTNmKwAM3oGbD/Vqff+07K2gN0WfNkMohmG+dVw==",
             "cpu": [
                 "x64"
             ],
@@ -9744,9 +9772,9 @@
             }
         },
         "node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-            "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz",
+            "integrity": "sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==",
             "cpu": [
                 "arm64"
             ],
@@ -10747,10 +10775,11 @@
             }
         },
         "node_modules/focus-trap": {
-            "version": "6.7.3",
-            "license": "MIT",
+            "version": "6.9.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+            "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
             "dependencies": {
-                "tabbable": "^5.2.1"
+                "tabbable": "^5.3.3"
             }
         },
         "node_modules/follow-redirects": {
@@ -10806,6 +10835,11 @@
             "engines": {
                 "node": ">= 0.12"
             }
+        },
+        "node_modules/form-request-submit-polyfill": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
+            "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
         },
         "node_modules/forwarded": {
             "version": "0.2.0",
@@ -12217,9 +12251,10 @@
             }
         },
         "node_modules/is-core-module": {
-            "version": "2.8.1",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+            "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "has": "^1.0.3"
             },
@@ -13150,7 +13185,8 @@
         },
         "node_modules/lodash-es": {
             "version": "4.17.21",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash._reinterpolate": {
             "version": "3.0.0",
@@ -13172,7 +13208,8 @@
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "node_modules/lodash.kebabcase": {
             "version": "4.1.1",
@@ -13328,8 +13365,9 @@
             "license": "MIT"
         },
         "node_modules/luxon": {
-            "version": "2.1.1",
-            "license": "MIT",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
+            "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA==",
             "engines": {
                 "node": ">=12"
             }
@@ -13779,13 +13817,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/moment": {
-            "version": "2.29.2",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/move-concurrently": {
@@ -17604,11 +17635,12 @@
             "dev": true
         },
         "node_modules/resolve": {
-            "version": "1.22.0",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.8.1",
+                "is-core-module": "^2.9.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -17742,9 +17774,10 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.70.1",
+            "version": "2.77.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
+            "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -19291,8 +19324,9 @@
             "optional": true
         },
         "node_modules/tabbable": {
-            "version": "5.2.1",
-            "license": "MIT"
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
         },
         "node_modules/tailwindcss": {
             "version": "3.0.23",
@@ -19371,23 +19405,6 @@
                 "terraformer": "~1.0.4"
             }
         },
-        "node_modules/terser": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-            "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-            "dev": true,
-            "dependencies": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
-            },
-            "bin": {
-                "terser": "bin/terser"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/terser-webpack-plugin": {
             "version": "1.4.5",
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
@@ -19410,6 +19427,12 @@
             "peerDependencies": {
                 "webpack": "^4.0.0"
             }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/terser-webpack-plugin/node_modules/find-cache-dir": {
             "version": "2.1.0",
@@ -19528,11 +19551,22 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/terser/node_modules/commander": {
-            "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true
+        "node_modules/terser-webpack-plugin/node_modules/terser": {
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+            "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+            "dev": true,
+            "dependencies": {
+                "commander": "^2.20.0",
+                "source-map": "~0.6.1",
+                "source-map-support": "~0.5.12"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/text-encoding-polyfill": {
             "version": "0.6.7",
@@ -20549,9 +20583,9 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "2.9.12",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-            "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
+            "version": "2.9.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.14.tgz",
+            "integrity": "sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.14.27",
@@ -22613,8 +22647,9 @@
             "optional": true
         },
         "node_modules/xss": {
-            "version": "1.0.11",
-            "license": "MIT",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
+            "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
             "dependencies": {
                 "commander": "^2.20.3",
                 "cssfilter": "0.0.10"
@@ -22628,7 +22663,8 @@
         },
         "node_modules/xss/node_modules/commander": {
             "version": "2.20.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/xtend": {
             "version": "4.0.2",
@@ -22800,7 +22836,9 @@
     },
     "dependencies": {
         "@a11y/focus-trap": {
-            "version": "1.0.5"
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@a11y/focus-trap/-/focus-trap-1.0.5.tgz",
+            "integrity": "sha512-3JOd6g+BALysWS8LNf0qdB8ltR651H/RCLAvUmfS0LIHwHO579XfjZUIZbURYiAZrcbp1CBAq4QZ2YwKNQZ1hw=="
         },
         "@actions/core": {
             "version": "1.6.0",
@@ -22858,20 +22896,28 @@
             }
         },
         "@arcgis/core": {
-            "version": "4.22.2",
+            "version": "4.24.7",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.24.7.tgz",
+            "integrity": "sha512-uDkF4/3zOOFDzFEXxAaENhtz7hhkmOw71R96rfVPjqIfRxd2HxgrpNlrjXI8xYC2ub8rRpBZ6WmxlvaCn/zu7Q==",
             "requires": {
-                "@esri/arcgis-html-sanitizer": "~2.9.0-next.1",
+                "@esri/arcgis-html-sanitizer": "~2.10.0",
                 "@esri/calcite-colors": "~6.0.1",
-                "@esri/calcite-components": "1.0.0-beta.69",
-                "@popperjs/core": "~2.10.2",
-                "focus-trap": "~6.7.1",
-                "luxon": "~2.1.1",
-                "moment": "~2.29.1",
-                "sortablejs": "~1.14.0"
+                "@esri/calcite-components": "1.0.0-beta.82",
+                "@popperjs/core": "~2.11.5",
+                "focus-trap": "~6.9.4",
+                "luxon": "~2.4.0",
+                "sortablejs": "~1.15.0"
             },
             "dependencies": {
                 "@popperjs/core": {
-                    "version": "2.10.2"
+                    "version": "2.11.5",
+                    "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+                    "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+                },
+                "sortablejs": {
+                    "version": "1.15.0",
+                    "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+                    "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
                 }
             }
         },
@@ -24207,29 +24253,41 @@
             }
         },
         "@esri/arcgis-html-sanitizer": {
-            "version": "2.9.0",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.10.0.tgz",
+            "integrity": "sha512-OGrczx3sbszMVQESGdZf2BaZL/oGMm+wuFgF6od50ff0WThjiJDTxi5SXIleRF6QQVFywsab3sFbQ77Q/gSzsg==",
             "requires": {
                 "lodash.isplainobject": "^4.0.6",
-                "xss": "^1.0.10"
+                "xss": "^1.0.11"
             }
         },
         "@esri/calcite-colors": {
             "version": "6.0.1"
         },
         "@esri/calcite-components": {
-            "version": "1.0.0-beta.69",
+            "version": "1.0.0-beta.82",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.0-beta.82.tgz",
+            "integrity": "sha512-wAJeEZ4g/TiJ4J6z/GO9YQFSFubQERCWEo71jr2xLmegxEQIYHL3AvJaLmp0IBsr2tVzRG1TN2PVuew4ljp8WA==",
             "requires": {
                 "@a11y/focus-trap": "1.0.5",
-                "@popperjs/core": "2.10.2",
-                "@stencil/core": "2.10.0",
-                "@types/color": "3.0.2",
-                "color": "4.0.1",
+                "@popperjs/core": "2.11.5",
+                "@stencil/core": "2.15.1",
+                "@types/color": "3.0.3",
+                "color": "4.2.3",
+                "form-request-submit-polyfill": "2.0.0",
                 "lodash-es": "4.17.21",
-                "sortablejs": "1.14.0"
+                "sortablejs": "1.15.0"
             },
             "dependencies": {
                 "@popperjs/core": {
-                    "version": "2.10.2"
+                    "version": "2.11.5",
+                    "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+                    "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
+                },
+                "sortablejs": {
+                    "version": "1.15.0",
+                    "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+                    "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
                 }
             }
         },
@@ -24544,7 +24602,9 @@
             "dev": true
         },
         "@stencil/core": {
-            "version": "2.10.0"
+            "version": "2.15.1",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.15.1.tgz",
+            "integrity": "sha512-NYjRwQnjzscyFfqK+iIwRdr/dgYn33u6KE7kyQWdi7xsCkqMHalXYgJlN/QBQ9PN3qXmXKeBrJNG8EkNdCbK5g=="
         },
         "@szmarczak/http-timer": {
             "version": "1.1.2",
@@ -24579,19 +24639,25 @@
             "dev": true
         },
         "@types/color": {
-            "version": "3.0.2",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
+            "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
             "requires": {
                 "@types/color-convert": "*"
             }
         },
         "@types/color-convert": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
+            "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
             "requires": {
                 "@types/color-name": "*"
             }
         },
         "@types/color-name": {
-            "version": "1.1.1"
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "@types/connect": {
             "version": "3.4.35",
@@ -24967,7 +25033,9 @@
             }
         },
         "@vitejs/plugin-vue": {
-            "version": "2.3.1",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz",
+            "integrity": "sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==",
             "dev": true,
             "requires": {}
         },
@@ -28061,10 +28129,12 @@
             }
         },
         "color": {
-            "version": "4.0.1",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
             "requires": {
                 "color-convert": "^2.0.1",
-                "color-string": "^1.6.0"
+                "color-string": "^1.9.0"
             }
         },
         "color-convert": {
@@ -28743,7 +28813,9 @@
             "dev": true
         },
         "cssfilter": {
-            "version": "0.0.10"
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
         },
         "cssnano": {
             "version": "4.1.11",
@@ -29779,149 +29851,151 @@
             "dev": true
         },
         "esbuild": {
-            "version": "0.14.34",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.49.tgz",
+            "integrity": "sha512-/TlVHhOaq7Yz8N1OJrjqM3Auzo5wjvHFLk+T8pIue+fhnhIMpfAzsG6PLVMbFveVxqD2WOp3QHei+52IMUNmCw==",
             "dev": true,
             "requires": {
-                "esbuild-android-64": "0.14.34",
-                "esbuild-android-arm64": "0.14.34",
-                "esbuild-darwin-64": "0.14.34",
-                "esbuild-darwin-arm64": "0.14.34",
-                "esbuild-freebsd-64": "0.14.34",
-                "esbuild-freebsd-arm64": "0.14.34",
-                "esbuild-linux-32": "0.14.34",
-                "esbuild-linux-64": "0.14.34",
-                "esbuild-linux-arm": "0.14.34",
-                "esbuild-linux-arm64": "0.14.34",
-                "esbuild-linux-mips64le": "0.14.34",
-                "esbuild-linux-ppc64le": "0.14.34",
-                "esbuild-linux-riscv64": "0.14.34",
-                "esbuild-linux-s390x": "0.14.34",
-                "esbuild-netbsd-64": "0.14.34",
-                "esbuild-openbsd-64": "0.14.34",
-                "esbuild-sunos-64": "0.14.34",
-                "esbuild-windows-32": "0.14.34",
-                "esbuild-windows-64": "0.14.34",
-                "esbuild-windows-arm64": "0.14.34"
+                "esbuild-android-64": "0.14.49",
+                "esbuild-android-arm64": "0.14.49",
+                "esbuild-darwin-64": "0.14.49",
+                "esbuild-darwin-arm64": "0.14.49",
+                "esbuild-freebsd-64": "0.14.49",
+                "esbuild-freebsd-arm64": "0.14.49",
+                "esbuild-linux-32": "0.14.49",
+                "esbuild-linux-64": "0.14.49",
+                "esbuild-linux-arm": "0.14.49",
+                "esbuild-linux-arm64": "0.14.49",
+                "esbuild-linux-mips64le": "0.14.49",
+                "esbuild-linux-ppc64le": "0.14.49",
+                "esbuild-linux-riscv64": "0.14.49",
+                "esbuild-linux-s390x": "0.14.49",
+                "esbuild-netbsd-64": "0.14.49",
+                "esbuild-openbsd-64": "0.14.49",
+                "esbuild-sunos-64": "0.14.49",
+                "esbuild-windows-32": "0.14.49",
+                "esbuild-windows-64": "0.14.49",
+                "esbuild-windows-arm64": "0.14.49"
             },
             "dependencies": {
                 "esbuild-android-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-                    "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.49.tgz",
+                    "integrity": "sha512-g2HGr/hjOXCgSsvQZ1nK4nW/ei8JUx04Li74qub9qWrStlysaVmadRyTVuW32FGIpLQyc5sUjjZopj49eGGM2g==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-darwin-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-                    "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.49.tgz",
+                    "integrity": "sha512-3rvqnBCtX9ywso5fCHixt2GBCUsogNp9DjGmvbBohh31Ces34BVzFltMSxJpacNki96+WIcX5s/vum+ckXiLYg==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-freebsd-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-                    "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.49.tgz",
+                    "integrity": "sha512-NJ5Q6AjV879mOHFri+5lZLTp5XsO2hQ+KSJYLbfY9DgCu8s6/Zl2prWXVANYTeCDLlrIlNNYw8y34xqyLDKOmQ==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-freebsd-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-                    "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.49.tgz",
+                    "integrity": "sha512-lFLtgXnAc3eXYqj5koPlBZvEbBSOSUbWO3gyY/0+4lBdRqELyz4bAuamHvmvHW5swJYL7kngzIZw6kdu25KGOA==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-linux-32": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-                    "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.49.tgz",
+                    "integrity": "sha512-zTTH4gr2Kb8u4QcOpTDVn7Z8q7QEIvFl/+vHrI3cF6XOJS7iEI1FWslTo3uofB2+mn6sIJEQD9PrNZKoAAMDiA==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-linux-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-                    "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.49.tgz",
+                    "integrity": "sha512-hYmzRIDzFfLrB5c1SknkxzM8LdEUOusp6M2TnuQZJLRtxTgyPnZZVtyMeCLki0wKgYPXkFsAVhi8vzo2mBNeTg==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-linux-arm": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-                    "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.49.tgz",
+                    "integrity": "sha512-iE3e+ZVv1Qz1Sy0gifIsarJMQ89Rpm9mtLSRtG3AH0FPgAzQ5Z5oU6vYzhc/3gSPi2UxdCOfRhw2onXuFw/0lg==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-linux-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-                    "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.49.tgz",
+                    "integrity": "sha512-KLQ+WpeuY+7bxukxLz5VgkAAVQxUv67Ft4DmHIPIW+2w3ObBPQhqNoeQUHxopoW/aiOn3m99NSmSV+bs4BSsdA==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-linux-mips64le": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-                    "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.49.tgz",
+                    "integrity": "sha512-n+rGODfm8RSum5pFIqFQVQpYBw+AztL8s6o9kfx7tjfK0yIGF6tm5HlG6aRjodiiKkH2xAiIM+U4xtQVZYU4rA==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-linux-ppc64le": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-                    "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.49.tgz",
+                    "integrity": "sha512-WP9zR4HX6iCBmMFH+XHHng2LmdoIeUmBpL4aL2TR8ruzXyT4dWrJ5BSbT8iNo6THN8lod6GOmYDLq/dgZLalGw==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-netbsd-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-                    "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.49.tgz",
+                    "integrity": "sha512-BXaUwFOfCy2T+hABtiPUIpWjAeWK9P8O41gR4Pg73hpzoygVGnj0nI3YK4SJhe52ELgtdgWP/ckIkbn2XaTxjQ==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-openbsd-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-                    "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.49.tgz",
+                    "integrity": "sha512-lP06UQeLDGmVPw9Rg437Btu6J9/BmyhdoefnQ4gDEJTtJvKtQaUcOQrhjTq455ouZN4EHFH1h28WOJVANK41kA==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-sunos-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-                    "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.49.tgz",
+                    "integrity": "sha512-4c8Zowp+V3zIWje329BeLbGh6XI9c/rqARNaj5yPHdC61pHI9UNdDxT3rePPJeWcEZVKjkiAS6AP6kiITp7FSw==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-windows-32": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-                    "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.49.tgz",
+                    "integrity": "sha512-q7Rb+J9yHTeKr9QTPDYkqfkEj8/kcKz9lOabDuvEXpXuIcosWCJgo5Z7h/L4r7rbtTH4a8U2FGKb6s1eeOHmJA==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-windows-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-                    "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.49.tgz",
+                    "integrity": "sha512-+Cme7Ongv0UIUTniPqfTX6mJ8Deo7VXw9xN0yJEN1lQMHDppTNmKwAM3oGbD/Vqff+07K2gN0WfNkMohmG+dVw==",
                     "dev": true,
                     "optional": true
                 },
                 "esbuild-windows-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-                    "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
+                    "version": "0.14.49",
+                    "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.49.tgz",
+                    "integrity": "sha512-v+HYNAXzuANrCbbLFJ5nmO3m5y2PGZWLe3uloAkLt87aXiO2mZr3BTmacZdjwNkNEHuH3bNtN8cak+mzVjVPfA==",
                     "dev": true,
                     "optional": true
                 }
             }
         },
         "esbuild-android-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-            "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.49.tgz",
+            "integrity": "sha512-vYsdOTD+yi+kquhBiFWl3tyxnj2qZJsl4tAqwhT90ktUdnyTizgle7TjNx6Ar1bN7wcwWqZ9QInfdk2WVagSww==",
             "dev": true,
             "optional": true
         },
@@ -29940,7 +30014,9 @@
             "optional": true
         },
         "esbuild-darwin-arm64": {
-            "version": "0.14.34",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.49.tgz",
+            "integrity": "sha512-XMaqDxO846srnGlUSJnwbijV29MTKUATmOLyQSfswbK/2X5Uv28M9tTLUJcKKxzoo9lnkYPsx2o8EJcTYwCs/A==",
             "dev": true,
             "optional": true
         },
@@ -30001,16 +30077,16 @@
             "optional": true
         },
         "esbuild-linux-riscv64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-            "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.49.tgz",
+            "integrity": "sha512-h66ORBz+Dg+1KgLvzTVQEA1LX4XBd1SK0Fgbhhw4akpG/YkN8pS6OzYI/7SGENiN6ao5hETRDSkVcvU9NRtkMQ==",
             "dev": true,
             "optional": true
         },
         "esbuild-linux-s390x": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-            "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
+            "version": "0.14.49",
+            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.49.tgz",
+            "integrity": "sha512-DhrUoFVWD+XmKO1y7e4kNCqQHPs6twz6VV6Uezl/XHYGzM60rBewBF5jlZjG0nCk5W/Xy6y1xWeopkrhFFM0sQ==",
             "dev": true,
             "optional": true
         },
@@ -30782,9 +30858,11 @@
             }
         },
         "focus-trap": {
-            "version": "6.7.3",
+            "version": "6.9.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
+            "integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
             "requires": {
-                "tabbable": "^5.2.1"
+                "tabbable": "^5.3.3"
             }
         },
         "follow-redirects": {
@@ -30814,6 +30892,11 @@
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
+        },
+        "form-request-submit-polyfill": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
+            "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
         },
         "forwarded": {
             "version": "0.2.0",
@@ -31846,7 +31929,9 @@
             }
         },
         "is-core-module": {
-            "version": "2.8.1",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
+            "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -32505,7 +32590,9 @@
             "devOptional": true
         },
         "lodash-es": {
-            "version": "4.17.21"
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
@@ -32526,7 +32613,9 @@
             "dev": true
         },
         "lodash.isplainobject": {
-            "version": "4.0.6"
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
         },
         "lodash.kebabcase": {
             "version": "4.1.1",
@@ -32640,7 +32729,9 @@
             "dev": true
         },
         "luxon": {
-            "version": "2.1.1"
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.4.0.tgz",
+            "integrity": "sha512-w+NAwWOUL5hO0SgwOHsMBAmZ15SoknmQXhSO0hIbJCAmPKSsGeK8MlmhYh2w6Iib38IxN2M+/ooXWLbeis7GuA=="
         },
         "magic-string": {
             "version": "0.25.9",
@@ -32981,9 +33072,6 @@
         "mkdirp": {
             "version": "1.0.4",
             "dev": true
-        },
-        "moment": {
-            "version": "2.29.2"
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -35899,10 +35987,12 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.22.0",
+            "version": "1.22.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+            "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
             "dev": true,
             "requires": {
-                "is-core-module": "^2.8.1",
+                "is-core-module": "^2.9.0",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             }
@@ -35997,7 +36087,9 @@
             }
         },
         "rollup": {
-            "version": "2.70.1",
+            "version": "2.77.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
+            "integrity": "sha512-vL8xjY4yOQEw79DvyXLijhnhh+R/O9zpF/LEgkCebZFtb6ELeN9H3/2T0r8+mp+fFTBHZ5qGpOpW2ela2zRt3g==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -37196,7 +37288,9 @@
             "optional": true
         },
         "tabbable": {
-            "version": "5.2.1"
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
         },
         "tailwindcss": {
             "version": "3.0.23",
@@ -37248,25 +37342,6 @@
                 "terraformer": "~1.0.4"
             }
         },
-        "terser": {
-            "version": "4.8.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
-            "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
-            "dev": true,
-            "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
-            },
-            "dependencies": {
-                "commander": {
-                    "version": "2.20.3",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-                    "dev": true
-                }
-            }
-        },
         "terser-webpack-plugin": {
             "version": "1.4.5",
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
@@ -37284,6 +37359,12 @@
                 "worker-farm": "^1.7.0"
             },
             "dependencies": {
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+                    "dev": true
+                },
                 "find-cache-dir": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -37370,6 +37451,17 @@
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
+                },
+                "terser": {
+                    "version": "4.8.1",
+                    "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+                    "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+                    "dev": true,
+                    "requires": {
+                        "commander": "^2.20.0",
+                        "source-map": "~0.6.1",
+                        "source-map-support": "~0.5.12"
+                    }
                 }
             }
         },
@@ -38160,9 +38252,9 @@
             }
         },
         "vite": {
-            "version": "2.9.12",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.12.tgz",
-            "integrity": "sha512-suxC36dQo9Rq1qMB2qiRorNJtJAdxguu5TMvBHOc/F370KvqAe9t48vYp+/TbPKRNrMh/J55tOUmkuIqstZaew==",
+            "version": "2.9.14",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.14.tgz",
+            "integrity": "sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==",
             "dev": true,
             "requires": {
                 "esbuild": "^0.14.27",
@@ -39747,14 +39839,18 @@
             "optional": true
         },
         "xss": {
-            "version": "1.0.11",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.13.tgz",
+            "integrity": "sha512-clu7dxTm1e8Mo5fz3n/oW3UCXBfV89xZ72jM8yzo1vR/pIS0w3sgB3XV2H8Vm6zfGnHL0FzvLJPJEBhd86/z4Q==",
             "requires": {
                 "commander": "^2.20.3",
                 "cssfilter": "0.0.10"
             },
             "dependencies": {
                 "commander": {
-                    "version": "2.20.3"
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "format": "prettier .  --write"
     },
     "dependencies": {
-        "@arcgis/core": "4.22.2",
+        "@arcgis/core": "4.24.7",
         "@braid/vue-formulate": "~2.5.2",
         "@ecgc/vue-slider-component": "4.0.0-beta.7",
         "@popperjs/core": "~2.9.2",

--- a/scripts/vite-plugin-version.ts
+++ b/scripts/vite-plugin-version.ts
@@ -14,7 +14,7 @@ export default (): Plugin => {
             const [major, minor, patch] = pkg.version.split('.');
 
             config.define
-                ? (config.define.__VERSION__ = {
+                ? (config.define.__RAMP_VERSION__ = {
                       major,
                       minor,
                       patch,

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -8,7 +8,7 @@ import type { FixtureBase, FixtureBaseSet } from '@/store/modules/fixture';
 import type { RampConfig } from '@/types';
 
 const fixtureModules = import.meta.glob<{ default: typeof FixtureInstance }>(
-    `@/fixtures/*/index.ts`
+    '../fixtures/*/index.ts'
 );
 
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -77,10 +77,10 @@ export class InstanceAPI {
         options?: RampOptions
     ) {
         console.log(
-            `RAMP v${__VERSION__.major}.${__VERSION__.minor}.${
-                __VERSION__.patch
-            } [${__VERSION__.hash.slice(0, 9)}] (Built on ${new Date(
-                __VERSION__.timestamp.toString()
+            `RAMP v${__RAMP_VERSION__.major}.${__RAMP_VERSION__.minor}.${
+                __RAMP_VERSION__.patch
+            } [${__RAMP_VERSION__.hash.slice(0, 9)}] (Built on ${new Date(
+                __RAMP_VERSION__.timestamp.toString()
             ).toLocaleString()})`
         );
 

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -19,7 +19,7 @@ import type {
 } from '@/store/modules/panel';
 
 import ScreenSpinnerV from '@/components/panel-stack/screen-spinner.vue';
-const screenModules = import.meta.glob<Component>(`@/fixtures/*/screen.vue`);
+const screenModules = import.meta.glob<Component>('../fixtures/*/screen.vue');
 
 export class PanelInstance extends APIScope {
     /**

--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -52,7 +52,6 @@ import EsriSimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import EsriSimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
 import EsriSymbol from '@arcgis/core/symbols/Symbol';
 import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jsonUtils';
-import EsriGeometryService from '@arcgis/core/tasks/GeometryService';
 import EsriFeatureFilter from '@arcgis/core/layers/support/FeatureFilter';
 import EsriMapView from '@arcgis/core/views/MapView';
 import EsriBasemapGallery from '@arcgis/core/widgets/BasemapGallery';
@@ -72,7 +71,6 @@ export {
     EsriField,
     EsriGeometry,
     EsriGeometryFromJson,
-    EsriGeometryService,
     EsriGraphic,
     EsriGraphicsLayer,
     // EsriIdentifyParameters,

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { configUpgrade2to4, InstanceAPI } from '@/api/internal';
 import type { RampOptions } from '@/api/instance';
 import type { RampConfigs } from './types';
 
-export const version = __VERSION__;
+export const version = __RAMP_VERSION__;
 export function configUpgrade(ramp2Config: any | Array<any>): any {
     return configUpgrade2to4(ramp2Config);
 }


### PR DESCRIPTION
- updated @arcgis/core to version 4.24.7
- Changed __VERSION__ to __RAMP_VERSION__ to avoid the esri collision
- EsriGeometryService has been removed or is missing from the newer version of esri
- changed `` to '' for import.meta.glob (vite warning)

Closes #1256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1268)
<!-- Reviewable:end -->
