### PR TITLE
Various layer improvements

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -691,6 +691,11 @@
                     "default": 0,
                     "description": "The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
                 },
+                "expectedDrawTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
+                },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
@@ -756,6 +761,11 @@
                     "type": "string",
                     "default": "",
                     "description": "Display name of the layer."
+                },
+                "expectedDrawTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
                     "type": "number",
@@ -823,6 +833,11 @@
                     "type": "number",
                     "default": 0,
                     "description": "The automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
+                },
+                "expectedDrawTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
                     "type": "number",
@@ -1029,6 +1044,11 @@
                     "default": 0,
                     "description": "Automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
                 },
+                "expectedDrawTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
+                },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
@@ -1144,6 +1164,11 @@
                     "default": "",
                     "description": "Hex code representing the layer symbology colour."
                 },
+                "expectedDrawTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
+                },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
@@ -1254,6 +1279,11 @@
                     "default": "",
                     "description": "The service endpoint of the layer. It should match the type provided in layerType."
                 },
+                "expectedDrawTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
+                },
                 "expectedResponseTime": {
                     "type": "number",
                     "default": 4000,
@@ -1360,6 +1390,11 @@
                     "type": "number",
                     "default": 0,
                     "description": "Automatic refresh interval of the layer in minutes. Maximum interval is 100 minutes. Currently not supported."
+                },
+                "expectedDrawTime": {
+                    "type": "number",
+                    "default": 4000,
+                    "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
                     "type": "number",

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -578,6 +578,7 @@ export interface RampLayerConfig {
     customRenderer?: any;
     // TODO revisit issue #1019 after v1.0.0
     // refreshInterval?: number;
+    expectedDrawTime?: number;
     expectedResponseTime?: number;
     fieldMetadata?: RampLayerFieldMetadataConfig;
     nameField?: string;

--- a/src/geo/layer/csv-layer.ts
+++ b/src/geo/layer/csv-layer.ts
@@ -27,16 +27,10 @@ export class CsvLayer extends FileLayer {
             // TODO validation? check that type is string?
             csvData = this.origRampConfig.rawData;
         } else if (this.origRampConfig.url) {
-            // make web call to download csv file
-
-            // not implemented yet
-            // steps will be
-            //   1. await web response of this.origRampConfig.url
-            //   2. any parsing required to get web result into string format
-            //   3. store parsed result in local var csvData
-
-            // temp line to warn people
-            throw new Error('remote file csv loader not yet supported');
+            csvData = await this.$iApi.geo.layer.files.fetchFileData(
+                this.origRampConfig.url,
+                this.layerType
+            );
         } else {
             throw new Error('Csv file config contains no raw data or url');
         }

--- a/src/geo/layer/geojson-layer.ts
+++ b/src/geo/layer/geojson-layer.ts
@@ -1,5 +1,4 @@
 // handles static geojson (e.g. from a user file or hardcoded in a config) or a geojson file hosted on a web server
-
 import { FileLayer, InstanceAPI } from '@/api/internal';
 import { LayerType, type RampLayerConfig } from '@/geo/api';
 
@@ -21,43 +20,10 @@ export class GeoJsonLayer extends FileLayer {
             // TODO validation? check that type is string?
             this.sourceGeoJson = this.origRampConfig.rawData;
         } else if (this.origRampConfig.url) {
-            // make web call to download geojson file
-
-            // TODO the bulk of this logic (download and parse) might be better put in the
-            //      file-utils service class. That way a wizard or random api caller code
-            //      could also make use of it.
-
-            // this is RAMP2 code. untested, needs conversion from angular libs to vue libs.
-            // steps will be
-            //   1. await web response of this.origRampConfig.url
-            //   2. any parsing required to get web result into Json string or Json object
-            //   3. store parsed result on this.sourceGeoJson
-
-            /*
-            const [error, response] = await to<any>($http.get(this.config.url, {
-                responseType: 'blob'
-            }));
-
-            if (!response) {
-                console.error(`File data failed to load for "${this.config.id}"`, error);
-                return Promise.reject(error);
-            }
-
-            const reader = new FileReader();
-
-            return $q((resolve: any, reject: any) => {
-                reader.onerror = error => {
-                    console.error(`File data failed to load for "${this.config.id}"`, error);
-                    reject({ reason: 'error', message: 'Failed to read file' });
-                };
-                reader.onload = () =>
-                    resolve(reader.result);
-
-                reader.readAsArrayBuffer(response.data);
-            });
-            */
-            // temp line to warn people
-            throw new Error('remote file geojson loader not yet supported');
+            this.sourceGeoJson = await this.$iApi.geo.layer.files.fetchFileData(
+                this.origRampConfig.url,
+                this.layerType
+            );
         } else {
             throw new Error('GeoJson layer config contains no raw data or url');
         }

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -124,6 +124,14 @@ export class LayerInstance extends APIScope {
     oidField: string;
 
     /**
+     * Object that contains values for the expected draw/response time.
+     */
+    expectedTime: {
+        draw: number;
+        load: number;
+    };
+
+    /**
      * If the layer has Sublayers
      */
     supportsSublayers: boolean;
@@ -242,6 +250,7 @@ export class LayerInstance extends APIScope {
         this.geomType = GeometryType.UNKNOWN;
         this.legend = [];
         this._sublayers = [];
+        this.expectedTime = { draw: 0, load: 0 };
     }
 
     /**

--- a/src/geo/layer/shapefile-layer.ts
+++ b/src/geo/layer/shapefile-layer.ts
@@ -16,12 +16,6 @@ export class ShapefileLayer extends FileLayer {
         // set geojson to special property.
         // then initiate the FileLayer
 
-        if (!this.origRampConfig.latField || !this.origRampConfig.longField) {
-            throw new Error(
-                'shapefile file config missing lat or long field names'
-            );
-        }
-
         let shapefileData: any; // i believe this needs to be an ArrayBuffer
 
         if (this.origRampConfig.rawData) {
@@ -33,18 +27,10 @@ export class ShapefileLayer extends FileLayer {
             // TODO add check that errors if typeof is string?
             shapefileData = this.origRampConfig.rawData;
         } else if (this.origRampConfig.url) {
-            // make web call to download shapefile file
-
-            // not implemented yet
-            // steps will be
-            //   1. await web response of this.origRampConfig.url
-            //   2. any parsing required to get web result into array buffer format
-            //   3. store parsed result in local var shapefileData
-
-            // might make sense to put those steps in geo.layers.files module for re-use
-
-            // temp line to warn people
-            throw new Error('remote file shapefile loader not yet supported');
+            shapefileData = await this.$iApi.geo.layer.files.fetchFileData(
+                this.origRampConfig.url,
+                this.layerType
+            );
         } else {
             throw new Error(
                 'shapefile file config contains no raw data or url'

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -44,4 +44,6 @@ panels.controls.moveLeft,Move Left,1,Aller à gauche,1
 panels.alert.open,{name} panel opened,1,Panneau de {name} ouvert,0
 panels.alert.close,{name} panel closed,1,Panneau de {name} fermé,0
 panels.alert.minimize,{name} panel minimized,1,Panneau de {name} minimisé,0
-layer.longload,{id} is taking longer than expected to load,1,{id} prend plus longtemps que prévu,0
+layer.error,{id} failed to load,1,{id} n'a pas pu être chargée,0
+layer.longload,{id} is taking longer than expected to load,1,{id} prend plus longtemps que prévu à charger,0
+layer.longdraw,{id} is taking longer than expected to draw,1,{id} prend plus longtemps que prévu pour dessiner,0


### PR DESCRIPTION
Closes #1261, #1327.

### Changes
* File layers can now be loaded from remote URLs. I have added a file layer of each type (geojson, shape, csv) to the main demo page for testing purposes. **Note:** I tried as much as possible to refactor the code in the wizard to avoid duplication but I wasn't able to do this perfectly. If anyone has suggestions for how to do this better, let me know.
* Implemented `expectedDrawTime` - a slow to draw notification is shown via the notification API for slow drawing layers. For testing this out, I have temporarily set the `expectedDrawTime` for the `WaterQuantity` layer to 1 millisecond - this should trigger the notification every time the layer redraws i.e. on pan, zoom, etc.
* Layers that error will now display a failed to load notification via the notification API. Thought I'd throw this in as it was requested during the RASC.

### A question/thought
If we want to keep around any of the file layers on the main demo page permanently, or even if not, we should probably figure out a better solution for storing the various file layer samples we used to have in the now dead Azure blob thing. One idea I had was to store a few inside a `file-layers` subfolder in the `public` folder that is part of the demo builds. There are likely things that I'm overlooking, but I thought I'd throw this out there in case its something we want to have. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1360)
<!-- Reviewable:end -->
