### PR TITLE
add qa to branches to build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
             - 'main'
             - 'master'
             - 'develop'
+            - 'qa'
         tags:
             - v**
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
     push:
         branches:
             - 'main'
-            - 'master'
-            - 'develop'
             - 'qa'
         tags:
             - v**


### PR DESCRIPTION
#1295 

Adding `qa` as a branch to build demos for, once this is on main I'll create the `qa` branch.

My plan for QA builds is to rebase QA whenever we want to deploy a new build. If we find out we need multiple concurrent QA builds we will have to use multiple branches since even if we PR off of `qa` they will all want to deploy to `/qa` is `gh-pages`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1373)
<!-- Reviewable:end -->
