### PR TITLE
Feature Highlighting

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -116,6 +116,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_SCALECHANGE<br>'map/scalechanged'              | scale denominator: number                                      | The map scale changed                            |
 | MAP_START<br>'map/start'                           | none                                                           | The map startup was requested                    |
 | PANEL_CLOSED<br>'panel/closed'                     | PanelInstance object                                           | A panel was closed                               |
+| PANEL_MINIMIZED<br>'panel/closed'                 | PanelInstance object                                           | A panel was minimized                             |
 | PANEL_OPENED<br>'panel/opened'                     | PanelInstance object                                           | A panel was opened                               |
 | USER_LAYER_ADDED<br>'user/layeradded'              | LayerInstance object                                           | A layer was added during the session             |
 

--- a/schema.json
+++ b/schema.json
@@ -2101,6 +2101,22 @@
                 "scrollguard": {
                     "$ref": "#/$defs/scrollguard",
                     "description": "Provides the configuration to the scrollguard fixture"
+                },
+                "hilight": {
+                    "description": "Provides configuration to the map's highlighter",
+                    "type": "object",
+                    "properties": {
+                        "mode": {
+                            "description": "The hilight mode to use. The default mode is glow.",
+                            "type": "string",
+                            "default": "glow",
+                            "enum": ["glow", "lift", "none"]
+                        },
+                        "options": {
+                            "description": "Options for the selected hilight mode.",
+                            "type": "object"
+                        }
+                    }
                 }
             },
             "unevaluatedProperties": false

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -15,6 +15,7 @@ import type { LayerReorderAPI } from '@/fixtures/layer-reorder/api/layer-reorder
 import type { MetadataAPI } from '@/fixtures/metadata/api/metadata';
 import type { MetadataPayload } from '@/fixtures/metadata/store';
 import { AppbarAction } from '@/fixtures/appbar/store';
+import type { HilightAPI } from '@/fixtures/hilight/api/hilight';
 import { LegendStore } from '@/fixtures/legend/store';
 import { GridStore, GridAction } from '@/fixtures/grid/store';
 import { LayerState } from '@/geo/api';
