### PR TITLE
Fix attempt for details panel identify refresh

### DIFF
--- a/src/fixtures/details/layers-screen.vue
+++ b/src/fixtures/details/layers-screen.vue
@@ -230,8 +230,7 @@ export default defineComponent({
                         }
                     });
                 } else {
-                    // if last opened layer no longer exists close items panel and proceed with case 1
-                    this.closeResult();
+                    // if last opened layer no longer exists proceed with case 1
                     this.autoOpenAny(newPayload);
                 }
             } else {


### PR DESCRIPTION
## Refers #1179

## Changes
Fixed this identify edge case:
> minimize the details panel > remove the layer > open details panel > click on another feature - the panel will first close before opening again to show the loading spinner

However this change affects another case:
> minimize the details panel > remove the layer > open details panel > click on the **empty part of map**

Previously with the `closeResult` call, this case is handled and panel will close immediately since there are no identify results. However now with the call removed, the panel will not close right away but rather will be blank for a brief moment before closing. I am not sure if this case should be handled where the panel should close immediately when there is no payload. Hence I created this PR to generate a demo link so others can test and provide feedback.

If this fix is acceptable, then we can donethanks #1179.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1313)
<!-- Reviewable:end -->
