### PR TITLE
Legend item in error state fixes

### DIFF
--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -137,8 +137,7 @@ export class LegendAPI extends FixtureInstance {
                 layerId: layer.id,
                 sublayerIndex:
                     layer.layerIdx !== -1 ? layer.layerIdx : undefined,
-                name: layer.name,
-                visibility: layer.visibility
+                name: layer.name
             },
             parent,
             layer
@@ -396,8 +395,8 @@ export class LegendAPI extends FixtureInstance {
         ) => {
             const layerItem: LayerItem | undefined = this.getLayerItem(layer);
             if (error) {
-                if (layer instanceof LayerInstance) {
-                    layerItem!.layer = layer;
+                if (layerItem && layer instanceof LayerInstance) {
+                    layerItem.layer = layer;
                 }
                 layerItem?.error();
             } else {

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -48,6 +48,7 @@
                                   : 'legend.group.expand'
                           )
                         : legendItem instanceof LayerItem &&
+                          legendItem.type === LegendType.Item &&
                           controlAvailable('datatable') &&
                           getDatagridExists()
                         ? $t('legend.layer.data')
@@ -62,7 +63,7 @@
             >
                 <!-- smiley face. very important that we migrate this -->
                 <div
-                    class="flex mr-10"
+                    class="flex ml-3 mr-10"
                     v-if="legendItem.type !== LegendType.Item"
                 >
                     <svg
@@ -188,8 +189,9 @@
                 >
                     <span>{{
                         legendItem.name ??
-                        legendItem?.layer?.name ??
-                        legendItem.layerId
+                        (!legendItem.layer || legendItem?.layer?.name === ''
+                            ? legendItem.layerId
+                            : legendItem.layer?.name)
                     }}</span>
                 </div>
                 <div v-else class="flex-1">
@@ -228,6 +230,15 @@
                         :class="{
                             disabled: !controlAvailable(`reload`)
                         }"
+                        :content="
+                            controlAvailable('reload')
+                                ? $t('legend.layer.controls.reload')
+                                : ''
+                        "
+                        v-tippy="{
+                            placement: 'top-start'
+                        }"
+                        @mouseover.stop
                         @click.stop="reloadLayer"
                     >
                         <div class="flex p-8">
