### PR TITLE
Exclusive fields cleanup

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -983,22 +983,7 @@
                     "additionalProperties": true
                 },
                 "fieldMetadata": {
-                    "type": "object",
-                    "description": "Specifies options for the fields of a layer.",
-                    "properties": {
-                        "fieldInfo": {
-                            "type": "array",
-                            "description": "Specifies field info for layer.",
-                            "items": {
-                                "$ref": "#/$defs/fieldMetadataEntry"
-                            }
-                        },
-                        "exclusiveFields": {
-                            "type": "boolean",
-                            "default": false,
-                            "description": "If true, only fields in fieldInfo are downloaded. Otherwise, download all fields."
-                        }
-                    }
+                    "$ref": "#/$defs/fieldMetadata"
                 },
                 "initialFilteredQuery": {
                     "type": "string",
@@ -1104,11 +1089,7 @@
                     "additionalProperties": true
                 },
                 "fieldMetadata": {
-                    "type": "array",
-                    "description": "Specifies options for the fields of a layer.",
-                    "items": {
-                        "$ref": "#/$defs/fieldMetadataEntry"
-                    }
+                    "$ref": "#/$defs/fieldMetadata"
                 },
                 "initialFilteredQuery": {
                     "type": "string",
@@ -1224,11 +1205,7 @@
                     "additionalProperties": true
                 },
                 "fieldMetadata": {
-                    "type": "array",
-                    "description": "Specifies options for the fields of a layer.",
-                    "items": {
-                        "$ref": "#/$defs/fieldMetadataEntry"
-                    }
+                    "$ref": "#/$defs/fieldMetadata"
                 },
                 "initialFilteredQuery": {
                     "type": "string",
@@ -1341,11 +1318,7 @@
                     "additionalProperties": true
                 },
                 "fieldMetadata": {
-                    "type": "array",
-                    "description": "Specifies options for the fields of a layer.",
-                    "items": {
-                        "$ref": "#/$defs/fieldMetadataEntry"
-                    }
+                    "$ref": "#/$defs/fieldMetadata"
                 },
                 "initialFilteredQuery": {
                     "type": "string",
@@ -1585,6 +1558,24 @@
                 }
             },
             "required": ["name"]
+        },
+        "fieldMetadata": {
+            "type": "object",
+            "description": "Specifies options for the fields of a layer.",
+            "properties": {
+                "fieldInfo": {
+                    "type": "array",
+                    "description": "Specifies field info for layer.",
+                    "items": {
+                        "$ref": "#/$defs/fieldMetadataEntry"
+                    }
+                },
+                "exclusiveFields": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, only fields in fieldInfo are recognized and downloaded. Otherwise, all fields are used."
+                }
+            }
         },
         "initialLayerSettings": {
             "type": "object",

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -332,6 +332,8 @@ export interface AttributeSet {
     oidIndex: { [key: number]: number };
 }
 
+// the type field values are aligned with the ESRI API values.
+// https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-Field.html#type
 export interface FieldDefinition {
     name: string;
     alias: string;
@@ -391,7 +393,6 @@ export interface QueryFeaturesParams {
     filterGeometry?: BaseGeometry; // filter by geometry
     filterSql?: string; // filter by sql query
     includeGeometry?: boolean; // if geometry should be included in the result
-    outFields?: string; // comma separated list of attributes to restrict what is downloaded
     sourceSR?: SpatialReference; // the spatial reference of the web service. providing helps avoid some reprojection issues
 }
 

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -821,7 +821,6 @@ export class AttribLayer extends CommonLayer {
      * - filterGeometry : a RAMP API geometry to restrict results to
      * - filterSql : a where clause to apply against feature attributes
      * - includeGeometry : a boolean to indicate if result features should include the geometry
-     * - outFields : a string of comma separated field names. will restrict fields included in the output
      * - sourceSR : a spatial reference indicating what the source layer is encoded in. providing can assist in result geometry being of a proper resolution
      *
      * @param options {Object} options to provide filters and helpful information.
@@ -838,10 +837,6 @@ export class AttribLayer extends CommonLayer {
         //      layers record count, and this.attLoader.isLoaded is false,
         //      we could trigger a getattributes call to bulk download them upfront.
         //      would be more efficient (way less web calls).
-
-        if (!options.outFields) {
-            options.outFields = this.fieldList;
-        }
 
         const oids = await this.queryOIDs(options);
 

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -208,7 +208,6 @@ export class FeatureLayer extends AttribLayer {
             // run a spatial query
             // TODO investigate if we need the sourceSR param set here
             const qOpts: QueryFeaturesParams = {
-                outFields: this.fieldList,
                 includeGeometry: false
             };
 

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -181,11 +181,15 @@ export class FileLayer extends AttribLayer {
             esriConfig[p] = this.esriJson[p];
         });
 
-        esriConfig.displayField =
-            fieldValidator(
-                <Array<EsriField>>esriConfig.fields,
-                this.origRampConfig.nameField || ''
-            ) || oidField;
+        if (this.origRampConfig.nameField) {
+            esriConfig.displayField =
+                fieldValidator(
+                    <Array<EsriField>>esriConfig.fields,
+                    this.origRampConfig.nameField!
+                ) || oidField;
+        } else {
+            esriConfig.displayField = oidField;
+        }
         esriConfig.outFields = ['*']; // TODO eventually will want this overridable by the config.
 
         // TODO inspect rampLayerConfig for any config field alias overrides or field restrictions. apply them to esriConfig.fields
@@ -325,7 +329,6 @@ export class FileLayer extends AttribLayer {
         ) {
             // run a spatial query
             const qOpts: QueryFeaturesParams = {
-                outFields: this.fieldList,
                 includeGeometry: false
             };
 

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -169,6 +169,7 @@ export class AttributeAPI extends APIScope {
                 //      but we may need to do it for stuff like populating a grid with reduced columns.
                 //      if we do this, we may need to clone the attribute objects then remove properties;
                 //      we don't want to mess with the original source in the layer.
+                // If we do a stripping, use details.attribs as the source for what to keep.
                 return toRaw(g).attributes;
             }
         );


### PR DESCRIPTION
Ah yes the joy when you spec a solution then discover it already exists just with different name and not in the schema.

- Corrects the schema to show all layers can use the `exclusiveFields` flag.
- Removes redundant outfields parameter from query calls (the layer stores it's own list, that is what was being used).
- Restructured file layer name field finder to avoid console warnings.
- Created new issue https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1375 to cover if and how we want to do file layer field stripping.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1376)
<!-- Reviewable:end -->