@@ -282,6 +283,12 @@ export enum GlobalEvents {
      * Payload: `(panel: PanelInstance)`
      */
     PANEL_CLOSED = 'panel/closed',
+
+    /**
+     * Fires when a panel is minimized.
+     * Payload: `(panel: PanelInstance)`
+     */
+    PANEL_MINIMIZED = 'panel/minimized',
 
     /**
      * Fires when a panel opens.

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -195,6 +195,7 @@ export class FixtureAPI extends APIScope {
                 'geosearch',
                 'grid',
                 'help',
+                'hilight',
                 'layer-reorder',
                 'legend',
                 'mapnav',

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -245,6 +245,8 @@ export class PanelAPI extends APIScope {
             })
         );
 
+        this.$iApi.event.emit(GlobalEvents.PANEL_MINIMIZED, panel);
+
         return panel;
     }
 

--- a/src/components/controls/toggle-switch-control.vue
+++ b/src/components/controls/toggle-switch-control.vue
@@ -7,7 +7,7 @@
         </div>
         <div class="flex-1"></div>
         <toggle
-            @change="value => $emit('toggled', value)"
+            @change="(value: any) => $emit('toggled', value)"
             @keyup.enter.capture.stop="handleKeyup"
             @keyup.space.capture.stop="handleKeyup"
             :disabled="isDisabled"

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -1,5 +1,5 @@
-import { FixtureInstance } from '@/api';
-import type { IdentifyResult } from '@/geo/api';
+import { AttribLayer, FixtureInstance, LayerInstance } from '@/api';
+import type { Graphic, IdentifyItem, IdentifyResult } from '@/geo/api';
 import { DetailsItemInstance, DetailsStore } from '../store';
 
 import type {
@@ -7,6 +7,11 @@ import type {
     DetailsConfigItem,
     DetailsItemSet
 } from '../store';
+
+import type { HilightAPI } from '../../hilight/api/hilight';
+import { HilightMode } from '../../hilight/api/hilight-defs';
+
+export const ORIGIN_DETAILS = 'details';
 
 export class DetailsAPI extends FixtureInstance {
     get config(): DetailsConfig | undefined {
@@ -143,5 +148,93 @@ export class DetailsAPI extends FixtureInstance {
                 );
             }
         });
+    }
+
+    /**
+     * Highlight identified items
+     * @param items identified items
+     */
+    async hilightDetailsItems(
+        items: IdentifyItem | Array<IdentifyItem>,
+        layerUid: string
+    ) {
+        // hilight all provided identify items for this layer
+        const layer: LayerInstance | undefined =
+            this.$iApi.geo.layer.getLayer(layerUid);
+        if (layer) {
+            const hItems = items instanceof Array ? items : [items];
+            const hilightFix: HilightAPI = this.$iApi.fixture.get('hilight');
+            if (hilightFix) {
+                await hilightFix.removeHilight(
+                    hilightFix.getGraphicsByKey((origin = ORIGIN_DETAILS))
+                );
+
+                // get all the identified Graphics
+                const gs: Array<Graphic> = [];
+                await Promise.all(
+                    hItems.map(async item => {
+                        const oid = item.data[layer.oidField];
+                        const g: Graphic = await (
+                            layer as AttribLayer
+                        ).getGraphic(oid, {
+                            getGeom: true,
+                            getAttribs: true,
+                            getStyle: true
+                        });
+                        g.id = hilightFix.constructGraphicKey(
+                            ORIGIN_DETAILS,
+                            layerUid,
+                            oid
+                        );
+                        gs.push(g);
+                    })
+                );
+
+                hilightFix.addHilight(gs);
+            }
+        }
+    }
+
+    /**
+     * Remove all details panel map hilights.
+     */
+    removeDetailsHilight() {
+        const hilightFix: HilightAPI = this.$iApi.fixture.get('hilight');
+        if (hilightFix) {
+            hilightFix.removeHilight(
+                hilightFix.getGraphicsByKey((origin = ORIGIN_DETAILS))
+            );
+        }
+    }
+
+    /**
+     * Updates hilighted graphics when the hilight toggler is toggled.
+     *
+     * @param hilightOn Whether the toggler has been turned on/off
+     * @param items The items that are affected by the toggle
+     * @param layerUid the layer UID
+     */
+    onHilightToggle(
+        hilightOn: boolean,
+        items: IdentifyItem | Array<IdentifyItem>,
+        layerUid: string
+    ) {
+        if (hilightOn) {
+            // hilight got turned on
+            this.hilightDetailsItems(items, layerUid);
+            this.$vApp.$store.set(DetailsStore.hilightToggle, true);
+        } else {
+            // hilight got turned off
+            this.removeDetailsHilight();
+            this.$vApp.$store.set(DetailsStore.hilightToggle, false);
+        }
+    }
+
+    /**
+     * Return whether or not a HilightMode has been defined (other than NONE)
+     */
+    hasHilighter() {
+        const hilightFix: HilightAPI = this.$iApi.fixture.get('hilight');
+        return hilightFix.hilightMode.mode !== HilightMode.NONE;
     }
 }

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -5,19 +5,33 @@
         </template>
         <template #content>
             <div v-if="result.loaded && activeGreedy === 0">
+                <!-- layer name -->
                 <div
-                    class="flex flex-col justify-between py-8 px-8 mb-8 bg-gray-100"
+                    class="p-8 font-bold break-words mb-8 bg-gray-100"
                     v-if="layerExists"
                 >