@@ -572,7 +583,7 @@ export default defineComponent({
                     // catch error if reload fails
                     this.legendItem.loadPromise.catch(() => {
                         console.error(
-                            'Failed to reload layer - ',
+                            'Failed to reload layer -',
                             this.legendItem.name
                         );
                     });

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -77,13 +77,7 @@ export class LayerItem extends LegendItem {
         this._layerId = layer.id;
         this._layerIdx = layer.layerIdx;
         this._layerUid = layer.uid;
-        this._layerInitVis = layer.visibility;
-        const cont = this.$iApi.geo.layer.getLayerControls(layer.id);
-        if (this._layerControls.length === 0)
-            this._layerControls = cont?.controls ?? [];
-        if (this._layerDisabledControls.length === 0)
-            this._layerDisabledControls = cont?.disabledControls ?? [];
-        //TODO may change this for when you enable a control that shouldnt be enabled (i.e metadata)
+        this.updateLayerControls();
     }
 
     get layerRedrawing(): boolean {
@@ -210,6 +204,7 @@ export class LayerItem extends LegendItem {
                             `MapImageLayer has no sublayerIndex defined for layer: ${this._layerId}.`
                         );
                     } else {
+                        this._layerInitVis = layer.visibility;
                         super.load();
 
                         // override layer item visibility in favour of layer visibility
@@ -243,6 +238,11 @@ export class LayerItem extends LegendItem {
         }
     }
 
+    error(): void {
+        this.updateLayerControls();
+        super.error();
+    }
+
     /**
      * Check if a control is available for the layer item.
      *
@@ -253,5 +253,16 @@ export class LayerItem extends LegendItem {
         return this._layerDisabledControls?.includes(control)
             ? false
             : this._layerControls?.includes(control);
+    }
+
+    // Update layer controls and disabled controls for this layer item.
+    updateLayerControls() {
+        const cont =
+            this.$iApi.geo.layer.getLayerControls(this.layerId) ??
+            this.$iApi.geo.layer.getLayerControls(this.parentLayerId ?? '');
+        if (this._layerControls.length === 0)
+            this._layerControls = cont?.controls ?? [];
+        if (this._layerDisabledControls.length === 0)
+            this._layerDisabledControls = cont?.disabledControls ?? [];
     }
 }

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -244,12 +244,8 @@ export class LegendItem extends APIScope {
         } else if (this.parent?.exclusive) {
             // toggle not visible if item is part of a exclusive set with another item's visibility already toggled on
             const siblingVisible = this.parent.children.some(
-                item =>
-                    item.visibility &&
-                    item.type === LegendType.Item &&
-                    item !== this
+                item => item.visibility && item !== this
             );
-
             if (siblingVisible) {
                 this.toggleVisibility(false, false);
             }
@@ -276,13 +272,13 @@ export class LegendItem extends APIScope {
                 this._visibleChildren = this.children.filter(
                     item => item.visibility
                 );
-                if (this instanceof LayerItem) {
+                if (this instanceof LayerItem && this.layer) {
                     this.layer.visibility = true;
                 }
             } else {
                 this._visibility = false;
                 this._visibleChildren = [];
-                if (this instanceof LayerItem) {
+                if (this instanceof LayerItem && this.layer) {
                     this.layer.visibility = false;
                 }
             }
@@ -295,7 +291,7 @@ export class LegendItem extends APIScope {
             });
             this._lastVisible = toggledChild;
             this._visibility = true;
-            if (this instanceof LayerItem) {
+            if (this instanceof LayerItem && this.layer) {
                 this.layer.visibility = true;
             }
         } else {
@@ -303,7 +299,10 @@ export class LegendItem extends APIScope {
             // if this causes all items in the exclusive set to be off, we first attempt to find an item that should have been on
             // and we turn that item on
             // if our search is unsuccessful and all items in the set are off, turn the parent off
-            if (!this.children.some(child => child.visibility)) {
+            if (
+                this.visibility &&
+                !this.children.some(child => child.visibility)
+            ) {
                 const onChild = this.children.find(
                     child =>
                         child instanceof LayerItem &&
@@ -315,7 +314,7 @@ export class LegendItem extends APIScope {
                     this._lastVisible = onChild;
                 } else {
                     this._visibility = false;
-                    if (this instanceof LayerItem) {
+                    if (this instanceof LayerItem && this.layer) {
                         this.layer.visibility = false;
                     }
                     this._lastVisible = toggledChild;
@@ -390,5 +389,6 @@ export class LegendItem extends APIScope {
     error() {
         this._type = LegendType.Error;
         this._loadPromise.rejectMe();
+        this.checkVisibilityRules();
     }
 }

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -384,6 +384,8 @@ export class CommonLayer extends LayerInstance {
                 id: this.id
             })
         );
+        this.stopTimer(TimerType.DRAW);
+        this.stopTimer(TimerType.LOAD);
     }
 
     // performs setup on the layer that needs to occur after the esri layer

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -136,7 +136,11 @@ export class LayerAPI extends APIScope {
           }
         | undefined {
         // fetch the layer first since given layerId can be layer id or uid
-        const layer: LayerInstance | undefined = this.getLayer(layerId);
+        const layer: LayerInstance | undefined =
+            this.getLayer(layerId) ??
+            this.allErrorLayers().find(
+                layer => layer.id === layerId || layer.uid === layerId
+            );
         if (!layer) {
             return;
         }

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -337,10 +337,18 @@ export class MapImageLayer extends AttribLayer {
                     // apply any updates that were in the configuration snippets
                     const subC = subConfigs[miSL.layerIdx];
                     if (subC) {
+                        // Sublayer visibility is normally checked (and set) in the following order:
+                        // sublayer config -> server -> parent config -> true.
+                        // First value in the order that is defined is taken as the sublayer's visibility.
+                        // However, if parent vis is set to false on config, we prioritize parent config over server vis.
+                        // The order in that case is sublayer config -> parent config -> server -> true.
                         miSL.visibility =
                             subC.state?.visibility ??
-                            miSL._serverVisibility ??
-                            this.origState.visibility ??
+                            (this.origState.visibility
+                                ? miSL._serverVisibility ??
+                                  this.origState.visibility
+                                : this.origState.visibility ??
+                                  miSL._serverVisibility) ??
                             true;
                         miSL.opacity =
                             subC.state?.opacity ?? this.origState.opacity ?? 1;


### PR DESCRIPTION
Closes #1417, #1428, #1431.

The following bugs were fixed for layers/legend items in an error state:
* Fixed the 'show data' tooltip sometimes appearing on hover.
* Added tooltip to reload button.
* Fixed alignment of sad face to better align with symbology toggle.
* Fixed the reload button being incorrectly disabled even when the reload control was available.
* Fixed the longer-than-expected draw timer always triggering the notification alert on layer error.
* Fixed disrespectful visibility behaviour for legend items in error state.
* Fixed `addLayerItem` trying to configure `visibility` and then getting yelled at by the console.
* [Edit] Fixed a bug from the server visibility PR where MIL sublayers disrespected `false` setting on parent config.
* [Edit] Fixed a bug where file layers would start off as invisible.

To test these changes, go to [sample 1](https://ramp4-pcar4.github.io/ramp4-pcar4/issue1417/demos/index-samples.html?sample=1), where I have temporarily made a layer error. Ensure all behaviour is respectful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1424)
<!-- Reviewable:end -->
