### PR TITLE
fix 'apply filter' tooltip staying visible on mobile

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -47,7 +47,7 @@
                     class="p-4 h-40 disabled:opacity-30 disabled:cursor-default text-gray-500 hover:text-black"
                     @click="applyFiltersToMap"
                     :content="$t('grid.label.filters.apply')"
-                    v-tippy="{ placement: 'bottom', hideOnClick: false }"
+                    v-tippy="{ placement: 'bottom' }"
                     :disabled="filterSync"
                 >
                     <svg
@@ -92,7 +92,9 @@
                             ? $t('grid.label.filters.hide')
                             : $t('grid.label.filters.show')
                     "
-                    v-tippy="{ placement: 'bottom', hideOnClick: false }"
+                    v-tippy="{
+                        placement: 'bottom'
+                    }"
                 >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Closes #1229 

This PR fixes the issue where the "Apply Filters to Map" tooltip would stay visible on the grid until it is closed in mobile mode. 

I also looked into the documentation for [mobile options](https://kabbouchi.github.io/vue-tippy/4.0/all-options.html) provided by Sharven in the original issue to see if they would fix similar issues but these don't seem to have any effect for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1282)
<!-- Reviewable:end -->
