### PR TITLE
Instance reload fix

### DIFF
--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -3,6 +3,7 @@ import type { Component, ComponentOptions } from 'vue';
 
 import { APIScope, GlobalEvents, InstanceAPI } from './internal';
 import { FixtureMutation } from '@/store/modules/fixture';
+import { ConfigStore } from '@/store/modules/config';
 import type { FixtureBase, FixtureBaseSet } from '@/store/modules/fixture';
 import type { RampConfig } from '@/types';
 
@@ -233,7 +234,7 @@ export class FixtureAPI extends APIScope {
                 'wizard'
             ];
         }
-
+        this.$vApp.$store.set(ConfigStore.setStartingFixtures, fixtureNames);
         // add all the requested default promises.
         // return the promise-all of all the add fixture promises
         // TODO alterately, don't do a promise.all, and just return the array of promises. not sure which is more useful.

--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -1,6 +1,7 @@
 <template>
     <div
         name="esriMap"
+        id="esriMap"
         class="h-full overflow-hidden"
         v-tippy="{
             allowHTML: true,
@@ -18,49 +19,24 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
-
-import type { RampLayerConfig, RampMapConfig } from '@/geo/api';
-import type { LayerInstance } from '@/api/internal';
-
-import { ConfigStore } from '@/store/modules/config';
-import { LayerStore } from '@/store/modules/layer';
-
-import to from 'await-to-js';
+import { defineComponent } from 'vue';
 import { MaptipStore } from '@/store/modules/maptip';
 
 export default defineComponent({
     name: 'EsriMapV',
     data() {
         return {
-            mapConfig: this.get(ConfigStore.getMapConfig),
-            layers: this.get(LayerStore.layers),
-            layerConfigs: this.get(LayerStore.layerConfigs),
             maptipPoint: this.get(MaptipStore.maptipPoint),
             maptipInstance: this.get(MaptipStore.maptipInstance),
             maptipContent: this.get(MaptipStore.content),
-            map: ref(), // TODO assuming we need this as a local property for vue binding. if we don't, remove it and just use $iApi.geo.map,
             watchers: [] as Array<Function>
         };
     },
 
     created() {
-        // temporarily print out loaded layers to console for grid testing purposes.
-        console.log(this.layers, this.mapConfig);
-
         // Set config watcher up here to be able to call it immediately on created
         // regularly `immediate` makes it get called during `created`
         // Keep track of the unwatch method returned by each watch so we can call it when the component is unmounted
-        this.watchers.push(
-            this.$watch('mapConfig', this.onMapConfigChange, {
-                immediate: true
-            })
-        );
-        this.watchers.push(
-            this.$watch('layerConfigs', this.onLayerConfigArrayChange, {
-                immediate: true
-            })
-        );
         this.watchers.push(
             this.$watch('maptipPoint', (maptipPoint: any) => {
                 if (this.maptipPoint) {
@@ -107,98 +83,6 @@ export default defineComponent({
     },
 
     methods: {
-        async onLayerConfigArrayChange(
-            newValue: RampLayerConfig[],
-            oldValue: RampLayerConfig[]
-        ) {
-            console.log(
-                'Saw layer config change',
-                oldValue,
-                newValue,
-                !!this.map
-            );
-
-            // TODO we are getting frequent errors at startup; something reacts to layer array
-            //      change before map exists. kicking out for now to make demos work.
-            //      possibly this is evil in vue state land. if so, then someone figure out
-            //      the root cause and fix that.
-
-            if (!this.map || !newValue) {
-                return;
-            }
-
-            const layers = await Promise.all(
-                newValue
-                    .filter(lc => !oldValue || !oldValue.includes(lc))
-                    .map(layerConfig => {
-                        return new Promise<LayerInstance | null>(
-                            async resolve => {
-                                // create the layer instantiation
-                                const layer =
-                                    this.$iApi.geo.layer.createLayer(
-                                        layerConfig
-                                    );
-                                const [initiateErr] = await to(
-                                    this.map.addLayer(layer!)
-                                );
-                                if (initiateErr) {
-                                    console.error(initiateErr);
-                                }
-                                resolve(layer!);
-                            }
-                        );
-                    })
-            );
-
-            // need to wait for all layers before reordering since esri reorder does
-            // not allow reordering/inserting into arbitrary indices (i.e. no holes)
-            layers
-                .filter(Boolean)
-                .forEach((layer: LayerInstance | null, index: number) => {
-                    // wait on layer load to check for valid state
-                    layer
-                        ?.loadPromise()
-                        .then(() => {
-                            if (layer?.isLoaded) {
-                                this.$iApi.geo.map.reorder(
-                                    layer!,
-                                    oldValue ? oldValue.length + index : index
-                                );
-                            }
-                        })
-                        .catch(() =>
-                            console.log(`Unable to reorder ${layer.id}.`)
-                        );
-                });
-        },
-        onMapConfigChange(newValue: RampMapConfig) {
-            console.log('new map config change: ', newValue, this.mapConfig);
-
-            if (!newValue) {
-                return;
-            }
-
-            const mapViewElement: Element | null = this.$el;
-
-            this.$iApi.geo.map.createMap(
-                newValue,
-                mapViewElement as HTMLDivElement
-            );
-            this.map = this.$iApi.geo.map;
-
-            // Hide hovertip on map creation
-            //@ts-ignore
-            mapViewElement._tippy.hide(0);
-            this.$iApi.$vApp.$store.set(
-                MaptipStore.setMaptipInstance,
-                //@ts-ignore
-                mapViewElement._tippy
-            );
-
-            // TODO see if we still need this. map config should trigger the array watcher due to the store.
-            //      possibly layer config is processed before map config is done creating map?
-            this.onLayerConfigArrayChange(this.layerConfigs.value, []);
-        },
         mouseFocus() {
             // focused the map using the mouse, as opposed to keyboard controls
             this.$iApi.geo.map.setMouseFocus();

--- a/src/fixtures/legend/components/error.vue
+++ b/src/fixtures/legend/components/error.vue
@@ -160,13 +160,9 @@ export default defineComponent({
                             reject(reloadErr);
                         }
                     } else {
-                        const [initiateErr] = await to(
-                            this.$iApi.geo.map.addLayer(layer!)
-                        );
-
-                        if (initiateErr) {
-                            reject(initiateErr);
-                        }
+                        this.$iApi.geo.map
+                            .addLayer(layer!)
+                            .catch(() => reject());
                     }
                     resolve(layer!);
                 });

--- a/src/fixtures/northarrow/northarrow.vue
+++ b/src/fixtures/northarrow/northarrow.vue
@@ -155,7 +155,7 @@ export default defineComponent({
                             layerType: LayerType.GRAPHIC,
                             cosmetic: true // mark this layer as a cosmetic layer
                         });
-                        await this.$iApi.geo.map.addLayer(poleLayer);
+                        this.$iApi.geo.map.addLayer(poleLayer);
 
                         const poleGraphic = new Graphic(projPole, 'northpole');
                         const poleStyle = new PointStyle(

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -538,7 +538,7 @@ export default defineComponent({
             const config = Object.assign(this.layerInfo!.config, data);
 
             const layer = this.$iApi.geo.layer.createLayer(config);
-            await this.$iApi.geo.map.addLayer(layer);
+            this.$iApi.geo.map.addLayer(layer);
             layer.userAdded = true;
 
             // notify the legend to prepare a legend item

--- a/src/store/modules/config/config-store.ts
+++ b/src/store/modules/config/config-store.ts
@@ -24,12 +24,15 @@ const getters = {
     getActiveConfig:
         (state: ConfigState) =>
         (lang: string): RampConfig => {
-            if (state.registeredConfigs[lang] === undefined) {
+            if (
+                state.registeredConfigs[state.registeredLangs[lang]] ===
+                undefined
+            ) {
                 throw new Error(
                     'Unsupported language or no registered config exists for requested language'
                 );
             }
-            return state.registeredConfigs[lang];
+            return state.registeredConfigs[state.registeredLangs[lang]];
         },
 
     getMapConfig: (state: ConfigState): RampMapConfig => {
@@ -61,7 +64,6 @@ const actions = {
         // const newConfig = merge(context.state.config, config);
 
         context.commit('SET_CONFIG', config);
-        console.log('new config adding layers', config.layers);
         this.set(LayerStore.addLayerConfigs, config.layers);
     },
     registerConfig: function (
@@ -73,24 +75,21 @@ const actions = {
         const configLangs = configInfo.configLangs;
         const config = configInfo.config;
         const allLangs = configInfo.allLangs;
-
-        if (allLangs !== undefined && allLangs.length > 0) {
-            // register config for all available languages
-            allLangs.forEach((lang: string) => {
-                context.state.registeredConfigs[lang] = config;
-                // initially each language corresponds to first config by default
-                context.state.registeredLangs[lang] = Object.keys(
-                    context.state.registeredConfigs
-                )[0];
-            });
-        }
-
         if (configLangs !== undefined && configLangs.length > 0) {
             // register config for specified languages
             configLangs.forEach((lang: string) => {
                 context.state.registeredConfigs[lang] = config;
                 // add correspondence between language and config
                 context.state.registeredLangs[lang] = lang;
+            });
+        }
+        if (allLangs !== undefined && allLangs.length > 0) {
+            // register config for all available languages
+            allLangs.forEach((lang: string) => {
+                // initially each language corresponds to first config by default
+                context.state.registeredLangs[lang] = Object.keys(
+                    context.state.registeredConfigs
+                )[0];
             });
         }
     },


### PR DESCRIPTION
Closes #1277, #1293.

Should be working now. As proposed in the comments of #1277, the config array watchers are gone and the map and layers are now created in the `initialize` method. 

Feel free to test different cases such as no config, different config, different config for different languages, and so on. 
[Here](https://gist.github.com/mohsin-r/9109d8ddde73d2fe03e9fb79578c2e08) is a snippet you can paste in the console (change up the config as you please) for testing purposes.
Let me know if there are any print statements or unused imports/properties I forgot to clean up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1318)
<!-- Reviewable:end -->
