### PR TITLE
Disabled legend options styling fix

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -27,7 +27,7 @@ import {
     PanelAPI,
     NotificationAPI
 } from './internal';
-import { LayerInstance } from './internal';
+import type { LayerInstance } from './internal';
 
 import PanelScreenV from '@/components/panel-stack/panel-screen.vue';
 import PinV from '@/components/panel-stack/controls/pin.vue';
@@ -45,7 +45,6 @@ import MapnavButtonV from '@/fixtures/mapnav/button.vue';
 
 import AppbarButtonV from '@/fixtures/appbar/button.vue';
 import type { MaptipAPI } from '@/geo/map/maptip';
-import { layer } from '@/store/modules/layer';
 
 export interface RampOptions {
     loadDefaultFixtures?: boolean;
@@ -150,6 +149,7 @@ export class InstanceAPI {
             this.$vApp.$store.set(ConfigStore.registerConfig, {
                 config: langConfig,
                 configLangs: Object.keys(langConfigs),
+                // @ts-ignore
                 allLangs: Object.keys(this.$vApp.$i18n.messages)
             });
 

--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -132,8 +132,10 @@ export default defineComponent({
 .rv-dropdown > * {
     padding: 0.5rem 1rem;
     display: block !important;
-    color: #2d3748 !important;
     text-decoration: none !important;
+}
+.rv-dropdown > *:not(.disabled) {
+    color: #2d3748 !important;
 }
 .rv-dropdown > *:hover:not(.disabled) {
     background-color: #eee;


### PR DESCRIPTION
Closes #1316.

Disabled legend options are now being correctly greyed-out. 
Also removed some imports that got accidentally snuck in at the last moment in the instance reload PR.

