### PR TITLE
Mobile CSS small fixes party

### DIFF
--- a/demos/index-e2e.html
+++ b/demos/index-e2e.html
@@ -21,7 +21,10 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app" style="height: 100vh"></div>
+        <div
+            id="app"
+            style="height: 100vh; max-height: -webkit-fill-available"
+        ></div>
 
         <script>
             // get RAMP "starter" script from url param

--- a/demos/index.html
+++ b/demos/index.html
@@ -21,7 +21,10 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app" style="height: 100vh"></div>
+        <div
+            id="app"
+            style="height: 100vh; max-height: -webkit-fill-available"
+        ></div>
 
         <script type="module" src="./starter-scripts/main.js"></script>
     </body>

--- a/public/index-cam.html
+++ b/public/index-cam.html
@@ -22,7 +22,10 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app" style="height: 100vh"></div>
+        <div
+            id="app"
+            style="height: 100vh; max-height: -webkit-fill-available"
+        ></div>
         <script src="./lib/ramp.global.js"></script>
         <script type="module" src="./starter-scripts/cam.js"></script>
     </body>

--- a/public/index-cesi.html
+++ b/public/index-cesi.html
@@ -22,7 +22,10 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app" style="height: 100vh"></div>
+        <div
+            id="app"
+            style="height: 100vh; max-height: -webkit-fill-available"
+        ></div>
         <script src="./lib/ramp.global.js"></script>
         <script type="module" src="./starter-scripts/cesi.js"></script>
     </body>

--- a/public/index.html
+++ b/public/index.html
@@ -22,7 +22,10 @@
         </noscript>
 
         <div id="IE"></div>
-        <div id="app" style="height: 100vh"></div>
+        <div
+            id="app"
+            style="height: 100vh; max-height: -webkit-fill-available"
+        ></div>
         <script src="./lib/ramp.global.js"></script>
         <script type="module" src="./starter-scripts/index.js"></script>
     </body>

--- a/src/fixtures/help/section.vue
+++ b/src/fixtures/help/section.vue
@@ -20,7 +20,7 @@
 
                 <!-- dropdown icon -->
                 <div
-                    class="icon"
+                    class="dropdown-icon"
                     :class="{ 'transform -rotate-180': expanded }"
                 >
                     <svg
@@ -85,7 +85,7 @@ export default defineComponent({
         @apply inline;
     }
 }
-.help-section-header .icon {
+.help-section-header .dropdown-icon {
     transition: transform 0.3s cubic-bezier(0.35, 0, 0.25, 1);
 }
 .help-item-leave-active,

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -37,8 +37,8 @@
         <dropdown-menu
             class="relative"
             position="left-start"
-            :tooltip="$t('legend.header.groups')"
-            tooltip-placement="left"
+            :content="$t('legend.header.groups')"
+            v-tippy="{ placement: 'left' }"
             v-show="isControlAvailable('groupToggle')"
         >
             <template #header>
@@ -72,8 +72,8 @@
         <dropdown-menu
             class="relative"
             position="left-start"
-            :tooltip="$t('legend.header.visible')"
-            tooltip-placement="left"
+            :content="$t('legend.header.visible')"
+            v-tippy="{ placement: 'left' }"
             v-show="isControlAvailable('visibilityToggle')"
         >
             <template #header>


### PR DESCRIPTION
Closes #1241, closes #1243, closes #1265

### Changes
- fixed mobile viewport on Safari, URL at the bottom of the screen no longer overlaps with RAMP
- help section dropdown icon no longer conflicts with WET styles
- legend dropdown menu tooltips are no longer covered by panel header

### Testing
- fire up RAMP on a moblie device and poke around

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1312)
<!-- Reviewable:end -->
