### PR TITLE
Small Grid Fixes

### DIFF
--- a/src/fixtures/grid/accessibility.ts
+++ b/src/fixtures/grid/accessibility.ts
@@ -56,7 +56,6 @@ export class GridAccessibilityManager {
             this.element.querySelectorAll(HEADER_ROW_SELECTOR)
         ) as HTMLElement[];
 
-        this.element.querySelector('.ag-horizontal-left-spacer')?.remove();
         this.element
             .querySelector('.ag-body-horizontal-scroll-viewport')
             ?.setAttribute('tabindex', '-1');

--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -1,23 +1,24 @@
 <template>
     <div class="ag-custom-header flex flex-1 items-center h-full w-full">
-        <div v-if="sortable" class="flex flex-1 items-center min-w-0">
+        <div
+            v-if="sortable"
+            class="flex flex-1 items-center min-w-0"
+            truncate-trigger
+        >
             <button
                 @click="onSortRequested('asc', $event)"
                 :content="$t(`grid.header.sort.${sort}`)"
                 v-tippy="{ placement: 'top', hideOnClick: false }"
                 class="customHeaderLabel hover:bg-gray-300 font-bold p-8 max-w-full"
                 role="columnheader"
-                truncate-trigger
                 tabindex="-1"
             >
-                <!-- <div v-truncate="{ externalTrigger: true }"> -->
-                <div>
+                <div v-truncate="{ externalTrigger: true }">
                     {{ params.displayName }}
                 </div>
             </button>
         </div>
-        <!-- <span v-else class="customHeaderLabel" role="columnheader" v-truncate>{{ -->
-        <span v-else class="customHeaderLabel" role="columnheader">{{
+        <span v-else class="customHeaderLabel" role="columnheader" v-truncate>{{
             params.displayName
         }}</span>
 


### PR DESCRIPTION
Closes #1369.

### Changes
- Long column names in custom header now truncate with tooltip
- Datagrid is no longer cut off on the right hand side

~~Edit: it seems like the second issue is not happening on main, though it was yesterday, will need to investigate.~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1381)
<!-- Reviewable:end -->
