### PR TITLE
Appbar button overlap fix

### DIFF
--- a/src/components/shell.vue
+++ b/src/components/shell.vue
@@ -20,7 +20,7 @@
             <notification-floating-button
                 v-if="!appbarFixture"
             ></notification-floating-button>
-            <map-caption class="z-10"></map-caption>
+            <map-caption class="z-30"></map-caption>
         </div>
 
         <esri-map v-if="start"></esri-map>

--- a/src/fixtures/appbar/default-button.vue
+++ b/src/fixtures/appbar/default-button.vue
@@ -5,7 +5,8 @@
         :tooltip="$t(panelButton.tooltip)"
         :id="panelId"
         ><div
-            class="fill-current w-24 h-24 ml-8 sm:ml-20"
+            class="default fill-current w-24 h-24 ml-8 sm:ml-20"
+            :class="{ 'ml-20': overflow }"
             v-html="panelButton.icon"
         ></div
     ></appbar-button>
@@ -24,6 +25,9 @@ export default defineComponent({
         minimize: {
             type: Boolean,
             default: false
+        },
+        overflow: {
+            type: Boolean
         }
     },
     computed: {

--- a/src/fixtures/appbar/more-button.vue
+++ b/src/fixtures/appbar/more-button.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="relative inset-x-0 w-full h-48 text-center">
+    <div class="appbar-item relative inset-x-0 w-full text-center">
         <button
-            class="text-gray-400 w-full h-full focus:outline-none hover:text-white"
+            class="text-gray-400 w-full h-48 focus:outline-none hover:text-white"
             @click="open = !open"
             v-focus-item
             :content="$t('appbar.more')"
@@ -23,7 +23,7 @@
             @blur="open = false"
             :position="position"
             id="dropdown"
-            class="dropdown shadow-md border border-gray:200 absolute py-8 w-64 bg-white rounded text-center z-10"
+            class="dropdown shadow-md border border-gray:200 absolute w-64 flex flex-col bg-white rounded"
         >
             <slot></slot>
         </div>
@@ -74,14 +74,6 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.dropdown > * {
-    display: block;
-    padding: 0.5rem 1rem 0.5rem 1rem;
-    color: #2d3748;
-    &:hover:not(.disabled) {
-        background-color: #eee;
-    }
-}
 .dropdown {
     @apply left-full bottom-0;
 }


### PR DESCRIPTION
Closes #1248.

Opening a bunch of temporary buttons on a small-sized appbar will no longer cause overlap with the notification button. Instead, a "more options" dropdown should be opened.

**Note**: Spencer suggested preserving the order of temporary buttons being after permanent ones. I have managed to do this, however I am having trouble preserving the order of the temporary buttons themselves to be in the order that they are opened in certain edge cases. Basically, all the temporary buttons will always appear after configured ones, but its possible in certain cases that grid appears after metadata even though grid was opened first. This happens because of the different edge cases requiring buttons to be added in different places. If this is something we really care about (it will only happen if a user is out to get us lol and tries all the edge cases), then I believe we should revamp the current DOM trickery solution and maybe pass in an array of permanent and temporary buttons into the dropdown and render them there or something similar. Unless someone has a better solution, of course.

**TLDR**: Normal case of "I ran out of space in the appbar when opening buttons" works well, certain edge cases don't break anything but make the order of temporary buttons not as ideal. Looking for suggestions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1310)
<!-- Reviewable:end -->
