### PR TITLE
Layer name fixes

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -369,7 +369,7 @@
             "properties": {
                 "name": {
                     "type": "string",
-                    "default": "",
+                    "default": "Layer name for layer items. Undefined for section items.",
                     "description": "Title of the legend item."
                 },
                 "hidden": {

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -81,6 +81,7 @@ export class LayerItem extends LegendItem {
         this._layerId = layer.id;
         this._layerIdx = layer.layerIdx;
         this._layerUid = layer.uid;
+        this._name = this._name ?? layer.name;
         const cont = this.$iApi.geo.layer.getLayerControls(layer.id);
         if (this._layerControls.length === 0)
             this._layerControls = cont?.controls ?? [];

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -47,7 +47,7 @@ export class LegendItem extends APIScope {
         super(iApi);
 
         this._uid = geo.sharedUtils.generateUUID();
-        this._name = config.name ?? '';
+        this._name = config.name;
         this._type = config.type ?? LegendType.Placeholder;
         this._parent = parent;
         this._children = [];

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -217,6 +217,14 @@ export class AttribLayer extends CommonLayer {
                 attribs: '*' // NOTE we set to * here for generic case. loader may override later once config settings are applied
             };
             this.attLoader = new ArcServerAttributeLoader(this.$iApi, loadData);
+
+            /* See https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#title
+               In particular, if the service has several layers, then the title of each layer will be the concatenation
+               of the service name and the layer name.
+               For consistency with map image sublayers, we set the layer's name to only the service name below. */
+            if (!this.origRampConfig.name) {
+                this.name = sData.name ?? this.id;
+            }
         } else {
             this.dataFormat = DataFormat.ESRI_RASTER;
             this.esriFields = [];

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -121,9 +121,6 @@ export class FeatureLayer extends AttribLayer {
         // feature has only one layer
         this.serviceUrl = layerUrl;
 
-        this.layerTree.name = this.name;
-        this.layerTree.layerIdx = featIdx;
-
         // update asynch data
         const pLD: Promise<void> = this.loadLayerMetadata(
             hasCustRed ? { customRenderer: this.esriLayer?.renderer } : {}
@@ -162,6 +159,9 @@ export class FeatureLayer extends AttribLayer {
         });
 
         const pFC = this.loadFeatureCount();
+
+        this.layerTree.name = this.name;
+        this.layerTree.layerIdx = featIdx;
 
         // if file based (or server extent was fried), calculate extent based on geometry
         // TODO implement this. may need a manual loop to calculate graphicsExtent since ESRI torpedo'd the function

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -215,6 +215,7 @@ export class MapImageLayer extends AttribLayer {
                             // TODO: Revisit once issue #961 is implemented.
                             // See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/1045#pullrequestreview-977116071
                             layerType: LayerType.SUBLAYER,
+                            name: subConfigs[sid].name,
                             // If the state isn't defined, use the same state as the parent.
                             state: subConfigs[sid]?.state ?? {
                                 opacity: this.opacity,
@@ -371,33 +372,6 @@ export class MapImageLayer extends AttribLayer {
             }
         });
 
-        // get mapName of the legend entry from the service to use as the name if not provided in config
-        // TODO error handling on request?
-        //      consider using   import to from 'await-to-js';
-        if (!this.name) {
-            const serviceRequest = EsriRequest(this.esriLayer.url, {
-                query: {
-                    f: 'json'
-                }
-            });
-            const setTitle = serviceRequest.then(serviceResult => {
-                if (serviceResult.data) {
-                    this.name = serviceResult.data.mapName || '';
-                    // @ts-ignore
-                    this.layerTree.name = this.name;
-                } else {
-                    this.name = '[server error]';
-                    // @ts-ignore
-                    this.layerTree.name = '[server error]';
-                    console.error(
-                        // @ts-ignore
-                        `Get map name service failed: ${this.esriLayer.url}`
-                    );
-                }
-            });
-            loadPromises.push(setTitle);
-        }
-
         return loadPromises;
     }
 
@@ -500,7 +474,6 @@ export class MapImageLayer extends AttribLayer {
                 qOpts.filterGeometry = options.geometry;
             }
 
-            qOpts.outFields = sublayer.fieldList;
             qOpts.filterSql = sublayer.getCombinedSqlFilter();
 
             sublayer.queryFeaturesDiscrete(qOpts).then(results => {


### PR DESCRIPTION
Closes #1383, #1385.

### Changes
* The legend will now display the layer's name if it does not have a name defined.
* In case of missing name in config, map image sublayers and feature layers will both use the `Feature Service Name` as their `name`.
* Removed buggy/unused code from `map-image-layer.ts` file.

### Testing
Wait for #1382 to merge, then go to the basic feature layer and basic MIL samples, and witness that everything related to the layer names works well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1390)
<!-- Reviewable:end -->
