### PR TITLE
Fixes for multiple mobile panel issues

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -114,6 +114,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_RESIZED<br>'map/resized'                       | _height_: new height, _width_: new width                       | The map view changed size                        |
 | MAP_SCALECHANGE<br>'map/scalechanged'              | scale denominator: number                                      | The map scale changed                            |
 | MAP_START<br>'map/start'                           | none                                                           | The map startup was requested                    |
+| MOBILE_VIEW<br>'panel/mobile'                      | mobileMode: boolean                                            | The screen changes to/from mobile resolution     |
 | PANEL_CLOSED<br>'panel/closed'                     | PanelInstance object                                           | A panel was closed                               |
 | PANEL_OPENED<br>'panel/opened'                     | PanelInstance object                                           | A panel was opened                               |
 | USER_LAYER_ADDED<br>'user/layeradded'              | LayerInstance object                                           | A layer was added during the session             |

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -265,10 +265,16 @@ export enum GlobalEvents {
     MAP_START = 'map/start',
 
     /**
-     * Fires when a request is issued to open the Metadata panel
+     * Fires when a request is issued to open the Metadata panel.
      * Payload: `({ type: string, layerName: string, url: string })`
      */
     METADATA_OPEN = 'metadata/open',
+
+    /**
+     * Fires when screen size changes from/to mobile resolution.
+     * Payload `(mobileMode: boolean)`
+     */
+    MOBILE_VIEW = 'panel/mobile',
 
     /**
      * Fires when a panel is closed.

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -1,6 +1,5 @@
 import { createApp, defineComponent, h, render } from 'vue';
-
-import type { Component, ComponentOptions, ComponentPublicInstance } from 'vue';
+import type { Component, ComponentOptions } from 'vue';
 
 import { APIScope, GlobalEvents, InstanceAPI } from './internal';
 import { FixtureMutation } from '@/store/modules/fixture';
@@ -427,7 +426,11 @@ export class FixtureInstance extends APIScope implements FixtureBase {
      * @param {Array<string>} panels list of panel names for the calling fixture
      */
     handlePanelWidths(panels: Array<string>): void {
-        if (this.config?.panelWidth) {
+        // for mobile mode, disregard specified panel widths and use default 100% width
+        if (
+            this.config?.panelWidth &&
+            !this.$vApp.$store.get('panel/mobileView')
+        ) {
             const panelWidths: any = {};
 
             // If only a number was provided, use it as the `default` value.

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -297,11 +297,12 @@ export class InstanceAPI {
      * @memberof InstanceAPI
      */
     get screenSize(): string | null {
-        if (!this.$root || !this.$root.$refs['app-size']) {
+        if (!this.$vApp?.$root || !this.$vApp.$root.$refs['app-size']) {
             return null;
         }
 
-        const classList = this.$root.$refs['app-size'].classList;
+        const classList = (this.$vApp.$root.$refs['app-size'] as HTMLElement)
+            .classList;
         if (classList.contains('lg')) {
             return 'lg';
         } else if (classList.contains('md')) {

--- a/src/components/panel-stack/panel-container.vue
+++ b/src/components/panel-stack/panel-container.vue
@@ -36,31 +36,8 @@ export default defineComponent({
     data() {
         return {
             // indicates if the transition should be skipped
-            skipTransition: false,
-            mobileMode: this.get('panel/mobileView'),
-            watchers: [] as Array<Function>
+            skipTransition: false
         };
-    },
-
-    mounted() {
-        // make panel container responsive when resizing to mobile resolution
-        this.watchers.push(
-            this.$watch(
-                'mobileMode',
-                (newMobileMode: boolean, oldMobileMode: boolean) => {
-                    if (newMobileMode !== oldMobileMode && newMobileMode) {
-                        // set width back to 100% for mobile
-                        this.$iApi.panel.setStyle(this.panel, {
-                            width: '100%'
-                        });
-                    }
-                }
-            )
-        );
-    },
-
-    beforeUnmount() {
-        this.watchers.forEach(unwatch => unwatch());
     },
 
     methods: {

--- a/src/components/panel-stack/panel-container.vue
+++ b/src/components/panel-stack/panel-container.vue
@@ -20,11 +20,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
-import type { PropType } from 'vue';
-
+import { defineComponent, type PropType } from 'vue';
 import anime from 'animejs';
-
 import type { PanelInstance } from '@/api';
 
 export default defineComponent({
@@ -39,8 +36,31 @@ export default defineComponent({
     data() {
         return {
             // indicates if the transition should be skipped
-            skipTransition: false
+            skipTransition: false,
+            mobileMode: this.get('panel/mobileView'),
+            watchers: [] as Array<Function>
         };
+    },
+
+    mounted() {
+        // make panel container responsive when resizing to mobile resolution
+        this.watchers.push(
+            this.$watch(
+                'mobileMode',
+                (newMobileMode: boolean, oldMobileMode: boolean) => {
+                    if (newMobileMode !== oldMobileMode && newMobileMode) {
+                        // set width back to 100% for mobile
+                        this.$iApi.panel.setStyle(this.panel, {
+                            width: '100%'
+                        });
+                    }
+                }
+            )
+        );
+    },
+
+    beforeUnmount() {
+        this.watchers.forEach(unwatch => unwatch());
     },
 
     methods: {

--- a/src/components/panel-stack/panel-stack.vue
+++ b/src/components/panel-stack/panel-stack.vue
@@ -47,7 +47,9 @@ export default defineComponent({
             // then the screen is too large).
             this.$store.set(
                 'panel/mobileView',
-                !this.$root.$refs['app-size'].classList.contains('sm')
+                !(
+                    this.$root?.$refs['app-size'] as HTMLElement
+                ).classList.contains('sm')
             );
 
             this.$store.set('panel/stackWidth', entries[0].contentRect.width);

--- a/src/components/panel-stack/panel-stack.vue
+++ b/src/components/panel-stack/panel-stack.vue
@@ -16,9 +16,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { GlobalEvents } from '@/api';
 
 import anime from 'animejs';
-
 import PanelContainerV from './panel-container.vue';
 
 declare class ResizeObserver {
@@ -36,21 +36,26 @@ export default defineComponent({
 
     data() {
         return {
-            visible: this.get('panel/getVisible')
+            visible: this.get('panel/getVisible'),
+            mobileMode: this.get('panel/mobileView')
         };
     },
 
     mounted(): void {
         // sync the `panel-stack` width into the store so that visible can get calculated
         const resizeObserver = new ResizeObserver((entries: any) => {
-            // Determine if the app is in mobile mode (the app container ONLY has the `xs` class on it. If it contains `sm`
-            // then the screen is too large).
-            this.$store.set(
-                'panel/mobileView',
-                !(
-                    this.$root?.$refs['app-size'] as HTMLElement
-                ).classList.contains('sm')
-            );
+            // determine if app is in mobile mode (app container ONLY has the `xs` class on it,
+            // if it contains `sm` then the screen is too large)
+            const newMode = !(
+                this.$root?.$refs['app-size'] as HTMLElement
+            ).classList.contains('sm');
+            const oldMode = this.mobileMode;
+
+            this.$store.set('panel/mobileView', newMode);
+            // fire event when mobile mode changes
+            if (oldMode !== newMode) {
+                this.$iApi.event.emit(GlobalEvents.MOBILE_VIEW, newMode);
+            }
 
             this.$store.set('panel/stackWidth', entries[0].contentRect.width);
         });

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -5,7 +5,9 @@ import DetailsLayerScreenV from './layers-screen.vue';
 import DetailsResultScreenV from './result-screen.vue';
 import DetailsItemScreenV from './item-screen.vue';
 import messages from './lang/lang.csv?raw';
+
 import { markRaw } from 'vue';
+import { GlobalEvents } from '@/api';
 
 class DetailsFixture extends DetailsAPI {
     async added() {
@@ -54,10 +56,33 @@ class DetailsFixture extends DetailsAPI {
             (value: DetailsConfig | undefined) => this._parseConfig(value)
         );
 
+        let eventHandlers: string[] = [];
+        // make panel container responsive when resizing to mobile resolution
+        eventHandlers.push(
+            this.$iApi.event.on(
+                GlobalEvents.MOBILE_VIEW,
+                (mobileMode: boolean) => {
+                    const detailsPanels = ['details-items', 'details-layers'];
+                    if (!mobileMode) {
+                        this.handlePanelWidths(detailsPanels);
+                    } else {
+                        // set width to 100% on mobile
+                        for (const panel of detailsPanels) {
+                            this.$iApi.panel.setStyle(panel, {
+                                width: '100%'
+                            });
+                        }
+                    }
+                }
+            )
+        );
+
         // override the removed method here to get access to scope
         this.removed = () => {
             console.log(`[fixture] ${this.id} removed`);
             unwatch();
+            eventHandlers.forEach(h => this.$iApi.event.off(h));
+
             this.$iApi.panel.remove('details-items');
             this.$iApi.panel.remove('details-layers');
 

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -115,7 +115,7 @@ const actions = {
     },
 
     [PanelAction.updateVisible](context: PanelContext): void {
-        //TODO: update when panel width system is in place
+        // TODO: update when panel width system is in place
         let remainingWidth = context.state.stackWidth;
         let nowVisible: PanelInstance[] = [];
 
@@ -123,15 +123,19 @@ const actions = {
         for (let i = context.state.orderedItems.length - 1; i >= 0; i--) {
             let panelWidth = context.state.orderedItems[i].width || 350;
 
-            // If not in mobile view, all panels have a 12px margin to the right.
+            // if not in mobile view, all panels have a 12px margin to the right
             if (!context.state.mobileView) {
                 panelWidth += 12;
             } else {
-                // If in mobile view, a single panel will take up the whole view.
-                panelWidth = 0;
+                // if in mobile view, a single panel will take up the whole view
+                panelWidth = remainingWidth;
             }
 
-            if (remainingWidth >= panelWidth) {
+            // mobile mode only allows for one panel to be visible
+            if (
+                (remainingWidth >= panelWidth && !context.state.mobileView) ||
+                nowVisible.length === 0
+            ) {
                 remainingWidth -= panelWidth;
                 nowVisible.unshift(context.state.orderedItems[i]);
             }


### PR DESCRIPTION
Closes #1225, #1227, #1242

**Changes**: 
- fix screensize pointers to invalid values that resulted in panels being queued in mobile
- change panel visibility logic on mobile to avoid needing two clicks opening a hidden panel from appbar when it was previously open
- add `MOBILE_VIEW` event for when screen resolution changes to/from mobile view
- fix default config widths for details being cut-off on mobile and make it responsive to when screen size changes based on listening for `MOBILE_VIEW` event

**Testing** (mobile testing in progress)
- opening panels on mobile should not hide them in a queue 
- opening previously open panels (hidden) in mobile should not require 2 clicks from appbar
- details default config widths should not be applied on mobile and should take up 100% width (also try resizing from normal browser size to mobile to ensure responsive details panel widths)
- opening grid should not take two clicks (have not been able to test this yet on mobile - could not reproduce on Chrome)