### PR TITLE
Panel width on mobile from 100% to 80%

### DIFF
--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -208,7 +208,7 @@ export class PanelInstance extends APIScope {
 
         // set the panel width to 100% for mobile resolutions. The flex-basis property above
         // will handle the regular width.
-        this.style['width'] = '100%';
+        this.style['width'] = '80%';
     }
 
     /**


### PR DESCRIPTION
For #1224, #1237.

One of the suggestions in the RASC to resolve these issues was to copy google maps and make the panel 4/5ths of the space. Here is a demo for people to play around with that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1377)
<!-- Reviewable:end -->
