### PR TITLE
Projection API, `expectedDrawTime` default from 4 to 10 seconds

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -688,7 +688,7 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 4000,
+                    "default": 10000,
                     "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
@@ -759,7 +759,7 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 4000,
+                    "default": 10000,
                     "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
@@ -831,7 +831,7 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 4000,
+                    "default": 10000,
                     "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
@@ -1026,7 +1026,7 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 4000,
+                    "default": 10000,
                     "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
@@ -1142,7 +1142,7 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 4000,
+                    "default": 10000,
                     "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
@@ -1253,7 +1253,7 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 4000,
+                    "default": 10000,
                     "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {
@@ -1361,7 +1361,7 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 4000,
+                    "default": 10000,
                     "description": "The time span after which a 'slow-to-draw' notification is shown for any drawing layer."
                 },
                 "expectedResponseTime": {

--- a/src/geo/api/utils/projection.ts
+++ b/src/geo/api/utils/projection.ts
@@ -59,6 +59,16 @@ export class ProjectionAPI {
         }
     }
 
+    /**
+     * Add a projection definition.
+     * @param {number | string} code the projection code to add.
+     * @param {string} proj4formula the formula for the projection.
+     */
+    addProjection(code: number | string, proj4formula: string) {
+        code = typeof code === 'number' ? `EPSG:${code}` : code;
+        proj4.defs(code, proj4formula);
+    }
+
     // default for lazyness. uses official epsg website, hardcoded for extra style points.
     private defaultEpsgLookup(code: string | number): Promise<string> {
         const urnRegex = /urn:ogc:def:crs:EPSG::(\d+)/;

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -86,7 +86,7 @@ export class CommonLayer extends LayerInstance {
         this.layerType = LayerType.UNKNOWN;
         this.layerFormat = LayerFormat.UNKNOWN;
         this._drawOrder = [];
-        this.expectedTime.draw = rampConfig.expectedDrawTime ?? 4000;
+        this.expectedTime.draw = rampConfig.expectedDrawTime ?? 10000;
         this.expectedTime.load = rampConfig.expectedResponseTime ?? 4000;
         this.timers = {
             draw: undefined,


### PR DESCRIPTION
Closes #1411. Basically what the title says.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1421)
<!-- Reviewable:end -->
