### PR TITLE
Support layer extent override from config

### DIFF
--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -133,9 +133,11 @@ export class AttribLayer extends CommonLayer {
         this.scaleSet.minScale = sData.effectiveMinScale || sData.minScale;
         this.scaleSet.maxScale = sData.effectiveMaxScale || sData.maxScale;
         this.supportsFeatures = false; // saves us from having to keep comparing type to 'Feature Layer' on the client
-        this.extent = sData.extent
-            ? Extent.fromArcServer(sData.extent, this.id + '_extent')
-            : undefined;
+        this.extent =
+            this.extent ??
+            (sData.extent
+                ? Extent.fromArcServer(sData.extent, this.id + '_extent')
+                : undefined);
         this._serverVisibility = sData.defaultVisibility;
 
         if (sData.type === 'Feature Layer') {

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -104,6 +104,9 @@ export class CommonLayer extends LayerInstance {
         this.supportsSublayers = false; // by default layers do not support sublayers
         this._serverVisibility = undefined;
         this.isFile = false; // default state.
+        this.extent = rampConfig.extent
+            ? Extent.fromConfig(`${this.id}_extent`, rampConfig.extent)
+            : undefined;
         this.layerState = LayerState.NEW;
         this.initiationState = InitiationState.NEW;
         this.drawState = DrawState.NOT_LOADED;
@@ -402,16 +405,6 @@ export class CommonLayer extends LayerInstance {
             this.identify =
                 this.config.state?.identify ?? this.supportsIdentify;
         }
-
-        // TODO implement extent defaulting. Need to add property, get appropriate format from incoming ramp config, maybe need an interface
-        /*
-        if (!this.extent) {
-            // no extent from config. attempt layer extent
-            this.extent = this.esriLayer.fullExtent;
-        }
-
-        this.extent = shared.makeSafeExtent(this.extent);
-        */
 
         // layer base class doesnt have spatial ref, but we will assume all our layers do.
         // consider adding fancy checks if its missing, and if so just promise.resolve

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -433,7 +433,8 @@ export class FileLayer extends AttribLayer {
         this.scaleSet.maxScale = l.maxScale || 0;
 
         // ESRI API appears to calculate the extent correctly. Well done!
-        this.extent = Extent.fromESRI(l.fullExtent, this.id + '_extent');
+        this.extent =
+            this.extent ?? Extent.fromESRI(l.fullExtent, this.id + '_extent');
 
         this.esriFields = markRaw(l.fields.slice());
         this.fields = this.esriFields.map(f => {

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -161,10 +161,9 @@ export class MapImageLayer extends AttribLayer {
         this.isDynamic =
             this.esriLayer.capabilities.exportMap.supportsDynamicLayers;
 
-        this.extent = Extent.fromESRI(
-            this.esriLayer.fullExtent,
-            this.id + '_extent'
-        );
+        this.extent =
+            this.extent ??
+            Extent.fromESRI(this.esriLayer.fullExtent, this.id + '_extent');
 
         const findSublayer = (targetIndex: number): __esri.Sublayer => {
             const finder = this.esriLayer?.allSublayers.find(s => {
@@ -219,6 +218,7 @@ export class MapImageLayer extends AttribLayer {
                 if (!this._sublayers[sid]) {
                     this._sublayers[sid] = new MapImageSublayer(
                         {
+                            id: `${this.id}-${sid}`,
                             // TODO: Revisit once issue #961 is implemented.
                             // See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/1045#pullrequestreview-977116071
                             layerType: LayerType.SUBLAYER,
@@ -230,6 +230,7 @@ export class MapImageLayer extends AttribLayer {
                                 hovertips: this.hovertips,
                                 identify: this.identify
                             },
+                            extent: subConfigs[sid]?.extent,
                             controls: subConfigs[sid]?.controls,
                             disabledControls: subConfigs[sid]?.disabledControls,
                             initialFilteredQuery:

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -25,7 +25,6 @@ export class MapImageSublayer extends AttribLayer {
         this.isSublayer = true;
         this.layerIdx = layerIdx;
         this.parentLayer = parent;
-        this.id = `${parent.id}-${layerIdx}`;
 
         this.dataFormat = DataFormat.ESRI_FEATURE; // this will get flipped to raster during the server metadata checks if needed
         this.tooltipField = '';


### PR DESCRIPTION
Closes #1404, #1405.

The layer extent can now be defined via the config. 

As a demo, I have temporarily added a silly extent to the `Nature` layer in [sample 16](https://ramp4-pcar4.github.io/ramp4-pcar4/issue1404/demos/index-samples.html?sample=16). Try clicking on 'Zoom to Layer Boundary' from the legend and you will (hopefully) end up staring at Australia. 

If we feel it is important enough and want to have a permanent sample showing off layer extents, let me know and I will add one in. I also removed the commented RAMP2 code in `common-layer.ts` mentioned in the issue seeing as each layer type does its own defaulting. Let me know if this needs to be added back as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1425)
<!-- Reviewable:end -->
