### PR TITLE
Decouple settings fixture from legend fixture

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -288,7 +288,11 @@ let config = {
                                 opacity: 0.5,
                                 visibility: false
                             },
-                            disabledControls: ['opacity']
+                            fixtures: {
+                                settings: {
+                                    disabledControls: ['opacity']
+                                }
+                            }
                         }
                     ],
                     state: {
@@ -325,6 +329,15 @@ let config = {
                         opacity: 0.8,
                         visibility: true,
                         hovertips: false
+                    },
+                    fixtures: {
+                        settings: {
+                            disabledControls: [
+                                'visibility',
+                                'opacity',
+                                'identify'
+                            ]
+                        }
                     },
                     tolerance: 10,
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in

--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -50,7 +50,9 @@ The `help` provides a means to display user help for the application. TODO creat
 
 ### Settings
 
-The `settings` allow you to make live modifications to a layer on the map. TODO create and hyperlink to `settings.md`
+The `settings` allow you to make live modifications to a layer on the map.
+
+Continued [here](settings.md).
 
 ### Northarrow
 

--- a/docs/app/legend.md
+++ b/docs/app/legend.md
@@ -1,5 +1,4 @@
-# RAMP4 Legend Documentation
-
+# Legend
 
 ## Overview
 

--- a/docs/app/settings.md
+++ b/docs/app/settings.md
@@ -1,0 +1,76 @@
+# Settings
+
+## Overview
+
+The settings fixture displays a panel containing information about a given layer. The settings panel also enables a user to modify layer settings. Settings can be made adjustable or fixed in the `config`. 
+
+The settings fixture is a default fixture, meaning it will be automatically loaded using a standard configuration.
+
+
+## Configuration
+Unlike most fixtures, the settings fixture is configured separately for each layer in the main configuration file. A very simple configuration file below shows that the legend configuration object should be placed within a layer object, directly under the `fixtures` property:
+
+```text
+const config = {
+    layers: [ 
+        {
+            id: 'RAMP Layer',
+            layerType: 'esri-feature',
+            url: '...',
+            fixtures: {
+                settings: { 
+                ... layer settings go here ...
+                }
+            }
+        },
+        ... more layers
+    ]
+}
+```
+
+### Properties
+
+The settings configuration object supports the following two properties:
+
+- `controls`: keeps track of the list of enabled layer controls
+    - Visibility (`visibility`): *determines whether layer visibility can be toggled*
+    - Opacity (`opacity`): *determines whether layer opacity can be adjusted*
+    - Identify (`metadata`): *determines whether layer identification can be toggled*
+- `disabledControls`: keeps track of the list of enabled layer controls
+    - See above
+
+By default, if no `settings` configuration object is provided within a layer configuration, all layer controls are enabled. There are two ways to disable layer controls: 
+1. Add the `disabledControls` property to the object as an array with the names for each control (in parenthesis above). The following example demonstrates disabling the visibility and identify controls for the layer item `RAMP Layer`:
+
+```
+    {
+        id: 'RAMP Layer',
+        layerType: 'esri-feature',
+        url: '...',
+        fixtures: {
+            settings: { 
+                disabledControls: [
+                    'visibility',
+                    'identify'
+                ]
+            }
+        }
+    }
+```
+        
+1. Add the `controls` property to the object as an array and omit the names of the disabled layers. The next example configures `RAMP Layer`  in the same way as before:
+
+```
+    {
+        id: 'RAMP Layer',
+        layerType: 'esri-feature',
+        url: '...',
+        fixtures: {
+            settings: { 
+                controls: [
+                    'opacity'
+                ]
+            }
+        }
+    }
+```

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -626,6 +626,11 @@ export class LegendAPI extends FixtureInstance {
                 this._insertItem(child, item.parent);
             });
         }
+        // unhook layer item listeners
+        if (item instanceof LayerItem) {
+            item.handlers.forEach(handler => this.$iApi.event.off(handler));
+        }
+
         // remove item from store
         this.$iApi.$vApp.$store.dispatch(LegendStore.removeItem, item);
 

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -686,6 +686,9 @@ export default defineComponent({
                 });
             });
         }
+    },
+    beforeUnmount() {
+        this.handlers.forEach(handler => this.$iApi.event.off(handler));
     }
 });
 </script>

--- a/src/fixtures/settings/api/settings.ts
+++ b/src/fixtures/settings/api/settings.ts
@@ -1,7 +1,4 @@
 import { FixtureInstance, LayerInstance } from '@/api';
-import type { LegendAPI } from '@/fixtures/legend/api/legend';
-import { legend } from '@/fixtures/legend/store';
-
 export class SettingsAPI extends FixtureInstance {
     /**
      * Opens the settings panel. Passes the provided LayerInstance object to the panel.
@@ -9,32 +6,23 @@ export class SettingsAPI extends FixtureInstance {
      */
     toggleSettings(layer: LayerInstance): void {
         const panel = this.$iApi.panel.get('settings');
-        const legendApi = this.$iApi.fixture.get<LegendAPI>('legend');
-        if (!legendApi) {
-            console.error(
-                'Layer settings not access legend API. Please ensure the legend fixture is added.'
-            );
-            return;
-        }
 
-        const legendItem = legendApi.getLayerItem(layer.id);
         if (!panel.isOpen) {
             this.$iApi.panel.open({
                 id: 'settings',
-                props: { layer: layer, legendItem: legendItem }
+                props: { layer: layer }
             });
         } else {
             const currentUid = (panel.route.props! as any).layer.uid;
+            panel.close();
             if (currentUid !== layer.uid) {
-                panel.show({
-                    screen: 'settings-screen-content',
-                    props: {
-                        layer: layer,
-                        legendItem: legendItem
-                    }
-                });
-            } else {
-                panel.close();
+                // close and reopen settings panel to indicate settings for a different layer
+                setTimeout(() => {
+                    this.$iApi.panel.open({
+                        id: 'settings',
+                        props: { layer: layer }
+                    });
+                }, 100);
             }
         }
     }

--- a/src/fixtures/settings/index.ts
+++ b/src/fixtures/settings/index.ts
@@ -1,12 +1,12 @@
 import { markRaw } from 'vue';
 import { SettingsAPI } from './api/settings';
-
 import SettingsScreenV from './screen.vue';
-
 import messages from './lang/lang.csv?raw';
 
 class SettingsFixture extends SettingsAPI {
     async added() {
+        console.log(`[fixture] ${this.id} added`);
+
         this.$iApi.panel.register(
             {
                 settings: {


### PR DESCRIPTION
Closes #1287.

### Changes
- The settings fixture and `SettingsAPI` are no longer dependent on the existence of the legend fixture.
    - The interaction between legend items and the settings panel should be the same as before, i.e. adjusting visibility via the legend is reflected in the settings panel, and vice versa.
    - Since the settings panel now acts as a secondary method of user layer control, a disabled visibility control in one fixture will not prevent control in another fixture. For example, a layer item in the legend with a locked visibility will still be toggled if control is input from the settings panel. Of course, both can be disabled to totally prevent control.
- Added settings fixture documentation.

### Testing
- Fiddle with changing layer visibility in both the legend and the settings panel and see that the other fixture stays up to date.
- I tested a RAMP instance without the legend fixture but with the settings fixture to make sure that the settings fixture could operate independently. I didn't include a demo because it was annoying to configure RAMP with settings but without the legend, but I can pull something if anyone wants to see for themselves.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1365)
<!-- Reviewable:end -->
