### PR TITLE
Fog Hilighter

### DIFF
--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -253,7 +253,7 @@ export default defineComponent({
         this.handlers.push(
             this.$iApi.event.on(GlobalEvents.MAP_BASEMAPCHANGE, () => {
                 if (this.hilightToggle) {
-                    this.details.hilightDetailsItems(
+                    this.details.reloadDetailsHilight(
                         this.result.items[this.currentIdx],
                         this.result.uid
                     );

--- a/src/fixtures/details/result-screen.vue
+++ b/src/fixtures/details/result-screen.vue
@@ -210,7 +210,7 @@ export default defineComponent({
         this.handlers.push(
             this.$iApi.event.on(GlobalEvents.MAP_BASEMAPCHANGE, () => {
                 if (this.hilightToggle) {
-                    this.details.hilightDetailsItems(
+                    this.details.reloadDetailsHilight(
                         this.result.items,
                         this.result.uid
                     );

--- a/src/fixtures/hilight/api/hilight-defs.ts
+++ b/src/fixtures/hilight/api/hilight-defs.ts
@@ -1,4 +1,5 @@
 export const HILIGHT_LAYER_NAME = 'Ramp-Hilight';
+export const FOG_HILIGHT_LAYER_NAME = 'Ramp-Hilight-Fog-Basemap';
 
 export const DEFAULT_CONFIG = {
     mode: 'glow',
@@ -11,7 +12,8 @@ export const DEFAULT_CONFIG = {
 export enum HilightMode {
     NONE = 'none', // no hilight
     GLOW = 'glow', // an ESRI highlight
-    LIFT = 'lift' // adds identified graphics to the hilightlayer
+    LIFT = 'lift', // adds identified graphics to the hilightlayer
+    FOG = 'fog' // dims non-hilighted geometries
 }
 
 export interface HilightConfig {

--- a/src/fixtures/hilight/api/hilight-mode/base-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/base-hilight-mode.ts
@@ -28,6 +28,11 @@ export class BaseHilightMode extends APIScope {
     }
 
     /**
+     * Reload the hilighter's map elements.
+     */
+    async reloadHilight(graphics: Array<Graphic>) {}
+
+    /**
      * Returns the Hilight layer.
      */
     getHilightLayer(): CommonGraphicLayer | undefined {
@@ -35,7 +40,7 @@ export class BaseHilightMode extends APIScope {
         if (hilightLayer && hilightLayer instanceof CommonGraphicLayer) {
             return hilightLayer;
         } else {
-            console.warn('hilight layer could not be fetched.');
+            console.warn('Hilight layer could not be fetched.');
             return undefined;
         }
     }

--- a/src/fixtures/hilight/api/hilight-mode/lift-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/lift-hilight-mode.ts
@@ -24,4 +24,12 @@ export class LiftHilightMode extends BaseHilightMode {
         }
         await hilightLayer.removeGraphic(graphics);
     }
+
+    /**
+     * Reload the hilighter's map elements.
+     */
+    async reloadHilight(graphics: Array<Graphic>) {
+        await this.remove(graphics);
+        await this.add(graphics);
+    }
 }

--- a/src/fixtures/hilight/api/hilight.ts
+++ b/src/fixtures/hilight/api/hilight.ts
@@ -12,6 +12,7 @@ import {
     type HilightConfig
 } from './hilight-defs';
 import { BaseHilightMode } from './hilight-mode/base-hilight-mode';
+import { FogHilightMode } from './hilight-mode/fog-hilight-mode';
 import { GlowHilightMode } from './hilight-mode/glow-hilight-mode';
 import { LiftHilightMode } from './hilight-mode/lift-hilight-mode';
 
@@ -48,6 +49,12 @@ export class HilightAPI extends FixtureInstance {
                     break;
                 case HilightMode.LIFT:
                     this.hilightMode = new LiftHilightMode(
+                        hilightConfig,
+                        this.$iApi
+                    );
+                    break;
+                case HilightMode.FOG:
+                    this.hilightMode = new FogHilightMode(
                         hilightConfig,
                         this.$iApi
                     );
@@ -101,6 +108,11 @@ export class HilightAPI extends FixtureInstance {
                 : [graphics]
             : undefined;
         await this.hilightMode.remove(gs);
+    }
+
+    async reloadHilight(graphics: Array<Graphic> | Graphic) {
+        const gs = graphics instanceof Array ? graphics : [graphics];
+        await this.hilightMode.reloadHilight(gs);
     }
 
     /**

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -228,7 +228,7 @@ export class CommonMapAPI extends APIScope {
      * @returns {Basemap} the found basemap
      * @protected
      */
-    protected findBasemap(id: string): Basemap {
+    findBasemap(id: string): Basemap {
         const bm: Basemap | undefined = this._basemapStore.find(
             bms => bms.id === id
         );


### PR DESCRIPTION
## Changes
- Added a `FOG` hilighter which emulates r2 and dims the geometries on the map. See #1303 for implementation discussion.
- Changed Hilighter API to include an `reload` function for when the caller needs to reload all of the hilighter's map elements (e.g., when basemap changes).

## Notes
- Currently, only the first URL provided for a basemap is used. I was originally going to ask James about this, but he's been down for the count (get well soon James). I've left a `TODO` where this is relevant, and I'll open a new issue for it too.
- `GLOW` is still the default hilighter, so we'll want to reverse the config changes. Seems like I might be gone before this PR will be pulled though, so someone else will probably have to do it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1347)
<!-- Reviewable:end -->
