### PR TITLE
Miscellaneous Fixes & Tweaks

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -381,7 +381,7 @@ let config = {
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/1',
                     state: {
                         opacity: 1,
-                        visibility: true
+                        visibility: false
                     },
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 },
@@ -392,7 +392,7 @@ let config = {
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/2',
                     state: {
                         opacity: 1,
-                        visibility: true
+                        visibility: false
                     },
                     customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
                 }

--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -84,22 +84,22 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added                         |
 | FIXTURE_REMOVED<br>'fixture/removed'               | FixtureInstance object                                         | A fixture has been removed                       |
 | LAYER_DRAWSTATECHANGE<br>'layer/drawstatechange'   | _state_: new value, layer: LayerInstance object                | The layer draw state changed                     |
+| LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, layer: LayerInstance object      | The layer layer state changed |
+| LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange' | _state_: new value, layer: LayerInstance object                | The layer load state changed |                     |
 | LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, layer: LayerInstance object              | The layer opacity changed                        |
 | LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was added to the map                   |
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
 | LAYER_RELOAD_START<br>'layer/reloadstart'          | LayerInstance object                                           | The layer started reloading                      |
-| LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |
-| LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange'   | _state_: new value, layer: LayerInstance object                | The layer load state changed |
-| LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, layer: LayerInstance object                | The layer layer state changed                 |
+| LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |       
 | LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, layer: LayerInstance object           | The layer visibility changed                     |
 | MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | basemapId: string, schemaChanged: boolean                      | The basemap was changed                          |
-| MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                                |
 | MAP_BLUR<br>'map/blur'                             | KeyboardEvent object                                           | The map lost focus                               |
 | MAP_CLICK<br>'map/click'                           | MapClick object                                                | The map was clicked                              |
 | MAP_CREATED<br>'map/created'                       | none                                                           | The map was created                              |
 | MAP_DESTROYED<br>'map/destroyed'                   | none                                                           | The map was destroyed                            |
 | MAP_DOUBLECLICK<br>'map/doubleclick'               | MapClick object                                                | The map was double clicked                       |
 | MAP_EXTENTCHANGE<br>'map/extentchanged'            | RAMP Extent object                                             | The map extent changed                           |
+| MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                                |
 | MAP_GRAPHICHIT<br>'map/graphichit'                 | { layer, graphicHit, attributes, icon, screenPoint}            | A graphic was found where the mouse/crosshair is |
 | MAP_IDENTIFY<br>'map/identify'                     | MapIdentifyResult object                                       | A map identify was requested                     |
 | MAP_KEYDOWN<br>'map/keydown'                       | KeyboardEvent object                                           | A key was pressed                                |
@@ -110,13 +110,14 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_MOUSEMOVE_START<br>'map/mousemovestart'        | MapMove object                                                 | The mouse stopped moving over the map            |
 | MAP_REFRESH_END<br>'map/refreshend'                | none                                                           | The map view started refreshing                  |
 | MAP_REFRESH_START<br>'map/refreshstart'            | none                                                           | The map view finished refreshing                 |
+| MAP_REORDER<br>'map/reorder'                       | _newIndex_: z-index, layer: LayerInstance object               | A layer was reordered |
 | MAP_RESIZED<br>'map/resized'                       | _height_: new height, _width_: new width                       | The map view changed size                        |
 | MAP_SCALECHANGE<br>'map/scalechanged'              | scale denominator: number                                      | The map scale changed                            |
 | MAP_START<br>'map/start'                           | none                                                           | The map startup was requested                    |
-| RAMP_MOBILEVIEW_CHANGE<br>'ramp/mobile'            | mobileMode: boolean                                            | The screen changes to/from mobile resolution     |
 | PANEL_CLOSED<br>'panel/closed'                     | PanelInstance object                                           | A panel was closed                               |
-| PANEL_MINIMIZED<br>'panel/closed'                 | PanelInstance object                                           | A panel was minimized                             |
+| PANEL_MINIMIZED<br>'panel/closed'                  | PanelInstance object                                           | A panel was minimized                             |
 | PANEL_OPENED<br>'panel/opened'                     | PanelInstance object                                           | A panel was opened                               |
+| RAMP_MOBILEVIEW_CHANGE<br>'ramp/mobile'            | mobileMode: boolean                                            | The screen changes to/from mobile resolution     |
 | USER_LAYER_ADDED<br>'user/layeradded'              | LayerInstance object                                           | A layer was added during the session             |
 
 ### Core Fixture Events
@@ -131,9 +132,9 @@ TODO add stuff as we make events that core fixtures raise
 | GRID_TOGGLE<br>'grid/toggle'         | layer: LayerInstance, _open_: boolean (optional)        | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |
 | METADATA_OPEN<br>'metadata/open'     | { type: string, layerName: string, url: string, layer: LayerInstance }         | A metadata view was requested                                  |
