### PR TITLE
Remove metadata from default fixtures

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -48,10 +48,6 @@ Continued [here](geosearch.md).
 
 The `help` provides a means to display user help for the application. TODO create and hyperlink to `help.md`, or provide any other relevant info here.
 
-### Metadata
-
-The `metadata` provides an interface to view extra information about a layer. TODO create and hyperlink to `metadata.md`, or provide any other relevant info here.
-
 ### Settings
 
 The `settings` allow you to make live modifications to a layer on the map. TODO create and hyperlink to `settings.md`

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -838,7 +838,7 @@ function layerCommonPropertiesUpgrader(r2layer: any) {
         'visibility'
     ];
     if (r2layer.controls && r2layer.controls.length > 0) {
-        r4layer.controls = controlsUpgrader(r2layer.controlsm, allowedControls);
+        r4layer.controls = controlsUpgrader(r2layer.controls, allowedControls);
     }
 
     if (r2layer.disabledControls && r2layer.disabledControls.length > 0) {

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -224,7 +224,6 @@ export class FixtureAPI extends APIScope {
                 'layer-reorder',
                 'legend',
                 'mapnav',
-                'metadata',
                 'northarrow',
                 'overviewmap',
                 'scrollguard',

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -21,12 +21,12 @@
             </template>
             <!-- metadata -->
             <a
+                v-if="getFixtureExists('metadata')"
                 href="#"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem!.controlAvailable(LayerControls.Metadata) ||
-                        !getFixtureExists('metadata')
+                        !legendItem!.controlAvailable(LayerControls.Metadata)
                 }"
                 @click="toggleMetadata"
             >

--- a/src/fixtures/legend/store/legend-defs.ts
+++ b/src/fixtures/legend/store/legend-defs.ts
@@ -281,6 +281,15 @@ export class LegendEntry extends LegendItem {
                     if (layer.extent === undefined) {
                         controlsToRemove.push(LayerControls.BoundaryZoom);
                     }
+                    const metaConfig =
+                        layer.config?.metadata ||
+                        (layer.isSublayer
+                            ? layer.parentLayer?.config?.metadata
+                            : {}) ||
+                        {};
+                    if (!metaConfig.url) {
+                        controlsToRemove.push(LayerControls.Metadata);
+                    }
                     controlsToRemove.forEach(control => {
                         let idx: number =
                             this._controls?.indexOf(control) ?? -1;


### PR DESCRIPTION
## Closes #293

## Changes
- Removed metadata from fixture `addDefaultFixtures` default list
- Legend will auto-remove metadata layer control if layer doesn't specify a metadata config


## Notes
- The metadata `LayerControl` will still be included in the default list of controls (for both layers and legend) if the map author doesn't specify a set of enabled controls
    - I kept this way so that the map author only needs to specify a layer metadata config instead of having to specify metadata config + add `"metadata"` to the list of controls along with layer controls
    - Note that if metadata config is not specified, the control will be removed automatically from layer and legend controls

## Testing
- The metadata fixture should not be added by default (check with `debugInstance.fixture.get('metadata') === undefined`)
- Legend options menu should no longer have a metadata option

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1315)
<!-- Reviewable:end -->
