### PR TITLE
Horizontal scroll for grid

### DIFF
--- a/src/fixtures/grid/accessibility.ts
+++ b/src/fixtures/grid/accessibility.ts
@@ -56,9 +56,7 @@ export class GridAccessibilityManager {
             this.element.querySelectorAll(HEADER_ROW_SELECTOR)
         ) as HTMLElement[];
 
-        this.element
-            .querySelector('.ag-center-cols-viewport')
-            ?.classList.add('overflow-hidden');
+        this.element.querySelector('.ag-horizontal-left-spacer')?.remove();
         this.element
             .querySelector('.ag-body-horizontal-scroll-viewport')
             ?.setAttribute('tabindex', '-1');

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -168,8 +168,7 @@
             @cell-key-press="onCellKeyPress"
             :doesExternalFilterPass="doesExternalFilterPass"
             :isExternalFilterPresent="isExternalFilterPresent"
-        >
-        </ag-grid-vue>
+        />
     </div>
 </template>
 


### PR DESCRIPTION
Closes #1246.

Restores horizontal scrolling for the table in the grid panel. The small horizontal scrollbar on the first column has been removed, now the primary scrollbar spans the width of the table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1288)
<!-- Reviewable:end -->
