### PR TITLE
External fixtures fix

### DIFF
--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -20,11 +20,14 @@
                     <option value="custom-overviewmap">
                         08. Custom Overview Map
                     </option>
-                    <option value="custom-arrow">09. Custom North Arrow</option>
-                    <option value="grid">10. Grid</option>
-                    <option value="geosearch">11. Geosearch</option>
-                    <option value="help">12. Help</option>
-                    <option value="mapnav">13. Mapnav</option>
+                    <option value="custom-appbar-button">
+                        09. Custom Appbar Button
+                    </option>
+                    <option value="custom-arrow">10. Custom North Arrow</option>
+                    <option value="grid">11. Grid</option>
+                    <option value="geosearch">12. Geosearch</option>
+                    <option value="help">13. Help</option>
+                    <option value="mapnav">14. Mapnav</option>
                 </select>
             </div>
         </section>

--- a/demos/starter-scripts/custom-appbar-button.js
+++ b/demos/starter-scripts/custom-appbar-button.js
@@ -1,0 +1,104 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    }
+                ],
+                lodSets: [
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            },
+            fixtures: {
+                appbar: {
+                    items: [
+                        {
+                            id: 'random-number',
+                            componentId: 'random-number-button'
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    startingFixtures: ['appbar']
+};
+
+let options = {
+    loadDefaultFixtures: false,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+window.debugInstance = rInstance;
+
+// create custom appbar button
+rInstance.$element.component('random-number-button', {
+    props: [`options`],
+    template: `<appbar-button :onClickFunction="onClick" tooltip="Click for random number!">
+                    <span :style="{ color: color }">{{ number }}</span>
+                </appbar-button>`,
+    data() {
+        return {
+            number: this.options?.initial ?? 1,
+            color: '#BDBDBD'
+        };
+    },
+    methods: {
+        onClick() {
+            this.number = Math.floor(Math.random() * 100000) + 1;
+            this.color =
+                '#' +
+                Math.floor(Math.random() * 16777215)
+                    .toString(16)
+                    .padStart(6, '0');
+        }
+    }
+});

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -1,4 +1,7 @@
 import { createInstance, geo } from '@/main';
+import { IklobFixture } from './sample-fixtures/iklob/main';
+import { DiligordFixture } from './sample-fixtures/diligord/diligord-fixture';
+import { MourugeFixture } from './sample-fixtures/mouruge/main';
 
 window.debugInstance = null;
 
@@ -301,11 +304,16 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://geo.weather.gc.ca/geomet-beta/features/collections/hydrometric-stations/items?startindex=7740',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#FF5555',
                     state: {
                         visibility: true
                     },
                     customRenderer: {},
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md'
+                    },
                     fixtures: {
                         details: {
                             template: 'WFSLayer-Custom'
@@ -350,9 +358,15 @@ let config = {
                 },
                 appbar: {
                     items: [
-                        [{ id: 'gazebo', options: { colour: '#54a0ff' } }],
-                        ['snowman', 'legend', 'geosearch', 'basemap'],
-                        ['export']
+                        [
+                            'diligord-p1',
+                            {
+                                id: 'gazebo'
+                            },
+                            'iklob-p1',
+                            'mouruge-p1'
+                        ],
+                        ['snowman', 'legend', 'geosearch', 'basemap']
                     ]
                 },
                 mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
@@ -362,14 +376,22 @@ let config = {
                     }
                 }
             },
+            panels: {
+                open: [
+                    { id: 'diligord-p1' },
+                    { id: 'iklob-p1' },
+                    { id: 'mouruge-p1' }
+                ]
+            },
             system: { animate: true }
         }
     }
 };
 
 let options = {
-    loadDefaultFixtures: false,
-    loadDefaultEvents: true
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
 };
 
 const rInstance = createInstance(
@@ -378,25 +400,15 @@ const rInstance = createInstance(
     options
 );
 
-var iklobLoad = rInstance.event.on('fixture/added', fixture => {
-    if (fixture.id === 'iklob') {
-        rInstance.event.off(iklobLoad);
-        rInstance.panel.open('iklob-p1');
-    }
-});
+window.debugInstance = rInstance;
 
-rInstance.fixture.addDefaultFixtures().then(() => {
-    rInstance.panel.open('geosearch');
-    rInstance.panel.open('basemap');
-    rInstance.panel.open('legend');
-    rInstance.panel.open('help');
-    // Emits an event to open the metadata panel. Usually, this is be done by any fixture that wants the metadata panel to open.
-    rInstance.event.emit('metadata/open', {
-        type: 'html',
-        layerName: 'Sample Layer Name',
-        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md'
-    });
-});
+// add fixtures
+rInstance.fixture.add('iklob', IklobFixture);
+rInstance.fixture.add('diligord', DiligordFixture);
+rInstance.fixture.add('mouruge', MourugeFixture);
+rInstance.fixture.add('gazebo');
+rInstance.fixture.add('snowman');
+rInstance.fixture.add('export');
 
 // Load custom templates.
 rInstance.$element.component('WFSLayer-Custom', {
@@ -483,51 +495,3 @@ rInstance.$element.component('Water-Quantity-Template', {
         }
     }
 });
-
-// start loading non-default fixtures; this is just an example
-
-// TODO: fix console errors
-rInstance.fixture.add('snowman');
-rInstance.fixture.add('gazebo').then(() => {
-    rInstance.panel.get('p2').open({ screen: 'p-2-screen-2' }).pin();
-});
-/* rInstance.fixture.add('diligord', window.hostFixtures.diligord).then(() => {
-    rInstance.panel.open('diligord-p1');
-});
-rInstance.fixture.add('mouruge', window.hostFixtures.mouruge).then(() => {
-    rInstance.panel.open('mouruge-p1');
-}); */
-
-// add export fixtures
-rInstance.fixture.add('export');
-
-// sample event declared by the page
-
-// interesting race condition here. we could use rInstance.availableEvents to find the name,
-// but given the async nature of fixture.add, the name will not be registered yet.
-var gazeboEventName = 'gazebo/beholdMyText';
-
-// a one time handler. clicking "see a cat" many times should only result in one console log
-var onceHandler = function (text) {
-    console.log('EVENTS API SAMPLE: a one time event : ' + text);
-};
-rInstance.event.once(gazeboEventName, onceHandler, 'SAMPLE_HANDLER_ONCE');
-
-function switchLang() {
-    if (rInstance.language === 'en') {
-        rInstance.setLanguage('fr');
-    } else {
-        rInstance.setLanguage('en');
-    }
-    document.getElementById('instance-language').innerText = rInstance.language;
-}
-
-function animateToggle() {
-    if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
-        rInstance.$vApp.$el.classList.remove('animation-enabled');
-    } else {
-        rInstance.$vApp.$el.classList.add('animation-enabled');
-    }
-    document.getElementById('animate-status').innerText =
-        'Animate: ' + rInstance.animate;
-}