-| REORDER_OPEN<br>'reorder/open'       | none                                                    | The reorder panel was requested                                |
-| SETTINGS_TOGGLE<br>'settings/toggle' | layer: LayerInstance                                    | Settings panel toggle was requested for a layer                |
-| WIZARD_OPEN<br>'wizard/open'         | none                                                    | A request was made to add a layer                              |
+| REORDER_TOGGLE<br>'reorder/toggle'   | boolean (optional)                                      | Layer reorder panel toggle was requested with optional force open/close |
+| SETTINGS_TOGGLE<br>'settings/toggle' | layer: LayerInstance, _open_: boolean (optional)        | Settings panel toggle was requested for a layer with optional force open/close |
+| WIZARD_TOGGLE<br>'wizard/open'       | boolean (optional)                                      | Wizard panel toggle was requested with optional force open/close |
 
 ## Default Events Handlers
 

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -98,6 +98,12 @@ export enum GlobalEvents {
     LAYER_INITIATIONSTATECHANGE = 'layer/initiationStatechange',
 
     /**
+     * Fires when the load state of a layer changes.
+     * Payload: `({ layer: LayerInstance, state: string })`
+     */
+    LAYER_LAYERSTATECHANGE = 'layer/layerstatechange',
+
+    /**
      * Fires when the opacity of a layer changes.
      * Payload: `({ layer: LayerInstance, opacity: number })`
      */
@@ -128,12 +134,6 @@ export enum GlobalEvents {
     LAYER_REMOVE = 'layer/remove',
 
     /**
-     * Fires when the load state of a layer changes.
-     * Payload: `({ layer: LayerInstance, state: string })`
-     */
-    LAYER_LAYERSTATECHANGE = 'layer/layerstatechange',
-
-    /**
      * Fires when the visibility of a layer changes.
      * Payload: `({ layer: LayerInstance, visibility: boolean })`
      */
@@ -144,12 +144,6 @@ export enum GlobalEvents {
      * Payload: `({ basemapId: string, schemaChanged: boolean })`
      */
     MAP_BASEMAPCHANGE = 'map/basemapchanged',
-
-    /**
-     * Fires when the map gains focus.
-     * Payload: `(params: KeyboardEvent)` (DOM Event)
-     */
-    MAP_FOCUS = 'map/focus',
 
     /**
      * Fires when the map loses focus.
@@ -186,6 +180,12 @@ export enum GlobalEvents {
      * Payload: `(extent: Extent)`
      */
     MAP_EXTENTCHANGE = 'map/extentchanged',
+
+    /**
+     * Fires when the map gains focus.
+     * Payload: `(params: KeyboardEvent)` (DOM Event)
+     */
+    MAP_FOCUS = 'map/focus',
 
     /**
      * Fires when the mouse enters the graphic of a vector layer symbol.
@@ -278,12 +278,6 @@ export enum GlobalEvents {
     METADATA_OPEN = 'metadata/open',
 
     /**
-     * Fires when screen size changes from/to mobile resolution.
-     * Payload `(mobileMode: boolean)`
-     */
-    RAMP_MOBILEVIEW_CHANGE = 'ramp/mobileviewchange',
-
-    /**
      * Fires when a panel is closed.
      * Payload: `(panel: PanelInstance)`
      */
@@ -302,6 +296,12 @@ export enum GlobalEvents {
     PANEL_OPENED = 'panel/opened',
 
     /**
+     * Fires when screen size changes from/to mobile resolution.
+     * Payload `(mobileMode: boolean)`
+     */
+    RAMP_MOBILEVIEW_CHANGE = 'ramp/mobileviewchange',
+
+    /**
      * Fires when a request is issued to toggle (open/close) the Layer Reorder panel.
      * Payload: none
      */
@@ -309,7 +309,7 @@ export enum GlobalEvents {
 
     /**
      * Fires when a request is issued to toggle (show if hidden, hide if showing) layer settings.
-     * Payload: `(uid: string)`
+     * Payload: `(uid: string, force?: boolean)`
      */
     SETTINGS_TOGGLE = 'settings/toggle',
 
@@ -336,36 +336,36 @@ export enum GlobalEvents {
 enum DefEH {
     APPBAR_ADDS_PANEL_BUTTON = 'appbar_adds_panel_button',
     APPBAR_REMOVES_PANEL_BUTTON = 'appbar_removes_panel_button',
+    CONFIG_CHANGE_ATTRIBUTION = 'updates_map_caption_attribution_config',
+    DETAILS_REMOVES_LAYER = 'details_removes_layer',
+    EXTENT_CHANGE_MAPTIP_CHECK = 'checks_maptip_extent_change',
+    GRID_REMOVES_LAYER_GRID = 'grid_removes_layer_grid',
     IDENTIFY_DETAILS = 'ramp_identify_opens_details',
+    LEGEND_RELOADS_LAYER_ENTRY = 'legend_reloads_layer_entry',
+    LEGEND_REMOVES_LAYER_ENTRY = 'legend_removes_layer_entry',
+    MAP_BASEMAPCHANGE_ATTRIBUTION = 'updates_map_caption_attribution_basemap',
+    MAP_BLUR = 'ramp_map_blur',
+    MAP_CREATED_ATTRIBUTION = 'updates_map_caption_attribution_map_created',
     MAP_IDENTIFY = 'ramp_map_click_runs_identify',
     MAP_KEYDOWN = 'ramp_map_keydown',
     MAP_KEYUP = 'ramp_map_keyup',
-    MAP_BLUR = 'ramp_map_blur',
-    TOGGLE_SETTINGS = 'ramp_settings_toggles_panel',
-    OPEN_DETAILS = 'opens_feature_details',
-    TOGGLE_HELP = 'toggles_help_panel',
-    TOGGLE_GRID = 'toggles_grid_panel',
-    TOGGLE_WIZARD = 'toggles_wizard_panel',
-    TOGGLE_LAYER_REORDER = 'toggles_layer_reorder_panel',
-    OPEN_METADATA = 'opens_metadata_panel',
-    UPDATE_LEGEND_LAYER_REGISTER = 'updates_legend_layer_register',
-    UPDATE_LEGEND_LAYER_ERROR = 'updates_legend_layer_error',
-    UPDATE_LEGEND_WIZARD_ADDED = 'updates_legend_wizard_added',
-    UPDATE_LEGEND_LAYER_RELOAD = 'updates_legend_layer_reload',
-    MAP_BASEMAPCHANGE_ATTRIBUTION = 'updates_map_caption_attribution_basemap',
-    CONFIG_CHANGE_ATTRIBUTION = 'updates_map_caption_attribution_config',
-    MAP_CREATED_ATTRIBUTION = 'updates_map_caption_attribution_map_created',
     MAP_RESIZED_SCALEBAR = 'resizes_map_caption_scale',
     MAP_SCALECHANGE_SCALEBAR = 'updates_map_caption_scale',
-    MOUSE_MOVE_MAPTIP_CHECK = 'checks_maptip_mouse_move',
-    EXTENT_CHANGE_MAPTIP_CHECK = 'checks_maptip_extent_change',
-    SHOW_DEFAULT_MAPTIP = 'show_default_maptip',
-    MAP_UPDATE_MOUSE_COORDS = 'updates_map_mouse_coords',
     MAP_UPDATE_CROSSHAIRS_COORDS = 'updates_map_crosshairs_coords',
-    LEGEND_REMOVES_LAYER_ENTRY = 'legend_removes_layer_entry',
-    LEGEND_RELOADS_LAYER_ENTRY = 'legend_reloads_layer_entry',
-    GRID_REMOVES_LAYER_GRID = 'grid_removes_layer_grid',
-    DETAILS_REMOVES_LAYER = 'details_removes_layer'
+    MAP_UPDATE_MOUSE_COORDS = 'updates_map_mouse_coords',
+    MOUSE_MOVE_MAPTIP_CHECK = 'checks_maptip_mouse_move',
+    OPEN_DETAILS = 'opens_feature_details',
+    OPEN_METADATA = 'opens_metadata_panel',
+    SHOW_DEFAULT_MAPTIP = 'show_default_maptip',
+    TOGGLE_GRID = 'toggles_grid_panel',
+    TOGGLE_HELP = 'toggles_help_panel',
+    TOGGLE_LAYER_REORDER = 'toggles_layer_reorder_panel',
+    TOGGLE_SETTINGS = 'ramp_settings_toggles_panel',
+    TOGGLE_WIZARD = 'toggles_wizard_panel',
+    UPDATE_LEGEND_LAYER_ERROR = 'updates_legend_layer_error',
+    UPDATE_LEGEND_LAYER_REGISTER = 'updates_legend_layer_register',
+    UPDATE_LEGEND_LAYER_RELOAD = 'updates_legend_layer_reload',
+    UPDATE_LEGEND_WIZARD_ADDED = 'updates_legend_wizard_added'
 }
 
 // private for EventBus internals, so don't export
@@ -615,36 +615,36 @@ export class EventAPI extends APIScope {
             eventHandlerNames = [
                 DefEH.APPBAR_ADDS_PANEL_BUTTON,
                 DefEH.APPBAR_REMOVES_PANEL_BUTTON,
+                DefEH.CONFIG_CHANGE_ATTRIBUTION,
+                DefEH.DETAILS_REMOVES_LAYER,
+                DefEH.EXTENT_CHANGE_MAPTIP_CHECK,
+                DefEH.GRID_REMOVES_LAYER_GRID,
+                DefEH.IDENTIFY_DETAILS,
+                DefEH.LEGEND_RELOADS_LAYER_ENTRY,
+                DefEH.LEGEND_REMOVES_LAYER_ENTRY,
+                DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION,
+                DefEH.MAP_BLUR,
+                DefEH.MAP_CREATED_ATTRIBUTION,
                 DefEH.MAP_IDENTIFY,
                 DefEH.MAP_KEYDOWN,
                 DefEH.MAP_KEYUP,
-                DefEH.MAP_BLUR,
-                DefEH.IDENTIFY_DETAILS,
-                DefEH.TOGGLE_SETTINGS,
-                DefEH.OPEN_DETAILS,
-                DefEH.TOGGLE_HELP,
-                DefEH.TOGGLE_GRID,
-                DefEH.TOGGLE_WIZARD,
-                DefEH.TOGGLE_LAYER_REORDER,
-                DefEH.OPEN_METADATA,
-                DefEH.UPDATE_LEGEND_LAYER_REGISTER,
-                DefEH.UPDATE_LEGEND_LAYER_ERROR,
-                DefEH.UPDATE_LEGEND_WIZARD_ADDED,
-                DefEH.UPDATE_LEGEND_LAYER_RELOAD,
-                DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION,
-                DefEH.CONFIG_CHANGE_ATTRIBUTION,
-                DefEH.MAP_CREATED_ATTRIBUTION,
                 DefEH.MAP_RESIZED_SCALEBAR,
                 DefEH.MAP_SCALECHANGE_SCALEBAR,
-                DefEH.MOUSE_MOVE_MAPTIP_CHECK,
-                DefEH.EXTENT_CHANGE_MAPTIP_CHECK,
-                DefEH.SHOW_DEFAULT_MAPTIP,
-                DefEH.MAP_UPDATE_MOUSE_COORDS,
                 DefEH.MAP_UPDATE_CROSSHAIRS_COORDS,
-                DefEH.LEGEND_REMOVES_LAYER_ENTRY,
-                DefEH.LEGEND_RELOADS_LAYER_ENTRY,
-                DefEH.GRID_REMOVES_LAYER_GRID,
-                DefEH.DETAILS_REMOVES_LAYER
+                DefEH.MAP_UPDATE_MOUSE_COORDS,
+                DefEH.MOUSE_MOVE_MAPTIP_CHECK,
+                DefEH.OPEN_DETAILS,
+                DefEH.OPEN_METADATA,
+                DefEH.SHOW_DEFAULT_MAPTIP,
+                DefEH.TOGGLE_GRID,
+                DefEH.TOGGLE_HELP,
+                DefEH.TOGGLE_LAYER_REORDER,
+                DefEH.TOGGLE_SETTINGS,
+                DefEH.TOGGLE_WIZARD,
+                DefEH.UPDATE_LEGEND_LAYER_ERROR,
+                DefEH.UPDATE_LEGEND_LAYER_REGISTER,
+                DefEH.UPDATE_LEGEND_LAYER_RELOAD,
+                DefEH.UPDATE_LEGEND_WIZARD_ADDED
             ];
         }
 
@@ -695,250 +695,6 @@ export class EventAPI extends APIScope {
                 };
                 this.on(GlobalEvents.PANEL_CLOSED, zeHandler, handlerName);
                 break;
-            case DefEH.MAP_IDENTIFY:
-                // when map clicks, run the identify action
-                zeHandler = (clickParam: MapClick) => {
-                    if (clickParam.button === 0) {
-                        this.$iApi.geo.map.runIdentify(clickParam);
-                    }
-                };
-                this.on(GlobalEvents.MAP_CLICK, zeHandler, handlerName);
-                break;
-            case DefEH.IDENTIFY_DETAILS:
-                // when identify runs, open details fixture and show the results
-                zeHandler = (identifyParam: any) => {
-                    const detailFix =
-                        this.$iApi.fixture.get<DetailsAPI>('details');
-                    if (detailFix) {
-                        detailFix.openDetails(identifyParam.results);
-                    }
-                };
-                this.on(GlobalEvents.MAP_IDENTIFY, zeHandler, handlerName);
-                break;
-            case DefEH.TOGGLE_SETTINGS:
-                // opens or closes the settings panel and hooks it up to the requested layer.
-                zeHandler = (layer: LayerInstance) => {
-                    const settingsFixture =
-                        this.$iApi.fixture.get<SettingsAPI>('settings');
-                    if (settingsFixture) {
-                        settingsFixture.toggleSettings(layer);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.SETTINGS_TOGGLE,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.OPEN_DETAILS:
-                // opens the standard details panel when a show details event happens
-                zeHandler = (payload: {
-                    data: any;
-                    uid: string;
-                    format: string;
-                }) => {
-                    const detailsFixture =
-                        this.$iApi.fixture.get<DetailsAPI>('details');
-                    if (detailsFixture) {
-                        detailsFixture.openFeature(payload);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.DETAILS_OPEN,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.TOGGLE_HELP:
-                // opens or closes the standard help panel when a toggle help event happens
-                zeHandler = (payload?: boolean) => {
-                    const helpFixture = this.$iApi.fixture.get<HelpAPI>('help');
-                    if (helpFixture) {
-                        helpFixture.toggleHelp(payload);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.HELP_TOGGLE,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.TOGGLE_GRID:
-                // opens or closes the standard grid panel when a toggle grid event happens
-                zeHandler = (layer: LayerInstance, open?: boolean) => {
-                    const gridFixture = this.$iApi.fixture.get<GridAPI>('grid');
-                    if (gridFixture) {
-                        gridFixture.toggleGrid(layer.uid, open);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.GRID_TOGGLE,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.TOGGLE_WIZARD:
-                // opens or closes the standard add layer wizard panel when an toggle wizard event happens
-                zeHandler = () => {
-                    const wizardFixture =
-                        this.$iApi.fixture.get<WizardAPI>('wizard');
-                    if (wizardFixture) {
-                        wizardFixture.toggleWizard();
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.WIZARD_TOGGLE,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.TOGGLE_LAYER_REORDER:
-                // opens or closes the standard layer reorder panel when a toggle reorder event happens
-                zeHandler = () => {
-                    const reorderFixture =
-                        this.$iApi.fixture.get<LayerReorderAPI>(
-                            'layer-reorder'
-                        );
-                    if (reorderFixture) {
-                        reorderFixture.toggleLayerReorder();
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.REORDER_TOGGLE,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.OPEN_METADATA:
-                // opens the standard metadata panel when an open metadata event happens
-                zeHandler = (payload: MetadataPayload) => {
-                    const metadataFixture =
-                        this.$iApi.fixture.get<MetadataAPI>('metadata');
-                    if (metadataFixture) {
-                        metadataFixture.toggleMetadata(payload);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.METADATA_OPEN,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.UPDATE_LEGEND_LAYER_REGISTER:
-                // when a layer is registered, have the standard legend update in accordance to the layer
-                zeHandler = (layer: LayerInstance) => {
-                    const legendFixture =
-                        this.$iApi.fixture.get<LegendAPI>('legend');
-                    if (legendFixture) {
-                        legendFixture.updateLegend(layer);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.LAYER_REGISTERED,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.UPDATE_LEGEND_LAYER_ERROR:
-                // when a layer errors, have the standard legend update in accordance to the layer
-                zeHandler = (payload: {
-                    state: String;
-                    layer: LayerInstance;
-                }) => {
-                    if (payload.layer.layerState === LayerState.ERROR) {
-                        const legendFixture: LegendAPI =
-                            this.$iApi.fixture.get('legend');
-                        if (legendFixture) {
-                            legendFixture.updateLegend(payload.layer);
-                        }
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.LAYER_LAYERSTATECHANGE,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.UPDATE_LEGEND_WIZARD_ADDED:
-                // when a layer is user-added, have the standard legend create a new stock entry for the layer
-                zeHandler = (layer: LayerInstance) => {
-                    const legendFixture =
-                        this.$iApi.fixture.get<LegendAPI>('legend');
-                    if (legendFixture) {
-                        legendFixture.addLayerItem(layer);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.USER_LAYER_ADDED,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.UPDATE_LEGEND_LAYER_RELOAD:
-                // when a layer is reloaded, have the standard legend update in accordance to the layer
-                zeHandler = (layer: LayerInstance) => {
-                    const legendFixture =
-                        this.$iApi.fixture.get<LegendAPI>('legend');
-                    if (legendFixture) {
-                        legendFixture.updateLegend(layer);
-                    }
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.LAYER_RELOAD_END,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.MAP_KEYDOWN:
-                // processes keyboard interaction from the map view
-                zeHandler = (payload: KeyboardEvent) => {
-                    this.$iApi.geo.map.mapKeyDown(payload);
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.MAP_KEYDOWN,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.MAP_KEYUP:
-                // processes keyboard interaction from the map view
-                zeHandler = (payload: KeyboardEvent) => {
-                    this.$iApi.geo.map.mapKeyUp(payload);
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.MAP_KEYUP,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.MAP_BLUR:
-                // processes loss of focus from the map view
-                zeHandler = (payload: KeyboardEvent) => {
-                    this.$iApi.geo.map.stopKeyPan();
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.MAP_BLUR,
-                    zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION:
-                // update any basemap attribution in the map caption when the basemap changes
-                zeHandler = () => {
-                    this.$iApi.geo.map.caption.updateAttribution(
-                        (
-                            this.$iApi.$vApp.$store.get(
-                                ConfigStore.getActiveBasemapConfig
-                            ) as RampBasemapConfig
-                        )?.attribution
-                    );
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.MAP_BASEMAPCHANGE,
-                    zeHandler,
-                    handlerName
-                );
-                break;
             case DefEH.CONFIG_CHANGE_ATTRIBUTION:
                 // update any basemap attribution in the map caption when the config changes (likely langauge switch)
                 zeHandler = (payload: RampConfig) => {
@@ -959,56 +715,20 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
-            case DefEH.MAP_CREATED_ATTRIBUTION:
-                // update any basemap attribution in the map caption when the map is created
-                zeHandler = () => {
-                    this.$iApi.geo.map.caption.updateAttribution(
-                        (
-                            this.$iApi.$vApp.$store.get(
-                                ConfigStore.getActiveBasemapConfig
-                            ) as RampBasemapConfig
-                        )?.attribution
-                    );
+            case DefEH.DETAILS_REMOVES_LAYER:
+                // when a layer is removed, remove it from the details payload
+                zeHandler = (layer: LayerInstance) => {
+                    if (this.$iApi.fixture.get<DetailsAPI>('details')) {
+                        // remove the layer from the payload results
+                        this.$iApi.$vApp.$store.set(
+                            DetailsStore.removeLayer,
+                            layer
+                        )!;
+                    }
                 };
-                // update basemap attribution if map was created before adding event handler
-                if (this.$iApi.geo.map.created) zeHandler();
                 this.$iApi.event.on(
-                    GlobalEvents.MAP_CREATED,
+                    GlobalEvents.LAYER_REMOVE,
                     zeHandler,
-                    handlerName
-                );
-                break;
-            case DefEH.MAP_RESIZED_SCALEBAR:
-                // update the map scale caption when the window is resized
-                this.$iApi.event.on(
-                    GlobalEvents.MAP_RESIZED,
-                    debounce(100, () =>
-                        this.$iApi.geo.map.caption.updateScale()
-                    ),
-                    handlerName
-                );
-                break;
-            case DefEH.MAP_SCALECHANGE_SCALEBAR:
-                // update the map scale caption when the map scale changes
-                this.$iApi.event.on(
-                    GlobalEvents.MAP_SCALECHANGE,
-                    debounce(300, () =>
-                        this.$iApi.geo.map.caption.updateScale()
-                    ),
-                    handlerName
-                );
-                break;
-            case DefEH.MOUSE_MOVE_MAPTIP_CHECK:
-                // update any maptip state when the mouse moves over the map
-                zeHandler = (mapMove: MapMove) => {
-                    this.$iApi.geo.map.maptip.checkAtCoord({
-                        screenX: mapMove.screenX,
-                        screenY: mapMove.screenY
-                    });
-                };
-                this.$iApi.event.on(
-                    GlobalEvents.MAP_MOUSEMOVE,
-                    throttle(200, (mapMove: MapMove) => zeHandler(mapMove)),
                     handlerName
                 );
                 break;
@@ -1033,47 +753,175 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
-            case DefEH.SHOW_DEFAULT_MAPTIP:
-                // show a maptip in default format when the mouse goes over a vector feature
-                zeHandler = (tooltipInfo: any) => {
-                    this.$iApi.geo.map.maptip.generateDefaultMaptip(
-                        tooltipInfo
-                    );
+            case DefEH.GRID_REMOVES_LAYER_GRID:
+                // when a layer is removed, close the standard grid if open for that layer
+                zeHandler = (layer: LayerInstance) => {
+                    if (this.$iApi.fixture.get<GridAPI>('grid')) {
+                        // remove cached grid state for layer from grid store
+                        this.$vApp.$store.dispatch(
+                            `grid/${GridAction.removeGrid}`,
+                            layer.uid
+                        );
+                        // close grid panel if open or minimized with removed layer
+                        const currentUid = this.$vApp.$store.get(
+                            GridStore.currentUid
+                        );
+                        if (layer.uid === currentUid) {
+                            const panel = this.$iApi.panel.get('grid');
+                            if (panel.isOpen) {
+                                this.$iApi.panel.close(panel);
+                            }
+                            this.$vApp.$store.set(GridStore.currentUid, null);
+                        }
+                    }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.MAP_GRAPHICHIT,
+                    GlobalEvents.LAYER_REMOVE,
                     zeHandler,
                     handlerName
                 );
                 break;
-            case DefEH.MAP_UPDATE_MOUSE_COORDS:
-                // update the co-ordinate caption when the mouse moves over the map
+            case DefEH.IDENTIFY_DETAILS:
+                // when identify runs, open details fixture and show the results
+                zeHandler = (identifyParam: any) => {
+                    const detailFix =
+                        this.$iApi.fixture.get<DetailsAPI>('details');
+                    if (detailFix) {
+                        detailFix.openDetails(identifyParam.results);
+                    }
+                };
+                this.on(GlobalEvents.MAP_IDENTIFY, zeHandler, handlerName);
+                break;
+            case DefEH.LEGEND_RELOADS_LAYER_ENTRY:
+                // when a layer starts to reload, reset any entries in the standard legend to a loading state
+                zeHandler = (layer: LayerInstance) => {
+                    const legendApi =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
+                    if (legendApi) {
+                        legendApi.reloadLayerItem(layer.uid);
+                    }
+                };
                 this.$iApi.event.on(
-                    GlobalEvents.MAP_MOUSEMOVE,
-                    throttle(200, (mapMove: MapMove) => {
-                        // check if coords are disabled
-                        // if it is, then do not update it
-                        const currentCursorCoords: MapCoords | undefined =
-                            this.$iApi.$vApp.$store.get(MapCaptionStore.coords);
-                        if (currentCursorCoords?.disabled) {
-                            return;
-                        }
-
-                        this.$iApi.geo.map.caption
-                            .formatPoint(
-                                this.$iApi.geo.map.screenPointToMapPoint(
-                                    mapMove
-                                )
-                            )
-                            .then(fs => {
-                                this.$iApi.$vApp.$store.set(
-                                    MapCaptionStore.setCoords,
-                                    {
-                                        formattedString: fs
-                                    }
-                                );
-                            });
-                    }),
+                    GlobalEvents.LAYER_RELOAD_START,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.LEGEND_REMOVES_LAYER_ENTRY:
+                // when a layer is removed from the map, remove any bound entries from the standard legend
+                zeHandler = (layer: LayerInstance) => {
+                    const legendApi =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
+                    if (legendApi) {
+                        legendApi.removeLayerItem(layer);
+                        this.$iApi.updateAlert(
+                            this.$vApp.$t('legend.alert.layerRemoved', {
+                                name: layer.name
+                            })
+                        );
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.LAYER_REMOVE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_BASEMAPCHANGE_ATTRIBUTION:
+                // update any basemap attribution in the map caption when the basemap changes
+                zeHandler = () => {
+                    this.$iApi.geo.map.caption.updateAttribution(
+                        (
+                            this.$iApi.$vApp.$store.get(
+                                ConfigStore.getActiveBasemapConfig
+                            ) as RampBasemapConfig
+                        )?.attribution
+                    );
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_BASEMAPCHANGE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_BLUR:
+                // processes loss of focus from the map view
+                zeHandler = (payload: KeyboardEvent) => {
+                    this.$iApi.geo.map.stopKeyPan();
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_BLUR,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_CREATED_ATTRIBUTION:
+                // update any basemap attribution in the map caption when the map is created
+                zeHandler = () => {
+                    this.$iApi.geo.map.caption.updateAttribution(
+                        (
+                            this.$iApi.$vApp.$store.get(
+                                ConfigStore.getActiveBasemapConfig
+                            ) as RampBasemapConfig
+                        )?.attribution
+                    );
+                };
+                // update basemap attribution if map was created before adding event handler
+                if (this.$iApi.geo.map.created) zeHandler();
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_CREATED,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_IDENTIFY:
+                // when map clicks, run the identify action
+                zeHandler = (clickParam: MapClick) => {
+                    if (clickParam.button === 0) {
+                        this.$iApi.geo.map.runIdentify(clickParam);
+                    }
+                };
+                this.on(GlobalEvents.MAP_CLICK, zeHandler, handlerName);
+                break;
+            case DefEH.MAP_KEYDOWN:
+                // processes keyboard interaction from the map view
+                zeHandler = (payload: KeyboardEvent) => {
+                    this.$iApi.geo.map.mapKeyDown(payload);
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_KEYDOWN,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_KEYUP:
+                // processes keyboard interaction from the map view
+                zeHandler = (payload: KeyboardEvent) => {
+                    this.$iApi.geo.map.mapKeyUp(payload);
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_KEYUP,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_RESIZED_SCALEBAR:
+                // update the map scale caption when the window is resized
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_RESIZED,
+                    debounce(100, () =>
+                        this.$iApi.geo.map.caption.updateScale()
+                    ),
+                    handlerName
+                );
+                break;
+            case DefEH.MAP_SCALECHANGE_SCALEBAR:
+                // update the map scale caption when the map scale changes
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_SCALECHANGE,
+                    debounce(300, () =>
+                        this.$iApi.geo.map.caption.updateScale()
+                    ),
                     handlerName
                 );
                 break;
@@ -1108,82 +956,234 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
-            case DefEH.LEGEND_REMOVES_LAYER_ENTRY:
-                // when a layer is removed from the map, remove any bound entries from the standard legend
-                zeHandler = (layer: LayerInstance) => {
-                    const legendApi =
-                        this.$iApi.fixture.get<LegendAPI>('legend');
-                    if (legendApi) {
-                        legendApi.removeLayerItem(layer);
-                        this.$iApi.updateAlert(
-                            this.$vApp.$t('legend.alert.layerRemoved', {
-                                name: layer.name
-                            })
-                        );
+            case DefEH.MAP_UPDATE_MOUSE_COORDS:
+                // update the co-ordinate caption when the mouse moves over the map
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_MOUSEMOVE,
+                    throttle(200, (mapMove: MapMove) => {
+                        // check if coords are disabled
+                        // if it is, then do not update it
+                        const currentCursorCoords: MapCoords | undefined =
+                            this.$iApi.$vApp.$store.get(MapCaptionStore.coords);
+                        if (currentCursorCoords?.disabled) {
+                            return;
+                        }
+
+                        this.$iApi.geo.map.caption
+                            .formatPoint(
+                                this.$iApi.geo.map.screenPointToMapPoint(
+                                    mapMove
+                                )
+                            )
+                            .then(fs => {
+                                this.$iApi.$vApp.$store.set(
+                                    MapCaptionStore.setCoords,
+                                    {
+                                        formattedString: fs
+                                    }
+                                );
+                            });
+                    }),
+                    handlerName
+                );
+                break;
+            case DefEH.MOUSE_MOVE_MAPTIP_CHECK:
+                // update any maptip state when the mouse moves over the map
+                zeHandler = (mapMove: MapMove) => {
+                    this.$iApi.geo.map.maptip.checkAtCoord({
+                        screenX: mapMove.screenX,
+                        screenY: mapMove.screenY
+                    });
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_MOUSEMOVE,
+                    throttle(200, (mapMove: MapMove) => zeHandler(mapMove)),
+                    handlerName
+                );
+                break;
+            case DefEH.OPEN_DETAILS:
+                // opens the standard details panel when a show details event happens
+                zeHandler = (payload: {
+                    data: any;
+                    uid: string;
+                    format: string;
+                }) => {
+                    const detailsFixture =
+                        this.$iApi.fixture.get<DetailsAPI>('details');
+                    if (detailsFixture) {
+                        detailsFixture.openFeature(payload);
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.LAYER_REMOVE,
+                    GlobalEvents.DETAILS_OPEN,
                     zeHandler,
                     handlerName
                 );
                 break;
-            case DefEH.LEGEND_RELOADS_LAYER_ENTRY:
-                // when a layer starts to reload, reset any entries in the standard legend to a loading state
-                zeHandler = (layer: LayerInstance) => {
-                    const legendApi =
-                        this.$iApi.fixture.get<LegendAPI>('legend');
-                    if (legendApi) {
-                        legendApi.reloadLayerItem(layer.uid);
+            case DefEH.OPEN_METADATA:
+                // opens the standard metadata panel when an open metadata event happens
+                zeHandler = (payload: MetadataPayload) => {
+                    const metadataFixture =
+                        this.$iApi.fixture.get<MetadataAPI>('metadata');
+                    if (metadataFixture) {
+                        metadataFixture.toggleMetadata(payload);
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.LAYER_RELOAD_START,
+                    GlobalEvents.METADATA_OPEN,
                     zeHandler,
                     handlerName
                 );
                 break;
-            case DefEH.GRID_REMOVES_LAYER_GRID:
-                // when a layer is removed, close the standard grid if open for that layer
-                zeHandler = (layer: LayerInstance) => {
-                    if (this.$iApi.fixture.get<GridAPI>('grid')) {
-                        // remove cached grid state for layer from grid store
-                        this.$vApp.$store.dispatch(
-                            `grid/${GridAction.removeGrid}`,
-                            layer.uid
+            case DefEH.SHOW_DEFAULT_MAPTIP:
+                // show a maptip in default format when the mouse goes over a vector feature
+                zeHandler = (tooltipInfo: any) => {
+                    this.$iApi.geo.map.maptip.generateDefaultMaptip(
+                        tooltipInfo
+                    );
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.MAP_GRAPHICHIT,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.TOGGLE_GRID:
+                // opens or closes the standard grid panel when a toggle grid event happens
+                zeHandler = (layer: LayerInstance, open?: boolean) => {
+                    const gridFixture = this.$iApi.fixture.get<GridAPI>('grid');
+                    if (gridFixture) {
+                        gridFixture.toggleGrid(layer.uid, open);
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.GRID_TOGGLE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.TOGGLE_HELP:
+                // opens or closes the standard help panel when a toggle help event happens
+                zeHandler = (payload?: boolean) => {
+                    const helpFixture = this.$iApi.fixture.get<HelpAPI>('help');
+                    if (helpFixture) {
+                        helpFixture.toggleHelp(payload);
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.HELP_TOGGLE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.TOGGLE_LAYER_REORDER:
+                // opens or closes the standard layer reorder panel when a toggle reorder event happens
+                zeHandler = (payload?: boolean) => {
+                    const reorderFixture =
+                        this.$iApi.fixture.get<LayerReorderAPI>(
+                            'layer-reorder'
                         );
-                        // close grid panel if open or minimized with removed layer
-                        const currentUid = this.$vApp.$store.get(
-                            GridStore.currentUid
-                        );
-                        if (layer.uid === currentUid) {
-                            const panel = this.$iApi.panel.get('grid');
-                            if (panel.isOpen) {
-                                this.$iApi.panel.close(panel);
-                            }
-                            this.$vApp.$store.set(GridStore.currentUid, null);
+                    if (reorderFixture) {
+                        reorderFixture.toggleLayerReorder(payload);
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.REORDER_TOGGLE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.TOGGLE_SETTINGS:
+                // opens or closes the settings panel and hooks it up to the requested layer.
+                zeHandler = (layer: LayerInstance, payload?: boolean) => {
+                    const settingsFixture =
+                        this.$iApi.fixture.get<SettingsAPI>('settings');
+                    if (settingsFixture) {
+                        settingsFixture.toggleSettings(layer, payload);
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.SETTINGS_TOGGLE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.TOGGLE_WIZARD:
+                // opens or closes the standard add layer wizard panel when an toggle wizard event happens
+                zeHandler = (payload?: boolean) => {
+                    const wizardFixture =
+                        this.$iApi.fixture.get<WizardAPI>('wizard');
+                    if (wizardFixture) {
+                        wizardFixture.toggleWizard(payload);
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.WIZARD_TOGGLE,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.UPDATE_LEGEND_LAYER_ERROR:
+                // when a layer errors, have the standard legend update in accordance to the layer
+                zeHandler = (payload: {
+                    state: String;
+                    layer: LayerInstance;
+                }) => {
+                    if (payload.layer.layerState === LayerState.ERROR) {
+                        const legendFixture: LegendAPI =
+                            this.$iApi.fixture.get('legend');
+                        if (legendFixture) {
+                            legendFixture.updateLegend(payload.layer);
                         }
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.LAYER_REMOVE,
+                    GlobalEvents.LAYER_LAYERSTATECHANGE,
                     zeHandler,
                     handlerName
                 );
                 break;
-            case DefEH.DETAILS_REMOVES_LAYER:
-                // when a layer is removed, remove it from the details payload
+            case DefEH.UPDATE_LEGEND_LAYER_REGISTER:
+                // when a layer is registered, have the standard legend update in accordance to the layer
                 zeHandler = (layer: LayerInstance) => {
-                    if (this.$iApi.fixture.get<DetailsAPI>('details')) {
-                        // remove the layer from the payload results
-                        this.$iApi.$vApp.$store.set(
-                            DetailsStore.removeLayer,
-                            layer
-                        )!;
+                    const legendFixture =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
+                    if (legendFixture) {
+                        legendFixture.updateLegend(layer);
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.LAYER_REMOVE,
+                    GlobalEvents.LAYER_REGISTERED,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.UPDATE_LEGEND_LAYER_RELOAD:
+                // when a layer is reloaded, have the standard legend update in accordance to the layer
+                zeHandler = (layer: LayerInstance) => {
+                    const legendFixture =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
+                    if (legendFixture) {
+                        legendFixture.updateLegend(layer);
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.LAYER_RELOAD_END,
+                    zeHandler,
+                    handlerName
+                );
+                break;
+            case DefEH.UPDATE_LEGEND_WIZARD_ADDED:
+                // when a layer is user-added, have the standard legend create a new stock entry for the layer
+                zeHandler = (layer: LayerInstance) => {
+                    const legendFixture =
+                        this.$iApi.fixture.get<LegendAPI>('legend');
+                    if (legendFixture) {
+                        legendFixture.addLayerItem(layer);
+                    }
+                };
+                this.$iApi.event.on(
+                    GlobalEvents.USER_LAYER_ADDED,
                     zeHandler,
                     handlerName
                 );

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -302,10 +302,10 @@ export enum GlobalEvents {
     PANEL_OPENED = 'panel/opened',
 
     /**
-     * Fires when a request is issued to open the Layer Reorder panel.
+     * Fires when a request is issued to toggle (open/close) the Layer Reorder panel.
      * Payload: none
      */
-    REORDER_OPEN = 'reorder/open',
+    REORDER_TOGGLE = 'reorder/toggle',
 
     /**
      * Fires when a request is issued to toggle (show if hidden, hide if showing) layer settings.
@@ -320,10 +320,10 @@ export enum GlobalEvents {
     USER_LAYER_ADDED = 'user/layeradded',
 
     /**
-     * Fires when a request is issued to open the Add Layer Wizard.
+     * Fires when a request is issued to toggle (open/close) the Add Layer Wizard panel.
      * Payload: none
      */
-    WIZARD_OPEN = 'wizard/open'
+    WIZARD_TOGGLE = 'wizard/toggle'
 }
 
 // TODO export this enum?
@@ -345,8 +345,8 @@ enum DefEH {
     OPEN_DETAILS = 'opens_feature_details',
     TOGGLE_HELP = 'toggles_help_panel',
     TOGGLE_GRID = 'toggles_grid_panel',
-    OPEN_WIZARD = 'opens_wizard_panel',
-    OPEN_LAYER_REORDER = 'opens_layer_reorder_panel',
+    TOGGLE_WIZARD = 'toggles_wizard_panel',
+    TOGGLE_LAYER_REORDER = 'toggles_layer_reorder_panel',
     OPEN_METADATA = 'opens_metadata_panel',
     UPDATE_LEGEND_LAYER_REGISTER = 'updates_legend_layer_register',
     UPDATE_LEGEND_LAYER_ERROR = 'updates_legend_layer_error',
@@ -624,8 +624,8 @@ export class EventAPI extends APIScope {
                 DefEH.OPEN_DETAILS,
                 DefEH.TOGGLE_HELP,
                 DefEH.TOGGLE_GRID,
-                DefEH.OPEN_WIZARD,
-                DefEH.OPEN_LAYER_REORDER,
+                DefEH.TOGGLE_WIZARD,
+                DefEH.TOGGLE_LAYER_REORDER,
                 DefEH.OPEN_METADATA,
                 DefEH.UPDATE_LEGEND_LAYER_REGISTER,
                 DefEH.UPDATE_LEGEND_LAYER_ERROR,
@@ -777,34 +777,34 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
-            case DefEH.OPEN_WIZARD:
-                // opens the standard add layer wizard panel when an open wizard event happens
+            case DefEH.TOGGLE_WIZARD:
+                // opens or closes the standard add layer wizard panel when an toggle wizard event happens
                 zeHandler = () => {
                     const wizardFixture =
                         this.$iApi.fixture.get<WizardAPI>('wizard');
                     if (wizardFixture) {
-                        wizardFixture.openWizard();
+                        wizardFixture.toggleWizard();
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.WIZARD_OPEN,
+                    GlobalEvents.WIZARD_TOGGLE,
                     zeHandler,
                     handlerName
                 );
                 break;
-            case DefEH.OPEN_LAYER_REORDER:
-                // opens the standard layer reorder panel when an open reorder event happens
+            case DefEH.TOGGLE_LAYER_REORDER:
+                // opens or closes the standard layer reorder panel when a toggle reorder event happens
                 zeHandler = () => {
                     const reorderFixture =
                         this.$iApi.fixture.get<LayerReorderAPI>(
                             'layer-reorder'
                         );
                     if (reorderFixture) {
-                        reorderFixture.openLayerReorder();
+                        reorderFixture.toggleLayerReorder();
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.REORDER_OPEN,
+                    GlobalEvents.REORDER_TOGGLE,
                     zeHandler,
                     handlerName
                 );

--- a/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/src/components/about-ramp/about-ramp-dropdown.vue
@@ -32,13 +32,19 @@
                         <close @click="scope.close"></close>
                     </div>
 
-                    <div>
+                    <div class="select-text">
                         <div>
-                            <span class="font-bold">{{ versionString }} </span>
-                            <span class="text-sm"> [{{ versionHash }}] </span>
+                            <span class="font-bold cursor-text">
+                                {{ versionString }}
+                            </span>
+                            <span class="text-sm cursor-text">
+                                [{{ versionHash }}]
+                            </span>
                         </div>
                         <div>
-                            <span class="text-sm"> {{ buildDate }} </span>
+                            <span class="text-sm cursor-text">
+                                {{ buildDate }}
+                            </span>
                         </div>
                         <div class="mt-5">
                             <a
@@ -104,7 +110,7 @@ export default defineComponent({
          */
         buildDate(): string {
             let timestamp = new Date(version.timestamp);
-            if (isNaN(<any>timestamp)) {
+            if (isNaN(timestamp as any)) {
                 // this appears to be broken in dev serve mode (but not always).
                 // likely the vite `git log -1 --format=%cd` command isnt working in that context
                 return 'dev mode, no date';

--- a/src/components/notification-center/caption-button.vue
+++ b/src/components/notification-center/caption-button.vue
@@ -36,7 +36,12 @@
                     <div class="absolute flex right-3 top-3">
                         <button
                             @click="clearAll"
-                            class="text-gray-500 hover:text-black p-4 mr-6"
+                            class="p-4 mr-6"
+                            :class="[
+                                !number
+                                    ? 'text-gray-300 cursor-default pointer-events-none'
+                                    : 'text-gray-500 hover:text-black'
+                            ]"
                             :content="$t('notifications.controls.clearAll')"
                             v-tippy="{
                                 placement: 'bottom',
@@ -78,7 +83,6 @@ export default defineComponent({
         'dropdown-menu': DropdownMenuV,
         'notification-list': NotificationListV
     },
-
     data() {
         return {
             number: this.get('notification/notificationNumber'),

--- a/src/components/notification-center/notification-item.vue
+++ b/src/components/notification-center/notification-item.vue
@@ -1,6 +1,6 @@
 <template>
     <li
-        class="flex-col default-focus-style px-4"
+        class="flex-col default-focus-style p-4"
         :content="
             $t(
                 open
@@ -18,16 +18,16 @@
             >
             <span class="flex-grow"></span>
             <div
-                class="mx-4 p-4 pointer-events-none"
-                :class="{ 'rotate-180': true }"
+                class="dropdown-icon p-4 pointer-events-none"
+                :class="{ 'transform -rotate-180': open }"
                 v-if="notification.messageList"
             >
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
+                    height="24"
                     viewBox="0 0 24 24"
-                    class="fill-current w-16 h-16"
+                    width="24"
                 >
-                    <path d="M0 0h24v24H0V0z" fill="none" />
                     <path
                         d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
                     />
@@ -97,4 +97,8 @@ export default defineComponent({
 });
 </script>
 
-<style lang="scss"></style>
+<style lang="scss">
+.dropdown-icon {
+    transition: transform 0.3s cubic-bezier(0.35, 0, 0.25, 1);
+}
+</style>

--- a/src/components/notification-center/screen.vue
+++ b/src/components/notification-center/screen.vue
@@ -9,7 +9,12 @@
                 <div class="w-full flex mb-6">
                     <button
                         @click="clearAll"
-                        class="text-gray-500 hover:text-black p-4 ml-auto"
+                        class="p-4 ml-auto"
+                        :class="[
+                            !number
+                                ? 'text-gray-300 cursor-default pointer-events-none'
+                                : 'text-gray-500 hover:text-black'
+                        ]"
                         :content="$t('notifications.controls.clearAll')"
                         v-tippy="{
                             placement: 'bottom',
@@ -59,6 +64,7 @@ export default defineComponent({
 
     data() {
         return {
+            number: this.get('notification/notificationNumber'),
             clearAll: this.call('notification/clearAll')
         };
     }

--- a/src/fixtures/help/api/help.ts
+++ b/src/fixtures/help/api/help.ts
@@ -11,13 +11,7 @@ export class HelpAPI extends FixtureInstance {
      */
     toggleHelp(open?: boolean) {
         const panel = this.$iApi.panel.get('help');
-        if (open === undefined) {
-            this.$iApi.panel.toggle(panel);
-        } else if (open && !panel.isOpen) {
-            this.$iApi.panel.open(panel);
-        } else if (!open && panel.isOpen) {
-            this.$iApi.panel.close(panel);
-        }
+        this.$iApi.panel.toggle(panel, open);
     }
 
     /**

--- a/src/fixtures/layer-reorder/api/layer-reorder.ts
+++ b/src/fixtures/layer-reorder/api/layer-reorder.ts
@@ -2,14 +2,13 @@ import { FixtureInstance } from '@/api';
 
 export class LayerReorderAPI extends FixtureInstance {
     /**
-     * Opens the layer reorder fixture panel
+     * Opens or closes the layer reorder fixture panel
      *
+     * @param {boolean} [open] force panel open or closed
      * @memberof LayerReorderAPI
      */
-    openLayerReorder(): void {
+    toggleLayerReorder(open?: boolean): void {
         const panel = this.$iApi.panel.get('layer-reorder');
-        if (!panel.isOpen) {
-            this.$iApi.panel.open('layer-reorder');
-        }
+        this.$iApi.panel.toggle(panel, open);
     }
 }

--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -16,9 +16,11 @@
             @keyup.enter.stop="toggleVisibility()"
             :class="[
                 isRadio ? 'form-radio' : 'form-checkbox rounded-none',
-                disabled ? 'text-gray-400 ' : 'text-black cursor-pointer'
+                disabled
+                    ? 'text-gray-400 border-gray-300'
+                    : 'text-black cursor-pointer border-gray-500 hover:border-black'
             ]"
-            class="mx-5 h-15 w-15 border-gray-500 hover:border-black"
+            class="mx-5 h-15 w-15"
             tabindex="-1"
             :disabled="disabled"
             :content="

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -2,7 +2,7 @@
     <div class="relative legend-header flex">
         <!-- open import wizard -->
         <button
-            @click="openWizard"
+            @click="toggleWizard"
             class="relative mr-auto text-gray-500 hover:text-black mb-3"
             v-show="getWizardExists() && isControlAvailable('wizard')"
             :content="$t('legend.header.addlayer')"
@@ -14,7 +14,7 @@
         </button>
         <!-- open layer reorder -->
         <button
-            @click="openLayerReorder"
+            @click="toggleLayerReorder"
             class="relative mr-auto text-gray-500 hover:text-black p-8 mb-3"
             v-show="
                 getLayerReorderExists() && isControlAvailable('layerReorder')
@@ -119,8 +119,8 @@ export default defineComponent({
     },
 
     methods: {
-        openWizard() {
-            this.$iApi.event.emit(GlobalEvents.WIZARD_OPEN);
+        toggleWizard() {
+            this.$iApi.event.emit(GlobalEvents.WIZARD_TOGGLE);
         },
         getWizardExists(): boolean {
             try {
@@ -129,8 +129,8 @@ export default defineComponent({
                 return false;
             }
         },
-        openLayerReorder() {
-            this.$iApi.event.emit(GlobalEvents.REORDER_OPEN);
+        toggleLayerReorder() {
+            this.$iApi.event.emit(GlobalEvents.REORDER_TOGGLE);
         },
         getLayerReorderExists(): boolean {
             try {

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -217,7 +217,7 @@ export class LayerItem extends LegendItem {
                     }
 
                     // override layer item visibility in favour of layer visibility
-                    this.toggleVisibility(layer.visibility);
+                    this.toggleVisibility(layer.visibility, true, true);
 
                     // event listener must be added after the layer is loaded
                     this.handlers.push(

--- a/src/fixtures/settings/api/settings.ts
+++ b/src/fixtures/settings/api/settings.ts
@@ -2,19 +2,23 @@ import { FixtureInstance, LayerInstance } from '@/api';
 export class SettingsAPI extends FixtureInstance {
     /**
      * Opens the settings panel. Passes the provided LayerInstance object to the panel.
-     * @param layer
+     *
+     * @param {LayerInstance} layer controlled layer
+     * @param {boolean} open force panel open or closed
      */
-    toggleSettings(layer: LayerInstance): void {
+    toggleSettings(layer: LayerInstance, open?: boolean): void {
         const panel = this.$iApi.panel.get('settings');
 
-        if (!panel.isOpen) {
+        // open if closed and not forced to close
+        if (!panel.isOpen && open !== false) {
             this.$iApi.panel.open({
                 id: 'settings',
                 props: { layer: layer }
             });
         } else {
             const currentUid = (panel.route.props! as any).layer.uid;
-            panel.close();
+            // close if open and not forced to open
+            if (open !== true) panel.close();
             if (currentUid !== layer.uid) {
                 // close and reopen settings panel to indicate settings for a different layer
                 setTimeout(() => {

--- a/src/fixtures/wizard/api/wizard.ts
+++ b/src/fixtures/wizard/api/wizard.ts
@@ -2,18 +2,13 @@ import { FixtureInstance } from '@/api';
 
 export class WizardAPI extends FixtureInstance {
     /**
-     * Opens the wizard fixture panel
+     * Opens or closes the wizard fixture panel
      *
      * @memberof WizardAPI
+     * @param open force panel open or closed
      */
-    openWizard(): void {
+    toggleWizard(open?: boolean): void {
         const panel = this.$iApi.panel.get('wizard');
-
-        if (!panel.isOpen) {
-            this.$iApi.panel.open({
-                id: 'wizard',
-                screen: 'wizard-screen'
-            });
-        }
+        this.$iApi.panel.toggle(panel, open);
     }
 }


### PR DESCRIPTION
 Closes #1393, #1392, #1370, #1391, #1380.

### Changes
- The wizard and reorder layer buttons in the legend are now toggle buttons
- Text in the About RAMP dropdown is selectable
- Unchecked legend items with locked visibility now have a lighter checkbox border to indicate that they are disabled to the user
- Notification clear all button is disabled when notification list is empty
- Notifications have slightly more padding to prevent the select box around the close icon from overflowing
- Notification group dropdown icons are correctly sized and spin when clicked

### Notes
For #1380, I didn't align the close icon for each notification with the close icon for the panel. Since they perform distinct actions I think it's unnecessary, but if people feel otherwise it the change can still be included.

### Testing
For the legend checkbox change, I modified the [main sample](https://ramp4-pcar4.github.io/ramp4-pcar4/misc-fixes/demos/index-samples.html) so that the items in 'Regular Group' demonstrate the difference in border colours

To observe the notification changes, copy/paste this snippet into your console

```
for (let i = 0; i < 5; i++)
  debugInstance.notify.show(
      'info',
      `Notification ${i + 1}: The map has been created!`
  );
let serverErrors = debugInstance.notify.addGroup('server-errors', 'error', 'Some servers seem to be having issues');
serverErrors.show('Could not connect to server A');
serverErrors.show('No response from server B in 10 seconds');
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1396)
<!-- Reviewable:end -->
