### PR TITLE
Add CRUD methods to legend

### DIFF
--- a/demos/starter-scripts/legend.js
+++ b/demos/starter-scripts/legend.js
@@ -1,0 +1,362 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WaterQuantity',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 1,
+                            name: 'Water quantity child',
+                            state: {
+                                opacity: 1,
+                                visibility: true
+                            },
+                            fixtures: {
+                                settings: {
+                                    controls: ['visibility', 'opacity']
+                                }
+                            }
+                        },
+                        {
+                            index: 9,
+                            name: 'Carbon monoxide emissions by facility',
+                            state: {
+                                opacity: 0.5,
+                                visibility: true
+                            },
+                            disabledControls: ['opacity', 'visibility']
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md',
+                        name: 'Read Me!'
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WaterQuality',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 5,
+                            state: {}
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'CleanAir',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/EcoGeo/EcoGeo/MapServer/9',
+                    state: {
+                        opacity: 0.8,
+                        visibility: true,
+                        hovertips: false
+                    },
+                    tolerance: 10,
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#FF5555',
+                    state: {
+                        visibility: false
+                    },
+                    customRenderer: {},
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md'
+                    },
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
+                    }
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                layerId: 'WFSLayer',
+                                name: 'WFSLayer'
+                            },
+                            {
+                                name: 'Visibility Set',
+                                exclusiveVisibility: [
+                                    {
+                                        layerId: 'CleanAir',
+                                        name: 'Clean Air in Set'
+                                    },
+                                    {
+                                        name: 'Group in Set',
+                                        children: [
+                                            {
+                                                layerId: 'WaterQuantity',
+                                                name: 'Water Quantity in Nested Group',
+                                                sublayerIndex: 1,
+                                                controls: [
+                                                    'datatable',
+                                                    'metadata',
+                                                    'reload',
+                                                    'remove',
+                                                    'settings',
+                                                    'symbology'
+                                                ]
+                                            },
+                                            {
+                                                layerId: 'WaterQuantity',
+                                                name: 'CO2 in Nested Group',
+                                                sublayerIndex: 9
+                                            },
+                                            {
+                                                layerId: 'WaterQuality',
+                                                name: 'Water Quality in Nested Group',
+                                                sublayerIndex: 5
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: ['wizard', 'legend']
+                }
+            }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: false,
+    loadDefaultEvents: true
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+window.debugInstance = rInstance;
+
+// add a minimal set of fixtures
+rInstance.fixture
+    .addDefaultFixtures([
+        'appbar',
+        'crosshairs',
+        'grid',
+        'legend',
+        'metadata',
+        'scrollguard',
+        'panguard',
+        'settings',
+        'wizard'
+    ])
+    .then(async () => {
+        rInstance.panel.open('legend');
+        rInstance.panel.pin('legend');
+
+        // manually override CleanAir item's uid for testing
+        let items = rInstance.$vApp.$store.get('legend/children');
+        items[1].children[0]._uid = '😎';
+
+        window.lApi = window.debugInstance.fixture.get('legend');
+
+        // run test suite
+        await testSuite();
+    });
+
+// test suite method
+const testSuite = async () => {
+    console.log('===== RUNNING LEGEND API CRUD TESTS =====');
+
+    console.log('*********** Create ***********');
+
+    let group = window.lApi.createItem(
+        {
+            name: 'Created Group',
+            children: []
+        },
+        window.lApi.getItem(window.lApi.getLegendConfig().root.children[1].uid)
+    );
+
+    console.log(
+        'create group under "Visibility Set"',
+        window.lApi.addItem(
+            group,
+            window.lApi.getItem(
+                window.lApi.getLegendConfig().root.children[1].uid
+            )
+        )
+    );
+
+    const layer = window.debugInstance.geo.layer.createLayer({
+        id: 'Oilsands',
+        url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Oilsands/MapServer',
+        layerType: 'esri-map-image',
+        name: 'Oil Sands',
+        sublayers: [
+            {
+                index: 0,
+                state: {
+                    opacity: 0.5,
+                    visibility: true
+                }
+            },
+            {
+                index: 1,
+                state: {
+                    opacity: 1,
+                    visibility: false
+                }
+            },
+            {
+                index: 2,
+                state: {
+                    opacity: 1,
+                    visibility: false
+                }
+            }
+        ],
+        state: {
+            opacity: 1,
+            visibility: true
+        }
+    });
+    await window.debugInstance.geo.map.addLayer(layer);
+    let layerItem = await window.lApi.addLayerItem(layer, group);
+
+    console.log('Add Oil Sands layer item under "Created Group"', layerItem);
+
+    console.log('*********** Read ***********');
+
+    console.log('get legend', window.lApi.getLegend());
+    console.log('get legend config', window.lApi.getLegendConfig());
+    console.log('get item WFSLayer', window.lApi.getItem('WFSLayer'));
+    console.log(
+        'get layer item with layer id CleanAir',
+        window.lApi.getLayerItem('CleanAir')
+    );
+    console.log(
+        'get item layer id MIL sublayer',
+        window.lApi.getItem('WaterQuantity-9')
+    );
+    console.log('get item with uid', window.lApi.getItem('😎'));
+    console.log(
+        'get all expanded (undefined=true)',
+        window.lApi.getAllExpanded()
+    );
+    console.log('get all expanded true', window.lApi.getAllExpanded(true));
+    console.log('get all expanded false', window.lApi.getAllExpanded(false));
+    console.log(
+        'get all visible (undefined=true)',
+        window.lApi.getAllVisible(true)
+    );
+    console.log('get all visible true', window.lApi.getAllVisible());
+    console.log('get all visible false', window.lApi.getAllVisible(false));
+
+    console.log('*********** Update ***********');
+
+    console.log('toggle expand/visibility using the buttons in the legend');
+
+    console.log('*********** Delete ***********');
+
+    console.log(
+        'remove item by legend id: run `window.lApi.removeItem(uid or legend item instance)`'
+    );
+    console.log(
+        'remove item by legend id: run `window.lApi.removeLayerItem(layerId)`'
+    );
+
+    console.log('=========================================');
+};

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -5,18 +5,17 @@ import {
     LayerInstance,
     PanelInstance
 } from './internal';
+import type { AppbarAPI } from '@/fixtures/appbar/api/appbar';
 import type { DetailsAPI } from '@/fixtures/details/api/details';
-import type { SettingsAPI } from '@/fixtures/settings/api/settings';
-import type { HelpAPI } from '@/fixtures/help/api/help';
 import type { GridAPI } from '@/fixtures/grid/api/grid';
-import type { WizardAPI } from '@/fixtures/wizard/api/wizard';
-import type { LegendAPI } from '@/fixtures/legend/api/legend';
+import type { HelpAPI } from '@/fixtures/help/api/help';
 import type { LayerReorderAPI } from '@/fixtures/layer-reorder/api/layer-reorder';
+import type { LegendAPI } from '@/fixtures/legend/api/legend';
 import type { MetadataAPI } from '@/fixtures/metadata/api/metadata';
 import type { MetadataPayload } from '@/fixtures/metadata/store';
+import type { SettingsAPI } from '@/fixtures/settings/api/settings';
+import type { WizardAPI } from '@/fixtures/wizard/api/wizard';
 import { AppbarAction } from '@/fixtures/appbar/store';
-import type { HilightAPI } from '@/fixtures/hilight/api/hilight';
-import { LegendStore } from '@/fixtures/legend/store';
 import { GridStore, GridAction } from '@/fixtures/grid/store';
 import { LayerState } from '@/geo/api';
 import type {
@@ -667,7 +666,7 @@ export class EventAPI extends APIScope {
             case DefEH.APPBAR_ADDS_PANEL_BUTTON:
                 zeHandler = (panel: PanelInstance) => {
                     if (
-                        this.$iApi.fixture.get('appbar') &&
+                        this.$iApi.fixture.get<AppbarAPI>('appbar') &&
                         !(this.$iApi.$vApp.$store.get('appbar/order') as any)
                             .flat()
                             .find((item: string) => item === panel.id)
@@ -683,7 +682,7 @@ export class EventAPI extends APIScope {
             case DefEH.APPBAR_REMOVES_PANEL_BUTTON:
                 zeHandler = (panel: PanelInstance) => {
                     if (
-                        this.$iApi.fixture.get('appbar') &&
+                        this.$iApi.fixture.get<AppbarAPI>('appbar') &&
                         !(this.$iApi.$vApp.$store.get('appbar/order') as any)
                             .flat()
                             .find((item: string) => item === panel.id)
@@ -708,8 +707,8 @@ export class EventAPI extends APIScope {
             case DefEH.IDENTIFY_DETAILS:
                 // when identify runs, open details fixture and show the results
                 zeHandler = (identifyParam: any) => {
-                    const detailFix: DetailsAPI =
-                        this.$iApi.fixture.get('details');
+                    const detailFix =
+                        this.$iApi.fixture.get<DetailsAPI>('details');
                     if (detailFix) {
                         detailFix.openDetails(identifyParam.results);
                     }
@@ -719,8 +718,8 @@ export class EventAPI extends APIScope {
             case DefEH.TOGGLE_SETTINGS:
                 // opens or closes the settings panel and hooks it up to the requested layer.
                 zeHandler = (layer: LayerInstance) => {
-                    const settingsFixture: SettingsAPI =
-                        this.$iApi.fixture.get('settings');
+                    const settingsFixture =
+                        this.$iApi.fixture.get<SettingsAPI>('settings');
                     if (settingsFixture) {
                         settingsFixture.toggleSettings(layer);
                     }
@@ -738,8 +737,8 @@ export class EventAPI extends APIScope {
                     uid: string;
                     format: string;
                 }) => {
-                    const detailsFixture: DetailsAPI =
-                        this.$iApi.fixture.get('details');
+                    const detailsFixture =
+                        this.$iApi.fixture.get<DetailsAPI>('details');
                     if (detailsFixture) {
                         detailsFixture.openFeature(payload);
                     }
@@ -753,7 +752,7 @@ export class EventAPI extends APIScope {
             case DefEH.TOGGLE_HELP:
                 // opens or closes the standard help panel when a toggle help event happens
                 zeHandler = (payload?: boolean) => {
-                    const helpFixture: HelpAPI = this.$iApi.fixture.get('help');
+                    const helpFixture = this.$iApi.fixture.get<HelpAPI>('help');
                     if (helpFixture) {
                         helpFixture.toggleHelp(payload);
                     }
@@ -767,7 +766,7 @@ export class EventAPI extends APIScope {
             case DefEH.TOGGLE_GRID:
                 // opens or closes the standard grid panel when a toggle grid event happens
                 zeHandler = (layer: LayerInstance, open?: boolean) => {
-                    const gridFixture: GridAPI = this.$iApi.fixture.get('grid');
+                    const gridFixture = this.$iApi.fixture.get<GridAPI>('grid');
                     if (gridFixture) {
                         gridFixture.toggleGrid(layer.uid, open);
                     }
@@ -781,8 +780,8 @@ export class EventAPI extends APIScope {
             case DefEH.OPEN_WIZARD:
                 // opens the standard add layer wizard panel when an open wizard event happens
                 zeHandler = () => {
-                    const wizardFixture: WizardAPI =
-                        this.$iApi.fixture.get('wizard');
+                    const wizardFixture =
+                        this.$iApi.fixture.get<WizardAPI>('wizard');
                     if (wizardFixture) {
                         wizardFixture.openWizard();
                     }
@@ -796,8 +795,10 @@ export class EventAPI extends APIScope {
             case DefEH.OPEN_LAYER_REORDER:
                 // opens the standard layer reorder panel when an open reorder event happens
                 zeHandler = () => {
-                    const reorderFixture: LayerReorderAPI =
-                        this.$iApi.fixture.get('layer-reorder');
+                    const reorderFixture =
+                        this.$iApi.fixture.get<LayerReorderAPI>(
+                            'layer-reorder'
+                        );
                     if (reorderFixture) {
                         reorderFixture.openLayerReorder();
                     }
@@ -811,8 +812,8 @@ export class EventAPI extends APIScope {
             case DefEH.OPEN_METADATA:
                 // opens the standard metadata panel when an open metadata event happens
                 zeHandler = (payload: MetadataPayload) => {
-                    const metadataFixture: MetadataAPI =
-                        this.$iApi.fixture.get('metadata');
+                    const metadataFixture =
+                        this.$iApi.fixture.get<MetadataAPI>('metadata');
                     if (metadataFixture) {
                         metadataFixture.toggleMetadata(payload);
                     }
@@ -826,8 +827,8 @@ export class EventAPI extends APIScope {
             case DefEH.UPDATE_LEGEND_LAYER_REGISTER:
                 // when a layer is registered, have the standard legend update in accordance to the layer
                 zeHandler = (layer: LayerInstance) => {
-                    const legendFixture: LegendAPI =
-                        this.$iApi.fixture.get('legend');
+                    const legendFixture =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
                     if (legendFixture) {
                         legendFixture.updateLegend(layer);
                     }
@@ -861,10 +862,10 @@ export class EventAPI extends APIScope {
             case DefEH.UPDATE_LEGEND_WIZARD_ADDED:
                 // when a layer is user-added, have the standard legend create a new stock entry for the layer
                 zeHandler = (layer: LayerInstance) => {
-                    const legendFixture: LegendAPI =
-                        this.$iApi.fixture.get('legend');
+                    const legendFixture =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
                     if (legendFixture) {
-                        legendFixture.generateLegend(layer);
+                        legendFixture.addLayerItem(layer);
                     }
                 };
                 this.$iApi.event.on(
@@ -876,8 +877,8 @@ export class EventAPI extends APIScope {
             case DefEH.UPDATE_LEGEND_LAYER_RELOAD:
                 // when a layer is reloaded, have the standard legend update in accordance to the layer
                 zeHandler = (layer: LayerInstance) => {
-                    const legendFixture: LegendAPI =
-                        this.$iApi.fixture.get('legend');
+                    const legendFixture =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
                     if (legendFixture) {
                         legendFixture.updateLegend(layer);
                     }
@@ -1108,11 +1109,9 @@ export class EventAPI extends APIScope {
             case DefEH.LEGEND_REMOVES_LAYER_ENTRY:
                 // when a layer is removed from the map, remove any bound entries from the standard legend
                 zeHandler = (layer: LayerInstance) => {
-                    if (!!this.$iApi.fixture.get('legend')) {
-                        this.$iApi.$vApp.$store.dispatch(
-                            LegendStore.removeLayerEntry,
-                            layer.uid
-                        );
+                    let legendApi = this.$iApi.fixture.get<LegendAPI>('legend');
+                    if (legendApi) {
+                        legendApi.removeLayerItem(layer);
                         this.$iApi.updateAlert(
                             this.$vApp.$t('legend.alert.layerRemoved', {
                                 name: layer.name
@@ -1129,11 +1128,9 @@ export class EventAPI extends APIScope {
             case DefEH.LEGEND_RELOADS_LAYER_ENTRY:
                 // when a layer starts to reload, reset any entries in the standard legend to a loading state
                 zeHandler = (layer: LayerInstance) => {
-                    if (!!this.$iApi.fixture.get('legend')) {
-                        this.$iApi.$vApp.$store.dispatch(
-                            LegendStore.reloadLayerEntry,
-                            layer.uid
-                        );
+                    let legendApi = this.$iApi.fixture.get<LegendAPI>('legend');
+                    if (legendApi) {
+                        legendApi.reloadLayerItem(layer.uid);
                     }
                 };
                 this.$iApi.event.on(
@@ -1145,7 +1142,7 @@ export class EventAPI extends APIScope {
             case DefEH.GRID_REMOVES_LAYER_GRID:
                 // when a layer is removed, close the standard grid if open for that layer
                 zeHandler = (layer: LayerInstance) => {
-                    if (!!this.$iApi.fixture.get('grid')) {
+                    if (!!this.$iApi.fixture.get<GridAPI>('grid')) {
                         // remove cached grid state for layer from grid store
                         this.$vApp.$store.dispatch(
                             `grid/${GridAction.removeGrid}`,
@@ -1173,7 +1170,7 @@ export class EventAPI extends APIScope {
             case DefEH.DETAILS_REMOVES_LAYER:
                 // when a layer is removed, remove it from the details payload
                 zeHandler = (layer: LayerInstance) => {
-                    if (!!this.$iApi.fixture.get('details')) {
+                    if (!!this.$iApi.fixture.get<DetailsAPI>('details')) {
                         // remove the layer from the payload results
                         this.$iApi.$vApp.$store.set(
                             DetailsStore.removeLayer,

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -1,32 +1,16 @@
 import { FixtureInstance, LayerInstance } from '@/api';
+import type { TreeNode } from '@/geo/api';
 import { LegendStore } from '../store';
 import type { LegendConfig } from '../store';
 import { LegendItem, LegendEntry, LegendGroup } from '../store/legend-defs';
 
 export class LegendAPI extends FixtureInstance {
     /**
-     * Returns `LegendConfig` section of the global config file.
-     *
-     * @readonly
-     * @type {LegendConfig}
-     * @memberof LegendFixture
-     */
-    get config(): LegendConfig | undefined {
-        return super.config;
-    }
-
-    /**
      * Parses the legend config JSON snippet from the config file and save resulting objects to the fixture store.
      *
-     * @param {LegendConfig} [legendConfig]
-     * @returns
-     * @memberof LegendAPI
+     * @param {LegendConfig | undefined} legendConfig
      */
-    _parseConfig(legendConfig?: LegendConfig) {
-        // get all layer fixture configs to read layer-specific legend properties
-        let layerLegendConfigs: { [layerId: string]: any } =
-            this.getLayerFixtureConfigs();
-
+    _parseConfig(legendConfig?: LegendConfig): void {
         // parse the header controls, or default the controls
         let controls: Array<string> = legendConfig?.headerControls?.slice() ?? [
             'wizard',
@@ -42,48 +26,15 @@ export class LegendAPI extends FixtureInstance {
 
         this.handlePanelWidths(['legend']);
 
-        let legendEntries: Array<LegendItem> = [];
-        let stack: Array<any> = [];
-        // initialize stack with all legend elements listed in config
+        // get all layer fixture configs to read layer-specific legend properties
+        let layerLegendConfigs: { [layerId: string]: any } =
+            this.getLayerFixtureConfigs();
 
-        legendConfig.root.children.forEach(legendItem =>
-            stack.push(legendItem)
-        );
-
-        // parse children from legend root structure through traversal
-        while (stack.length > 0) {
-            // pop legend entry in stack and check if it has a corresponding layer
-            const lastEntry = stack.pop();
-
-            // pass the layer fixture config to legend item for easy access
-            lastEntry.layerLegendConfigs = layerLegendConfigs;
-
-            // (assuming visibility sets and groups will specify in config `exclusiveVisibility` or `children` properties, respectively)
-            if (
-                lastEntry.children !== undefined ||
-                lastEntry.exclusiveVisibility !== undefined
-            ) {
-                // create a wrapper legend object for group or visibility set
-                let legendGroup = new LegendGroup(lastEntry, lastEntry.parent);
-                legendEntries.push(legendGroup);
-            } else if (lastEntry.layerId !== undefined) {
-                // create a wrapper legend object for single legend entry
-                // if the entry is a sublayer, override the entry id to the sublayers id
-                if (lastEntry.sublayerIndex !== undefined) {
-                    lastEntry.layerParentId = lastEntry.layerId;
-                    lastEntry.layerId = `${lastEntry.layerId}-${lastEntry.sublayerIndex}`;
-                }
-                const legendEntry = new LegendEntry(
-                    lastEntry,
-                    lastEntry.parent
-                );
-                legendEntries.push(legendEntry);
-            }
-        }
-
-        this.$vApp.$store.set(LegendStore.children, legendEntries);
-
-        // TODO: validate legend items?
+        legendConfig.root.children.forEach(legendItem => {
+            // pass the layer legend fixture config
+            legendItem.layerLegendConfigs = layerLegendConfigs;
+            this.addItem(legendItem);
+        });
 
         // update legend in case layers were added before the legend was created
         this.$iApi.geo.layer.allLayers().forEach(l => {
@@ -94,67 +45,364 @@ export class LegendAPI extends FixtureInstance {
         });
     }
 
+    // Create
+
     /**
-     * Generate a legend entry/group given a layer
+     * Construct a legend item given the legend config
      *
-     * @param {LayerInstance} layer the layer to be used for the legend entry
-     * @param {LegendGroup | undefined} parent the parent legend group for this entry
-     * @memberOf LegendFixture
+     * @param {any} itemConf legend item config
+     * @param {LegendItem | undefined} parent the parent legend item for the created item
+     * @returns {LegendItem} returns the constructed legend item
+     * @memberof LegendAPI
      */
-    generateLegend(layer: LayerInstance, parent?: LegendGroup | undefined) {
-        // if layer supports sublayers, create a legend group
-        // else create a legend entry
-        const item: LegendEntry | LegendGroup = layer.supportsSublayers
+    createItem(itemConf: any, parent?: LegendItem): LegendItem {
+        // validate the parent
+        let parentItem = this._validateParent(parent);
+        let item: LegendItem | undefined = undefined;
+
+        if (
+            itemConf.children !== undefined ||
+            itemConf.exclusiveVisibility !== undefined
+        ) {
+            // (assuming visibility sets and groups will specify in config `exclusiveVisibility` or `children` properties, respectively)
+            // create a wrapper legend object for group or visibility set
+            item = new LegendGroup(itemConf, parentItem);
+
+            // initialize objects for all non-hidden group/set children entries
+            const children =
+                itemConf.exclusiveVisibility !== undefined
+                    ? itemConf.exclusiveVisibility
+                    : itemConf.children;
+
+            // construct children
+            children
+                .filter((childConf: any) => !childConf.hidden)
+                .forEach((childConf: any) => {
+                    // pass the layer fixture config to child items
+                    if (itemConf.layerLegendConfigs !== undefined) {
+                        childConf.layerLegendConfigs =
+                            itemConf.layerLegendConfigs;
+                    }
+
+                    // ts ignoring below because returned item is "LegendItem", but accepted type is "LegendEntry | LegendGroup"
+                    // which is the same thing! (╯°□°）╯︵ ┻━┻
+                    //@ts-ignore
+                    item!.children.push(this.createItem(childConf, item));
+                });
+        } else if (itemConf.layerId !== undefined) {
+            // create a wrapper legend object for single legend entry
+            // if the entry is a sublayer, override the entry id to the sublayers id
+            if (itemConf.sublayerIndex !== undefined) {
+                itemConf.layerParentId = itemConf.layerId;
+                itemConf.layerId = `${itemConf.layerId}-${itemConf.sublayerIndex}`;
+            }
+            item = new LegendEntry(itemConf, parentItem);
+        }
+
+        return item!;
+    }
+
+    /**
+     * Add a legend item given the legend config, or legend item instance
+     *
+     * @param {any | LegendItem} item the config for the legend item or a legend item instance
+     * @param {LegendItem | undefined} parent optional parent item to create this item under
+     * @returns {LegendItem} the added legend item
+     * @memberof LegendAPI
+     */
+    addItem(item: any | LegendItem, parent?: LegendItem): LegendItem {
+        // validate the parent
+        parent = this._validateParent(parent);
+
+        let constructedItem: LegendItem =
+            item instanceof LegendItem ? item : this.createItem(item, parent);
+        this._insertItem(constructedItem, parent);
+
+        return constructedItem;
+    }
+
+    /**
+     * Add a layer legend item given a layer instance
+     *
+     * @param {LayerInstance} layer the layer to create an item for
+     * @param {LegendItem | undefined} parent optional parent item to create this item under
+     * @returns {Promise<LegendItem>} a promise that resolves with the added legend item
+     * @memberof LegendAPI
+     */
+    async addLayerItem(
+        layer: LayerInstance,
+        parent?: LegendItem
+    ): Promise<LegendItem> {
+        // validate the parent
+        let parentItem = this._validateParent(parent);
+
+        // only create a top-level legend item for the layer that will be in a placeholder state
+        // if layer supports sublayers, create a legend group, else create a legend entry
+        const item: LegendItem = layer.supportsSublayers
             ? new LegendGroup(
                   {
                       layer: layer,
-                      name: layer.name
+                      name: layer.name,
+                      visibility: layer.visibility
                   },
-                  parent
+                  parentItem
               )
             : new LegendEntry(
                   {
                       layer: layer,
                       name: layer.name,
-                      layerId: layer.id
+                      layerId: layer.id,
+                      visibility: layer.visibility
                   },
-                  parent
+                  parentItem
               );
 
         // add the legend entry/group to store
-        this.$vApp.$store.set(LegendStore.addItem, item);
+        // will be in a placeholder state until the layer is loaded
+        this._insertItem(item, parentItem);
 
-        if (layer.userAdded) {
-            this.$iApi.updateAlert(
-                this.$vApp.$t('legend.alert.layerAdded', {
-                    name: layer.name
+        if (layer.supportsSublayers) {
+            // if layer supports sublayers, then we need to parse the
+            // layer tree after loading and generate the children
+
+            await layer.isLayerLoaded();
+
+            // TODO: could modify LayerInstance's getSublayer to do what this helper is doing.
+            //       current getSublayer only checks the sublayer list one level down, but in
+            //       a more complex layer tree the requested sublayer can be much more nested
+
+            // local function to search a sublayer instance in the layer's tree with the given layer uid
+            // we need this local function because it is possible that this layer has not been added to
+            // the map yet, hence using geo.layer.getLayer will not work
+            const getLayer = (uid: string): LayerInstance | undefined => {
+                let queue = [layer];
+                while (queue.length > 0) {
+                    const l = queue.shift();
+                    if (l && l.uid === uid) {
+                        return l;
+                    }
+                    if (l) {
+                        queue.push(...l.sublayers);
+                    }
+                }
+            };
+
+            // map out the layer's layer tree children into a legend configs and call addItem on each config
+            const treeWalker = (node: TreeNode): any => {
+                // the tree node does not have a reference to the layer, so we need to fetch sublayers manually
+                // will be undefined for non-root + non-logical layers (a.k.a MIL sub groups)
+                let currLayer = getLayer(node.uid)!;
+
+                // current item legend config snippet
+                let currItem: any = {};
+
+                if (node.isLayerRoot && !node.isLogicalLayer) {
+                    // is root, but not logical layer (MIL)
+                    currItem.layer = currLayer;
+                    currItem.name = currLayer.name;
+                    // TODO: since .children is used here, only legend groups will be created here when MIL is added
+                    //       can enhance later to use .exclusiveVisibility if user wants to add MIL as visibility set from wizard
+                    currItem.children = node.children.map(childNode =>
+                        treeWalker(childNode)
+                    );
+                } else if (!node.isLayerRoot && !node.isLogicalLayer) {
+                    // is not root, and is not logical layer (MIL sub groups)
+                    // coud merge above if-branch with this one, but will keep them separate for clarity
+                    currItem.name = node.name;
+                    // TODO: since .children is used here, only legend groups will be created here when MIL is added
+                    //       can enhance later to use .exclusiveVisibility if user wants to add MIL as visibility set from wizard
+                    currItem.children = node.children.map(childNode =>
+                        treeWalker(childNode)
+                    );
+                } else if (node.isLogicalLayer) {
+                    // is logical layer (regular layers and sublayers)
+                    currItem.layer = currLayer;
+                    currItem.name = currLayer.name;
+                    currItem.layerId = currLayer.id;
+                    currItem.sublayerIndex =
+                        layer.layerIdx === -1 ? undefined : layer.layerIdx;
+                }
+
+                return currItem;
+            };
+
+            // for each child node -> parse & create item config -> create child legend item and append to this item
+            layer
+                .getLayerTree()
+                .children.map(childNode => treeWalker(childNode))
+                .map(childConf => this.addItem(childConf, item));
+        }
+
+        return item;
+    }
+
+    // Read
+
+    /**
+     * Returns `LegendConfig` section of the global config file.
+     *
+     * @readonly
+     * @type {LegendConfig}
+     * @memberof LegendAPI
+     */
+    get config(): LegendConfig | undefined {
+        return super.config;
+    }
+
+    /**
+     * Returns the full legend tree.
+     * Note: This returns a direct reference to the legend tree. Mutations will persist.
+     *
+     * @returns {Array<LegendItem>} returns the full legend tree
+     * @memberof LegendAPI
+     */
+    getLegend(): Array<LegendItem> {
+        return (
+            this.$vApp.$store.get<Array<LegendItem>>(LegendStore.children) || []
+        );
+    }
+
+    /**
+     * Maps the current legend tree into a legend config snippet.
+     *
+     * In addition to legend config schema properties, this snippet will also include
+     * properties such as the item type, item's uid, layer uid etc.
+     *
+     * @returns {any} returns the legend config
+     * @memberof LegendAPI
+     */
+    getLegendConfig(): any {
+        return {
+            root: {
+                children: this.getLegend().map(item => item.getConfig())
+            }
+        };
+    }
+
+    /**
+     * Get a legend item given its id or uid.
+     *
+     * @param {string} id the id or uid of the legend item
+     * @returns {LegendItem | undefined} return legend item with given id or uid. returns undefined if item is not found.
+     * @memberof LegendAPI
+     */
+    getItem(id: string): LegendItem | undefined {
+        let legend: Array<LegendItem> = this.getLegend();
+
+        let result: LegendItem | undefined;
+
+        // first try fetching item with id
+        legend.some((item: LegendItem) => {
+            result = this._searchTree(
+                item,
+                (item: LegendItem) => item.id === id
+            );
+            return result !== undefined;
+        });
+
+        if (result === undefined) {
+            // if item couldn't be found with the id, try using uid instead
+            legend.some((item: LegendItem) => {
+                result = this._searchTree(
+                    item,
+                    (item: LegendItem) => item.uid === id
+                );
+                return result !== undefined;
+            });
+        }
+
+        return result;
+    }
+
+    /**
+     * Get a legend item connected to the layer with the given id/uid or the given layer instance.
+     *
+     * @param {string | LayerInstance} layer the id/uid of the layer or layer instance
+     * @returns {LegendItem | undefined} return legend item tied to the found layer. returns undefined if no such item is found.
+     * @memberof LegendAPI
+     */
+    getLayerItem(layer: string | LayerInstance): LegendItem | undefined {
+        let l: LayerInstance | undefined =
+            typeof layer === 'string'
+                ? this.$iApi.geo.layer.getLayer(layer)
+                : layer;
+        return this.getItem(l?.id || '');
+    }
+
+    /**
+     * Get all legend items with the given expanded state.
+     * Not specifying the expanded state will return all items with expanded set to `true`
+     *
+     * @param {boolean | undefined} expanded the expanded state to check for
+     * @returns {Array<LegendItem>} the items with the given expanded state
+     * @memberof LegendAPI
+     */
+    getAllExpanded(expanded?: boolean): Array<LegendItem> {
+        let legend: Array<LegendItem> = this.getLegend();
+        let items: Array<LegendItem> = [];
+        let check = expanded ?? true;
+
+        legend.forEach(item => {
+            items.push(
+                ...this._searchTreeAll(item, (item: LegendItem) => {
+                    return (
+                        item instanceof LegendGroup && item.expanded === check
+                    );
                 })
             );
-        }
+        });
+
+        return items;
     }
+
+    /**
+     * Get all legend items with the given visibility state.
+     * Not specifying the visibility state will return all items with visibility set to `true`
+     *
+     * @param {boolean | undefined} visibility the visibility state to check for
+     * @returns {Array<LegendItem>} the items with the given expanded state
+     * @memberof LegendAPI
+     */
+    getAllVisible(visibility?: boolean): Array<LegendItem> {
+        let legend: Array<LegendItem> = this.getLegend();
+        let items: Array<LegendItem> = [];
+        let check = visibility ?? true;
+
+        legend.forEach(item => {
+            items.push(
+                ...this._searchTreeAll(item, (item: LegendItem) => {
+                    return (
+                        (item instanceof LegendGroup ||
+                            item instanceof LegendEntry) &&
+                        item.visibility === check
+                    );
+                })
+            );
+        });
+
+        return items;
+    }
+
+    // Update
 
     /**
      * Update an existing legend entry with data from the given layer
      * Does nothing if the legend entry is not found
      *
      * @param {LayerInstance} layer the layer to update the legend entry with
-     * @memberOf LegendFixture
+     * @memberof LegendAPI
      */
-    updateLegend(layer: LayerInstance) {
+    updateLegend(layer: LayerInstance): void {
         // helper function to link a layer into a legend entry
         const updateEntry = (layer: LayerInstance) => {
-            const entry: LegendEntry | undefined = this.$vApp.$store.get(
-                LegendStore.getChildById,
-                layer.id
-            );
-            entry?.loadLayer(layer);
+            const entry: LegendItem | undefined = this.getLayerItem(layer.id);
+            (entry as LegendEntry)?.loadLayer(layer);
         };
-        const errorEntry = (layer: LayerInstance | String) => {
-            const entry: LegendEntry | undefined = this.$vApp.$store.get(
-                LegendStore.getChildById,
+        const errorEntry = (layer: LayerInstance | string) => {
+            const entry: LegendItem | undefined = this.getLayerItem(
                 layer instanceof LayerInstance ? layer.id : layer
             );
-            entry?.setErrorType();
+            (entry as LegendEntry)?.setErrorType();
         };
         layer
             .isLayerLoaded()
@@ -174,5 +422,241 @@ export class LegendAPI extends FixtureInstance {
                     });
                 }
             });
+    }
+
+    /**
+     * Set the expanded state of legend items to `expanded`
+     *
+     * @param {boolean} expanded the expanded state the items will be set to
+     * @param {LegendItem | undefined} root the root item to start updating the expanded state from
+     * @memberof LegendAPI
+     */
+    expandItems(expanded: boolean, root?: LegendItem): void {
+        let legend: Array<LegendItem> = this.getLegend();
+        let items = root === undefined ? legend : root.children;
+        if (root !== undefined) {
+            this._toggleState(root, { expanded: expanded });
+        }
+        items.forEach((item: LegendItem) => {
+            this._toggleState(item, { expanded: expanded });
+        });
+    }
+
+    /**
+     * Set the visibility state of legend items to `visibility`
+     *
+     * @param {boolean} visibility the visibility state the items will be set to
+     * @param {LegendItem | undefined} root the root item to start updating the visibility state from
+     * @memberof LegendAPI
+     */
+    showItems(visibility: boolean, root?: LegendItem): void {
+        let legend: Array<LegendItem> = this.getLegend();
+        let items = root === undefined ? legend : root.children;
+        if (root !== undefined) {
+            this._toggleState(root, { visibility: visibility });
+        }
+        items.forEach((item: LegendItem) => {
+            this._toggleState(item, { visibility: visibility });
+        });
+    }
+
+    /**
+     * Reload the legend item connected to the layer with the given layer id/uid
+     *
+     * @param {string} layerId the id or uid of the reloaded layer
+     * @returns {boolean} returns true if item was successfully reloaded, false otherwise
+     * @memberof LegendAPI
+     */
+    reloadLayerItem(layerId: string): boolean {
+        let item: LegendItem | undefined = this.getLayerItem(layerId);
+
+        if (!item) {
+            return false;
+        }
+
+        if (!(item instanceof LegendEntry)) {
+            console.warn(
+                'reloading is not supported for non-legend entry items'
+            );
+            return false;
+        }
+
+        item.reload();
+        return true;
+    }
+
+    // Delete
+
+    /**
+     * Removes the legend item with the given id, uid, or the item instance.
+     *
+     * @param {string | LegendItem} item the uid/id of item or legend item instance to be removed
+     * @returns {boolean} returns true if item was removed, false otherwise
+     * @memberof LegendAPI
+     */
+    removeItem(item: string | LegendItem): boolean {
+        let itemToRemove: LegendItem | undefined =
+            typeof item === 'string' ? this.getItem(item) : item;
+
+        if (itemToRemove !== undefined) {
+            return this._deleteItem(itemToRemove);
+        }
+
+        return false;
+    }
+
+    /**
+     * Remove the legend item connected to the layer with the given id/uid or the given layer instance.
+     *
+     * @param {string | LayerInstance} layer the id/uid of the layer or layer instance
+     * @returns {boolean} returns true if item was removed, false otherwise
+     * @memberof LegendAPI
+     */
+    removeLayerItem(layer: string | LayerInstance): boolean {
+        let itemToRemove: LegendItem | undefined = this.getLayerItem(layer);
+
+        if (itemToRemove !== undefined) {
+            return this._deleteItem(itemToRemove);
+        }
+
+        return false;
+    }
+
+    // _Helpers
+
+    /**
+     * Search for first legend item that satisfies the predicate, starting from the given root item.
+     *
+     * @param {LegendItem} root the root item to start searching from
+     * @param {(item: LegendItem) => boolean} predicate boolean predicate to test each item
+     * @returns {LegendItem \ undefined} return the first item that satisfies the given predicate. returns undefined if item is not found.
+     */
+    private _searchTree(
+        root: LegendItem,
+        predicate: (item: LegendItem) => boolean
+    ): LegendItem | undefined {
+        if (predicate(root)) {
+            return root;
+        } else {
+            let result: LegendItem | undefined;
+            root.children.some((child: LegendItem) => {
+                result = this._searchTree(child, predicate);
+                return result !== undefined;
+            });
+            return result;
+        }
+    }
+
+    /**
+     * Search for all legend items that satisfy the predicate, starting from the given root item.
+     *
+     * @param {LegendItem} root the root item to start searching from
+     * @param {(item: LegendItem) => boolean} predicate predicate boolean predicate to test each item
+     * @returns {LegendItem \ undefined} return the first item that satisfies the given predicate. returns undefined if item is not found.
+     */
+    private _searchTreeAll(
+        root: LegendItem,
+        predicate: (item: LegendItem) => boolean
+    ): Array<LegendItem> {
+        let items: Array<LegendItem> = [];
+
+        // good-ol' bfs
+        let queue: Array<LegendItem> = [root];
+        while (queue.length > 0) {
+            const item = queue.shift();
+            if (item && predicate(item)) {
+                items.push(item);
+            }
+            if (item) {
+                queue.push(...item.children);
+            }
+        }
+
+        return items;
+    }
+
+    /**
+     * Toggles visibility for all items or expands/collapses all groups.
+     *
+     * @param {LegendItem} item current legend item that is being checked
+     * @param {any} options specifies whether visibility or expand/collapse functionality is to be changed
+     */
+    private _toggleState(item: LegendItem, options: any): void {
+        const visibility = options.visibility;
+        const expanded = options.expanded;
+        // for current legend child toggle properties if possible, check for appropriate legend element type
+        if (
+            visibility !== undefined &&
+            (item instanceof LegendGroup || item instanceof LegendEntry)
+        ) {
+            // visibility set edge case
+            if (
+                !(
+                    item.parent instanceof LegendGroup &&
+                    item.parent.visibility === visibility
+                )
+            ) {
+                item.toggleVisibility(visibility);
+            }
+        }
+        if (expanded !== undefined && item instanceof LegendGroup) {
+            item.toggleExpanded(expanded);
+        }
+        // traverse the tree and make recursive calls
+        if (item.children && item.children.length > 0) {
+            item.children.forEach(ch => {
+                // level order traversal
+                this._toggleState(ch, options);
+            });
+        }
+    }
+
+    /**
+     * Add the given legend item to the legend store
+     *
+     * @param {Legenditem} item the legend item to be added
+     * @param {LegendItem | undefined} parent the parent legend group for this entry
+     */
+    private _insertItem(item: LegendItem, parent?: LegendItem): void {
+        // remove item to store
+        this.$iApi.$vApp.$store.dispatch(LegendStore.addItem, { item, parent });
+    }
+
+    /**
+     * Deletes the given legend item from the legend store
+     *
+     * @param {Legenditem} item the legend item to be deleted
+     * @returns {boolean} returns true if item was removed, false otherwise
+     */
+    private _deleteItem(item: LegendItem): boolean {
+        // Need this check for now because LegendItem does not completely encapsulate the entry and group classes
+        if (!(item instanceof LegendEntry)) {
+            console.error(
+                'deleting is not supported for non-legend entry items'
+            );
+            return false;
+        }
+
+        // remove item from store
+        this.$iApi.$vApp.$store.dispatch(LegendStore.removeItem, item);
+
+        return true;
+    }
+
+    /**
+     * Checks if the given legend item is a legend group.
+     * Will return the same item if it is a legend group, and will return undefined otherwise
+     *
+     * @param {LegendItem | undefined} parent the legend item to validate
+     * @returns {LegendGroup | undefined} returns the parent parameter if it is a legend group, and returns undefined otherwise
+     */
+    private _validateParent(parent?: LegendItem): LegendGroup | undefined {
+        if (parent !== undefined && !(parent instanceof LegendGroup)) {
+            console.warn(
+                'attempted to use a non-group legend item as a parent item - will default to using the legend root'
+            );
+            return undefined;
+        }
+        return parent;
     }
 }

--- a/src/fixtures/legend/components/component.vue
+++ b/src/fixtures/legend/components/component.vue
@@ -1,12 +1,10 @@
 <template>
-    <KeepAlive>
-        <component
-            class="select-none"
-            :is="templates[legendItem.type]"
-            :legendItem="legendItem"
-            :props="props"
-        ></component>
-    </KeepAlive>
+    <component
+        class="select-none"
+        :is="templates[legendItem.type]"
+        :legendItem="legendItem"
+        :props="props"
+    ></component>
 </template>
 
 <script lang="ts">

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -56,14 +56,14 @@
             <a
                 href="#"
                 class="flex leading-snug items-center overflow-hidden whitespace-nowrap"
-                @click="expand"
+                @click="legendApi.expandItems(true)"
             >
                 {{ $t('legend.header.groups.expand') }}
             </a>
             <a
                 href="#"
                 class="flex leading-snug items-center overflow-hidden whitespace-nowrap"
-                @click="collapse"
+                @click="legendApi.expandItems(false)"
             >
                 {{ $t('legend.header.groups.collapse') }}
             </a>
@@ -88,14 +88,14 @@
             <a
                 href="#"
                 class="flex leading-snug items-center w-100 overflow-hidden whitespace-nowrap"
-                @click="show"
+                @click="legendApi.showItems(true)"
             >
                 {{ $t('legend.header.visible.show') }}
             </a>
             <a
                 href="#"
                 class="flex leading-snug items-center w-100 overflow-hidden whitespace-nowrap"
-                @click="hide"
+                @click="legendApi.showItems(false)"
             >
                 {{ $t('legend.header.visible.hide') }}
             </a>
@@ -108,17 +108,16 @@ import { defineComponent } from 'vue';
 
 import { LegendStore } from './store';
 import { GlobalEvents } from '../../api/internal';
+import type { LegendAPI } from './api/legend';
 
 export default defineComponent({
     name: 'LegendHeaderV',
     data() {
         return {
-            show: this.call(LegendStore.showAll),
-            hide: this.call(LegendStore.hideAll),
-            expand: this.call(LegendStore.expandGroups),
-            collapse: this.call(LegendStore.collapseGroups)
+            legendApi: this.$iApi.fixture.get<LegendAPI>('legend')!
         };
     },
+
     methods: {
         openWizard() {
             this.$iApi.event.emit(GlobalEvents.WIZARD_OPEN);

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -21,8 +21,8 @@
 import type { PanelInstance } from '@/api';
 import { defineComponent, defineAsyncComponent } from 'vue';
 import type { PropType } from 'vue';
-
-import { LegendStore } from './store';
+import type { LegendAPI } from './api/legend';
+import type { LegendItem } from './store/legend-defs';
 
 export default defineComponent({
     name: 'LegendScreenV',
@@ -33,16 +33,22 @@ export default defineComponent({
         }
     },
 
+    computed: {
+        children(): Array<LegendItem> {
+            let legendApi = this.$iApi.fixture.get<LegendAPI>('legend');
+            if (legendApi) {
+                return [...legendApi.getLegend()];
+            }
+            return [];
+        }
+    },
+
     components: {
         // async components to avoid circular dependency breakage
         'legend-header': defineAsyncComponent(() => import('./header.vue')),
         'legend-component': defineAsyncComponent(
             () => import('./components/component.vue')
         )
-    },
-
-    data() {
-        return { children: this.get(LegendStore.children) };
     }
 });
 </script>

--- a/src/fixtures/legend/store/legend-state.ts
+++ b/src/fixtures/legend/store/legend-state.ts
@@ -1,9 +1,9 @@
 import type { PanelWidthObject } from '@/api';
-import type { LegendEntry, LegendGroup } from './legend-defs';
+import type { LegendItem } from './legend-defs';
 
 export class LegendState {
     legendConfig: LegendConfig | undefined = undefined;
-    children: Array<LegendEntry | LegendGroup> = [];
+    children: Array<LegendItem> = [];
     headerControls: Array<string> = [];
 }
 

--- a/src/fixtures/legend/store/legend-store.ts
+++ b/src/fixtures/legend/store/legend-store.ts
@@ -8,63 +8,58 @@ import type { RootState } from '@/store';
 // use for actions
 type LegendContext = ActionContext<LegendState, RootState>;
 
-const searchTree = function (root: any, predicate: (root: any) => boolean) {
-    if (predicate(root)) {
-        return root;
-    } else {
-        let result: LegendItem | undefined;
-        root.children.some((child: LegendItem) => {
-            result = searchTree(child, predicate);
-            return result !== undefined;
-        });
-        return result;
-    }
-};
-
-const getters = {
-    getChildById:
-        (state: LegendState) =>
-        (id: string): LegendItem | undefined => {
-            return searchTree(state, (root: LegendItem) => root.id === id);
-        },
-    getChildByUid:
-        (state: LegendState) =>
-        (uid: string): LegendItem | undefined => {
-            return searchTree(state, (root: LegendItem) => root.uid === uid);
-        },
-    getAllExpanded: (state: LegendState, expanded: boolean): boolean => {
-        return state.children.every(
-            (entry: LegendItem) =>
-                !(entry instanceof LegendGroup) ||
-                checkExpanded(entry, expanded)
-        );
-    },
-    getAllVisibility: (state: LegendState, visible: boolean): boolean => {
-        return state.children.every((entry: LegendEntry | LegendGroup) =>
-            checkVisibility(entry, visible)
-        );
-    }
-};
+const getters = {};
 
 const mutations = {
-    ADD_ITEM: (state: LegendState, value: LegendEntry | LegendGroup) => {
-        state.children = [...state.children, value];
+    ADD_ITEM: (
+        state: LegendState,
+        value: { item: LegendItem; parent: LegendItem | undefined }
+    ) => {
+        if (value.parent === undefined) {
+            // add to root level
+            state.children = [...state.children, value.item];
+        } else {
+            // validate items to keep ts happy
+
+            // below checks should never trigger if legend API is used correctly
+            if (!(value.parent instanceof LegendGroup)) {
+                console.error(
+                    'attempted to create legend item under a non-group legend item'
+                );
+                return;
+            }
+
+            if (
+                !(value.item instanceof LegendGroup) &&
+                !(value.item instanceof LegendEntry)
+            ) {
+                console.error(
+                    'attempted to add an unsupported legend item type'
+                );
+                return;
+            }
+
+            value.parent.children = [...value.parent.children, value.item];
+            if (value.item.visibility) {
+                value.parent.checkVisibility(value.item);
+            }
+        }
     },
-    REMOVE_LAYER_ENTRY: (state: LegendState, uid: string) => {
-        const removeLayerEntry = (children: (LegendEntry | LegendGroup)[]) => {
-            // remove entry if uid corresponds to entry or parent layer
+    REMOVE_ITEM: (state: LegendState, item: LegendItem) => {
+        const removeItem = (children: Array<LegendItem>) => {
+            // remove entry
             children = children.filter(entry => {
-                if (entry instanceof LegendEntry && entry.layerUID === uid) {
+                if (entry instanceof LegendEntry && entry === item) {
                     entry.remove();
                 }
-                return entry instanceof LegendGroup || entry.layerUID !== uid;
+                return entry !== item;
             });
 
             // recursively check child legend groups
             children
-                .filter(entry => entry instanceof LegendGroup)
-                .forEach(group => {
-                    group.children = removeLayerEntry(group.children);
+                .filter((entry: LegendItem) => entry instanceof LegendGroup)
+                .forEach((group: any) => {
+                    group.children = removeItem(group.children);
                 });
 
             // remove groups with no children
@@ -76,159 +71,23 @@ const mutations = {
             return children;
         };
 
-        state.children = removeLayerEntry(state.children);
-    },
-    RELOAD_LAYER_ENTRY: (state: LegendState, uid: string) => {
-        const reloadLayerEntry = (children: (LegendEntry | LegendGroup)[]) => {
-            // reload entry (set to placeholder) if uid corresponds to entry or parent layer
-            children
-                .filter(
-                    entry =>
-                        entry instanceof LegendEntry && entry.layerUID === uid
-                )
-                .forEach(entry => {
-                    entry.reload();
-                });
-
-            // recursively check child legend groups
-            children
-                .filter(entry => entry instanceof LegendGroup)
-                .forEach(group => {
-                    group.children = reloadLayerEntry(group.children);
-                });
-
-            return children;
-        };
-
-        state.children = reloadLayerEntry(state.children);
+        state.children = removeItem(state.children);
     }
 };
 
 const actions = {
-    /** Expand all legend groups */
-    expandGroups: (context: LegendContext): void => {
-        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
-            toggle(entry, { expand: true });
-        });
+    /** Add legend item to store */
+    addItem: (
+        context: LegendContext,
+        value: { item: LegendItem; parent: LegendItem | undefined }
+    ) => {
+        context.commit('ADD_ITEM', value);
     },
-    /** Collapse all legend groups */
-    collapseGroups: (context: LegendContext): void => {
-        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
-            toggle(entry, { expand: false });
-        });
-    },
-    /** Turn visibility on for all legend entries */
-    showAll: (context: LegendContext): void => {
-        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
-            toggle(entry, { visibility: true });
-        });
-    },
-    /** Turn visibility off for all legend entries */
-    hideAll: (context: LegendContext): void => {
-        context.state.children.forEach((entry: LegendEntry | LegendGroup) => {
-            toggle(entry, { visibility: false });
-        });
-    },
-    /** Add legend entry to store */
-    addItem: (context: LegendContext, item: LegendEntry) => {
-        context.commit('ADD_ITEM', item);
-    },
-    /** Remove layer's corresponding entry from the store */
-    removeLayerEntry: (context: LegendContext, uid: string) => {
-        context.commit('REMOVE_LAYER_ENTRY', uid);
-    },
-    /** Reload layer's corresponding legend entry */
-    reloadLayerEntry: (context: LegendContext, uid: string) => {
-        context.commit('RELOAD_LAYER_ENTRY', uid);
+    /** Remove legend item from store */
+    removeItem: (context: LegendContext, item: LegendItem) => {
+        context.commit('REMOVE_ITEM', item);
     }
 };
-
-/**
- * Helper function that checks if all entries are visible/not visible.
- *
- * @function checkVisibility
- * @param {LegendElement}   child Current legend item that is being checked
- * @param {boolean}         visible Specifies whether visibility or expand/collapse functionality is to be changed
- */
-function checkVisibility(
-    child: LegendEntry | LegendGroup,
-    visible: boolean
-): boolean {
-    // traverse tree to check if all legend items have visibility toggled on/off
-    if (child.children && child.children.length > 0) {
-        child.children.forEach(ch => {
-            if (!checkVisibility(ch, visible)) {
-                return false;
-            }
-        });
-    }
-    // visibility set edge case: entry must be toggled on or must be part of a visbiility set and there is another entry in the set toggled on
-    if (
-        !child.visibility &&
-        !(child.parent instanceof LegendGroup && child.parent.visibility)
-    ) {
-        return false;
-    } else if (child.visibility !== visible) {
-        return false;
-    }
-    return true;
-}
-
-/**
- * Helper function that checks if all entries are expanded/collapsed.
- *
- * @function checkExpanded
- * @param {LegendElement} child Current legend item that is being checked
- * @param {Object}        expanded Specifies whether visibility or expand/collapse functionality is to be changed
- */
-function checkExpanded(child: LegendItem, expanded: boolean): boolean {
-    // traverse tree to check if all legend groups are expanded/collapsed
-    if (child.children && child.children.length > 0) {
-        child.children.forEach(ch => {
-            if (!checkExpanded(ch, expanded)) {
-                return false;
-            }
-        });
-    }
-    if (child instanceof LegendGroup && child.expanded === expanded) {
-        return false;
-    }
-    return true;
-}
-
-/**
- * Helper function that toggles visibility for all entries or expands/collapses all groups.
- *
- * @function toggle
- * @param {LegendElement}   child Current legend item that is being checked
- * @param {Object}          options Specifies whether visibility or expand/collapse functionality is to be changed
- */
-function toggle(child: LegendEntry | LegendGroup, options: any) {
-    const visibility = options.visibility;
-    const expand = options.expand;
-    // for current legend child toggle properties if possible, check for appropriate legend element type
-    if (visibility !== undefined) {
-        // visibility set edge case
-        if (
-            !(
-                child.parent instanceof LegendGroup &&
-                child.parent.visibility === visibility
-            )
-        ) {
-            child.toggleVisibility(visibility);
-        }
-    }
-    if (expand !== undefined && child instanceof LegendGroup) {
-        child.toggleExpanded(expand);
-    }
-    // traverse the tree and make recursive calls
-    if (child.children && child.children.length > 0) {
-        child.children.forEach(ch => {
-            // level order traversal
-            toggle(ch, options);
-        });
-    }
-}
 
 export enum LegendStore {
     /**
@@ -240,41 +99,13 @@ export enum LegendStore {
      */
     headerControls = 'legend/headerControls',
     /**
-     * (Getter) getChildById: (id: string) => LegendItem | undefined
+     * (Action) addItem: (value: { item: LegendItem; parent: LegendItem | undefined })
      */
-    getChildById = 'legend/getChildById',
+    addItem = 'legend/addItem',
     /**
-     * (Action) expandGroups - expand all possible legend groups
+     * (Action) removeItem: (item: LegendItem)
      */
-    expandGroups = 'legend/expandGroups',
-    /**
-     * (Action) collapseGroups - collapse all legend groups
-     */
-    collapseGroups = 'legend/collapseGroups',
-    /**
-     * (Action) showAll - turn on visibility for all possible legend entries
-     */
-    showAll = 'legend/showAll',
-    /**
-     * (Action) hideAll - turn off visibility for all legend entries
-     */
-    hideAll = 'legend/hideAll',
-    /**
-     * (Action) addItem - add entry to legend store
-     */
-    addItem = 'legend/addItem!',
-    /**
-     * (Action) removeLayerEntry - remove layer's corresponding entry from the store
-     */
-    removeLayerEntry = 'legend/removeLayerEntry',
-    /**
-     * (Action) reloadLayerEntry - set layer's corresponding entry to reload (placeholder) state
-     */
-    reloadLayerEntry = 'legend/reloadLayerEntry'
-    // /**
-    //  * (Action) updateDefaultEntry - replaces default placeholder after layer has loaded
-    //  */
-    // updateDefaultEntry = 'legend/updateDefaultEntry!'
+    removeItem = 'legend/removeItem'
 }
 
 export function legend() {

--- a/src/fixtures/settings/api/settings.ts
+++ b/src/fixtures/settings/api/settings.ts
@@ -1,5 +1,6 @@
 import { FixtureInstance, LayerInstance } from '@/api';
-import { LegendStore } from '@/fixtures/legend/store';
+import type { LegendAPI } from '@/fixtures/legend/api/legend';
+import { legend } from '@/fixtures/legend/store';
 
 export class SettingsAPI extends FixtureInstance {
     /**
@@ -8,10 +9,15 @@ export class SettingsAPI extends FixtureInstance {
      */
     toggleSettings(layer: LayerInstance): void {
         const panel = this.$iApi.panel.get('settings');
-        const legendItem = this.$iApi.$vApp.$store.get(
-            LegendStore.getChildById,
-            layer?.id
-        );
+        const legendApi = this.$iApi.fixture.get<LegendAPI>('legend');
+        if (!legendApi) {
+            console.error(
+                'Layer settings not access legend API. Please ensure the legend fixture is added.'
+            );
+            return;
+        }
+
+        const legendItem = legendApi.getLayerItem(layer.id);
         if (!panel.isOpen) {
             this.$iApi.panel.open({
                 id: 'settings',

--- a/src/fixtures/wizard/index.ts
+++ b/src/fixtures/wizard/index.ts
@@ -15,6 +15,10 @@ class WizardFixture extends WizardAPI {
                     screens: {
                         'wizard-screen': markRaw(WizardScreenV)
                     },
+                    button: {
+                        tooltip: 'wizard.title',
+                        icon: '<svg class="fill-current" viewBox="0 0 23 21"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path></svg>'
+                    },
                     style: {
                         width: '350px'
                     },

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -145,7 +145,6 @@ export class LayerAPI extends APIScope {
         const controls: Array<LayerControls> =
             layer.config.controls?.slice() ?? [
                 LayerControls.BoundaryZoom,
-                LayerControls.Boundingbox,
                 LayerControls.Datatable,
                 LayerControls.Identify,
                 LayerControls.Metadata,

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -316,8 +316,8 @@ export class MapImageLayer extends AttribLayer {
                     // apply any updates that were in the configuration snippets
                     const subC = subConfigs[miSL.layerIdx];
                     if (subC) {
-                        miSL.visibility = subC.state?.visibility || true;
-                        miSL.opacity = subC.state?.opacity || 1;
+                        miSL.visibility = subC.state?.visibility ?? true;
+                        miSL.opacity = subC.state?.opacity ?? 1;
                         // miSL.setQueryable(subC.state.identify); // TODO uncomment when done
                         miSL.nameField = subC.nameField || miSL.nameField || '';
                         miSL.processFieldMetadata(subC.fieldMetadata);

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -68,6 +68,10 @@ export class MapImageSublayer extends AttribLayer {
         //      every other layer. We don't want to wire up the standard "top level"
         //      layer stuff for sublayers.
 
+        // use the tree node created by the parent
+        this.layerTree = this.parentLayer!.getLayerTree().findChildByUid(
+            this.uid
+        )!;
         this.layerTree.name = this.name;
         this.layerTree.layerIdx = this.layerIdx;
 


### PR DESCRIPTION
## Closes #1222, Closes #1051
### Refers #1046, #1133, #938

## Changes
- Added the legend api CRUD suite as per discussion #1217 (with some tweaks)
- Added a new minimal `legend` sample to demos that runs a few test cases and dumps the output to the console
    - Note that for the sake of this PR, I added a `index-legend` to the public folder so it can be accessed in the PR build
    - I will remove this public sample before merging
- Fixed bug where items from the legend fixture config were being added in reverse order
- Fixed bug where MIL sublayers will ignore layer state and always set visibility to `true` and opacity to `1`
- Fixed bug where MIL sublayers were using their own `TreeNode` instead of the one created by the MIL root
- Added support for layer tree-grow where adding layers will have their layer tree mapped into legend items
- Removed `<KeepAlive>` tags around the legend item component because it was giving issues with the checkbox reactivity
- Added wizard appbar button to fully support wizard decoupling

## Notes
- I've noticed many cases where fixture components require access to its fixture api and so when the component is mounted/created, it has to manually fetch the api with `this.$iApi.fixture.get('fixture-name')`
    -  Just like how the panel instance is provided to all these components as a prop, maybe we can also provide the fixture api (if it has one)?
    - If this is a good idea, I can create a new discussion post + issue to look into this
- The new `addLayerItem` method now maps the layer tree into a legend tree
    - I think this donethanks' #1051 and handles parts of discussion #1133,
    - Would appreciate @yileifeng's and @james-rae's feedback on whether this can be closed
    - I also tried to reproduce #1046 but it seems like the MIL `onLoadActions` throws an error with this layer, so this issue can remain open

## Testing

[Public Legend Sample](https://ramp4-pcar4.github.io/ramp4-pcar4/1222/index-legend.html) - will be removed before this PR is merged
- The console should shows the outputs of various test calls to the api
- Use `window.lApi` to access the legend api and call its methods
- The legend should function the same as before
- Try adding `Group1` from this [MapImageLayer](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Nest/MapServer) - the layer tree structure in the server should be mirrored in the legend

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1281)
<!-- Reviewable:end -->
