### PR TITLE
Fix panguard & geolocator

### DIFF
--- a/src/fixtures/mapnav/buttons/geolocator-nav.vue
+++ b/src/fixtures/mapnav/buttons/geolocator-nav.vue
@@ -36,11 +36,24 @@ export default defineComponent({
                     maximumAge: Infinity,
                     timeout: 5000
                 }).catch((error: GeolocationPositionError) => {
-                    // send an error message if user accepts location access but something goes wrong with the navigator
-                    if (error.code > 1) {
+                    if (
+                        error.code ===
+                        GeolocationPositionError.PERMISSION_DENIED
+                    ) {
+                        // send an error message for a denied permission error
                         this.$iApi.notify.show(
                             NotificationType.ERROR,
-                            this.$iApi.$vApp.$t('mapnav.geolocator.error')
+                            this.$iApi.$vApp.$t(
+                                'mapnav.geolocator.error.permission'
+                            )
+                        );
+                    } else {
+                        // send an error message for an internal/timeout error
+                        this.$iApi.notify.show(
+                            NotificationType.ERROR,
+                            this.$iApi.$vApp.$t(
+                                'mapnav.geolocator.error.internal'
+                            )
                         );
                     }
                 });

--- a/src/fixtures/mapnav/lang/lang.csv
+++ b/src/fixtures/mapnav/lang/lang.csv
@@ -4,4 +4,5 @@ mapnav.zoomOut,Zoom Out,1,Zoom arrière,1
 mapnav.home,Home,1,Accueil,1
 mapnav.fullscreen,Full Screen,1,Plein Écran,1
 mapnav.geolocator,Your Location,1,Votre position,1
-mapnav.geolocator.error,Your location could not be found.,1,Votre emplacement n'a pu être trouvé.,1
+mapnav.geolocator.error.permission,The location request was denied. Please check your browser permission settings.,1,La demande de localisation a été refusée. Veuillez vérifier les paramètres d'autorisation de votre navigateur.,0
+mapnav.geolocator.error.internal,Your location could not be found.,1,Votre emplacement n'a pu être trouvé.,1

--- a/src/fixtures/panguard/lang/lang.csv
+++ b/src/fixtures/panguard/lang/lang.csv
@@ -1,2 +1,2 @@
 key,enValue,enValid,frValue,frValid
-panguard.instructions,Use two fingers to scroll the map,1,Utiliser deux doigts pour faire défiler la carte,1
+panguard.instructions,Use two fingers to pan the map,1,Utiliser deux doigts pour déplacer la carte,0

--- a/src/fixtures/panguard/map-panguard.vue
+++ b/src/fixtures/panguard/map-panguard.vue
@@ -67,7 +67,10 @@ export default defineComponent({
                         ['pointer-up', 'pointer-leave'],
                         e => {
                             if (e.pointerType !== 'touch') return;
-                            pointers.delete(e.pointerId);
+                            // small delay as to not offend panguard when lifting more than one finger
+                            window.setTimeout(() => {
+                                pointers.delete(e.pointerId);
+                            }, 200);
                         }
                     )
                 );
@@ -81,8 +84,10 @@ export default defineComponent({
                             !pointer ||
                             pointerType !== 'touch' ||
                             pointers.size !== 1
-                        )
+                        ) {
+                            this.$el.classList.remove('pg-active');
                             return;
+                        }
 
                         // ignore very small movements to avoid scrolling when someone is tapping the screen
                         const distance = Math.sqrt(


### PR DESCRIPTION
Closes #1239, #1306.

### Changes
- Panguard is now less unfriendly and full of hate.
- Geolocator now notifies user when their location permissions are blocking geolocation, so it no longer appears to be broken on mobile.

### Testing
- Play around with panning on mobile, there should be less interference from the panguard. 
- Also try geolocating on mobile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1307)
<!-- Reviewable:end -->
