### PR TITLE
Mobile tooltips and overview map fixes

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -31,6 +31,7 @@ export default defineComponent({
             animation: 'scale',
             inertia: true,
             trigger: 'mouseenter manual focus',
+            touch: ['hold', 200],
             // needed to have tooltips in fullscreen, by default it appends to document.body
             appendTo: this.$el
         });

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -73,7 +73,8 @@
                     placement: 'top',
                     hideOnClick: false,
                     theme: 'ramp4',
-                    animation: 'scale'
+                    animation: 'scale',
+                    touch: ['hold', 200]
                 }"
                 :content="$t('map.toggleScaleUnits')"
             >
@@ -89,8 +90,13 @@
             <dropdown-menu
                 class="flex-shrink-0 pointer-events-auto focus:outline-none px-4 mr-4"
                 position="top-end"
-                :tooltip="$t('map.changeLanguage')"
-                tooltip-placement="top-end"
+                v-tippy="{
+                    placement: 'top-end',
+                    theme: 'ramp4',
+                    animation: 'scale',
+                    touch: ['hold', 200]
+                }"
+                :content="$t('map.changeLanguage')"
             >
                 <template #header>
                     <span

--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -107,6 +107,7 @@ export class FocusListManager {
     highlightedItem: HTMLElement;
     isHorizontal: boolean;
     isClicked: boolean;
+    isTapped: boolean;
 
     /**
      * Creates an instance of FocusListManager
@@ -121,6 +122,7 @@ export class FocusListManager {
         this.isHorizontal = attributeValue === 'horizontal';
 
         this.isClicked = false;
+        this.isTapped = false;
 
         // remove the ability to tab to sub-items
         this.setTabIndex(-1);
@@ -140,6 +142,9 @@ export class FocusListManager {
         });
         element.addEventListener('mousedown', function (event: MouseEvent) {
             focusManager.onMousedown();
+        });
+        element.addEventListener('touchstart', function (event: MouseEvent) {
+            focusManager.onTouchstart();
         });
     }
 
@@ -194,12 +199,13 @@ export class FocusListManager {
         this.setAriaActiveDescendant(item);
         this.setTabIndex(0, item);
         item.scrollIntoView({ block: 'nearest' });
-        if ((item as any)._tippy) {
+        if ((item as any)._tippy && !this.isTapped) {
             (item as any)._tippy.show();
         }
         if (item.getAttribute(ITEM_ATTR) === SHOW_TRUNCATE) {
             (item.querySelector(`[${TRUNCATE_ATTR}]`)! as any)?._tippy?.show();
         }
+        this.isTapped = false;
     }
 
     /**
@@ -463,5 +469,12 @@ export class FocusListManager {
     onMousedown() {
         // set clicked flag so focus event knows its been triggered by a click and isn't currently being traversed by keyboard
         this.isClicked = true;
+    }
+
+    /**
+     * Callback for the TOUCHSTART event listener on the focus list element.
+     */
+    onTouchstart() {
+        this.isTapped = true;
     }
 }


### PR DESCRIPTION
Closes #1236, #1230.

### Changes
- Tooltips now appear only after holding down on an element on mobile, and won't stick around after you stop pressing down
- The map can no longer be panned via the overview map on mobile

### Notes
- Technically the overview map cannot be panned on any touch screen device, which means that a tablet user will also not be able to use the overview map. I don't know if we want to preserve the functionality for devices that use a touch screen but also have a larger screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1300)
<!-- Reviewable:end -->
