### PR TITLE
build: added index-samples

### DIFF
--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+        <title>ramp-core</title>
+    </head>
+    <body style="margin: 0">
+        <section id="header" style="width: 100%">
+            <div class="row">
+                <select id="selectConfig" class="tool">
+                    <option value="main">01. Default</option>
+                    <option value="panel-party">02. Lots of panels</option>
+                    <option value="basemap-only">03. Basemap only</option>
+                    <option value="lambert">04. Lambert projection</option>
+                    <option value="map-image-layer">05. Map Image Layer</option>
+                    <option value="wms-layer">06. WMS Layer</option>
+                    <option value="custom-renderer">07. Custom renderer</option>
+                    <option value="custom-overviewmap">
+                        08. Custom Overview Map
+                    </option>
+                    <option value="custom-arrow">09. Custom North Arrow</option>
+                    <option value="grid">10. Grid</option>
+                    <option value="geosearch">11. Geosearch</option>
+                    <option value="help">12. Help</option>
+                    <option value="mapnav">13. Mapnav</option>
+                </select>
+            </div>
+        </section>
+
+        <noscript>
+            <strong
+                >We're sorry but ramp-core doesn't work properly without
+                JavaScript enabled. Please enable it to continue.</strong
+            >
+        </noscript>
+
+        <div id="IE"></div>
+        <div id="app"></div>
+
+        <style>
+            #instance-language {
+                margin-left: 20px;
+            }
+            #container {
+                display: flex;
+                flex-direction: column;
+                height: 100vh;
+                max-height: 100vh;
+                overflow: hidden;
+            }
+            #header {
+                width: 100%;
+                background-color: grey;
+                display: flex;
+                justify-content: center;
+                height: 4vh;
+            }
+            .row {
+                margin: 10px;
+                flex-grow: 1;
+            }
+            #selectConfig {
+                width: 100%;
+            }
+            #app {
+                height: 96vh;
+            }
+        </style>
+
+        <script>
+            var SAMPLE_KEY = 'sample';
+            var currentUrl = new URL(window.location.href);
+
+            document
+                .getElementById('selectConfig')
+                .addEventListener('change', onConfigSelect);
+            initialLoad();
+
+            function appendScript(scriptName) {
+                // replace app div
+                document.getElementById('app').remove();
+                var newDiv = document.createElement('div');
+                newDiv.id = 'app';
+                document.body.append(newDiv);
+
+                //append script with time string to defeat caching
+                let script = document.createElement('script');
+                script.src =
+                    './starter-scripts/' +
+                    scriptName +
+                    '.js?nocache=' +
+                    new Date().getTime();
+                script.type = 'module';
+                document.head.appendChild(script);
+
+                // update url
+                currentUrl.searchParams.set(
+                    SAMPLE_KEY,
+                    document.getElementById('selectConfig').selectedIndex + 1
+                );
+                history.pushState({}, '', currentUrl);
+            }
+
+            function onConfigSelect(event) {
+                let scriptName = event.target.value;
+                appendScript(scriptName);
+            }
+
+            function initialLoad() {
+                var params = new URLSearchParams(currentUrl.search);
+                var sampleIndex = params.get(SAMPLE_KEY) - 1;
+                var selectElem = document.getElementById('selectConfig');
+                if (
+                    params.has(SAMPLE_KEY) &&
+                    sampleIndex >= 1 &&
+                    selectElem.item(sampleIndex)
+                ) {
+                    selectElem.options[sampleIndex].selected = 'selected';
+                } else {
+                    appendScript(selectElem.options[0].value);
+                }
+            }
+        </script>
+    </body>
+</html>

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -634,15 +634,6 @@ rInstance.fixture.add('areas-of-interest');
 // load map if startRequired is true
 rInstance.start();
 
