### PR TITLE
Increase MIL touch tolerance

### DIFF
--- a/demos/starter-scripts/legend.js
+++ b/demos/starter-scripts/legend.js
@@ -137,7 +137,7 @@ let config = {
                         visibility: true,
                         hovertips: false
                     },
-                    tolerance: 10,
+                    mouseTolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
                 {

--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -338,7 +338,7 @@ let config = {
                         visibility: true,
                         hovertips: false
                     },
-                    tolerance: 10,
+                    mouseTolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
                 {
@@ -775,7 +775,7 @@ let config2 = {
                         visibility: true,
                         hovertips: false
                     },
-                    tolerance: 10,
+                    mouseTolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
                 {
@@ -1212,7 +1212,7 @@ let config3 = {
                         visibility: true,
                         hovertips: false
                     },
-                    tolerance: 10,
+                    mouseTolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
                 {

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -326,7 +326,7 @@ let config = {
                         visibility: true,
                         hovertips: false
                     },
-                    tolerance: 10,
+                    mouseTolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
                 {

--- a/public/starter-scripts/cam.js
+++ b/public/starter-scripts/cam.js
@@ -320,7 +320,7 @@ let config = {
                             ]
                         }
                     },
-                    tolerance: 5,
+                    mouseTolerance: 5,
                     identifyMode: 'hybrid',
                     drawOrder: [{ field: 'Program_name', ascending: true }],
                     state: {

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -326,7 +326,7 @@ let config = {
                         visibility: true,
                         hovertips: false
                     },
-                    tolerance: 10,
+                    mouseTolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
                 {

--- a/schema.json
+++ b/schema.json
@@ -865,10 +865,15 @@
                     },
                     "minItems": 1
                 },
-                "tolerance": {
+                "mouseTolerance": {
                     "type": "number",
                     "default": 5,
                     "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"
+                },
+                "touchTolerance": {
+                    "type": "number",
+                    "default": 15,
+                    "description": "Specifies the tolerance in pixels when determining if a feature was tapped. Should be non-negative integer"
                 },
                 "extent": {
                     "$ref": "#/$defs/extentWithReference"
@@ -1051,7 +1056,7 @@
                     "enum": ["esri-feature"],
                     "description": "Service type shorthand for feature layers."
                 },
-                "tolerance": {
+                "mouseTolerance": {
                     "type": "number",
                     "default": 5,
                     "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"
@@ -1166,7 +1171,7 @@
                     "type": "string",
                     "description": "The longitude field of the layer (only for CSVs)."
                 },
-                "tolerance": {
+                "mouseTolerance": {
                     "type": "number",
                     "default": 5,
                     "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"
@@ -1273,7 +1278,7 @@
                     "default": "ogc-wfs",
                     "description": "Service type shorthand for WFS layers."
                 },
-                "tolerance": {
+                "mouseTolerance": {
                     "type": "number",
                     "default": 5,
                     "description": "Specifies the tolerance in pixels when determining if a feature was clicked. Should be non-negative integer"

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -674,7 +674,10 @@ function layerUpgrader(r2layer: any): any {
         r4layer.tooltipField = r2layer.tooltipField;
     }
     if (r2layer.tolerance) {
-        r4layer.tolerance = r2layer.tolerance;
+        r4layer.mouseTolerance = r2layer.tolerance;
+        if (r2layer.layerType === 'esriDynamic') {
+            r4layer.touchTolerance = r2layer.tolerance + 10;
+        }
     }
     if (r2layer.customRenderer) {
         r4layer.customRenderer = r2layer.customRenderer;

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -302,6 +302,7 @@ export interface MapClick {
     screenX: number;
     screenY: number;
     button: number;
+    input: string;
     clickTime: number;
 }
 
@@ -590,7 +591,8 @@ export interface RampLayerConfig {
     extent?: RampExtentConfig;
     latField?: string; // csv coord field
     longField?: string; // csv coord field
-    tolerance?: number; // click tolerance
+    mouseTolerance?: number; // mouse tolerance
+    touchTolerance?: number; // touch tolerance
     metadata?: { url: string; name?: string };
     catalogueUrl?: string;
     fixtures?: any; // layer-based fixture config

--- a/src/geo/api/graphic/geometry/geometry.ts
+++ b/src/geo/api/graphic/geometry/geometry.ts
@@ -69,6 +69,7 @@ export class GeometryAPI {
             screenX: esriMapClick.x,
             screenY: esriMapClick.y,
             button: esriMapClick.button,
+            input: esriMapClick.native.pointerType,
             clickTime: esriMapClick.timestamp
         };
     }

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -40,7 +40,8 @@ export class CommonLayer extends LayerInstance {
     _name: string;
     _scaleSet: ScaleSet;
     _legend: Array<LegendSymbology>;
-    _clickTolerance: number;
+    _mouseTolerance: number;
+    _touchTolerance: number;
     _featureCount: number;
     _fields: Array<FieldDefinition>;
     _nameField: string;
@@ -73,8 +74,14 @@ export class CommonLayer extends LayerInstance {
         this._scaleSet = new ScaleSet();
         this._legend = [];
         this._featureCount = -1;
-        this._clickTolerance =
-            rampConfig.tolerance != undefined ? rampConfig.tolerance : 5; // use default value of 5 if tolerance is undefined
+        this._mouseTolerance =
+            rampConfig.mouseTolerance != undefined
+                ? rampConfig.mouseTolerance
+                : 5; // use default value of 5 if mouse tolerance is undefined
+        this._touchTolerance =
+            rampConfig.touchTolerance != undefined
+                ? rampConfig.touchTolerance
+                : 15; // use default value of 15 if touch tolerance is undefined
         this._fields = [];
         this.geomType = GeometryType.NONE;
         this._nameField = 'error';
@@ -609,20 +616,20 @@ export class CommonLayer extends LayerInstance {
     }
 
     /**
-     * Get the click tolerance in pixels for this layer
+     * Get the mouse tolerance in pixels for this layer
      *
-     * @returns {number} the click tolerance of this layer
+     * @returns {number} the mouse tolerance of this layer
      */
-    get clickTolerance() {
-        return this._clickTolerance;
+    get mouseTolerance() {
+        return this._mouseTolerance;
     }
 
     /**
-     * Set the click tolerance for this layer in pixels
+     * Set the mouse tolerance for this layer in pixels
      *
-     * @param {number} tolerance the new click tolerance
+     * @param {number} tolerance the new mouse tolerance
      */
-    set clickTolerance(tolerance: number) {
+    set mouseTolerance(tolerance: number) {
         if (!this.supportsIdentify) {
             console.warn(
                 "Attempted to set click tolerance on a layer that doesn't support identify"
@@ -636,7 +643,37 @@ export class CommonLayer extends LayerInstance {
             return;
         }
 
-        this._clickTolerance = tolerance;
+        this._mouseTolerance = tolerance;
+    }
+
+    /**
+     * Get the touch tolerance in pixels for this layer
+     *
+     * @returns {number} the touch tolerance of this layer
+     */
+    get touchTolerance() {
+        return this._touchTolerance;
+    }
+
+    /**
+     * Set the touch tolerance in pixels for this layer
+     *
+     * @param {number} tolerance the new touch tolerance
+     */
+    set touchTolerance(tolerance: number) {
+        if (!this.supportsIdentify) {
+            console.warn(
+                "Attempted to set touch tolerance on a layer that doesn't support identify"
+            );
+            return;
+        }
+
+        if (tolerance < 0) {
+            console.error('Attempted to set a negative touch tolerance');
+            return;
+        }
+
+        this._touchTolerance = tolerance;
     }
 
     /**

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -446,20 +446,36 @@ export class LayerInstance extends APIScope {
     set featureCount(count: number) {}
 
     /**
-     * Get the click tolerance in pixels for this layer
+     * Get the mouse tolerance in pixels for this layer
      *
-     * @returns {number} the click tolerance of this layer
+     * @returns {number} the mouse tolerance of this layer
      */
-    get clickTolerance(): number {
+    get mouseTolerance(): number {
         return 0;
     }
 
     /**
-     * Set the click tolerance for this layer in pixels
+     * Set the mouse tolerance for this layer in pixels
      *
-     * @param {Integer} tolerance the new click tolerance
+     * @param {Integer} tolerance the new mouse tolerance
      */
-    set clickTolerance(tolerance: number) {}
+    set mouseTolerance(tolerance: number) {}
+
+    /**
+     * Get the touch tolerance in pixels for this layer
+     *
+     * @returns {number} the touch tolerance of this layer
+     */
+    get touchTolerance(): number {
+        return 0;
+    }
+
+    /**
+     * Set the touch tolerance in pixels for this layer
+     *
+     * @param {Integer} tolerance the new touch tolerance
+     */
+    set touchTolerance(tolerance: number) {}
 
     /**
      * Return the draw order for the layer, if applicable

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -175,31 +175,59 @@ export class MapImageSublayer extends AttribLayer {
     }
 
     /**
-     * Get the click tolerance in pixels for this sublayer's parent layer
+     * Get the mouse tolerance in pixels for this sublayer's parent layer
      *
-     * @returns {number} the click tolerance of the parent layer
+     * @returns {number} the mouse tolerance of the parent layer
      */
-    get clickTolerance(): number {
+    get mouseTolerance(): number {
         if (!this.parentLayer?.esriLayer || !this.esriSubLayer) {
             this.noLayerErr();
             return 0;
         }
 
-        return this.parentLayer.clickTolerance;
+        return this.parentLayer.mouseTolerance;
     }
 
     /**
-     * Set the click tolerance for this sublayer's parent layer in pixels
+     * Set the mouse tolerance for this sublayer's parent layer in pixels
      *
-     * @param {number} tolerance the new click tolerance
+     * @param {number} tolerance the new mouse tolerance
      */
-    set clickTolerance(tolerance: number) {
+    set mouseTolerance(tolerance: number) {
         if (!this.parentLayer?.esriLayer || !this.esriSubLayer) {
             this.noLayerErr();
             return;
         }
 
-        this.parentLayer.clickTolerance = tolerance;
+        this.parentLayer.mouseTolerance = tolerance;
+    }
+
+    /**
+     * Get the touch tolerance in pixels for this sublayer's parent layer
+     *
+     * @returns {number} the touch tolerance of the parent layer
+     */
+    get touchTolerance(): number {
+        if (!this.parentLayer?.esriLayer || !this.esriSubLayer) {
+            this.noLayerErr();
+            return 0;
+        }
+
+        return this.parentLayer.touchTolerance;
+    }
+
+    /**
+     * Set the touch tolerance in pixels for this sublayer's parent layer
+     *
+     * @param {number} tolerance the new touch tolerance of the parent layer
+     */
+    set touchTolerance(tolerance: number) {
+        if (!this.parentLayer?.esriLayer || !this.esriSubLayer) {
+            this.noLayerErr();
+            return;
+        }
+
+        this.parentLayer.touchTolerance = tolerance;
     }
 
     /**

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -918,6 +918,7 @@ export class MapAPI extends CommonMapAPI {
                 screenX: screenPoint.screenX,
                 screenY: screenPoint.screenY,
                 button: 0,
+                input: 'mouse',
                 clickTime: Date.now()
             };
         } else {
@@ -964,7 +965,11 @@ export class MapAPI extends CommonMapAPI {
         const identifyResults = layers
             .filter(layer => layer.supportsIdentify)
             .map(layer => {
-                p.tolerance = layer.clickTolerance;
+                // set identify tolerance based on input source
+                p.tolerance =
+                    mapClick.input == 'touch'
+                        ? layer.touchTolerance
+                        : layer.mouseTolerance;
                 return layer.runIdentify(p);
             })
             .flat();


### PR DESCRIPTION
Closes #1249.

### Changes
- Added `touchTolerance` property to map image layers. When identifying a point on a MIL, the source of the input (mouse/finger) determines whether to use the mouse tolerance or touch tolerance.
- Renamed `tolerance` to `mouseTolerance` for consistency.

### Notes
- The default touch tolerance is `15px`, compared to a mouse tolerance of `5px`. `15px` felt alright to me, but user feedback is welcome.
- The issue mentions difficulty selecting points on a WFS layer, that has been fixed by #897

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1305)
<!-- Reviewable:end -->
