### PR TITLE
Panel Open/Pin in Config

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -445,13 +445,16 @@ let config = {
                     fileName: 'ramp-pcar-4-map-carte'
                 }
             },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
             system: { animate: true }
         }
     }
 };
 
 let options = {
-    loadDefaultFixtures: false,
+    loadDefaultFixtures: true,
     loadDefaultEvents: true,
     startRequired: false
 };
@@ -461,10 +464,11 @@ const rInstance = createInstance(
     config,
     options
 );
-rInstance.fixture.addDefaultFixtures().then(() => {
-    rInstance.panel.open('legend');
-    rInstance.panel.pin('legend');
-});
+
+// rInstance.fixture.addDefaultFixtures().then(() => {
+//     rInstance.panel.open('legend');
+//     rInstance.panel.pin('legend');
+// });
 
 rInstance.$element.component('WFSLayer-Custom', {
     props: ['identifyData'],

--- a/docs/app/panels.md
+++ b/docs/app/panels.md
@@ -4,6 +4,11 @@
 
 Write other stuff.
 
+## Startup
+
+Panels can be opened/pinned when RAMP starts up via the config. The following stock panel ID's are currently supported:
+`basemap`, `export`, `geosearch`, `help`, `layer-reorder`, `legend`, `notifications`, and `wizard`.
+
 ## Buttons
 
 Panels can be registered with button options. These consist of an icon and a tooltip which the [appbar](appbar.md) will use to create default appbar buttons as needed.

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -455,13 +455,16 @@ let config = {
                     }
                 }
             },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
             system: { animate: true }
         }
     }
 };
 
 let options = {
-    loadDefaultFixtures: false,
+    loadDefaultFixtures: true,
     loadDefaultEvents: true,
     startRequired: false
 };
@@ -474,10 +477,10 @@ const rInstance = RAMP.createInstance(
 
 window.debugInstance = rInstance;
 
-rInstance.fixture.addDefaultFixtures().then(() => {
+/* rInstance.fixture.addDefaultFixtures().then(() => {
     rInstance.panel.open('legend');
     rInstance.panel.pin('legend');
-});
+}); */
 
 rInstance.$element.component('WFSLayer-Custom', {
     props: ['identifyData'],

--- a/schema.json
+++ b/schema.json
@@ -235,16 +235,6 @@
                         "visibilityToggle"
                     ]
                 },
-                "isOpen": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Specifies whether legend panel is open by default."
-                },
-                "isPinned": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Specifies whether legend panel is pinned by default."
-                },
                 "panelWidth": {
                     "$ref": "#/$defs/panelWidth"
                 },
@@ -1590,11 +1580,6 @@
                     "default": "",
                     "description": "Title of the datatable."
                 },
-                "isOpen": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Specifies if this table component should be open/closed on initial load."
-                },
                 "columns": {
                     "type": "array",
                     "description": "An array to specify how the columns (properties) of the table are defined. If a column is not present in the array, it is treated as disabled.",
@@ -2011,7 +1996,6 @@
                 "legend": {
                     "$ref": "#/$defs/legend",
                     "default": {
-                        "isOpen": false,
                         "root": {}
                     },
                     "description": "Provides configuration to legend. If not supplied, a blank legend is displayed."
@@ -2120,6 +2104,33 @@
                 }
             },
             "unevaluatedProperties": false
