### PR TITLE
Basemap attribution fix

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -970,6 +970,8 @@ export class EventAPI extends APIScope {
                         )?.attribution
                     );
                 };
+                // update basemap attribution if map was created before adding event handler
+                if (this.$iApi.geo.map.created) zeHandler();
                 this.$iApi.event.on(
                     GlobalEvents.MAP_CREATED,
                     zeHandler,


### PR DESCRIPTION
Closes #1329.

Open RAMP and notice that the basemap attribution has now returned on startup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1333)
<!-- Reviewable:end -->
