### PR TITLE
Small legend enhancements

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -414,7 +414,9 @@ let config = {
                                     {
                                         layerId: 'ReleasesDisposals',
                                         name: 'Releases and Disposals by Mining Facilities',
-                                        disabledLayerControls: ['boundaryZoom']
+                                        disabledLayerControls: ['boundaryZoom'],
+                                        description:
+                                            'Symbology description for releases and disposals by mining facilities'
                                     }
                                 ]
                             },

--- a/schema.json
+++ b/schema.json
@@ -343,7 +343,7 @@
                 "description": {
                     "type": "string",
                     "default": "",
-                    "description": "Optional description displayed above the symbology stack on mouse hover."
+                    "description": "Optional description displayed above the symbology stack when it is expanded."
                 },
                 "symbologyStack": {
                     "$ref": "#/$defs/symbologyStack"

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -619,11 +619,6 @@ function legendEntryUpgrader(r2legendEntry: any) {
             `entryId property defined in legend entry ${r2legendEntry.layerId} cannot be mapped and will be skipped.`
         );
     }
-    if (r2legendEntry.description) {
-        console.warn(
-            `description property defined in legend entry ${r2legendEntry.layerId} is currently not supported.`
-        );
-    }
     if (r2legendEntry.symbologyStack) {
         console.warn(
             `symbologyStack property defined in legend entry ${r2legendEntry.layerId} is currently not supported.`

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -83,20 +83,17 @@ export class LegendAPI extends FixtureInstance {
 
         // construct children
         if (children) {
-            children
-                .filter((childConf: any) => !childConf.hidden)
-                .forEach((childConf: any) => {
-                    // pass the layer fixture config to child items
-                    if (itemConf.layerLegendConfigs !== undefined) {
-                        childConf.layerLegendConfigs =
-                            itemConf.layerLegendConfigs;
-                    }
+            children.forEach((childConf: any) => {
+                // pass the layer fixture config to child items
+                if (itemConf.layerLegendConfigs !== undefined) {
+                    childConf.layerLegendConfigs = itemConf.layerLegendConfigs;
+                }
 
-                    // ts ignoring below because returned item is "LegendItem", but accepted type is "LayerItem | SectionItem"
-                    // which is the same thing! (╯°□°）╯︵ ┻━┻
-                    //@ts-ignore
-                    item!.children.push(this.createItem(childConf, item));
-                });
+                // ts ignoring below because returned item is "LegendItem", but accepted type is "LayerItem | SectionItem"
+                // which is the same thing! (╯°□°）╯︵ ┻━┻
+                //@ts-ignore
+                item!.children.push(this.createItem(childConf, item));
+            });
         }
 
         return item!;

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -163,10 +163,7 @@
 
                 <!-- dropdown icon -->
                 <div
-                    v-if="
-                        legendItem.children.length > 0 &&
-                        controlAvailable('expandButton')
-                    "
+                    v-if="isGroup && controlAvailable('expandButton')"
                     class="expand-toggle mr-5 pointer-events-none"
                     :class="{ 'rotate-180': legendItem.expanded }"
                 >
@@ -302,6 +299,15 @@
         >
             <div v-if="symbologyStack.length > 0">
                 <!-- display each symbol -->
+                <p
+                    v-if="
+                        legendItem instanceof LayerItem &&
+                        legendItem.description
+                    "
+                    class="m-5"
+                >
+                    {{ legendItem.description }}
+                </p>
                 <div class="m-5" v-for="item in symbologyStack" :key="item.uid">
                     <!-- for WMS layers -->
                     <div

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -110,6 +110,22 @@ export class LayerItem extends LegendItem {
     }
 
     /**
+     * Returns a legend config representation of this item.
+     */
+    getConfig() {
+        const config: any = {
+            layerId: this._layerId,
+            sublayerIndex: this._layerIdx,
+            layerControls: this._layerControls,
+            disabledLayerControls: this._layerDisabledControls,
+            symbologyExpanded: this._symbologyExpanded,
+            coverIcon: this._coverIcon,
+            description: this._description
+        };
+        return { ...super.getConfig(), ...config };
+    }
+
+    /**
      * Toggle visibility state of a layer item. Needs to verify parent visibility is updated.
      * @param {boolean} visibility set legend item to visible/not visible if given, otherwise toggle
      * @param {boolean} updateParent whether or not toggleVisibility should 'bubble-up' the legend tree

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -333,9 +333,12 @@ export class LegendItem extends APIScope {
      */
     getConfig(): any {
         const config: any = {
-            uid: this.uid,
-            name: this.name,
-            itemType: this.type
+            name: this._name,
+            hidden: this._hidden,
+            expanded: this._expanded,
+            exclusive: this._exclusive,
+            controls: this._controls,
+            disabledControls: this._disabledControls
         };
 
         const childConfigs: Array<any> = [];

--- a/src/fixtures/legend/store/section-item.ts
+++ b/src/fixtures/legend/store/section-item.ts
@@ -54,4 +54,15 @@ export class SectionItem extends LegendItem {
     set content(content: string) {
         this._content = content;
     }
+
+    /**
+     * Returns a legend config representation of this item.
+     */
+    getConfig() {
+        const config: any = {
+            infoType: this._infoType,
+            content: this._content
+        };
+        return { ...super.getConfig(), ...config };
+    }
 }


### PR DESCRIPTION
### Changes
* Implemented description above symbology stack. Toggle the "Releases and Disposals..." layer's symbology on [sample 1](https://ramp4-pcar4.github.io/ramp4-pcar4/small-legend-enhancements/demos/index-samples?sample=1.html) to see an example.
* Improved `getConfig()` methods in legend item classes to return proper configs for each class.
* Fixed a bug where hidden items wouldn't be added to the legend.
* ~~Fixed a weird Vue reactivity bug where when adding a MIL via the wizard, you wouldn't be able to expand/collapse the parent layer's group because the children are "added later". Removing the `isGroup()` computed property and accessing the children length property directly seemed to have fixed this bug, which is why I believe it is some sort of Vue issue. Blame Vue!~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1438)
<!-- Reviewable:end -->
