### PR TITLE
Default Query Enhancements

### DIFF
--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -416,7 +416,7 @@ console.log(svg);
 
 ### Filters
 
-Apply a SQL filter on a logical layer. This will alert any listeners on the `layer.filterChanged` event. Core SQL filters include `grid`, `symbol`, and `api`
+Apply a SQL filter on a logical layer. This will alert any listeners on the `layer.filterChanged` event. Core SQL filters include `grid`, `symbol`, `extent`, and `initial`. Avoid using core filter names for custom filters. If no filter name is provided, the generic `api` value will be used.
 
 ```js
 myLayer.setSqlFilter('dogfilter', `breed = 'terrier'`);

--- a/schema.json
+++ b/schema.json
@@ -990,6 +990,10 @@
                         }
                     }
                 },
+                "initialFilteredQuery": {
+                    "type": "string",
+                    "description": "Initial filter query to be applied to the layer. SQL WHERE clause format."
+                },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"
                 }
@@ -1093,7 +1097,7 @@
                 },
                 "initialFilteredQuery": {
                     "type": "string",
-                    "description": "Initial filter query to be applied to the layer."
+                    "description": "Initial filter query to be applied to the layer. SQL WHERE clause format."
                 },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"
@@ -1206,6 +1210,10 @@
                         "$ref": "#/$defs/fieldMetadataEntry"
                     }
                 },
+                "initialFilteredQuery": {
+                    "type": "string",
+                    "description": "Initial filter query to be applied to the layer. SQL WHERE clause format."
+                },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"
                 },
@@ -1313,6 +1321,10 @@
                     "items": {
                         "$ref": "#/$defs/fieldMetadataEntry"
                     }
+                },
+                "initialFilteredQuery": {
+                    "type": "string",
+                    "description": "Initial filter query to be applied to the layer. SQL WHERE clause format."
                 },
                 "fixtures": {
                     "$ref": "#/$defs/layerFixtureConfig"

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -233,8 +233,8 @@ export class DetailsAPI extends FixtureInstance {
     /**
      * Return whether or not a HilightMode has been defined (other than NONE)
      */
-    hasHilighter() {
+    hasHilighter(): boolean {
         const hilightFix: HilightAPI = this.$iApi.fixture.get('hilight');
-        return hilightFix.hilightMode.mode !== HilightMode.NONE;
+        return hilightFix && hilightFix.hilightMode.mode !== HilightMode.NONE;
     }
 }

--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -117,16 +117,24 @@ export default defineComponent({
             // Update the layer definition to filter child symbols
             // At the moment, only layers that support features will support sql filters
             if (this.legendItem.layer?.supportsFeatures) {
-                this.legendItem.layer?.setSqlFilter(
-                    CoreFilter.SYMBOL,
-                    this.legendItem
-                        .legend!.filter(
-                            (item: LegendSymbology) =>
-                                item.lastVisbility === true
-                        )
-                        .map((item: LegendSymbology) => item.definitionClause)
-                        .join(' OR ')
-                );
+                const filterGuts = this.legendItem
+                    .legend!.filter(
+                        (item: LegendSymbology) => item.lastVisbility === true
+                    )
+                    .map(
+                        (item: LegendSymbology) => item.definitionClause || ''
+                    );
+
+                let sql = ''; // default value, this computes to "show all"
+                if (filterGuts.length === 0) {
+                    // nothing visible.
+                    sql = '1=2';
+                } else if (filterGuts.length < this.legendItem.legend!.length) {
+                    // only a subset of checkboxes are checked. need filter
+                    sql = filterGuts.join(' OR ');
+                }
+
+                this.legendItem.layer?.setSqlFilter(CoreFilter.SYMBOL, sql);
             }
             this.initialChecked = true;
         }

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -549,6 +549,7 @@ export interface RampLayerMapImageSublayerConfig {
     disabledControls?: Array<LayerControls>;
     stateOnly?: boolean;
     fieldMetadata?: RampLayerFieldMetadataConfig;
+    initialFilteredQuery?: string;
     customRenderer?: any;
     fixtures?: any; // layer-based fixture config
 }

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -450,9 +450,10 @@ export interface FilterEventParam {
 // these represent filter keys that the core reserves. the above interface does not use it for typing as
 // 3rd parties can define their own keys.
 export enum CoreFilter {
-    SYMBOL = 'symbol',
-    GRID = 'grid',
-    EXTENT = 'extent',
+    SYMBOL = 'symbol', // used for symbol visibililty filters in the legend
+    GRID = 'grid', // used to apply grid filters to a layer
+    EXTENT = 'extent', // captures a filter based on an extent. leveraged by the grid to only show rows visible on screen
+    INITIAL = 'initial', // used to track an initial filter provided by the layer config
     API = 'api' // this would be a default api key. e.g. if someone just does an API filter set with no key parameter, it would use this.
 }
 

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -682,7 +682,7 @@ export class AttribLayer extends CommonLayer {
      */
     applySqlFilter(exclusions: Array<string> = []): void {
         throw new Error(
-            'attempted to apply sql filter to a layer not equipped for it. likely a new subclass of AttribFC did not override applySqlFilter'
+            'attempted to apply sql filter to a layer not equipped for it. likely a new subclass of AttribLayer did not override applySqlFilter'
         );
     }
 

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -1,5 +1,6 @@
 import { AttribLayer, InstanceAPI } from '@/api/internal';
 import {
+    CoreFilter,
     DataFormat,
     DefPromise,
     GeometryType,
@@ -69,10 +70,16 @@ export class FeatureLayer extends AttribLayer {
         // TODO add any extra properties for attrib-based layers here
         // if we have a definition at load, apply it here to avoid cancellation errors on
         if (rampLayerConfig.initialFilteredQuery) {
-            // TODO do we need to add something to the .filter? or is this
-            //      a fixed query never goes away?
+            // even though the layer filter would eventually propagate the query to
+            // the definition expression, by setting it on the esri config our initial
+            // layer load will apply the filter. This potentially avoids a very big
+            // data request that would just get filtered out seconds later.
             esriConfig.definitionExpression =
                 rampLayerConfig.initialFilteredQuery;
+            this.filter.setSql(
+                CoreFilter.INITIAL,
+                rampLayerConfig.initialFilteredQuery
+            );
         }
 
         if (

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -16,6 +16,7 @@ import type {
 } from '@/api/internal';
 
 import {
+    CoreFilter,
     DataFormat,
     DefPromise,
     Extent,
@@ -86,6 +87,7 @@ export class FileLayer extends AttribLayer {
         this.dataFormat = DataFormat.ESRI_FEATURE;
         this.layerFormat = LayerFormat.FEATURE;
         this.tooltipField = '';
+
         if (
             rampConfig.identifyMode &&
             rampConfig.identifyMode !== LayerIdentifyMode.NONE
@@ -93,6 +95,13 @@ export class FileLayer extends AttribLayer {
             this.identifyMode = rampConfig.identifyMode;
         } else {
             this.identifyMode = LayerIdentifyMode.HYBRID;
+        }
+
+        if (rampConfig.initialFilteredQuery) {
+            this.filter.setSql(
+                CoreFilter.INITIAL,
+                rampConfig.initialFilteredQuery
+            );
         }
     }
 
@@ -269,6 +278,13 @@ export class FileLayer extends AttribLayer {
             this.updateDrawState(DrawState.UP_TO_DATE);
         });
         */
+
+        // if we had an initial filter, apply it to the layer when it's done loading
+        if (this.filter.getSql(CoreFilter.INITIAL)) {
+            Promise.all(loadPromises).then(() => {
+                this.applySqlFilter();
+            });
+        }
 
         return loadPromises;
     }

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -212,7 +212,9 @@ export class MapImageLayer extends AttribLayer {
                                 identify: this.identify
                             },
                             controls: subConfigs[sid]?.controls,
-                            disabledControls: subConfigs[sid]?.disabledControls
+                            disabledControls: subConfigs[sid]?.disabledControls,
+                            initialFilteredQuery:
+                                subConfigs[sid]?.initialFilteredQuery
                         },
                         this.$iApi,
                         this,

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -4,7 +4,13 @@ import {
     InstanceAPI,
     type MapImageLayer
 } from '@/api/internal';
-import { DataFormat, InitiationState, LayerFormat, LayerType } from '@/geo/api';
+import {
+    CoreFilter,
+    DataFormat,
+    InitiationState,
+    LayerFormat,
+    LayerType
+} from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { markRaw } from 'vue';
 
@@ -37,6 +43,11 @@ export class MapImageSublayer extends AttribLayer {
         }
 
         this.fetchEsriSublayer(parent);
+
+        if (config.initialFilteredQuery) {
+            this.filter.setSql(CoreFilter.INITIAL, config.initialFilteredQuery);
+            this.applySqlFilter();
+        }
     }
 
     /**


### PR DESCRIPTION
Donethankses #1215 and  #1270

Fixes the overwriting of initial filters. The initial filter can be updated/removed using Layer API, targeting the filter with key name `initial`.

Adds the ability to use initial filters to MIL Sublayers, WFS, and file based layers.

Made a temporary change to CAM for fun. All 3 layer variants have been tested.

https://ramp4-pcar4.github.io/ramp4-pcar4/defq/index-cam.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1283)
<!-- Reviewable:end -->
