### PR TITLE
Class breaks symbol lookup fix

### DIFF
--- a/src/geo/utils/renderer.ts
+++ b/src/geo/utils/renderer.ts
@@ -352,6 +352,9 @@ export class ClassBreaksSymbolUnit extends BaseSymbolUnit {
 
     match(searchParams: any): boolean {
         // param will be a numeric value
+        if (this.minValue === this.maxValue) {
+            return this.maxValue === searchParams;
+        }
         return this.minValue < searchParams && this.maxValue >= searchParams;
     }
 }


### PR DESCRIPTION
Closes #1366.

Fixed symbol lookup matching when the bucket has exactly one value in it.