### PR TITLE
Layer visibility from server, other bug fixes

### DIFF
--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -396,6 +396,9 @@ export class LegendAPI extends FixtureInstance {
         ) => {
             const layerItem: LayerItem | undefined = this.getLayerItem(layer);
             if (error) {
+                if (layer instanceof LayerInstance) {
+                    layerItem!.layer = layer;
+                }
                 layerItem?.error();
             } else {
                 layerItem?.load(

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -186,7 +186,11 @@
                     class="flex-1 pointer-events-none"
                     v-truncate="{ externalTrigger: true }"
                 >
-                    <span>{{ legendItem.name }}</span>
+                    <span>{{
+                        legendItem.name ??
+                        legendItem?.layer?.name ??
+                        legendItem.layerId
+                    }}</span>
                 </div>
                 <div v-else class="flex-1">
                     <h3

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -78,7 +78,6 @@ export class LayerItem extends LegendItem {
         this._layerIdx = layer.layerIdx;
         this._layerUid = layer.uid;
         this._layerInitVis = layer.visibility;
-        this._name = this._name ?? layer.name;
         const cont = this.$iApi.geo.layer.getLayerControls(layer.id);
         if (this._layerControls.length === 0)
             this._layerControls = cont?.controls ?? [];
@@ -198,6 +197,7 @@ export class LayerItem extends LegendItem {
                     : this.$iApi.geo.layer.getLayer(
                           this._layerId ?? this._layerUid
                       );
+            this.layer = layer;
             this._layer
                 ?.loadPromise()
                 .then(() => {
@@ -210,7 +210,6 @@ export class LayerItem extends LegendItem {
                             `MapImageLayer has no sublayerIndex defined for layer: ${this._layerId}.`
                         );
                     } else {
-                        this.layer = layer;
                         super.load();
 
                         // override layer item visibility in favour of layer visibility

--- a/src/geo/api/utils/projection.ts
+++ b/src/geo/api/utils/projection.ts
@@ -81,7 +81,6 @@ export class ProjectionAPI {
                 epsgUrl,
                 params
             ); // TODO since this is outside of esri api, consider using the vue web request lib here
-
             restReq.then(
                 (serviceResult: __esri.RequestResponse) => {
                     if (serviceResult.data) {
@@ -196,12 +195,16 @@ export class ProjectionAPI {
 
         // function to execute a lookup & store result if success
         const doLookup = async (epsgStr: string): Promise<boolean> => {
-            const def = await this.epsgLookup(epsgStr);
-            if (def === null || def === '') {
+            try {
+                const def = await this.epsgLookup(epsgStr);
+                if (def === null || def === '') {
+                    return false;
+                }
+                proj4.defs(epsgStr, def);
+                return true;
+            } catch (e) {
                 return false;
             }
-            proj4.defs(epsgStr, def);
-            return true;
         };
 
         // check the latestWkid first, if it exists (as that wkid is usally the EPSG friendly one)

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -136,6 +136,7 @@ export class AttribLayer extends CommonLayer {
         this.extent = sData.extent
             ? Extent.fromArcServer(sData.extent, this.id + '_extent')
             : undefined;
+        this._serverVisibility = sData.defaultVisibility;
 
         if (sData.type === 'Feature Layer') {
             this.supportsFeatures = true;

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -131,6 +131,12 @@ export class FeatureLayer extends AttribLayer {
                 );
             }
 
+            // apply server visibility in case of missing visibility in config
+            this.visibility =
+                this.origRampConfig?.state?.visibility ??
+                this._serverVisibility ??
+                true;
+
             // apply any config based overrides to the data we just downloaded
             this.nameField =
                 this.origRampConfig.nameField || this.nameField || '';

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -222,7 +222,7 @@ export class MapImageLayer extends AttribLayer {
                             // TODO: Revisit once issue #961 is implemented.
                             // See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/1045#pullrequestreview-977116071
                             layerType: LayerType.SUBLAYER,
-                            name: subConfigs[sid].name,
+                            name: subConfigs[sid]?.name,
                             // If the state isn't defined, use the same state as the parent.
                             state: subConfigs[sid]?.state ?? {
                                 opacity: this.opacity,
@@ -339,6 +339,7 @@ export class MapImageLayer extends AttribLayer {
                     if (subC) {
                         miSL.visibility =
                             subC.state?.visibility ??
+                            miSL._serverVisibility ??
                             this.origState.visibility ??
                             true;
                         miSL.opacity =


### PR DESCRIPTION
Closes #1384, #1394, #1407.

### Changes
* Feature Layers and Map Image Layers will now use visibility from the server if one is not specified in the config.
* Layer will now update to error state in the legend if projection checking fails. To test this change, go to sample 15 (Basic Map with Feature Layers), where I have added a layer that fails projection checking. **Note**: Unfortunately, this will have to be tested locally as the projection check works fine on GitHub.
* Fixed a bug where legend would not display layer name when in error state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1418)
<!-- Reviewable:end -->