--- a/demos/starter-scripts/sample-fixtures/diligord/diligord-fixture.js
+++ b/demos/starter-scripts/sample-fixtures/diligord/diligord-fixture.js
@@ -1,0 +1,160 @@
+// this is a plain JS sample fixture that doesn't require a compilation step since it doesn't use Vue templates
+// instead, templates need to be written as a render function directly
+// consequently, this makes for a smallest fixture bundle
+import { h, markRaw, resolveComponent } from 'vue';
+
+// then, create a fixture config
+export class DiligordFixture {
+    added() {
+        // `this.id` and `this.$iApi` and `this.$vApp` are automatically made available on this object
+        this.id;
+        this.$iApi;
+        this.$vApp;
+
+        const messages = {
+            en: {
+                changeTitle: 'Change panel title'
+            },
+            fr: {
+                changeTitle: 'Changer le titre du panneau'
+            }
+        };
+        // Diligord Fixture creates a simple panel with a single screen with two header controls (pin and close),
+        // and increment button and an input field (bound to the panel title) in the content slot
+
+        // first, create a panel screen
+        // since this is a raw JS file, we need to create the template for our screen using the render function (https://vuejs.org/v2/guide/render-function.html)
+        // it's possible to write this as a regular Vue component with HTML-based template and compile it with `vue-template-compiler` if you don't want to bother with render functions
+        // TODO: make an example of a compiled external fixture
+        const dScreen1 = {
+            // the `panel` prop is automatically passed to all panel screen components by the panel-container
+            // this is the `PanelInstance` instance inside which this screen component is displayed, and it exposes panel API functions
+            // methods, computed functions and template will have access to the panel as `this.panel`
+            props: ['panel'],
+            i18n: {
+                messages
+            },
+            // reactive component data
+            data() {
+                return {
+                    title: 'Diligord Panel',
+                    count: 0
+                };
+            },
+            render() {
+                // Documentation for this: https://vuejs.org/guide/extras/render-function.html
+                const panelScreen = resolveComponent('panel-screen');
+                return h(
+                    panelScreen,
+                    {
+                        panel: this.panel
+                    },
+                    {
+                        header: () => h('span', this.title),
+                        content: () =>
+                            h(
+                                'div',
+                                {
+                                    class: 'flex flex-col items-center'
+                                },
+                                [
+                                    h(
+                                        'button',
+                                        {
+                                            class: 'bg-blue-500 hover:bg-blue-700 font-bold text-white py-8 px-16',
+                                            onClick: () => (this.count += 10)
+                                        },
+                                        [h('span', this.count)]
+                                    ),
+                                    h(
+                                        'label',
+                                        { class: 'mt-16' },
+                                        this.$t('changeTitle')
+                                    ),
+                                    h('input', {
+                                        class: 'border-2  p-8 mb-10',
+                                        // bind title to the input value
+                                        value: this.title,
+                                        onInput: $event => {
+                                            this.title = $event.target.value;
+                                        }
+                                    }),
+                                    h(
+                                        'label',
+                                        'Hint: Change title to fight for a surprise.'
+                                    ),
+                                    // A gif will show if the title is changed to "fight"
+                                    this.title === 'fight'
+                                        ? h('img', {
+                                              style: {
+                                                  width: '300px',
+                                                  marginTop: '30px'
+                                              },
+                                              src: 'https://media.giphy.com/media/sGAlRSaXKjTfq/giphy.gif'
+                                          })
+                                        : null
+                                ]
+                            )
+                    }
+                );
+            }
+        };
+
+        // then, create a panel config
+        const dpanel = {
+            id: 'diligord-p1',
+            config: {
+                screens: { 'diligord-s1': markRaw(dScreen1) },
+                button: {
+                    icon: `<span>D</span>`,
+                    tooltip: 'Diligord'
+                },
+                alertName: 'Diligord'
+            }
+        };
+
+        // you can also create a custom component using the helper `extend` function and put it anywhere on the page, even outside the R4MP container
+        // the helper function will add references to this fixture and `$iApi` to the extended component
+        const component = this.extend({
+            render() {
+                return h(
+                    'p',
+                    {
+                        style: {
+                            marginTop: '80px',
+                            fontWeight: 'bold',
+                            color: '#34495e',
+                            fontSize: '20pt',
+                            textAlign: 'center'
+                        }
+                    },
+                    [this.firstName, ' ', this.lastName, ' aka ', this.alias]
+                );
+            },
+            data() {
+                return {
+                    firstName: 'Walter',
+                    lastName: 'White',
+                    alias: 'Heisenberg'
+                };
+            }
+        });
+
+        // and put it on the page
+        document.querySelector('.ramp-app').after(component);
+
+        // this life hook is called when the fixture is added to R4MP, and now it's possible to open our panel
+        this.$iApi.panel.register(dpanel, {
+            i18n: {
+                messages: {
+                    en: {
+                        Diligord: 'Diligord'
+                    },
+                    fr: {
+                        Diligord: '[fr] Diligord'
+                    }
+                }
+            }
+        });
+    }
+}

