### PR TITLE
fix "access panel" tooltip appearing over panel in mobile

### DIFF
--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -5,6 +5,7 @@
         v-tippy="{
             trigger: 'focus',
             appendTo: 'parent',
+            onShow: checkMode,
             popperOptions: {
                 modifiers: [
                     { name: 'preventOverflow', options: { altAxis: true } }
@@ -87,8 +88,15 @@ export default defineComponent({
     },
     data() {
         return {
-            temporary: this.get('appbar/temporary')
+            temporary: this.get('appbar/temporary'),
+            mobileView: this.get('panel/mobileView')
         };
+    },
+    methods: {
+        checkMode() {
+            // If the application is in mobile mode (app only has `xs` CSS class), do not display tooltip.
+            return !this.mobileView;
+        }
     }
 });
 </script>


### PR DESCRIPTION
Closes #1231 

This PR fixes the bug where the 'Access Panel' tooltip would appear over panels when navigating the app in mobile mode. If the app is detected to be in mobile mode (the container only has the `xs` class), the tooltip is disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1269)
<!-- Reviewable:end -->
