### PR TITLE
Child Layer Visibility Fixes

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -437,8 +437,7 @@ let config = {
                                             {
                                                 layerId: 'WaterQuantity',
                                                 name: 'CO2 in Nested Group',
-                                                sublayerIndex: 9,
-                                                visibility: false
+                                                sublayerIndex: 9
                                             },
                                             {
                                                 layerId: 'WaterQuality',

--- a/demos/starter-scripts/map-image-layer.js
+++ b/demos/starter-scripts/map-image-layer.js
@@ -87,6 +87,27 @@ let config = {
                     },
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
+                {
+                    id: 'MarineWaterQuality',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/Shellfish_Sites_Samples_Mollusques_Echantillons/MapServer/',
+                    sublayers: [
+                        {
+                            index: 3
+                        },
+                        {
+                            index: 4
+                        },
+                        {
+                            index: 5
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: false
+                    },
+                    customRenderer: {}
+                },
                 { id: 'userOSM', layerType: 'osm-tile' }
             ],
             fixtures: {
@@ -105,6 +126,26 @@ let config = {
                                         layerId: 'AirEmissions',
                                         name: 'Sulphur oxide emissions by facility',
                                         sublayerIndex: 18
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'Marine water quality (invisible)',
+                                children: [
+                                    {
+                                        layerId: 'MarineWaterQuality',
+                                        name: 'Samples in British Columbia',
+                                        sublayerIndex: 3
+                                    },
+                                    {
+                                        layerId: 'MarineWaterQuality',
+                                        name: 'Samples in New Brunswick',
+                                        sublayerIndex: 4
+                                    },
+                                    {
+                                        layerId: 'MarineWaterQuality',
+                                        name: 'Samples in Newfoundland and Labrador',
+                                        sublayerIndex: 5
                                     }
                                 ]
                             },

--- a/docs/app/legend.md
+++ b/docs/app/legend.md
@@ -139,7 +139,6 @@ Every node in the legend tree structure is an instance of a legend item. All leg
 - `children`: list of child legend items
 - `hidden`: indicates if item (and its children) should be hidden from the legend
 - `expanded`: default expanded state of item
-- `visibility`: default visibility state of item
 - `exclusive`: indicates if toggling visibility should follow "exclusive" behavior
 - `controls:`: keeps track of list of enabled legend item controls
 - `disabledControls:`: keeps track of list of disabled legend item controls

--- a/schema.json
+++ b/schema.json
@@ -382,11 +382,6 @@
                     "default": true,
                     "description": "Specifies if the legend item is expanded by default."
                 },
-                "visibility": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Specifies that the legend item will be visible by default."
-                },
                 "exclusive": {
                     "type": "boolean",
                     "default": false,

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -1,10 +1,5 @@
 import { GlobalEvents, LayerInstance, type InstanceAPI } from '@/api';
-import {
-    DrawState,
-    LayerControl,
-    LayerType,
-    type LegendSymbology
-} from '@/geo/api';
+import { LayerControl, LayerType, type LegendSymbology } from '@/geo/api';
 import { LegendItem, LegendType } from './legend-item';
 
 export class LayerItem extends LegendItem {
@@ -219,6 +214,9 @@ export class LayerItem extends LegendItem {
                             this.setSymbologyVisibility(undefined, false);
                         }
                     }
+
+                    // override layer item visibility in favour of layer visibility
+                    this.toggleVisibility(layer.visibility);
 
                     // event listener must be added after the layer is loaded
                     this.handlers.push(

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -56,7 +56,7 @@ export class LegendItem extends APIScope {
 
         this._hidden = config.hidden ?? false;
         this._expanded = config.expanded ?? true;
-        this._visibility = config.visibility ?? true;
+        this._visibility = true; // default value, gets updated later
         this._exclusive = config.exclusive ?? false;
 
         this._controls = config.controls?.slice() ?? [


### PR DESCRIPTION
Closes #1108.

Edit: seems like #1384 has a very similar issue, so it gets fixed by this too. 

### Changes
- Instead of defaulting to `visibility: true`, map image sublayers now pull values from parent layer when missing `state` property.
- A map image layer with no `state` property now defaults to `visibility: true`.
- Layer items in the legend will now only get their visibility from the `layers` section of the config, meaning visibility is no longer configured in 2 separate places (`layers`/`fixtures`). Section items still get visibility from `fixtures`.

### Testing
- MIL with `visibility: false`: https://ramp4-pcar4.github.io/ramp4-pcar4/vis-issues/demos/index-samples.html?sample=14. Note that the legend and the map now remain in sync with each other

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1387)
<!-- Reviewable:end -->
