### PR TITLE
Layer Cleanup pt 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,44 +9,15 @@ RAMP - The Reusable Accessible Mapping Platform, is a Javascript based web mappi
 -   An application architecture and API that is more open and adjustable
 -   UI re-design with mobile use in mind
 
-This project is currently in development. Incomplete features, bugs, and breaking changes to the API and configuration schema should be expected until the `v1.0.0` release. The previous version can be found [here](https://github.com/fgpv-vpgf/fgpv-vpgf).
+This project is currently in development. Incomplete features, bugs, and breaking changes to the API and configuration schema should be expected until the `v1.0.0` release. The previous version (RAMP 2 / RAMP 3) can be found [here](https://github.com/fgpv-vpgf/fgpv-vpgf).
 
 > This is an unsupported product. If you require a supported version please contact applicationsdecartographieweb-webmappingapplications@ec.gc.ca for a cost estimate. The software and code samples available on this website are provided "as is" without warranty of any kind, either express or implied. Use at your own risk. Access to this GitHub repository could become unavailable at any point in time.
 
 ## Local development
 
-### public vs demos folders
-
-The `public` folder is a **static only** folder. It contains the help md files and end-user demo assets and ramp library source code in various formats (es, global). Files in this folder are not processed by vite and therefore cannot reference outside files. This is useful for testing if things are broken between the develop and production build. Later on these files will be published to npm, unpkg and others.
-
-To test the files in the `public` folder locally:
-
-```js
-npm run build
-npm run preview
-```
-
-Then open `http://localhost:5050/index.html` in your browser.
-
-The `demos` folder **is** processed by vite and can therefore reference any source file in the repo. This is the starting point for local development. For example, the `demos/starter-scripts/main.js` file imports `{ createInstance, geo } from '@/main';` whereas `public/starter-scripts/index.js` doesn't since RAMP is globally defined by the `index.html` file when it loads `<script src="./lib/ramp.global.js"></script>`.
-
-Run `npm run dev` then open `http://localhost:3000/demos/index.html` in your browser.
-
-During build, both `demos` and `public` folders are placed into `dist`.
-
-### Recommended IDE Setup
-
-[VSCode](https://code.visualstudio.com/) with the recommended extensions (VSCode should bug you to install them).
-
-#### Important:
-
-1. Install [Volar](https://marketplace.visualstudio.com/items?itemName=vue.volar).
-2. Disable/remove [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur).
-3. Type `@builtin typescript` in the search box on the VSCode extensions tab and **disable** "TypeScript and JavaScript Language Features". Volar has its own TS language server so we don't want to run two concurrently.
-
 ### Project Setup
 
-Download the latest [Node version](https://nodejs.org/en/download/), currently v18.3.0 or later.
+Download the latest [Node version](https://nodejs.org/en/download/), currently `v18.3.0` or later.
 
 ```sh
 npm ci
@@ -75,6 +46,35 @@ npm run preview
 ```
 
 Open `http://localhost:5050` in your browser.
+
+### Recommended IDE Setup
+
+[VSCode](https://code.visualstudio.com/) with the recommended extensions (VSCode should bug you to install them).
+
+#### Important:
+
+1. Install [Volar](https://marketplace.visualstudio.com/items?itemName=vue.volar).
+2. Disable/remove [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur).
+3. Type `@builtin typescript` in the search box on the VSCode extensions tab and **disable** "TypeScript and JavaScript Language Features". Volar has its own TS language server so we don't want to run two concurrently.
+
+### public vs demos folders
+
+The `public` folder is a **static only** folder. It contains the help md files and end-user demo assets and ramp library source code in various formats (es, global). Files in this folder are not processed by vite and therefore cannot reference outside files. This is useful for testing if things are broken between the develop and production build. Later on these files will be published to npm, unpkg and others.
+
+To test the files in the `public` folder locally:
+
+```js
+npm run build
+npm run preview
+```
+
+Then open `http://localhost:5050/index.html` in your browser.
+
+The `demos` folder **is** processed by vite and can therefore reference any source file in the repo. This is the starting point for local development. For example, the `demos/starter-scripts/main.js` file imports `{ createInstance, geo } from '@/main';` whereas `public/starter-scripts/index.js` doesn't since RAMP is globally defined by the `index.html` file when it loads `<script src="./lib/ramp.global.js"></script>`.
+
+Run `npm run dev` then open `http://localhost:3000/demos/index.html` in your browser.
+
+During build, the `public` folder contents are placed into the `dist` folder.
 
 ### Demo Builds
 

--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -127,12 +127,12 @@ The `.initiationState` property on the `Layer` will indicate the current state o
 
 In general, most layer properties and methods should only be accessed after the layer has loaded. Attempts to use prior to that may result in the data not existing (a console error will usually alert you to this mistake).
 
-The `Layer` object expose the `isLayerLoaded()` method, which returns a promise that will not resolve until the load has completed.
+The `Layer` object expose the `loadPromise()` method, which returns a promise that will not resolve until the load has completed.
 
 Of course, you can gate areas of logic so that code only runs after the layer is known to be loaded, and then you don't need to continually check the status.
 
 ```js
-await myLayer.isLayerLoaded();
+await myLayer.loadPromise();
 myLayer.dostuff();
 ```
 
@@ -189,10 +189,10 @@ Get the layer name (defined by configuration, and if not supplied, any server va
 myLayer.name; // "Fancy Layer"
 ```
 
-Determine if the layer is in a valid state. Invalid states would be pre-loaded or an error state. This can also be used as an alternative to `isLayerLoaded()` if the calling code does not require a `Promise` to wait on.
+Determine if the layer is loaded. This can also be used as an alternative to `loadPromise()` if the calling code does not require a `Promise` to wait on. It also serves as a shortcut to inspecting the `.layerState` property.
 
 ```js
-myLayer.isValidState; // true
+myLayer.isLoaded; // true
 ```
 
 Get the load state of the layer. This state tracks the loading life cycle (i.e. loading, loaded, error)
@@ -384,10 +384,10 @@ TODO figure out and document how the load count/status can be monitored.
 myLayer.abortAttributeLoad();
 ```
 
-Remove any attributes that had been loaded. The end result of this request is the appearance of the layer not having loaded attributes. Note this will not interrupt any loading process that is currently active. Use `abortAttributeLoad` to interrupt any enormous loads or hung calls.
+Remove any cached attributes or geometries that have been loaded. The end result of this request is the appearance of the layer not having loaded or cached attributes. Note this will not interrupt any loading process (`getAttributes()`) that is currently active. Use `abortAttributeLoad()` to interrupt any enormous loads or hung calls.
 
 ```js
-myLayer.destroyAttributes();
+myLayer.clearFeatureCache();
 ```
 
 Request the attributes in a tabular format with column metadata, suitable for grid or table consumption. This will use any pre-loaded attribute set, and if none exist, will execute the `getAttributes` request.

--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -157,9 +157,9 @@ export default defineComponent({
                 .forEach((layer: LayerInstance | null, index: number) => {
                     // wait on layer load to check for valid state
                     layer
-                        ?.isLayerLoaded()
+                        ?.loadPromise()
                         .then(() => {
-                            if (layer?.isValidState) {
+                            if (layer?.isLoaded) {
                                 this.$iApi.geo.map.reorder(
                                     layer!,
                                     oldValue ? oldValue.length + index : index

--- a/src/fixtures/export-legend/index.ts
+++ b/src/fixtures/export-legend/index.ts
@@ -59,8 +59,7 @@ class ExportLegendFixture extends FixtureInstance implements ExportSubFixture {
         const layers = this.$vApp.$store
             .get<LayerInstance[]>(LayerStore.layers)!
             .filter(
-                layer =>
-                    layer.isValidState && layer.visibility && !layer.isCosmetic
+                layer => layer.isLoaded && layer.visibility && !layer.isCosmetic
             );
 
         if (layers.length === 0) {

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -268,7 +268,7 @@ export default defineComponent({
     },
 
     beforeMount() {
-        this.config = this.grids[this.layerUid];
+        this.config = this.grids[this.layerUid!];
 
         this.filterInfo = {
             firstRow: 0,
@@ -328,7 +328,7 @@ export default defineComponent({
             return;
         }
 
-        fancyLayer.isLayerLoaded().then(() => {
+        fancyLayer.loadPromise().then(() => {
             const tableAttributePromise =
                 markRaw(fancyLayer).getTabularAttributes();
 
@@ -517,8 +517,9 @@ export default defineComponent({
                             layer.uid &&
                             (layer.uid === this.layerUid ||
                                 layer.uid ===
-                                    this.$iApi.geo.layer.getLayer(this.layerUid)
-                                        ?.uid)
+                                    this.$iApi.geo.layer.getLayer(
+                                        this.layerUid!
+                                    )?.uid)
                         ) {
                             this.applyLayerFilters();
                         }
@@ -529,7 +530,7 @@ export default defineComponent({
                 this.$iApi.event.on(
                     GlobalEvents.LAYER_RELOAD_END,
                     (reloadedLayer: LayerInstance) => {
-                        reloadedLayer.isLayerLoaded().then(() => {
+                        reloadedLayer.loadPromise().then(() => {
                             if (this.layerUid === reloadedLayer.uid) {
                                 this.applyLayerFilters();
                             }
@@ -838,7 +839,7 @@ export default defineComponent({
                     maxWidth: 82,
                     cellRenderer: (cell: any) => {
                         const layer: LayerInstance | undefined =
-                            this.$iApi.geo.layer.getLayer(this.layerUid);
+                            this.$iApi.geo.layer.getLayer(this.layerUid!);
                         if (layer === undefined) return;
                         const iconContainer = document.createElement('span');
                         const oid = cell.data[this.oidField];
@@ -876,14 +877,13 @@ export default defineComponent({
 
         // updates external grid filter based on layer filter and rerenders grid
         async applyLayerFilters() {
-            const layer = this.$iApi.geo.layer.getLayer(this.layerUid)!;
+            const layer = this.$iApi.geo.layer.getLayer(this.layerUid!)!;
             if (!layer || !layer.visibility) {
                 this.filteredOids = [];
             } else {
                 this.filteredOids = await layer.getFilterOIDs(
                     [CoreFilter.GRID],
-                    undefined,
-                    this.layerUid
+                    undefined
                 );
             }
             this.gridApi.onFilterChanged();
@@ -891,8 +891,8 @@ export default defineComponent({
 
         applyFiltersToMap() {
             const mapFilterQuery = this.getFiltersQuery();
-            const layer = this.$iApi.geo.layer.getLayer(this.layerUid);
-            layer?.setSqlFilter(CoreFilter.GRID, mapFilterQuery, this.layerUid);
+            const layer = this.$iApi.geo.layer.getLayer(this.layerUid!);
+            layer?.setSqlFilter(CoreFilter.GRID, mapFilterQuery);
             this.filterSync = true;
         },
 
@@ -1104,11 +1104,8 @@ export default defineComponent({
         // checks if current grid filters are applied to map
         gridFiltersApplied() {
             const gridQuery = this.getFiltersQuery();
-            const layer = this.$iApi.geo.layer.getLayer(this.layerUid);
-            const layerQuery = layer?.getSqlFilter(
-                CoreFilter.GRID,
-                this.layerUid
-            );
+            const layer = this.$iApi.geo.layer.getLayer(this.layerUid!);
+            const layerQuery = layer?.getSqlFilter(CoreFilter.GRID);
             return gridQuery === layerQuery;
         },
 

--- a/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
@@ -37,7 +37,7 @@ export class GlowHilightMode extends LiftHilightMode {
         if (
             hilightLayer &&
             hilightLayer.esriLayer &&
-            hilightLayer.isValidState &&
+            hilightLayer.isLoaded &&
             hilightLayer instanceof GraphicLayer
         ) {
             const gs: Array<Graphic> =

--- a/src/fixtures/hilight/api/hilight.ts
+++ b/src/fixtures/hilight/api/hilight.ts
@@ -171,7 +171,7 @@ export class HilightAPI extends FixtureInstance {
         const hilightLayer = this.$iApi.geo.layer.getLayer(HILIGHT_LAYER_NAME);
         if (
             hilightLayer &&
-            hilightLayer.isValidState &&
+            hilightLayer.isLoaded &&
             hilightLayer instanceof CommonGraphicLayer
         ) {
             return hilightLayer;

--- a/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/src/fixtures/layer-reorder/components/layer-component.vue
@@ -255,7 +255,7 @@ export default defineComponent({
             // add load promise listeners to update models
             this.layers.forEach((layer: LayerInstance) => {
                 layer
-                    .isLayerLoaded()
+                    .loadPromise()
                     .then(() => {
                         this.loadLayerData(layer);
                     })

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -165,7 +165,7 @@ export class LegendAPI extends FixtureInstance {
             // if layer supports sublayers, then we need to parse the
             // layer tree after loading and generate the children
 
-            await layer.isLayerLoaded();
+            await layer.loadPromise();
 
             // TODO: could modify LayerInstance's getSublayer to do what this helper is doing.
             //       current getSublayer only checks the sublayer list one level down, but in
@@ -405,7 +405,7 @@ export class LegendAPI extends FixtureInstance {
             (entry as LegendEntry)?.setErrorType();
         };
         layer
-            .isLayerLoaded()
+            .loadPromise()
             .then(() => {
                 updateEntry(layer); // update the root entry first
                 if (layer.supportsSublayers) {

--- a/src/fixtures/legend/store/legend-defs.ts
+++ b/src/fixtures/legend/store/legend-defs.ts
@@ -15,7 +15,7 @@ export class LegendItem {
     _disabledControls: Array<LayerControls> | undefined; // will use layer's disabled controls if undefined
     _children: Array<LegendEntry | LegendGroup> = [];
     _parent: LegendGroup | undefined = undefined; // can only be a legend group or visibility set
-    _loadPromise: DefPromise; // promise that resolves when legend item is loaded
+    _loadPromise: DefPromise; // deferred promise that resolves when legend item is loaded
 
     _hidden: boolean;
     _itemConfig: any;
@@ -252,7 +252,7 @@ export class LegendEntry extends LegendItem {
     loadLayer(layer: LayerInstance): void {
         this._layer = layer;
         this._layer
-            .isLayerLoaded()
+            .loadPromise()
             .then(() => {
                 if (
                     this._layer?.layerType === LayerType.MAPIMAGE &&
@@ -475,7 +475,7 @@ export class LegendGroup extends LegendItem {
         if (legendGroup.layer === undefined) {
             loadItem();
         } else {
-            legendGroup.layer.isLayerLoaded().then(() => {
+            legendGroup.layer.loadPromise().then(() => {
                 loadItem();
             });
         }

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -196,7 +196,7 @@ export default defineComponent({
             this.$iApi.event.on(
                 GlobalEvents.LAYER_RELOAD_END,
                 (reloadedLayer: LayerInstance) => {
-                    reloadedLayer.isLayerLoaded().then(() => {
+                    reloadedLayer.loadPromise().then(() => {
                         if (this.uid === reloadedLayer.uid) {
                             this.loadLayerProperties();
                         }
@@ -289,7 +289,7 @@ export default defineComponent({
                 this.layer !== undefined && !this.layer!.isRemoved;
 
             const oldUid = this.layer.uid;
-            this.layer.isLayerLoaded().then(() => {
+            this.layer.loadPromise().then(() => {
                 if (oldUid === this.layer.uid) {
                     // ensure that it's still the same layer
                     this.visibilityModel = this.layer.visibility;

--- a/src/geo/layer/common-graphic-layer.ts
+++ b/src/geo/layer/common-graphic-layer.ts
@@ -40,12 +40,15 @@ export class CommonGraphicLayer extends CommonLayer {
     }
 
     /**
-     * Get the feature count for the given sublayer.
+     * Get the number of graphics in the layer.
      *
-     * @param {Integer | String} [layerIdx] targets a layer index or uid to get the feature count for. Uses first/only if omitted.
-     * @returns {Integer} number of features in the sublayer
+     * @returns {Integer} number of graphics in the layer
      */
-    getFeatureCount(): number {
+    getGraphicCount(): number {
+        // TODO alternate, leverage the common layer property .featureCount,
+        //      and adjust it every time we add/remove graphics from the layer.
+        //      Pro: re-use property, similar interface
+        //      Con: it's graphics, not features. Lies!
         return this._graphics.length;
     }
 

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -145,7 +145,7 @@ export class MapImageLayer extends AttribLayer {
         // avoids multiple re-draws as child visibilities get set up.
         // so really the inner statement runs after everything else in this
         // function is done.
-        this.isLayerLoaded().then(() => {
+        this.loadPromise().then(() => {
             if (this.origRampConfig && this.origRampConfig.state) {
                 this.visibility = !!this.origRampConfig.state.visibility;
             }
@@ -543,7 +543,7 @@ export class MapImageLayer extends AttribLayer {
     }
 
     /**
-     * Invokes the process to get the full set of attribute values for the given sublayer.
+     * Invokes the process to get the full set of attribute values for the layer.
      * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
      *
      * @returns {Promise} resolves with set of attribute values
@@ -565,16 +565,16 @@ export class MapImageLayer extends AttribLayer {
     }
 
     /**
-     * Requests that any downloaded attribute sets be removed from memory. The next getAttributes request will pull from the server again.
+     * Requests that any downloaded attribute sets or cached geometry be removed from memory. The next requests will pull from the server again.
      *
      */
-    destroyAttributes(): void {
+    clearFeatureCache(): void {
         this.noFeaturesErr();
     }
 
     // formerly known as getFormattedAttributes
     /**
-     * Invokes the process to get the full set of attribute values for the given sublayer,
+     * Invokes the process to get the full set of attribute values for the layer,
      * formatted in a tabular format. Additional data properties are also included.
      * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
      *
@@ -621,7 +621,7 @@ export class MapImageLayer extends AttribLayer {
     }
 
     /**
-     * Returns the value of a named SQL filter for a given sublayer.
+     * Returns the value of a named SQL filter on the layer.
      *
      * @param {String} filterKey the filter key / named filter to view
      * @returns {String} the value of the where clause for the filter. Empty string if not defined.
@@ -642,7 +642,7 @@ export class MapImageLayer extends AttribLayer {
     }
 
     /**
-     * Gets array of object ids that currently pass any filters for the given sublayer
+     * Gets array of object ids that currently pass any filters on the layer
      *
      * @param {Array} [exclusions] list of any filters keys to exclude from the result. omission includes all filters
      * @param {Extent} [extent] if provided, the result list will only include features intersecting the extent

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -1,9 +1,4 @@
-import {
-    AttribLayer,
-    GlobalEvents,
-    InstanceAPI,
-    type MapImageLayer
-} from '@/api/internal';
+import { AttribLayer, InstanceAPI, type MapImageLayer } from '@/api/internal';
 import {
     CoreFilter,
     DataFormat,

--- a/src/geo/map/basemap.ts
+++ b/src/geo/map/basemap.ts
@@ -76,7 +76,7 @@ export class Basemap {
      * Set this basemap's name
      */
     set name(value: string | undefined) {
-        this.config.name = value;
+        this.config.name = value || '';
     }
 
     /**
@@ -90,7 +90,7 @@ export class Basemap {
      * Set this basemap's description
      */
     set description(value: string | undefined) {
-        this.config.description = value;
+        this.config.description = value || '';
     }
 
     /**
@@ -104,7 +104,7 @@ export class Basemap {
      * Set this basemap's alt text
      */
     set altText(value: string | undefined) {
-        this.config.altText = value;
+        this.config.altText = value || '';
     }
 
     /**

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -442,17 +442,8 @@ export class QuickCache {
         store[key] = geom;
     }
 
-    // TODO if we decide not to use cacheResult, this function might be so underpowered its not worth having
-    /*
-    private finder(store: {[key: number]: any}, key: number): any {
-        return store[key];
-
-
-        const x = store[key];
-        return {
-            found: !!x,
-            item: x
-        }
+    clearAll(): void {
+        this.attribs = {};
+        this.geoms = {};
     }
-    */
 }

--- a/src/geo/utils/query.ts
+++ b/src/geo/utils/query.ts
@@ -87,7 +87,7 @@ export class QueryAPI extends APIScope {
         }
 
         // TODO check strong typing of this line (after GeoJSON layers are implemented)
-        await options.layer.isLayerLoaded();
+        await options.layer.loadPromise();
 
         if (!options.layer.esriLayer) {
             throw new Error('file layer being queried contains no ESRI layer');


### PR DESCRIPTION
- General comment cleanup and re-wording.
- Converted redundant getters and setters to properties.
- Included clearing of quick cache when zapping attributes (will be important later when dealing with timed refresh layers). Renamed function to be more clear.
- Renamed the loading / loading promise properties & methods. After decoupling the refresh state from our layer state, property `isValidState` was a bit confusing. Promisey things now say promise in the name, and `isValidState` is now `isLoaded`, acting as a shortcut boolean since it's a question often asked.
- Re-arranged `README` so developer setup instructions were first thing encountered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1314)
<!-- Reviewable:end -->