+        },
+        "panels": {
+            "type": "object",
+            "description": "Configuration of panel properties.",
+            "properties": {
+                "open": {
+                    "type": "array",
+                    "description": "The panels to open on startup. Panels with props are currently not supported.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "The ID of the panel to open."
+                            },
+                            "pin": {
+                                "type": "boolean",
+                                "default": "false",
+                                "description": "Whether to pin the panel as well (in addition to opening)."
+                            }
+                        },
+                        "required": ["id"],
+                        "additionalProperties": "false"
+                    }
+                }
+            },
+            "additionalProperties": "false"
         },
         "layers": {
             "$ref": "#/$defs/layerList",

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -92,6 +92,7 @@ function individualConfigUpgrader(r2c: any): any {
         fixtures: {},
         layers: [],
         map: {},
+        panels: { open: [] },
         system: { animate: true },
         fixturesEnabled: [] // this will be removed in the final step of configUpgrade2to4
     };
@@ -1201,15 +1202,15 @@ function uiUpgrader(r2ui: any, r4c: any): void {
         // legend already mapped through mapUpgrader
         if (r4c.fixtures.legend) {
             r4c.fixtures.legend.headerControls = headerControls;
-            r4c.fixtures.legend.isOpen =
-                r2ui.legend.isOpen && r2ui.legend.isOpen.large;
         } else {
             r4c.fixturesEnabled.push('legend');
             r4c.fixtures.legend = {
                 headerControls: headerControls,
-                isOpen: r2ui.legend.isOpen && r2ui.legend.isOpen.large,
                 root: {}
             };
+        }
+        if (r2ui.legend.isOpen && r2ui.legend.isOpen.large) {
+            r4c.panels.open.push({ id: 'legend' });
         }
     }
 
@@ -1282,12 +1283,16 @@ function uiUpgrader(r2ui: any, r4c: any): void {
     ];
     if (
         r2ui.tableIsOpen &&
-        r2ui.tableIsOpen.id &&
-        r2ui.tableIsOpen.large &&
-        r4c.layers &&
-        r4c.layers.length > 0
+        // r2ui.tableIsOpen.id &&
+        r2ui.tableIsOpen.large
+        // r4c.layers &&
+        // r4c.layers.length > 0
     ) {
-        for (let i = 0; i < r4c.layers.length; i++) {
+        // TODO: revisit once layer usage is normalized and layer-bound panels can be opened on startup.
+        // See https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/1279 for details.
+        /*
+        r4c.panels.open.push({ id: 'grid' });
+         for (let i = 0; i < r4c.layers.length; i++) {
             if (
                 r4c.layers[i].id === r2ui.tableIsOpen.id &&
                 allowedTypes.includes(r4c.layers[i].layerType)
@@ -1336,7 +1341,7 @@ function uiUpgrader(r2ui: any, r4c: any): void {
                     }
                 }
             }
-        }
+        } */
     }
 
     // TODO: If any of these properties get implemented/used in the future, remove them from the warning list and map them appropriately.

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -172,6 +172,32 @@ export class FixtureAPI extends APIScope {
     }
 
     /**
+     * Provides a promise that resolves when the fixture(s) have finished loading.
+     *
+     * @param {(string | string[])} fixtureId the fixture ID(s) for which the promise is requested
+     * @memberof FixtureAPI
+     */
+    isLoaded(fixtureId: string | string[]): Promise<any> {
+        // We first create loadPromises for fixtures that don't have one
+        const idsToCheck = Array.isArray(fixtureId) ? fixtureId : [fixtureId];
+        idsToCheck.forEach((id: string) => {
+            if (
+                this.$vApp.$store.get(`fixture/loadPromises@${id}`) ===
+                undefined
+            ) {
+                this.$vApp.$store.set(
+                    `fixture/${FixtureMutation.ADD_LOAD_PROMISE}!`,
+                    id
+                );
+            }
+        });
+        // Now, get all the promises and return
+        return Promise.all(
+            this.$vApp.$store.get('fixture/getLoadPromises', idsToCheck) // not sure how to get typescript to stop yelling
+        );
+    }
+
+    /**
      * Loads the set of standard, built-in fixtures to the R4MP Vue instance.
      * This will quickly set up the vanilla version of RAMP.
      * Note this function is automatically run by the instance startup unless the loadDefaultFixtures option is

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -165,6 +165,28 @@ export class InstanceAPI {
                 )
             );
 
+            // open and pin appropiate panels on startup
+            // TODO: Note that certain panels like grid, settings, etc. need to get data for a specific layer.
+            // Because different fixtures get this data in different ways (some use LayerInstance, some uid, some custom config),
+            // there is no way to open the panel with layer data loaded without writing specific code for specific fixtures.
+            // Once layer usage throughout RAMP is normalized, add an extra nugget in the config called options or something so that the panel
+            // can load layer data as well.
+            if (
+                langConfig.panels &&
+                langConfig.panels.open &&
+                langConfig.panels.open.length > 0
+            ) {
+                const panelIds = langConfig.panels.open.map(p => p.id);
+                this.panel.isRegistered(panelIds).then(() => {
+                    langConfig.panels?.open?.forEach(panel => {
+                        this.panel.open(panel.id);
+                        if (panel.pin) {
+                            this.panel.pin(panel.id);
+                        }
+                    });
+                });
+            }
+
             // disable animations if needed
             if (
                 !langConfig.system?.animate &&

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -88,7 +88,9 @@ export default defineComponent({
     },
     data() {
         return {
-            temporary: this.get('appbar/temporary'),
+            temporary: this.$iApi.fixture.get('appbar')
+                ? this.$store.get('appbar/temporary')
+                : [],
             mobileView: this.get('panel/mobileView')
         };
     },

--- a/src/store/modules/fixture/fixture-state.ts
+++ b/src/store/modules/fixture/fixture-state.ts
@@ -1,5 +1,8 @@
+import type { DefPromise } from '@/geo/api';
+
 export class FixtureState {
     items: { [name: string]: FixtureBase } = {};
+    loadPromises: { [name: string]: DefPromise } = {};
 }
 
 export type FixtureBaseSet = { [name: string]: FixtureBase };

--- a/src/store/modules/panel/panel-state.ts
+++ b/src/store/modules/panel/panel-state.ts
@@ -1,6 +1,7 @@
 import type { Component, ComponentOptions, ComponentPublicInstance } from 'vue';
 
 import type { PanelInstance } from '@/api';
+import type { DefPromise } from '@/geo/api';
 
 export class PanelState {
     /**
@@ -10,6 +11,13 @@ export class PanelState {
      * @memberof PanelState
      */
     items: { [name: string]: PanelInstance } = {};
+
+    /**
+     * A list of registration promises for all panels.
+     * @type {{ [name: string]: DefPromise }}
+     * @memberof PanelState
+     */
+    regPromises: { [name: string]: DefPromise } = {};
 
     /**
      * A list of all panels in the arrangement they would be put on screen.

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -5,6 +5,7 @@ import { PanelState } from './panel-state';
 import type { PanelConfig } from './panel-state';
 import type { RootState } from '@/store/state';
 import type { PanelInstance } from '@/api';
+import { DefPromise } from '@/geo/api';
 
 type PanelContext = ActionContext<PanelState, RootState>;
 
@@ -23,6 +24,7 @@ export enum PanelMutation {
     OPEN_PANEL = 'OPEN_PANEL',
 
     ADD_TO_PANEL_ORDER = 'ADD_TO_PANEL_ORDER',
+    ADD_REG_PROMISE = 'ADD_REG_PROMISE',
     CLOSE_PANEL = 'CLOSE_PANEL',
     REMOVE_PANEL = 'REMOVE_PANEL',
 
@@ -57,7 +59,24 @@ const getters = {
      */
     getRemainingWidth: (state: PanelState): number => {
         return state.remainingWidth;
-    }
+    },
+
+    /**
+     * Returns registration promises from the state, for the specified panelIds.
+     * Should ideally be called when all panelIds have a promise associated with them.
+     * @param panelIds the panel Ids for which promises should be returned
+     */
+    getRegPromises:
+        (state: PanelState) =>
+        (panelIds: string[]): Promise<void>[] => {
+            const regPromises: Promise<void>[] = [];
+            panelIds.forEach((panelId: string) => {
+                if (panelId in state.regPromises) {
+                    regPromises.push(state.regPromises[panelId].getPromise());
+                }
+            });
+            return regPromises;
+        }
 };
 
 const actions = {
@@ -143,7 +162,6 @@ const actions = {
             !nowVisible.includes(context.state.pinned)
         ) {
             let lastElement: PanelInstance;
-
             // remove elements from visible until theres room for pinned
             for (
                 let i = 0;
@@ -176,14 +194,15 @@ const actions = {
             );
             // clone the current order, splice out the pinned item, insert it back in after the last element we removed from visible
             const newPanelOrder = context.state.orderedItems.slice();
-            newPanelOrder.splice(pinnedIndex, 1);
-            newPanelOrder.splice(lastRemovedIndex, 0, context.state.pinned);
+            if (lastRemovedIndex > -1) {
+                newPanelOrder.splice(pinnedIndex, 1);
+                newPanelOrder.splice(lastRemovedIndex, 0, context.state.pinned);
+            }
 
             context.commit(PanelMutation.SET_ORDERED_ITEMS, newPanelOrder);
         } else {
             context.commit(PanelMutation.SET_PRIORITY, null);
         }
-
         context.commit(PanelMutation.SET_REMAINING_WIDTH, remainingWidth);
         context.commit(PanelMutation.SET_VISIBLE, nowVisible);
     }
@@ -195,6 +214,17 @@ const mutations = {
         { panel }: { panel: PanelInstance }
     ): void {
         state.items = { ...state.items, [panel.id]: panel };
+        // since panel has successfully registered, resolve its associated registration promise
+        if (!(panel.id in state.regPromises)) {
+            const regPromise = new DefPromise();
+            regPromise.resolveMe();
+            state.regPromises = {
+                ...state.regPromises,
+                [panel.id]: regPromise
+            };
+        } else {
+            state.regPromises[panel.id].resolveMe();
+        }
     },
 
     [PanelMutation.OPEN_PANEL](
@@ -226,6 +256,10 @@ const mutations = {
             delete state.items[panel.id];
         }
 
+        // remove registration promise
+        if (state.regPromises[panel.id] !== undefined) {
+            delete state.regPromises[panel.id];
+        }
         // remove from visible
         const index = state.visible.indexOf(panel);
         if (index !== -1) {
@@ -239,6 +273,13 @@ const mutations = {
         if (state.pinned !== null && state.pinned.id == panel.id) {
             state.pinned = null;
         }
+    },
+
+    [PanelMutation.ADD_REG_PROMISE](state: PanelState, panelId: string): void {
+        state.regPromises = {
+            ...state.regPromises,
+            [panelId]: new DefPromise()
+        };
     }
 };
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,6 +9,12 @@ export interface RampConfig {
     map: RampMapConfig;
     layers: RampLayerConfig[];
     fixtures: { [key: string]: any };
+    panels?: {
+        open?: {
+            id: string;
+            pin?: boolean;
+        }[];
+    };
     system?: {
         proxyUrl?: string;
         animate?: boolean;


### PR DESCRIPTION
Closes #1166.

### Changes
* Panels can now be opened/pinned from the config according to the schema in `schema.json`. However, this currently only works properly for panels that are not "layer-specific". Panels like settings, grid, metadata will either open with their "default" version if they have one or won't open at all with an error in the console. Because different panels get layer data differently (`uid`, `LayerInstance` object, etc.), there is no way to open these panels without writing fixture-specific code. If opening these panels on startup is something we really care about, we would need to refactor the code so that fixtures can support "anything" to get their layer data (`id`, `uid`, `LayerInstance`). A discussion will be opened shortly for this.
* Added an `isRegistered(panelId | panelId[]):Promise` to the `PanelAPI` that provides a promise that resolves when the specified panels have registered. Note that if a non-existing panel is passed in, the promise will wait infinitely, but panels will still work normally in the app with screen interaction etc.
* Added an `isLoaded(fixtureId | fixtureId[]):Promise` to the `FixtureAPI` that provides a promise that resolves when the specified fixtures have loaded.

### Testing
* Notice that the legend is now opened and pinned in the main sample through the config.
* Feel free to pass in your own config into RAMP to test out different cases.
* Ensure that any existing panel functionality is not ruined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1275)
<!-- Reviewable:end -->