-                    <!-- layer name -->
-                    <div class="p-8 font-bold break-words">
-                        {{ layerName }}
-                    </div>
-                    <!-- paginator and list button for multiple features -->
-                    <div
-                        class="flex justify-between"
-                        v-if="result.items.length > 1"
-                    >
+                    {{ layerName }}
+                </div>
+                <!-- highlight toggle -->
+                <div
+                    class="p-8 mb-8 bg-gray-100 flex justify-between"
+                    v-if="details.hasHilighter()"
+                >
+                    <div>{{ $t('details.togglehilight.title') }}</div>
+                    <Toggle
+                        :config="{
+                            value: hilightToggle,
+                            disabled: false
+                        }"
+                        @toggled="onHilightToggle"
+                    ></Toggle>
+                </div>
+                <!-- paginator and list button for multiple features -->
+                <div
+                    class="flex flex-col justify-between p-8 mb-8 bg-gray-100"
+                    v-if="layerExists && result.items.length > 1"
+                >
+                    <div class="flex justify-between">
                         <button
                             class="px-8 font-bold hover:bg-gray-200 focus:bg-gray-200"
                             :aria-label="$t('details.item.see.list')"
@@ -146,8 +160,12 @@
 </template>
 
 <script lang="ts">
+// This screen is the view of a single identified geometry (details panel)
+
 import { defineComponent, type PropType } from 'vue';
 import { DetailsStore } from './store';
+import type { DetailsAPI } from './api/details';
+
 import { GlobalEvents } from '@/api';
 import { IdentifyResultFormat } from '@/geo/api';
 import type { FieldDefinition, IdentifyResult, IdentifyItem } from '@/geo/api';
@@ -155,6 +173,7 @@ import type { LayerInstance, PanelInstance } from '@/api/internal';
 
 import ESRIDefaultV from './templates/esri-default.vue';
 import HTMLDefaultV from './templates/html-default.vue';
