### PR TITLE
build: add typescript PR check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,32 +1,50 @@
 on:
     pull_request:
-        branches: [main]
+        types: [opened, synchronize]
+
+    push:
+        branches:
+            - 'main'
+            - 'develop'
+        tags:
+            - v**
 env:
     NODE_VERSION: '17.9.0'
 jobs:
-    pr-checks:
+    pr-status-checks:
         name: PR Status Checks
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
                   node-version: ${{ env.NODE_VERSION }}
+                  cache: 'npm'
 
-            - name: Extract branch or tag name
-              shell: bash
-              run: echo "##[set-output name=name;]$(echo ${GITHUB_REF#refs/*/})"
-              id: extract_ref
+            - name: Try to restore node_modules folder from cache
+              id: cache-node-modules
+              uses: actions/cache@v3
+              with:
+                  path: ./node_modules
+                  key: npm-${{ hashFiles('./package-lock.json') }}
 
-            - name: Check if Typescript is happy
-              shell: bash
-              run: echo "No"
+            - name: Otherwise install npm dependencies
+              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+              run: npm ci
 
-            - name: Check if ESLint is happy
-              shell: bash
-              run: echo "No"
+            - uses: milespetrov/status-checks@main
+              id: pr-checks
+              with:
+                  gh-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Check if prettier is happy
-              shell: bash
-              run: echo "Yes"
+            - name: Typescript badge
+              if: always()
+              uses: RubbaBoy/BYOB@v1.3.0
+              with:
+                  NAME: tsbadge
+                  ICON: typescript
+                  LABEL: 'TS Errors'
+                  STATUS: ${{ steps.pr-checks.outputs.ts-errors }}
+                  COLOR: blue
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This project is currently in development. Incomplete features, bugs, and breakin
 
 > This is an unsupported product. If you require a supported version please contact applicationsdecartographieweb-webmappingapplications@ec.gc.ca for a cost estimate. The software and code samples available on this website are provided "as is" without warranty of any kind, either express or implied. Use at your own risk. Access to this GitHub repository could become unavailable at any point in time.
 
+![](https://byob.yarr.is/ramp4-pcar4/ramp4-pcar4/tsbadge)
+
 ## Local development
 
 ### Project Setup

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "paths": {
             "@/*": ["./src/*"]
         },
-        "lib": ["DOM", "DOM.Iterable", "ES2020"]
+        "lib": ["DOM", "DOM.Iterable", "ES2020"],
+        "pretty": true
     },
 
     "references": [


### PR DESCRIPTION
This PR integrates a custom github action I wrote for PR status checking. Currently it only does typescript checking, the other checks will be added later. 

Since there are currently 153 errors I designed it so that it compares the difference between the head branch and the base (so 153 errors or less will pass).

There are a few config options if we want them like setting `ts-errors` to a negative value so that new PR's must reduce errors by that amount. See: https://github.com/milespetrov/status-checks#status-checks-action

Also added a status badge to the readme that shows the current number of errors.

The new status check will fail until this is merged into main.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1388)
<!-- Reviewable:end -->
