### PR TITLE
Notification Overflow Fix

### DIFF
--- a/src/components/notification-center/caption-button.vue
+++ b/src/components/notification-center/caption-button.vue
@@ -60,7 +60,7 @@
                         <close @click="scope.close"></close>
                     </div>
                 </div>
-                <notification-list class="overflow-y-auto"></notification-list>
+                <notification-list class="overflow-y-auto h-230" />
             </div>
         </template>
     </dropdown-menu>

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -2,7 +2,7 @@
     <div @click.stop @mouseover.stop class="options display-block cursor-auto">
         <dropdown-menu
             class="flex-shrink-0"
-            position="bottom-start"
+            position="bottom-end"
             :tooltip="$t('legend.layer.options')"
             tooltip-placement="left"
             ref="dropdown-menu"


### PR DESCRIPTION
Partially closes #1319.

### Changes
- Notification list no longer overflows out of page
- Fixed a small bug where legend options dropdown was justified incorrectly

### Notes
The original issue brings up dropdown issues at small screen sizes. Since these issues seem to occur only when the horizontal resolution is extremely constrained, to the point where other components (navbar, panels) start to break, I feel like they can be safely ignored for now, or at least until the QA team has had time to look.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1372)
<!-- Reviewable:end -->
