### PR TITLE
Exclusive set error fix

### DIFF
--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -239,12 +239,15 @@ export class LegendItem extends APIScope {
      */
     checkVisibilityRules(): void {
         if (this.parent && !this.parent.visibility) {
-            // if parent is not visible and legend item has visibiility control, turn visiblity off
+            // if parent is not visible and legend item has visibility control, turn visiblity off
             this.toggleVisibility(false, false);
         } else if (this.parent?.exclusive) {
             // toggle not visible if item is part of a exclusive set with another item's visibility already toggled on
             const siblingVisible = this.parent.children.some(
-                item => item.visibility && item !== this
+                item =>
+                    item.visibility &&
+                    item.type === LegendType.Item &&
+                    item !== this
             );
 
             if (siblingVisible) {


### PR DESCRIPTION
Closes #1361.

### Changes
- Added an extra check during initial visibility check in exclusive sets to see if the compared sibling item is loaded. 

### Testing
- The WFSLayer link on the [main sample](https://ramp4-pcar4.github.io/ramp4-pcar4/error-exlusive-fix/demos/index.html) is temporarily broken to observe the changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1363)
<!-- Reviewable:end -->
