### PR TITLE
Mobile on-screen keyboard fix

### DIFF
--- a/src/fixtures/geosearch/search-bar.vue
+++ b/src/fixtures/geosearch/search-bar.vue
@@ -6,7 +6,13 @@
             :placeholder="$t('geosearch.searchText')"
             :value="searchVal"
             @input="onSearchTermChange($event.target.value)"
+            @keyup.enter="
+                if ($store.get('panel/mobileView')) {
+                    $event?.target?.blur();
+                }
+            "
             :aria-label="$t('geosearch.searchText')"
+            enterkeyhint="done"
         />
     </div>
 </template>

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -3,7 +3,13 @@
         <div class="flex items-center justify-between pl-8 pb-8">
             <div class="flex items-center pb-4 mr-8 min-w-0">
                 <input
-                    @keyup="updateQuickSearch()"
+                    @input="updateQuickSearch()"
+                    @keyup.enter="
+                        if ($store.get('panel/mobileView')) {
+                            $event?.target?.blur();
+                        }
+                    "
+                    enterkeyhint="done"
                     v-model="quicksearch"
                     class="rv-global-search rv-input pr-32 min-w-0"
                     aria-invalid="false"

--- a/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/src/fixtures/grid/templates/custom-date-filter.vue
@@ -5,7 +5,13 @@
             type="date"
             placeholder="date min"
             v-model="minVal"
-            @change="minValChanged()"
+            @input="minValChanged()"
+            @keyup.enter="
+                if ($store.get('panel/mobileView')) {
+                    $event?.target?.blur();
+                }
+            "
+            enterkeyhint="done"
         />
         <span class="w-12" />
         <input
@@ -13,7 +19,13 @@
             type="date"
             placeholder="date max"
             v-model="maxVal"
-            @change="maxValChanged()"
+            @input="maxValChanged()"
+            @keyup.enter="
+                if ($store.get('panel/mobileView')) {
+                    $event?.target?.blur();
+                }
+            "
+            enterkeyhint="done"
         />
     </div>
 </template>

--- a/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/src/fixtures/grid/templates/custom-number-filter.vue
@@ -5,7 +5,13 @@
             style="width: 45%"
             type="text"
             v-model="minVal"
-            @keyup="minValChanged()"
+            @input="minValChanged()"
+            @keyup.enter="
+                if ($store.get('panel/mobileView')) {
+                    $event?.target?.blur();
+                }
+            "
+            enterkeyhint="done"
             :placeholder="$t('grid.filters.number.min')"
         />
         <span class="w-12" />
@@ -14,7 +20,13 @@
             style="width: 45%"
             type="text"
             v-model="maxVal"
-            @keyup="maxValChanged()"
+            @input="maxValChanged()"
+            @keyup.enter="
+                if ($store.get('panel/mobileView')) {
+                    $event?.target?.blur();
+                }
+            "
+            enterkeyhint="done"
             :placeholder="$t('grid.filters.number.max')"
         />
     </div>

--- a/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/src/fixtures/grid/templates/custom-text-filter.vue
@@ -3,8 +3,14 @@
         <input
             class="rv-input w-full bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
             type="text"
-            @keyup="valueChanged()"
+            @input="valueChanged()"
             v-model="filterValue"
+            @keyup.enter="
+                if ($store.get('panel/mobileView')) {
+                    $event?.target?.blur();
+                }
+            "
+            enterkeyhint="done"
             :placeholder="
                 $t('grid.filters.column.label.text', [
                     params.column.colDef.headerName


### PR DESCRIPTION
~~**Not ready for reviewing/pulling yet**~~ 
Ready for review now.

Closes #1247.

When typing in search input fields in geosearch and grid, as well as filter input fields in grid, the mobile on-screen keyboard should dissappear after clicking the "done" button in the bottom right corner. Feel free to test with your own devices.

Let me know if I missed any input fields that need fixing. Also, there is quite a lot of duplicate code - not sure if its necessary to avoid the duplication, and if it is, how to go about doing that. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1294)
<!-- Reviewable:end -->
