### PR TITLE
Panel Reorder

### DIFF
--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -447,6 +447,9 @@ let config = {
                     enabled: true
                 }
             },
+            panels: {
+                reorderable: false
+            },
             system: { animate: true }
         }
     }

--- a/schema.json
+++ b/schema.json
@@ -2144,6 +2144,11 @@
                         "required": ["id"],
                         "additionalProperties": "false"
                     }
+                },
+                "reorderable": {
+                    "type": "boolean",
+                    "description": "Enables panel reorder controls.",
+                    "default": true
                 }
             },
             "additionalProperties": "false"

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -35,6 +35,8 @@ import CloseV from '@/components/panel-stack/controls/close.vue';
 import BackV from '@/components/panel-stack/controls/back.vue';
 import ExpandV from '@/components/panel-stack/controls/expand.vue';
 import MinimizeV from '@/components/panel-stack/controls/minimize.vue';
+import RightV from '@/components/panel-stack/controls/right.vue';
+import LeftV from '@/components/panel-stack/controls/left.vue';
 import PanelOptionsMenuV from '@/components/panel-stack/controls/panel-options-menu.vue';
 import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
@@ -213,26 +215,31 @@ export class InstanceAPI {
                     });
             }
 
-            // open and pin appropiate panels on startup
-            // TODO: Note that certain panels like grid, settings, etc. need to get data for a specific layer.
-            // Because different fixtures get this data in different ways (some use LayerInstance, some uid, some custom config),
-            // there is no way to open the panel with layer data loaded without writing specific code for specific fixtures.
-            // Once layer usage throughout RAMP is normalized, add an extra nugget in the config called options or something so that the panel
-            // can load layer data as well.
-            if (
-                langConfig.panels &&
-                langConfig.panels.open &&
-                langConfig.panels.open.length > 0
-            ) {
-                const panelIds = langConfig.panels.open.map(p => p.id);
-                this.panel.isRegistered(panelIds).then(() => {
-                    langConfig.panels?.open?.forEach(panel => {
-                        this.panel.open(panel.id);
-                        if (panel.pin) {
-                            this.panel.pin(panel.id);
-                        }
+            if (langConfig.panels) {
+                // open and pin appropiate panels on startup
+                // TODO: Note that certain panels like grid, settings, etc. need to get data for a specific layer.
+                // Because different fixtures get this data in different ways (some use LayerInstance, some uid, some custom config),
+                // there is no way to open the panel with layer data loaded without writing specific code for specific fixtures.
+                // Once layer usage throughout RAMP is normalized, add an extra nugget in the config called options or something so that the panel
+                // can load layer data as well.
+                if (
+                    langConfig.panels.open &&
+                    langConfig.panels.open.length > 0
+                ) {
+                    const panelIds = langConfig.panels.open.map(p => p.id);
+                    this.panel.isRegistered(panelIds).then(() => {
+                        langConfig.panels?.open?.forEach(panel => {
+                            this.panel.open(panel.id);
+                            if (panel.pin) {
+                                this.panel.pin(panel.id);
+                            }
+                        });
                     });
-                });
+                }
+
+                // enable/disable reorder controls
+                const enable = langConfig.panels.reorderable ?? true;
+                this.$vApp.$store.set('panel/reorderable', enable);
             }
 
             // disable animations if needed
@@ -548,6 +555,8 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
     vueElement.component('panel-options-menu', PanelOptionsMenuV);
     vueElement.component('dropdown-menu', DropdownMenuV);
     vueElement.component('minimize', MinimizeV);
+    vueElement.component('right', RightV);
+    vueElement.component('left', LeftV);
 
     // ported from mapnav.vue
     vueElement.component('fullscreen-nav-button', FullscreenNavV);

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -288,6 +288,47 @@ export class PanelInstance extends APIScope {
     }
 
     /**
+     * Move this panel left or right in the stack.
+     * This is a proxy to `InstanceAPI.panel.move(...)`.
+     *
+     * @returns {this}
+     * @memberof PanelInstance
+     */
+    move(direction: string): this {
+        this.$iApi.panel.move(this, direction);
+
+        return this;
+    }
+
+    /**
+     * Checks if this panel is the leftmost visible panel.
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof PanelInstance
+     */
+    get isLeftMostPanel(): boolean {
+        if (this.$iApi.panel.visible.length > 0) {
+            return this.id === this.$iApi.panel.visible[0].id;
+        }
+        return false;
+    }
+
+    /**
+     * Checks if this panel is the rightmost visible panel.
+     *
+     * @readonly
+     * @type {boolean}
+     * @memberof PanelInstance
+     */
+    get isRightMostPanel(): boolean {
+        if (this.$iApi.panel.visible.length > 0) {
+            return this.id === this.$iApi.panel.visible.slice(-1)[0].id;
+        }
+        return false;
+    }
+
+    /**
      * Remove this panel.
      * This is a proxy to `InstanceAPI.panel.remove(...)`.
      *

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -276,6 +276,24 @@ export class PanelAPI extends APIScope {
     }
 
     /**
+     * Moves the specifed visible panel to the left or right.
+     *
+     * @param {(string | PanelInstance)} value
+     * @returns {PanelInstance}
+     * @memberof PanelAPI
+     */
+    move(value: string | PanelInstance, direction: string): PanelInstance {
+        const panel = this.get(value);
+
+        this.$vApp.$store.set(`panel/${PanelAction.movePanel}!`, {
+            panel,
+            direction
+        });
+
+        return panel;
+    }
+
+    /**
      * Toggle panel.
      *
      * @param {string | PanelInstance | PanelInstancePath} [value]

--- a/src/components/panel-stack/controls/left.vue
+++ b/src/components/panel-stack/controls/left.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="relative" tabindex="-1">
+        <button
+            class="p-8"
+            :class="{
+                'text-gray-500 hover:text-black focus:text-black': active,
+                'text-gray-300': !active
+            }"
+            :content="$t('panels.controls.moveLeft')"
+            v-tippy="{
+                placement: 'bottom',
+                theme: 'ramp4',
+                animation: 'scale'
+            }"
+        >
+            <svg
+                class="fill-current w-16 h-16"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="4 4 16 16"
+            >
+                <path
+                    d="M 15.41 16.09 L 10.83 11.5 L 15.41 6.91 L 14 5.5 L 8 11.5 L 14 17.5 Z"
+                />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'LeftV',
+    props: {
+        active: Boolean
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/panel-stack/controls/right.vue
+++ b/src/components/panel-stack/controls/right.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="relative" tabindex="-1">
+        <button
+            class="p-8"
+            :class="{
+                'text-gray-500 hover:text-black focus:text-black': active,
+                'text-gray-300': !active
+            }"
+            :content="$t('panels.controls.moveRight')"
+            v-tippy="{
+                placement: 'bottom',
+                theme: 'ramp4',
+                animation: 'scale'
+            }"
+        >
+            <svg
+                class="fill-current w-16 h-16"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="4 4 16 16"
+            >
+                <path
+                    d="M 8.59 16.34 L 13.17 11.75 L 8.59 7.16 L 10 5.75 L 16 11.75 L 10 17.75 Z"
+                />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'RightV',
+    props: {
+        active: Boolean
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -29,6 +29,16 @@
             </panel-options-menu>
 
             <div class="display-none sm:flex">
+                <left
+                    v-if="reorderable"
+                    @click="panel.move('left')"
+                    :active="!panel.isLeftMostPanel"
+                />
+                <right
+                    v-if="reorderable"
+                    @click="panel.move('right')"
+                    :active="!panel.isRightMostPanel"
+                />
                 <pin @click="panel.pin()" :active="panel.isPinned" />
                 <expand
                     v-if="panel.controls && panel.controls.expand"
@@ -91,7 +101,8 @@ export default defineComponent({
             temporary: this.$iApi.fixture.get('appbar')
                 ? this.$store.get('appbar/temporary')
                 : [],
-            mobileView: this.get('panel/mobileView')
+            mobileView: this.get('panel/mobileView'),
+            reorderable: this.get('panel/reorderable')
         };
     },
     methods: {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -39,6 +39,8 @@ panels.controls.optionsMenu,More,1,Plus,1
 panels.controls.minimize,Minimize,1,Réduire,1
 panels.controls.expand,Expand,1,Développer,1
 panels.controls.collapse,Collapse,1,Réduire,1
+panels.controls.moveRight,Move Right,1,Aller à droite,1
+panels.controls.moveLeft,Move Left,1,Aller à gauche,1
 panels.alert.open,{name} panel opened,1,Panneau de {name} ouvert,0
 panels.alert.close,{name} panel closed,1,Panneau de {name} fermé,0
 panels.alert.minimize,{name} panel minimized,1,Panneau de {name} minimisé,0

--- a/src/store/modules/panel/panel-state.ts
+++ b/src/store/modules/panel/panel-state.ts
@@ -77,6 +77,14 @@ export class PanelState {
      * @memberof PanelState
      */
     mobileView = false;
+
+    /**
+     * True if panels have the move left/right controls enabled.
+     *
+     * @type {boolean}
+     * @memberof PanelState
+     */
+    reorderable = true;
 }
 
 // this should have been `AsyncComponentPromise` type, but something is off there

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -1,4 +1,4 @@
-import type { ActionContext, Action, Mutation } from 'vuex';
+import type { ActionContext } from 'vuex';
 import { make } from 'vuex-pathify';
 
 import { PanelState } from './panel-state';
@@ -12,6 +12,7 @@ type PanelContext = ActionContext<PanelState, RootState>;
 export enum PanelAction {
     openPanel = 'openPanel',
     closePanel = 'closePanel',
+    movePanel = 'movePanel',
     removePanel = 'removePanel',
     setWidth = 'setWidth',
     setStackWidth = 'setStackWidth',
@@ -27,6 +28,7 @@ export enum PanelMutation {
     ADD_REG_PROMISE = 'ADD_REG_PROMISE',
     CLOSE_PANEL = 'CLOSE_PANEL',
     REMOVE_PANEL = 'REMOVE_PANEL',
+    MOVE_PANEL = 'MOVE_PANEL',
 
     SET_ORDERED_ITEMS = 'SET_ORDERED_ITEMS',
     SET_PRIORITY = 'SET_PRIORITY',
@@ -98,6 +100,14 @@ const actions = {
         }
 
         context.commit(PanelMutation.CLOSE_PANEL, value);
+        context.dispatch(PanelAction.updateVisible);
+    },
+
+    [PanelAction.movePanel](
+        context: PanelContext,
+        value: { panel: PanelConfig; direction: string }
+    ): void {
+        context.commit(PanelMutation.MOVE_PANEL, value);
         context.dispatch(PanelAction.updateVisible);
     },
 
@@ -247,6 +257,20 @@ const mutations = {
             state.orderedItems = [
                 ...state.orderedItems.slice(0, index),
                 ...state.orderedItems.slice(index + 1)
+            ];
+        }
+    },
+
+    [PanelMutation.MOVE_PANEL](
+        state: PanelState,
+        { panel, direction }: { panel: PanelInstance; direction: string }
+    ): void {
+        const index = state.orderedItems.indexOf(panel);
+        const delta = direction === 'right' ? 1 : -1;
+        if (state.visible.includes(state.orderedItems[index + delta])) {
+            [state.orderedItems[index], state.orderedItems[index + delta]] = [
+                state.orderedItems[index + delta],
+                state.orderedItems[index]
             ];
         }
     },

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -14,6 +14,7 @@ export interface RampConfig {
             id: string;
             pin?: boolean;
         }[];
+        reorderable?: boolean;
     };
     system?: {
         proxyUrl?: string;


### PR DESCRIPTION
PR based off prototype #1278.

### Changes
- added functionality that allows the user to swap the position of visible panels on the stack using arrow keys located at the top of each panel
- added `reorderable` config property that will enable/disable panel reorder controls

### Testing
- the [WET sample](https://ramp4-pcar4.github.io/ramp4-pcar4/panel-reorder/index-wet.html) was configured so that reordering panels is disabled