-function switchLang() {
-    if (rInstance.language === 'en') {
-        rInstance.setLanguage('fr');
-    } else {
-        rInstance.setLanguage('en');
-    }
-    document.getElementById('instance-language').innerText = rInstance.language;
-}
-
 function animateToggle() {
     if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
         rInstance.$vApp.$el.classList.remove('animation-enabled');

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -491,12 +491,12 @@ rInstance.fixture.add('snowman');
 rInstance.fixture.add('gazebo').then(() => {
     rInstance.panel.get('p2').open({ screen: 'p-2-screen-2' }).pin();
 });
-rInstance.fixture.add('diligord', window.hostFixtures.diligord).then(() => {
+/* rInstance.fixture.add('diligord', window.hostFixtures.diligord).then(() => {
     rInstance.panel.open('diligord-p1');
 });
 rInstance.fixture.add('mouruge', window.hostFixtures.mouruge).then(() => {
     rInstance.panel.open('mouruge-p1');
-});
+}); */
 
 // add export fixtures
 rInstance.fixture.add('export');
@@ -506,18 +506,6 @@ rInstance.fixture.add('export');
 // interesting race condition here. we could use rInstance.availableEvents to find the name,
 // but given the async nature of fixture.add, the name will not be registered yet.
 var gazeboEventName = 'gazebo/beholdMyText';
-
-// a handler to react to a gazebo event
-// click "see a cat" button to trigger console output
-var handler = function (text) {
-    // important to use get here, as the fixture might have been removed later on
-    var diligord = rInstance.fixture.get('diligord');
-    if (!diligord) {
-        return;
-    }
-    diligord.doAThing(text);
-};
-rInstance.event.on(gazeboEventName, handler, 'SAMPLE_HANDLER');
 
 // a one time handler. clicking "see a cat" many times should only result in one console log
 var onceHandler = function (text) {

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -87,8 +87,7 @@ export class PanelInstance extends APIScope {
             let asyncComponent: Promise<AsyncComponentEh>;
 
             if (typeof screen === 'string') {
-                asyncComponent =
-                    screenModules[`../fixtures/${screen}/screen.vue`]();
+                asyncComponent = screenModules[`../fixtures/${screen}`]();
             } else {
                 asyncComponent = screen(); // execute the async component function to get the promise
             }

--- a/src/fixtures/gazebo/index.ts
+++ b/src/fixtures/gazebo/index.ts
@@ -86,7 +86,7 @@ class GazeboFixture extends FixtureInstance {
                          * // TODO: This should work:
                          * letting the core to lazy-load a screen component; need to provide a path relative to the fixtures home folder
                          */
-                        'p-2-screen-2': 'gazebo/p2-screen-2.vue',
+                        'p-2-screen-2': markRaw(GazeboP2Screen2V),
 
                         /**
                          * // TODO: This should work:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ const baseConfig: UserConfigExport = {
         target: 'esnext'
     },
     server: {
-        open: '/demos/index.html'
+        open: '/demos/index-samples.html'
     }
 };
 
@@ -52,7 +52,8 @@ export default defineConfig(({ command, mode }) => {
                         main: '/index.html',
                         multi: '/index-multi.html',
                         e2e: '/index-e2e.html',
-                        wet: '/index-wet.html'
+                        wet: '/index-wet.html',
+                        samples: '/index-samples.html'
                     }
                 }
             });


### PR DESCRIPTION
Closes #1296 

- Added `index-samples` with our existing scripts as placeholders/examples.
- I set this new page as the default that opens for `npm run dev`, this won't be the default pointed to for PR builds... that will require more build tinkering as this resides in `/demos` and not `/public`
- Adding a new script: place it in the sample scripts folder in `/demos` and add an option line in `index-samples.html`.
- URL will update without reloading when a new script is selected (and it will load the script in the url on page load)

Some things to note;
- Attempted to use RAMP's reload but ran into race condition fun because configs were swapping before maps, fixtures, etc. were loading (spent a lot of time trying to figure it out). Will open a new issue to look into it since being able to reload at any point seems useful.
- Related to the above, right now I just delete the previous app div and add a new one. I had a system where I would reload or instantiate based on if a ramp instance is present but the race conditions above ended with me scrapping it. I would like to add it back in for easy testing of reload (and for this to be less hacky) if we can fix the race conditions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1359)
<!-- Reviewable:end -->
