### PR TITLE
Autolegend demo - ⛔ No Pulling ⛔ 

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -399,6 +399,7 @@ let config = {
             ],
             fixtures: {
                 legend: {
+                    type: 'auto',
                     root: {
                         children: [
                             {

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -199,21 +199,11 @@ export class LayerItem extends LegendItem {
             this._layer
                 ?.loadPromise()
                 .then(() => {
-                    if (
-                        this._layer?.layerType === LayerType.MAPIMAGE &&
-                        !this._layerIdx
-                    ) {
-                        this.error();
-                        console.error(
-                            `MapImageLayer has no sublayerIndex defined for layer: ${this._layerId}.`
-                        );
-                    } else {
-                        this.layer = layer;
-                        super.load();
-                        if (!layer.visibility) {
-                            // if the layer is invisible, set all child symbols to invisible
-                            this.setSymbologyVisibility(undefined, false);
-                        }
+                    this.layer = layer;
+                    super.load();
+                    if (!layer.visibility) {
+                        // if the layer is invisible, set all child symbols to invisible
+                        this.setSymbologyVisibility(undefined, false);
                     }
 
                     // override layer item visibility in favour of layer visibility

--- a/src/fixtures/legend/store/legend-state.ts
+++ b/src/fixtures/legend/store/legend-state.ts
@@ -8,8 +8,7 @@ export class LegendState {
 }
 
 export interface LegendConfig {
-    isOpen: boolean;
-    isPinned: boolean;
+    type: string;
     root: { name: string; children: Array<any> };
     headerControls: Array<string>;
     panelWidth: PanelWidthObject | number;

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -222,7 +222,7 @@ export class MapImageLayer extends AttribLayer {
                             // TODO: Revisit once issue #961 is implemented.
                             // See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/1045#pullrequestreview-977116071
                             layerType: LayerType.SUBLAYER,
-                            name: subConfigs[sid].name,
+                            name: subConfigs[sid]?.name,
                             // If the state isn't defined, use the same state as the parent.
                             state: subConfigs[sid]?.state ?? {
                                 opacity: this.opacity,


### PR DESCRIPTION
For discussion #1182.

This is a quick and dirty demo of the autolegend. In the config, specifying the legend's type as "auto" will ignore the rest of the config and generate the autolegend. 

This implementation takes the simple route of parsing each layer one by one in the same legend API (no new fancy autolegend fixture). 

Go to the [default sample](https://ramp4-pcar4.github.io/ramp4-pcar4/autolegend/demos/index-samples.html) and witness the legend in auto mode.

Feedback, suggestions for improvements, etc. are welcome.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1420)
<!-- Reviewable:end -->