--- a/demos/starter-scripts/sample-fixtures/iklob/main.ts
+++ b/demos/starter-scripts/sample-fixtures/iklob/main.ts
@@ -1,0 +1,49 @@
+import { markRaw } from 'vue';
+import screen from './screen.vue';
+export class IklobFixture {
+    added(): void {
+        const messages = {};
+        // TODO: import `FixtureInstance` types
+        (this as any).$iApi.panel.register(
+            {
+                id: 'iklob-p1',
+                config: {
+                    screens: { 'iklob-s1': markRaw(screen) },
+                    button: {
+                        icon: `<span>I</span>`,
+                        tooltip: 'Iklob'
+                    },
+                    alertName: 'Iklob'
+                }
+            },
+            {
+                i18n: {
+                    messages: {
+                        en: {
+                            Iklob: 'Iklob'
+                        },
+                        fr: {
+                            Iklob: '[fr] Iklob'
+                        }
+                    }
+                }
+            }
+        );
+    }
+}
+
+declare const rInstance: any;
+
+// if it's not possible to load the fixture file before `RAMP.umd.js` is
+// loaded, and therefore it's not guaranteed that RAMP won't be
+// instantiated earlier, the host page can save RAMP instance to a global
+// variable and the fixture can add itself to it after the instance is instantiated;
+// this method is more cumbersome since it requires watching a global variable
+
+/* const handle = setInterval(() => {
+    if (!rInstance) {
+        return;
+    }
+    rInstance.fixture.add('iklob', IklobFixture);
+    clearInterval(handle);
+}, 5000); */

