### PR TITLE
Add cancel button to grid splash screen

### DIFF
--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -3,6 +3,7 @@ grid.title,Features,1,Éléments,1
 grid.alertName,Grid,1,Grille,1
 grid.splash.loading,Loading data...,1,Chargement des données...,1
 grid.splash.building,Building table...,1,Création du tableau...,1
+grid.splash.cancel,Cancel,1,Annuler,1
 grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,1
 grid.layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
 grid.label.columns,Hide columns,1,Masquer les colonnes,1

--- a/src/fixtures/grid/screen.vue
+++ b/src/fixtures/grid/screen.vue
@@ -10,6 +10,7 @@
                 class="rv-grid"
                 ref="rvGrid"
                 :layerUid="currentUid"
+                :panel="panel"
             ></table-component>
         </template>
     </panel-screen>
@@ -27,8 +28,13 @@ import { LayerStore } from '@/store/modules/layer';
 
 export default defineComponent({
     props: {
-        panel: PanelInstance,
-        header: String
+        panel: {
+            type: PanelInstance,
+            required: true
+        },
+        header: {
+            type: String
+        }
     },
 
     components: {

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -19,6 +19,15 @@
                         : $t('grid.splash.building')
                 }}</span>
             </div>
+            <div>
+                <button
+                    @click="closeGrid"
+                    class="py-8 px-8 sm:px-16 bg-gray-300"
+                    :aria-label="$t('grid.splash.cancel')"
+                >
+                    {{ $t('grid.splash.cancel') }}
+                </button>
+            </div>
         </div>
 
         <!-- render grid if loading is done -->
@@ -32,6 +41,7 @@
                     @input="updateQuickSearch()"
                     @keyup.enter="
                         if ($store.get('panel/mobileView')) {
+                            //@ts-ignore
                             $event?.target?.blur();
                         }
                     "
@@ -214,7 +224,12 @@
 <script lang="ts">
 import { markRaw, defineComponent, ref } from 'vue';
 
-import { AttribLayer, GlobalEvents, LayerInstance } from '@/api/internal';
+import {
+    AttribLayer,
+    GlobalEvents,
+    LayerInstance,
+    PanelInstance
+} from '@/api/internal';
 
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-material.css';
@@ -260,8 +275,13 @@ export default defineComponent({
         AgGridVue
     },
     props: {
+        panel: {
+            type: PanelInstance,
+            required: true
+        },
         layerUid: {
-            type: String
+            type: String,
+            required: true
         }
     },
 
@@ -303,9 +323,13 @@ export default defineComponent({
     },
 
     beforeMount() {
-        this.config = this.grids[this.layerUid!];
+        this.config = this.grids[this.layerUid];
 
         this.isLoadingGrid = true;
+
+        // re-opening the grid for a cancelled layer doesn't re-render the grid properly
+        // hence we use this force update call to force re-render
+        this.$forceUpdate();
 
         this.filterInfo = {
             firstRow: 0,
@@ -385,6 +409,12 @@ export default defineComponent({
                 markRaw(fancyLayer).getTabularAttributes();
 
             tableAttributePromise.then((tableAttributes: any) => {
+                if ((fancyLayer as AttribLayer)?.attLoader?.isLoadAborted()) {
+                    // don't load grid any further
+                    this.isLoadingGrid = false;
+                    return;
+                }
+
                 // Iterate through table columns and set up column definitions and column filter stuff.
                 // Also adds the `rvSymbol` and `rvInteractive` columns to the table.
                 [
@@ -516,6 +546,9 @@ export default defineComponent({
     },
 
     beforeUnmount() {
+        // cancel attribute load
+        this.cancelAttributeLoad();
+
         // Remove all event handlers for this component
         this.handlers.forEach(handler => this.$iApi.event.off(handler));
         this.watchers.forEach(unwatch => unwatch());
@@ -573,9 +606,8 @@ export default defineComponent({
                             layer.uid &&
                             (layer.uid === this.layerUid ||
                                 layer.uid ===
-                                    this.$iApi.geo.layer.getLayer(
-                                        this.layerUid!
-                                    )?.uid)
+                                    this.$iApi.geo.layer.getLayer(this.layerUid)
+                                        ?.uid)
                         ) {
                             this.applyLayerFilters();
                         }
@@ -646,7 +678,7 @@ export default defineComponent({
 
         // Updates the current status of the filter.
         updateFilterInfo() {
-            if (this.gridApi) {
+            if (this.gridApi && !this.isLoadingGrid) {
                 this.filterInfo.firstRow =
                     this.gridApi.getFirstDisplayedRow() + 1;
                 this.filterInfo.lastRow =
@@ -895,7 +927,7 @@ export default defineComponent({
                     maxWidth: 82,
                     cellRenderer: (cell: any) => {
                         const layer: LayerInstance | undefined =
-                            this.$iApi.geo.layer.getLayer(this.layerUid!);
+                            this.$iApi.geo.layer.getLayer(this.layerUid);
                         if (layer === undefined) return;
                         const iconContainer = document.createElement('span');
                         const oid = cell.data[this.oidField];
@@ -933,7 +965,7 @@ export default defineComponent({
 
         // updates external grid filter based on layer filter and rerenders grid
         async applyLayerFilters() {
-            const layer = this.$iApi.geo.layer.getLayer(this.layerUid!)!;
+            const layer = this.$iApi.geo.layer.getLayer(this.layerUid)!;
             if (!layer || !layer.visibility) {
                 this.filteredOids = [];
             } else {
@@ -947,7 +979,7 @@ export default defineComponent({
 
         applyFiltersToMap() {
             const mapFilterQuery = this.getFiltersQuery();
-            const layer = this.$iApi.geo.layer.getLayer(this.layerUid!);
+            const layer = this.$iApi.geo.layer.getLayer(this.layerUid);
             layer?.setSqlFilter(CoreFilter.GRID, mapFilterQuery);
             this.filterSync = true;
         },
@@ -1160,7 +1192,7 @@ export default defineComponent({
         // checks if current grid filters are applied to map
         gridFiltersApplied() {
             const gridQuery = this.getFiltersQuery();
-            const layer = this.$iApi.geo.layer.getLayer(this.layerUid!);
+            const layer = this.$iApi.geo.layer.getLayer(this.layerUid);
             const layerQuery = layer?.getSqlFilter(CoreFilter.GRID);
             return gridQuery === layerQuery;
         },
@@ -1178,6 +1210,24 @@ export default defineComponent({
             ];
             if (arrowKeys.includes(event.key)) {
                 event.stopPropagation();
+            }
+        },
+
+        closeGrid() {
+            this.cancelAttributeLoad();
+
+            // close the grid panel
+            if (this.panel.isOpen) {
+                this.panel.close();
+            }
+        },
+
+        cancelAttributeLoad() {
+            if (this.isLoadingGrid) {
+                // stop the attribute loading
+                const layer = this.$iApi.geo.layer.getLayer(this.layerUid);
+                layer?.abortAttributeLoad();
+                layer?.clearFeatureCache();
             }
         }
     }

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -373,11 +373,21 @@ export class AttribLayer extends CommonLayer {
         // TODO figure out how to handle a failure in .getAttribs. See comment catch block at bottom of function.
         const attSet = await this.attLoader.getAttribs();
 
+        if (!attSet.features || attSet.features.length === 0) {
+            // return empty attributes (this will happen if the attribute load was aborted)
+            return {
+                columns: [],
+                rows: [],
+                fields: [],
+                oidField: ''
+            };
+        }
+
         // create columns array consumable by datables. We don't include the alias defined in the config here as
         // the grid handles it seperately.
         const columns = this.esriFields
             .filter(field =>
-                // assuming there is at least one attribute - empty attribute budnle promises should be rejected, so it never even gets this far
+                // assuming there is at least one attribute - empty attribute bundle promises should be rejected, so it never even gets this far
                 // filter out fields where there is no corresponding attribute data
                 attSet.features[0].hasOwnProperty(toRaw(field).name)
             )

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -91,6 +91,9 @@ export class AttributeAPI extends APIScope {
         if (len > 0) {
             // figure out if we hit the end of the data. different logic for newer vs older servers.
             controller.loadedCount += len;
+
+            await new Promise(resolve => setTimeout(resolve, 3000));
+
             let moreDataToLoad: boolean;
             if (details.supportsLimit) {
                 moreDataToLoad = serviceResult.data.exceededTransferLimit;
@@ -112,10 +115,14 @@ export class AttributeAPI extends APIScope {
                     controller
                 );
                 // take our current batch, append on everything the recursive call loaded, and return
-                return feats.concat(futureFeats);
+                // return empty list if aborted
+                return controller.loadAbortFlag
+                    ? []
+                    : feats.concat(futureFeats);
             } else {
                 // done thanks
-                return feats;
+                // return empty list if aborted
+                return controller.loadAbortFlag ? [] : feats;
             }
         } else {
             // no more data.  we are done
@@ -328,6 +335,10 @@ export class AttributeLoaderBase extends APIScope {
 
     isLoaded(): boolean {
         return this.aac.loadIsDone;
+    }
+
+    isLoadAborted(): boolean {
+        return this.aac.loadAbortFlag;
     }
 
     // this will be overrideable.


### PR DESCRIPTION
## Closes #1337

## Changes
- Added cancel button to grid splash screen
- Aborting an ArcGIS batch load will now return empty results instead of partial results

## Testing
_Added a 3 second delay when loading the feature batches - will remove this delay before merging._

- Open the grid for any layer and try clicking the cancel button - the attribute load should be aborted and the grid should close
- Try reopening an aborted layer's grid - it should load again with no issues