+import Toggle from '../../components/controls/toggle-switch-control.vue';
 
 export default defineComponent({
     name: 'DetailsItemScreenV',
@@ -175,7 +194,8 @@ export default defineComponent({
     },
     components: {
         'esri-default': ESRIDefaultV,
-        'html-default': HTMLDefaultV
+        'html-default': HTMLDefaultV,
+        Toggle
     },
     data() {
         return {
@@ -187,7 +207,9 @@ export default defineComponent({
             icon: '' as string,
             currentIdx: 0,
             layerExists: false, // tracks whether the layer still exists
-            handlers: [] as Array<string>
+            handlers: [] as Array<string>,
+            details: this.$iApi.fixture.get('details') as DetailsAPI,
+            hilightToggle: true
         };
     },
     mounted() {
@@ -204,6 +226,39 @@ export default defineComponent({
                     }
                 }
             )
+        );
+
+        this.handlers.push(
+            this.$iApi.event.on(
+                GlobalEvents.PANEL_CLOSED,
+                (panel: PanelInstance) => {
+                    if (panel.id == 'details-items') {
+                        this.detailsClosed();
+                    }
+                }
+            )
+        );
+
+        this.handlers.push(
+            this.$iApi.event.on(
+                GlobalEvents.PANEL_MINIMIZED,
+                (panel: PanelInstance) => {
+                    if (panel.id == 'details-items') {
+                        this.detailsMinimized();
+                    }
+                }
+            )
+        );
+
+        this.handlers.push(
+            this.$iApi.event.on(GlobalEvents.MAP_BASEMAPCHANGE, () => {
+                if (this.hilightToggle) {
+                    this.details.hilightDetailsItems(
+                        this.result.items[this.currentIdx],
+                        this.result.uid
+                    );
+                }
+            })
         );
     },
     beforeUnmount() {
@@ -299,11 +354,30 @@ export default defineComponent({
     },
     methods: {
         /**
+         * Clean up for when the details screen is closed.
+         */
+        detailsClosed() {
+            this.details.removeDetailsHilight();
+            this.$store.set(DetailsStore.hilightToggle, true);
+        },
+
+        /**
+         * Clean up for when the details screen is minimized.
+         */
+        detailsMinimized() {
+            this.details.removeDetailsHilight();
+            // TODO: do we want to keep track of the index on minimize?
+        },
+
+        /**
          * Initialize the details screen
          */
         initDetails() {
             this.currentIdx = this.itemIndex ?? 0;
             this.layerExists = true;
+            this.hilightToggle =
+                this.$store.get(DetailsStore.hilightToggle) ??
+                this.hilightToggle;
             this.itemChanged();
         },
 
@@ -333,6 +407,12 @@ export default defineComponent({
                             : ''
                     }`
                 );
+                if (this.hilightToggle) {
+                    this.details.hilightDetailsItems(
+                        this.result.items[this.currentIdx],
+                        this.result.uid
+                    );
+                }
             } else {
                 // wait for load.
                 const localCurrentIndex = this.currentIdx;
@@ -440,6 +520,15 @@ export default defineComponent({
 
             this.$iApi.updateAlert(
                 this.$iApi.$vApp.$t('details.item.alert.zoom')
+            );
+        },
+
+        onHilightToggle(value: boolean) {
+            this.hilightToggle = value;
+            this.details.onHilightToggle(
+                value,
+                this.result.items[this.currentIdx],
+                this.result.uid
             );
         }
     }

--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -15,3 +15,4 @@ details.item.no.data,No data to show because the layer has been removed,1,Aucune
 details.item.alert.zoom,Zoomed into feature,1,Zoomé sur l'élément,0
 details.item.alert.show.item,Showing result {itemName},1,Affichage des résultats {itemName},0
 details.item.alert.show.list,Showing all results for {layerName},1,Afficher tous les résultats pour {layerName},0
+details.togglehilight.title,Toggle Highlight,1,Toggle Souligner,0

--- a/src/fixtures/details/layers-screen.vue
+++ b/src/fixtures/details/layers-screen.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script lang="ts">
-// This screen is the view of all layers that were interrogated in the identify
+// This screen is the view of all layers that were interrogated in the identify (the identify panel)
 
 import { defineComponent } from 'vue';
 import { DetailsStore } from './store';

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -99,4 +99,12 @@ export class DetailsState {
      * @memberof DetailsState
      */
     activeGreedy: number = 0;
+
+    /**
+     * Whether or not the details hilight toggle is on.
+     *
+     * @type boolean
+     * @memberof DetailsState
+     */
+    hilightToggle: boolean = true;
 }

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -69,6 +69,10 @@ export enum DetailsStore {
      */
     activeGreedy = 'details/activeGreedy',
     /**
+     * (State) hilightToggle: boolean
+     */
+    hilightToggle = 'details/hilightToggle',
+    /**
      * (Action) setPayload: (payload: ItemResult[])
      */
     setPayload = 'details/setPayload!',

--- a/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/src/fixtures/geosearch/store/geosearch-store.ts
@@ -229,7 +229,7 @@ export enum GeosearchStore {
      */
     resultsVisible = 'geosearch/resultsVisible',
     /**
-     * (State) resultsVisible: boolean
+     * (State) loadingResults: boolean
      */
     loadingResults = 'geosearch/loadingResults',
     /**

--- a/src/fixtures/hilight/api/hilight-defs.ts
+++ b/src/fixtures/hilight/api/hilight-defs.ts
@@ -1,0 +1,20 @@
+export const HILIGHT_LAYER_NAME = 'Ramp-Hilight';
+
+export const DEFAULT_CONFIG = {
+    mode: 'glow',
+    options: {
+        haloColor: [0, 255, 0], // lime green
+        haloOpacity: 0.8
+    }
+};
+
+export enum HilightMode {
+    NONE = 'none', // no hilight
+    GLOW = 'glow', // an ESRI highlight
+    LIFT = 'lift' // adds identified graphics to the hilightlayer
+}
+
+export interface HilightConfig {
+    mode: HilightMode;
+    options: any; // options for the specified hilight mode
+}

--- a/src/fixtures/hilight/api/hilight-mode/base-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/base-hilight-mode.ts
@@ -1,0 +1,48 @@
+import { APIScope, CommonGraphicLayer, InstanceAPI } from '@/api';
+import { HilightMode, HILIGHT_LAYER_NAME } from '../hilight-defs';
+import type { Graphic } from '@/geo/api';
+
+// This hilight mode does nothing
+export class BaseHilightMode extends APIScope {
+    config: any = {};
+    mode: HilightMode = HilightMode.NONE;
+
+    constructor(config: any, iApi: InstanceAPI) {
+        super(iApi);
+        this.config = config;
+        this.mode = config.mode;
+    }
+
+    /**
+     * Adds the given graphics to the hilight layer.
+     */
+    async add(graphics: Array<Graphic>) {
+        this.notImplementedError('addGraphics');
+    }
+
+    /**
+     * Removes the given graphics from the hilight layer.
+     */
+    async remove(graphics?: Array<Graphic>) {
+        this.notImplementedError('removeGraphics');
+    }
+
+    /**
+     * Returns the Hilight layer.
+     */
+    getHilightLayer(): CommonGraphicLayer | undefined {
+        const hilightLayer = this.$iApi.geo.layer.getLayer(HILIGHT_LAYER_NAME);
+        if (hilightLayer && hilightLayer instanceof CommonGraphicLayer) {
+            return hilightLayer;
+        } else {
+            console.warn('hilight layer could not be fetched.');
+            return undefined;
+        }
+    }
+
+    private notImplementedError(method: string) {
+        console.warn(
+            'Hilight mode method {method} was not implemented by subclass.'
+        );
+    }
+}

--- a/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
@@ -1,0 +1,65 @@
+import { InstanceAPI, GraphicLayer, GlobalEvents } from '@/api';
+import type { Graphic } from '@/geo/api';
+import { HILIGHT_LAYER_NAME } from '../hilight-defs';
+import { LiftHilightMode } from './lift-hilight-mode';
+
+// This hilight mode uses the ESRI highlight to outline the given graphics, creating a "glow"
+export class GlowHilightMode extends LiftHilightMode {
+    handlers: Array<string> = [];
+
+    constructor(config: any, iApi: InstanceAPI) {
+        super(config, iApi);
+
+        this.hilightSetup(config);
+
+        this.handlers.push(
+            this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
+                this.hilightSetup(config);
+            })
+        );
+    }
+
+    private hilightSetup(config: any) {
+        this.$iApi.geo.map.viewPromise.then(() => {
+            this.$iApi.geo.map.esriView!.highlightOptions = config.options;
+        });
+    }
+
+    /**
+     * Adds the given graphics to the hilight layer.
+     */
+    async add(graphics: Array<Graphic>) {
+        // add the given graphics to the layer
+        await super.add(graphics);
+
+        // apply the esri highlight to the graphics
+        const hilightLayer = this.$iApi.geo.layer.getLayer(HILIGHT_LAYER_NAME);
+        if (
+            hilightLayer &&
+            hilightLayer.esriLayer &&
+            hilightLayer.isValidState &&
+            hilightLayer instanceof GraphicLayer
+        ) {
+            const gs: Array<Graphic> =
+                graphics instanceof Array ? graphics : [graphics];
+            this.$iApi.geo.map.esriView
+                ?.whenLayerView(hilightLayer.esriLayer)
+                ?.then(function (layerView) {
+                    gs.forEach((g: Graphic) => {
+                        const graphic = hilightLayer.getEsriGraphic(g.id);
+                        layerView.highlight(graphic);
+                    });
+                });
+        }
+    }
+
+    /**
+     * Removes the given graphics from the hilight layer.
+     */
+    async remove(graphics?: Array<Graphic>) {
+        await super.remove(graphics);
+        // removing the graphic will also remove the esri highlight
+        // so there's nothing else to do here
+        return;
+    }
+}

--- a/src/fixtures/hilight/api/hilight-mode/lift-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/lift-hilight-mode.ts
@@ -1,0 +1,27 @@
+import type { Graphic } from '@/geo/api';
+import { BaseHilightMode } from './base-hilight-mode';
+
+// This hilight mode populates the hilight layer with the given graphics, essentially "lifting" them
+export class LiftHilightMode extends BaseHilightMode {
+    /**
+     * Adds the given graphics to the hilight layer.
+     */
+    async add(graphics: Array<Graphic>) {
+        const hilightLayer = this.getHilightLayer();
+        if (!hilightLayer) {
+            return;
+        }
+        await hilightLayer.addGraphic(graphics);
+    }
+
+    /**
+     * Removes the given graphics from the hilight layer.
+     */
+    async remove(graphics: Array<Graphic> | undefined) {
+        const hilightLayer = this.getHilightLayer();
+        if (!hilightLayer) {
+            return;
+        }
+        await hilightLayer.removeGraphic(graphics);
+    }
+}

--- a/src/fixtures/hilight/api/hilight.ts
+++ b/src/fixtures/hilight/api/hilight.ts
@@ -1,0 +1,183 @@
+import {
+    InstanceAPI,
+    CommonGraphicLayer,
+    FixtureInstance,
+    GlobalEvents
+} from '@/api/internal';
+import { Graphic, LayerType } from '@/geo/api';
+import {
+    DEFAULT_CONFIG,
+    HILIGHT_LAYER_NAME,
+    HilightMode,
+    type HilightConfig
+} from './hilight-defs';
+import { BaseHilightMode } from './hilight-mode/base-hilight-mode';
+import { GlowHilightMode } from './hilight-mode/glow-hilight-mode';
+import { LiftHilightMode } from './hilight-mode/lift-hilight-mode';
+
+export class HilightAPI extends FixtureInstance {
+    hilightMode: BaseHilightMode = new BaseHilightMode({}, this.$iApi);
+
+    constructor(id: string, iApi: InstanceAPI) {
+        super(id, iApi);
+        // create the hilight layer
+        if (this.$iApi.geo.map.created) {
+            this.initHilightLayer();
+        } else {
+            this.$iApi.event.once(
+                GlobalEvents.MAP_CREATED,
+                this.initHilightLayer
+            );
+        }
+    }
+
+    _parseConfig(hilightConfig?: HilightConfig) {
+        if (hilightConfig) {
+            switch (hilightConfig.mode) {
+                case HilightMode.NONE:
+                    this.hilightMode = new BaseHilightMode(
+                        hilightConfig,
+                        this.$iApi
+                    );
+                    break;
+                case HilightMode.GLOW:
+                    this.hilightMode = new GlowHilightMode(
+                        hilightConfig,
+                        this.$iApi
+                    );
+                    break;
+                case HilightMode.LIFT:
+                    this.hilightMode = new LiftHilightMode(
+                        hilightConfig,
+                        this.$iApi
+                    );
+                    break;
+                default:
+                    // in this case, the hilighter will use NONE (BaseHilightMode)
+                    console.error(
+                        'Could not find hilight mode:',
+                        hilightConfig.mode
+                    );
+                    break;
+            }
+        } else {
+            // defaults to GLOW
+            this.hilightMode = new GlowHilightMode(DEFAULT_CONFIG, this.$iApi);
+        }
+    }
+
+    /**
+     * Create the Hilight layer.
+     */
+    async initHilightLayer() {
+        const hilightLayer = await this.$iApi.geo.layer.createLayer({
+            id: HILIGHT_LAYER_NAME,
+            layerType: LayerType.GRAPHIC,
+            cosmetic: true,
+            url: ''
+        });
+        this.$iApi.geo.map.addLayer(hilightLayer);
+    }
+
+    /**
+     * Add the given Graphics to the Hilighter
+     *
+     * @param graphics Graphics to add
+     */
+    async addHilight(graphics: Array<Graphic> | Graphic) {
+        const gs = graphics instanceof Array ? graphics : [graphics];
+        await this.hilightMode.add(gs);
+    }
+
+    /**
+     * Remove the given Graphics from the Hilighter
+     *
+     * @param graphics Graphics to remove
+     */
+    async removeHilight(graphics?: Array<Graphic> | Graphic) {
+        const gs: Array<Graphic> | undefined = graphics
+            ? graphics instanceof Array
+                ? graphics
+                : [graphics]
+            : undefined;
+        await this.hilightMode.remove(gs);
+    }
+
+    /**
+     * Return all Graphics that match the given origin/uid/oid
+     *
+     * @param origin Graphic origin
+     * @param uid Associated layer UID of the Graphic
+     * @param oid Associated OID of the Graphic
+     */
+    getGraphicsByKey(
+        origin?: string,
+        uid?: string,
+        oid?: number
+    ): Array<Graphic> {
+        const hilightLayer = this.getHilightLayer();
+        if (!hilightLayer) {
+            return [];
+        }
+
+        let keys = hilightLayer.graphics.map(g => ({
+            ...this.deconstructGraphicKey(g.id),
+            og: g
+        }));
+
+        if (origin) {
+            keys = keys.filter(k => k.origin === origin);
+        }
+
+        if (uid) {
+            keys = keys.filter(k => k.uid === uid);
+        }
+
+        if (oid) {
+            keys = keys.filter(k => k.oid === oid);
+        }
+
+        return keys.map(k => k.og);
+    }
+
+    /**
+     * Return a well-formed graphic key
+     */
+    constructGraphicKey(origin: string, uid: string, oid: number): string {
+        return `${HILIGHT_LAYER_NAME}~${origin}~${uid}~${oid}`;
+    }
+
+    /**
+     * Return a deconstructed graphic key.
+     *
+     * @param key The graphic key to deconstruct
+     */
+    deconstructGraphicKey(key: string): {
+        origin: string;
+        uid: string;
+        oid: number;
+    } {
+        const ids = key.split('~');
+        if (ids.length !== 4) {
+            console.warn('Malformed Hilight Graphic key provided:', key);
+        }
+        return { origin: ids[1], uid: ids[2], oid: parseInt(ids[3]) };
+    }
+
+    /**
+     * Return the hilightLayer
+     */
+    getHilightLayer(): CommonGraphicLayer | undefined {
+        const hilightLayer = this.$iApi.geo.layer.getLayer(HILIGHT_LAYER_NAME);
+        if (
+            hilightLayer &&
+            hilightLayer.isValidState &&
+            hilightLayer instanceof CommonGraphicLayer
+        ) {
+            return hilightLayer;
+        } else {
+            console.warn('hilight layer could not be fetched.');
+            return undefined;
+        }
+    }
+}

--- a/src/fixtures/hilight/index.ts
+++ b/src/fixtures/hilight/index.ts
@@ -1,0 +1,21 @@
+import { HilightAPI } from './api/hilight';
+
+class HilightFixture extends HilightAPI {
+    async added() {
+        console.log(`[fixture] ${this.id} added`);
+
+        this._parseConfig(this.config);
+        let unwatch = this.$vApp.$watch(
+            () => this.config,
+            (value: any) => this._parseConfig(value)
+        );
+
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            console.log(`[fixture] ${this.id} removed`);
+            unwatch();
+        };
+    }
+}
+
+export default HilightFixture;

--- a/src/fixtures/settings/component.vue
+++ b/src/fixtures/settings/component.vue
@@ -12,7 +12,7 @@ import { defineComponent, markRaw } from 'vue';
 
 // Import control templates.
 import SliderControl from './templates/slider-control.vue';
-import ToggleSwitchControl from './templates/toggle-switch-control.vue';
+import ToggleSwitchControl from '../../components/controls/toggle-switch-control.vue';
 import InputControl from './templates/input-control.vue';
 import { svgIcons } from './templates/icons';
 

--- a/src/geo/layer/common-graphic-layer.ts
+++ b/src/geo/layer/common-graphic-layer.ts
@@ -3,7 +3,7 @@
 // TODO add proper comments
 
 import { CommonLayer, InstanceAPI } from '@/api/internal';
-import type { EsriGraphicsLayer } from '@/geo/esri';
+import type { EsriGraphicsLayer, EsriGraphic } from '@/geo/esri';
 import { DataFormat, Graphic, LayerFormat } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 
@@ -63,6 +63,10 @@ export class CommonGraphicLayer extends CommonLayer {
      */
     getLocalGraphic(graphicId: string): Graphic | undefined {
         return this._graphics.find(g => g.id === graphicId);
+    }
+
+    getEsriGraphic(graphicId: string): EsriGraphic | undefined {
+        return this.esriLayer?.graphics.find((g: any) => g.id === graphicId);
     }
 
     protected notLoadedErr(): void {
@@ -143,6 +147,7 @@ export class CommonGraphicLayer extends CommonLayer {
         if (typeof graphics === 'undefined') {
             // TODO remove hover stuff once supported
             this.esriLayer.removeAll();
+            this._graphics = [];
             // TODO raise event?
             return;
         }
@@ -172,7 +177,7 @@ export class CommonGraphicLayer extends CommonLayer {
             if (target) {
                 targets.push(target);
                 const rampIdx = this._graphics.findIndex(g => g.id === id);
-                if (rampIdx) {
+                if (rampIdx != -1) {
                     this._graphics.splice(rampIdx, 1);
                 }
             }
@@ -180,6 +185,7 @@ export class CommonGraphicLayer extends CommonLayer {
 
         // TODO remove hover stuff once supported
         this.esriLayer.removeMany(targets);
+        this._graphics = this._graphics.filter(g => ids.includes(g.id));
 
         // TODO raise event?
     }

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -400,9 +400,10 @@ export class CommonLayer extends LayerInstance {
             this._name = this.esriLayer?.title || this.id;
         }
 
-        this.identify = !(this.config.state?.identify == undefined)
-            ? this.config.state.identify
-            : this.supportsIdentify;
+        if (!this.isCosmetic) {
+            this.identify =
+                this.config.state?.identify ?? this.supportsIdentify;
+        }
 
         // TODO implement extent defaulting. Need to add property, get appropriate format from incoming ramp config, maybe need an interface
         /*

--- a/src/geo/map/maptip.ts
+++ b/src/geo/map/maptip.ts
@@ -79,6 +79,7 @@ export class MaptipAPI extends APIScope {
             return;
         }
 
+        // TODO: remove this once we support hovers on RAMP graphics
         if (!layerInstance.hovertips) {
             // the hit layer doesn't support hovertips
             return;


### PR DESCRIPTION
Closes #127 🎉 
Related discussions: #837, #1084 

## Hilight API
- There is now a hilight API and the details panel is using it
- The hilight API is responsible for creating the hilightLayer, adding/removing Graphics from the hilightLayer, and applying the hilight effect
- The caller is responsible for providing correctly formatted Graphics and deciding when to add/remove graphics
- Hilight graphics can be identified by their graphic key, which the hilight API can build using the graphic's origin (e.g., "details"), the associated layer UID, and the associated OID

## Hilight Mode
- There are currently 3 hilight modes implemented: `NONE`, `LIFT`, and `GLOW`
  - `NONE` is the base hilight mode. No hilight happens.
  - `LIFT` will populate the hilightLayer with the given Graphics, essentially "lifting" them to the top of the map
  - `GLOW` inherits from `LIFT` and uses the Esri highlight to hilight the lifted graphics.
- `GLOW` is the default hilight mode and currently defaults to using a lime green halo
- Map authors can specify the Esri highlightOptions for `GLOW`, or choose a different hilight mode through the config
- There are plans to implement a `FOG` hilight mode which will more closely emulate what ramp2 does

## Hilight Removal
- See #1084 for discussion. I've gone with the Toggler + Hybrid approach, which means we are no longer using the "click to clear" method that ramp2 uses anymore
- Toggler + Hybrid specifics
  - Toggler appears at the top of the details panel
  - Toggler always starts on when the details panel is opened. This means that closing the details panel and then opening it again will reset the toggler
  - Toggling off will remove the hilight
  - Scrolling between items and switching between the item/result screens does not reset the toggler
  - As long as details is still open, switching between different layer results on the identify panel does not reset the toggler
  - Closing the details panel always removes the hilight
  - Minimizing the details panel removes the hilight, but remembers the toggle value
  - Panning does not remove the hilight (compared to ramp2 where it does get removed)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1271)
<!-- Reviewable:end -->