--- a/demos/starter-scripts/sample-fixtures/iklob/screen.vue
+++ b/demos/starter-scripts/sample-fixtures/iklob/screen.vue
@@ -1,0 +1,38 @@
+<template>
+    <panel-screen :panel="panel">
+        <template #header> Iklob Panel </template>
+
+        <template #content>
+            <div class="flex flex-col items-center mt-16">
+                <span class="text-6xl">🤷‍♂️</span>
+                <span class="mt-16">{{ gazeboText }}</span>
+            </div>
+        </template>
+    </panel-screen>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'IklobFixtureV',
+    data() {
+        return {
+            gazeboText: ''
+        };
+    },
+    props: {
+        panel: Object
+    },
+    methods: {
+        onCatSeen() {
+            this.gazeboText = 'The cat on the gazebo panel has been seen!';
+        }
+    },
+    created() {
+        this.$iApi.event.once('gazebo/beholdMyText', this.onCatSeen);
+    }
+});
+</script>
+
+<style scoped></style>

--- a/demos/starter-scripts/sample-fixtures/mouruge/main.ts
+++ b/demos/starter-scripts/sample-fixtures/mouruge/main.ts
@@ -1,0 +1,42 @@
+import screen from './screen.vue';
+import { markRaw } from 'vue';
+
+export class MourugeFixture {
+    added(): void {
+        // TODO: import `FixtureInstance` types
+        (this as any).$iApi.panel.register(
+            {
+                id: 'mouruge-p1',
+                config: {
+                    screens: { 'mouruge-s1': markRaw(screen) },
+                    button: {
+                        icon: `<span>M</span>`,
+                        tooltip: 'Mouruge'
+                    },
+                    alertName: 'Mouruge'
+                }
+            },
+            {
+                i18n: {
+                    messages: {
+                        en: {
+                            Mouruge: 'Mouruge'
+                        },
+                        fr: {
+                            Mouruge: '[fr] Mouruge'
+                        }
+                    }
+                }
+            }
+        );
+    }
+}
+
+// this is the preferred way to add fixtures to R4MP (the fixture file needs
+// to be loaded before the main RAMP file--`RAMP.umd.js`)
+// add the fixture class to the global variable and then add it to the R4MP
+// instance when R4MP is instantiated on the host page
+/* const ew = window as any;
+
+ew.hostFixtures = ew.hostFixtures || {};
+ew.hostFixtures['mouruge'] = MourugeFixture; */

--- a/demos/starter-scripts/sample-fixtures/mouruge/screen.vue
+++ b/demos/starter-scripts/sample-fixtures/mouruge/screen.vue
@@ -1,0 +1,26 @@
+<template>
+    <panel-screen :panel="panel">
+        <template #header> Mouruge Panel </template>
+
+        <template #content>
+            <div class="flex flex-col items-center mt-16">
+                <img
+                    class="my-16"
+                    src="https://i.pinimg.com/originals/5f/12/01/5f120106a81b52d9813aabe8d14b1552.gif"
+                    alt=""
+                    srcset=""
+                />
+            </div>
+        </template>
+    </panel-screen>
+</template>
+
+<script lang="ts">
+// use the simplest syntax to create a Vue component--no decorators or classes, just a plain object
+// this will result in the smallest possible bundle size for the fixture
+export default {
+    props: ['panel']
+};
+</script>
+
+<style scoped></style>

--- a/schema.json
+++ b/schema.json
@@ -2168,6 +2168,10 @@
                                 "type": "string",
                                 "description": "The ID of the panel to open."
                             },
+                            "screen": {
+                                "type": "string",
+                                "description": "The ID of the screen of the panel to show."
+                            },
                             "pin": {
                                 "type": "boolean",
                                 "default": "false",

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -229,7 +229,10 @@ export class InstanceAPI {
                     const panelIds = langConfig.panels.open.map(p => p.id);
                     this.panel.isRegistered(panelIds).then(() => {
                         langConfig.panels?.open?.forEach(panel => {
-                            this.panel.open(panel.id);
+                            this.panel.open({
+                                id: panel.id,
+                                screen: panel.screen
+                            });
                             if (panel.pin) {
                                 this.panel.pin(panel.id);
                             }

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -51,6 +51,8 @@ export class PanelInstance extends APIScope {
 
     controls: any;
 
+    button: any;
+
     /**
      * Checks if a given screen component id is already loaded and ready to render.
      *

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -190,7 +190,9 @@ export class PanelAPI extends APIScope {
             this.$vApp.$store.set(`panel/${PanelAction.openPanel}!`, { panel });
             this.$iApi.updateAlert(
                 this.$vApp.$t(`panels.alert.open`, {
-                    name: this.$vApp.$t(panel.alertName)
+                    name: panel.alertName
+                        ? this.$vApp.$t(panel.alertName)
+                        : panel.id
                 })
             );
             this.$iApi.event.emit(GlobalEvents.PANEL_OPENED, panel);
@@ -241,7 +243,9 @@ export class PanelAPI extends APIScope {
         this.$vApp.$store.set(`panel/${PanelAction.closePanel}!`, { panel });
         this.$iApi.updateAlert(
             this.$vApp.$t(`panels.alert.close`, {
-                name: this.$vApp.$t(panel.alertName)
+                name: panel.alertName
+                    ? this.$vApp.$t(panel.alertName)
+                    : panel.id
             })
         );
         this.$iApi.event.emit(GlobalEvents.PANEL_CLOSED, panel);
@@ -266,7 +270,9 @@ export class PanelAPI extends APIScope {
         this.$vApp.$store.set(`panel/${PanelAction.closePanel}!`, { panel });
         this.$iApi.updateAlert(
             this.$vApp.$t(`panels.alert.minimize`, {
-                name: this.$vApp.$t(panel.alertName)
+                name: panel.alertName
+                    ? this.$vApp.$t(panel.alertName)
+                    : panel.id
             })
         );
 
@@ -406,9 +412,14 @@ export class PanelAPI extends APIScope {
     ): PanelInstance | undefined {
         const panel = this.get(value);
 
+        // check if the requested screen exists, or bad things can happen on startup
+        if (!panel.screens[route.screen]) {
+            return undefined;
+        }
+
         // check if required props are there, or bad things can happen on startup
         // need this here until we figure out how to pass in props, after layer use is normalized
-        if (panel.screens[route.screen]) {
+        if (panel.screens[route.screen]?.props) {
             const propsToCheck = Object.keys(
                 panel.screens[route.screen]?.props
             ).filter((pr: String) => pr !== 'panel');

--- a/src/fixtures/appbar/api/appbar.ts
+++ b/src/fixtures/appbar/api/appbar.ts
@@ -87,11 +87,14 @@ export class AppbarAPI extends FixtureInstance {
                 }
                 // check for components with the id
                 [id].some(v => {
-                    if (this.$iApi.fixture.get(v)) {
+                    if (
+                        this.$iApi.fixture.get(v) &&
+                        !this.$vApp.$store.get(`appbar/items@${id}.componentId`)
+                    ) {
                         // if an item is registered globally, save the name of the registered component
                         this.$vApp.$store.set(
                             `appbar/items@${id}.componentId`,
-                            v
+                            `${v}-appbar-button`
                         );
                     }
                 });

--- a/src/fixtures/appbar/appbar.vue
+++ b/src/fixtures/appbar/appbar.vue
@@ -21,8 +21,8 @@
                     :is="item.componentId"
                     :key="`${item}-${index2}`"
                     :options="item.options"
-                    :id="item.id"
                     class="appbar-item h-48"
+                    :id="item.id"
                     :class="`identifier-${item}-${index2}`"
                 ></component>
             </template>

--- a/src/fixtures/appbar/store/appbar-state.ts
+++ b/src/fixtures/appbar/store/appbar-state.ts
@@ -40,6 +40,14 @@ export interface AppbarItemConfig {
     id: string;
 
     /**
+     * ID of the component of this appbar item.
+     *
+     * @type {string}
+     * @memberof AppbarItemConfig
+     */
+    componentId?: string;
+
+    /**
      * The options for the displayed appbar button.
      *
      * @type {object}
@@ -72,7 +80,11 @@ export class AppbarItemInstance implements AppbarItemConfig {
             options: {},
             ...value
         };
-        ({ id: this.id, options: this.options } = params);
+        ({
+            id: this.id,
+            options: this.options,
+            componentId: this.componentId
+        } = params);
 
         // this should work too, but it doesn't;
         // ({ id: this.id, options: this.options } = { options: {}, ...(typeof value === 'string' ? { id: value} : value) });

--- a/src/fixtures/gazebo/appbar-button.vue
+++ b/src/fixtures/gazebo/appbar-button.vue
@@ -1,10 +1,11 @@
 <template>
     <appbar-button :onClickFunction="onClick" tooltip="Gazebo">
-        <span :style="{ fontWeight: 'bold', color: options.colour }">G</span>
+        <span :style="{ color: options?.colour ?? '#BDBDBD' }">G </span>
     </appbar-button>
 </template>
 <script lang="ts">
-import { defineComponent, type PropType } from 'vue';
+import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
 
 export default defineComponent({
     name: 'GazeboAppbarButtonV',

--- a/src/fixtures/gazebo/lang/lang.csv
+++ b/src/fixtures/gazebo/lang/lang.csv
@@ -1,5 +1,5 @@
 key,enValue,enValid,frValue,frValid
-gz.hello,"I'm a simple panel. but from a locale file",1,"Bonjour. Je suis un panel.",0
-gz.hello2,"I'm a simple panel.",1,"Bonjour. Je suis un panel.",0
+gz.hello,I'm a simple panel - but from a locale file,1,Bonjour. Je suis un panel",0
+gz.hello2,I'm a simple panel,1,Bonjour. Je suis un panel",0
 gz.alert1,Gazebo,1,Gazebo,0
 gz.alert2,Gazebo two,1,Gazebo deux,0

--- a/src/fixtures/gazebo/p1-screen-1.vue
+++ b/src/fixtures/gazebo/p1-screen-1.vue
@@ -3,32 +3,25 @@
         <template #header> Gazebo/Panel 1/Screen A </template>
 
         <template #controls>
-            <div class="flex">
-                <!-- this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes -->
-                <panel-options-menu>
-                    <a href="#">Option 1</a>
-                    <a href="#">Option 2</a>
-                    <a href="#">Option 3</a>
-                </panel-options-menu>
-                <pin
-                    :active="pinned && pinned.id === 'p1'"
-                    @click="pinPanel"
-                    v-if="checkScreenSize"
-                ></pin>
-            </div>
+            <a href="#">Option 1</a>
+            <a href="#">Option 2</a>
+            <a href="#">Option 3</a>
         </template>
 
         <template #content>
             <div class="flex flex-col items-center">
                 <!-- setting panel route directly in the store will not work ❌  -->
                 <button
-                    @click="route = { screen: 'p-1-screen-2' }"
+                    @click="panel.show({ screen: 'p-1-screen-2' })"
                     class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16"
                 >
                     See Gazebo 2
                 </button>
-
-                <img width="350px" :src="url" alt="Gazebo1" srcset="" />
+                <br />
+                <img
+                    src="https://c.tenor.com/RJ3ZG5beDhIAAAAC/napoleon-dynamite-napoleon.gif"
+                    alt="Gazebo1"
+                />
             </div>
         </template>
     </panel-screen>
@@ -36,31 +29,16 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
 
 import type { PanelInstance } from '../../api';
 
 export default defineComponent({
     name: 'GazeboP1Screen1V',
-    data() {
-        return {
-            route: this.sync('panel/items@p1.route'),
-            pinned: this.sync('panel/pinned'),
-            url: 'https://i2.wp.com/freepngimages.com/wp-content/uploads/2017/08/wooden-garden-gazebo.png?w=860'
-        };
-    },
-    computed: {
-        checkScreenSize(): boolean {
-            return this.$iApi.screenSize !== 'xs';
-        }
-    },
-    methods: {
-        pinPanel(): void {
-            // this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes
-            const panel = this.$store.get<PanelInstance>(`panel/items@p1`)!;
-            this.pinned =
-                this.pinned === null || (this.pinned && this.pinned.id) !== 'p1'
-                    ? panel
-                    : null;
+    props: {
+        panel: {
+            type: Object as PropType<PanelInstance>,
+            required: true
         }
     }
 });

--- a/src/fixtures/gazebo/p1-screen-2.vue
+++ b/src/fixtures/gazebo/p1-screen-2.vue
@@ -2,26 +2,20 @@
     <panel-screen :panel="panel">
         <template #header> Gazebo/Panel 1/Screen B </template>
 
-        <template #controls>
-            <!-- this is fine, but the name of the panel is hardcoded there, so you wouldn't need to update it if it ever changes -->
-            <pin
-                :active="pinned() === 'p1'"
-                @click="pinPanel"
-                v-if="checkScreenSize"
-            ></pin>
-        </template>
-
         <template #content>
             <div class="flex flex-col items-center">
                 <!-- setting panel route directly in the store will not work ❌  -->
                 <button
-                    @click="goToScreen('p-1-screen-1')"
+                    @click="panel.show({ screen: 'p-1-screen-1' })"
                     class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16"
                 >
                     See Gazebo 1
                 </button>
-
-                <img width="350px" :src="url" alt="Gazebo2" srcset="" />
+                <br />
+                <img
+                    src="http://nesn.com/wp-content/uploads/2014/09/jeternephew.gif"
+                    alt="Gazebo2"
+                />
             </div>
         </template>
     </panel-screen>
@@ -29,35 +23,16 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
+
+import type { PanelInstance } from '../../api';
 
 export default defineComponent({
     name: 'GazeboP1Scree2V',
-    data() {
-        return {
-            url: 'https://i2.wp.com/freepngimages.com/wp-content/uploads/2016/02/garden-shed-transparent-image-2.png?w=693'
-        };
-    },
-    computed: {
-        checkScreenSize(): boolean {
-            return this.$iApi.screenSize !== 'xs';
-        }
-    },
-    methods: {
-        pinPanel(): void {
-            // ❌ this is bad because it's tappnig directly into the store circumventing the API
-            // this will work, but if the store changes structure, it might break 👇
-            const panel = this.get(`panel/items@p1`) as any;
-            this.$iApi.$vApp.$store.set(
-                'panel/pinned',
-                this.pinned() !== 'p1' ? panel : null
-            );
-        },
-        goToScreen(screen: string): void {
-            this.$iApi.$vApp.$store.set('panel/items@p1.route', { screen });
-        },
-        pinned(): string | null {
-            const panel = this.get('panel/pinned') as any;
-            return panel ? panel.id : null;
+    props: {
+        panel: {
+            type: Object as PropType<PanelInstance>,
+            required: true
         }
     }
 });

--- a/src/fixtures/gazebo/p2-screen-1.vue
+++ b/src/fixtures/gazebo/p2-screen-1.vue
@@ -2,20 +2,6 @@
     <panel-screen :panel="panel">
         <template #header> Gazebo/Panel 2/Screen A </template>
 
-        <template #controls>
-            <!-- <pin> is a global button component that any fixture/panel/screen can reuse -->
-
-            <!-- ✔ this is the correct way to pin a panel and bind the button active state whether this panel is pinned or not 👇 -->
-            <pin
-                @click="panel.pin(!isPinned)"
-                :active="isPinned"
-                v-if="checkScreenSize"
-            ></pin>
-
-            <!-- ✔ this will also work 👇 -->
-            <!-- <pin @click="panel.pin(!panel.isPinned)" :active="panel.isPinned"></pin> -->
-        </template>
-
         <template #content>
             {{ $t('gz.hello') }}
 
@@ -47,7 +33,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, type PropType } from 'vue';
+import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
 import type { PanelInstance } from '@/api';
 
 export default defineComponent({
@@ -55,16 +42,6 @@ export default defineComponent({
     props: {
         panel: { type: Object as PropType<PanelInstance>, required: true },
         greeting: { type: String }
-    },
-    computed: {
-        isPinned(): boolean {
-            return this.panel.isPinned;
-            // ✔ this also works 👇
-            // return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.panel.id;
-        },
-        checkScreenSize(): boolean {
-            return this.$iApi.screenSize !== 'xs';
-        }
     }
 });
 </script>

--- a/src/fixtures/gazebo/p2-screen-2.vue
+++ b/src/fixtures/gazebo/p2-screen-2.vue
@@ -2,21 +2,6 @@
     <panel-screen :panel="panel">
         <template #header> Gazebo/Panel 2/Screen B </template>
 
-        <template #controls>
-            <!-- <pin> is a global button component that any fixture/panel/screen can reuse -->
-
-            <!-- ✔ this is the correct way to pin a panel and bind the button active state whether this panel is pinned or not 👇 -->
-            <pin
-                @click="panel.pin()"
-                :active="isPinned"
-                v-if="checkScreenSize"
-            ></pin>
-
-            <!-- ✔ this will also work 👇 -->
-            <!-- <pin @click="panel.pin()" :active="panel.isPinned"></pin> -->
-            <close @click="panel.close()"></close>
-        </template>
-
         <template #content>
             {{ $t('gz.hello2') }}
 
@@ -48,7 +33,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, type PropType } from 'vue';
+import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
 import type { PanelInstance } from '@/api';
 
 export default defineComponent({
@@ -56,16 +42,6 @@ export default defineComponent({
     props: {
         panel: { type: Object as PropType<PanelInstance>, required: true },
         greeting: { type: String }
-    },
-    computed: {
-        isPinned(): boolean {
-            return this.panel.isPinned;
-            // ✔ this also works 👇
-            // return this.$iApi.panel.pinned !== null && this.$iApi.panel.pinned.id === this.panel.id;
-        },
-        checkScreenSize(): boolean {
-            return this.$iApi.screenSize !== 'xs';
-        }
     },
     methods: {
         enhancedCatActivities() {

--- a/src/fixtures/gazebo/p2-screen-3.vue
+++ b/src/fixtures/gazebo/p2-screen-3.vue
@@ -2,21 +2,6 @@
     <panel-screen :panel="panel">
         <template #header> Gazebo/Panel 2/Screen C </template>
 
-        <template #controls>
-            <!-- <pin> is a global button component that any fixture/panel/screen can reuse -->
-
-            <!-- ✔ this is the correct way to pin a panel and bind the button active state whether this panel is pinned or not 👇 -->
-            <pin
-                @click="panel.pin()"
-                :active="panel.isPinned"
-                v-if="checkScreenSize"
-            ></pin>
-
-            <!-- ✔ this will also work 👇 -->
-            <!-- <pin @click="panel.pin()" :active="panel.isPinned"></pin> -->
-            <close @click="panel.close()" v-if="checkScreenSize"></close>
-        </template>
-
         <template #content>
             <div class="flex flex-col items-center mt-16">
                 <!-- ✔ this is the correct way to switch between screens in the same panel 👇 -->
@@ -54,7 +39,8 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, type PropType } from 'vue';
+import { defineComponent } from 'vue';
+import type { PropType } from 'vue';
 import type { PanelInstance } from '@/api';
 
 export default defineComponent({
@@ -72,11 +58,6 @@ export default defineComponent({
                 lang_native: 'Fr',
                 who: '[moi chat]'
             }
-        }
-    },
-    computed: {
-        checkScreenSize(): boolean {
-            return this.$iApi.screenSize !== 'xs';
         }
     }
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,6 +12,7 @@ export interface RampConfig {
     panels?: {
         open?: {
             id: string;
+            screen?: string;
             pin?: boolean;
         }[];
         reorderable?: boolean;


### PR DESCRIPTION
Closes #692.

### Changes
- Fixed external fixtures not rendering. The three external fixtures (Diligord, Iklob, and Mouruge) have been added to sample 2 (lots of panels) in `index-samples`. **Note:** Seeing as the original issue referred to this being an issue when running locally, I would recommend pulling [my fork](https://github.com/mohsin-r/ramp4-pcar4/tree/issue692) and running RAMP locally for testing purposes. 
- Fixed a bug where custom appbar buttons did not have their `componentId` configurable. To test this change, I have created a custom appbar button - see sample 9 in `index-samples` to play around with this.
- Added the ability to specify which screen to show when opening panels via the config on startup. 
- Fixed the gazebo fixture not switching to its different screens correctly. The gazebo has also been added to sample 2 (lots of panels) in `index-samples`.
- Fixed an error in the console when the panel's `alertName` property was missing on registration.