### PR TITLE
Miscellaneous fixes and improvements

### DIFF
--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -146,6 +146,10 @@ export class LegendAPI extends FixtureInstance {
         // add the layer item to store
         // will be in a placeholder state until the layer is loaded
         this._insertItem(item as unknown as LegendItem, parent);
+        // Vue reactivity stuff being annoying, maybe the store stores a copy of the object rather than a reference? Not sure.
+        // Re fetching the item from the store and then modifying seems to fix things.
+        const updatedItem = this.getLayerItem(layer);
+        updatedItem?.load(layer);
 
         if (layer.supportsSublayers) {
             // if layer supports sublayers, then we need to parse the
@@ -217,10 +221,12 @@ export class LegendAPI extends FixtureInstance {
                 .getLayerTree()
                 .children.map(childNode => treeWalker(childNode))
                 .map(childConf =>
-                    this.addItem(childConf, item as unknown as LegendItem)
+                    this.addItem(
+                        childConf,
+                        updatedItem as unknown as LegendItem
+                    )
                 );
         }
-
         return item;
     }
 

--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -2,7 +2,7 @@
     <div class="relative" @mouseover.stop>
         <!-- TODO: see if getting this to use v-model works; children wouldnt update properly on initial try -->
         <input
-            :type="isRadio ? 'radio' : 'checkbox'"
+            type="checkbox"
             :aria-label="
                 $t(
                     checked

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -35,10 +35,6 @@ export class LayerItem extends LegendItem {
         this._layerControls = config.layerControls ?? [];
         this._layerDisabledControls = config.disabledLayerControls ?? [];
         this._layerRedrawing = false;
-        if (layer) {
-            this.layer = layer;
-            this.load(layer);
-        }
         this._symbologyExpanded = config.symbologyExpanded || false;
         if (config.coverIcon) this._coverIcon = config.coverIcon;
         if (config.description) this._description = config.description;
@@ -222,12 +218,13 @@ export class LayerItem extends LegendItem {
                         this.$iApi.event.on(
                             GlobalEvents.LAYER_VISIBILITYCHANGE,
                             (updatedLayer: any) => {
-                                if (updatedLayer.layer.uid === this.layer.uid)
+                                if (updatedLayer.layer.uid === this.layer.uid) {
                                     this.toggleVisibility(
                                         updatedLayer.visibility,
                                         true,
                                         true
                                     );
+                                }
                             }
                         )
                     );

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -244,7 +244,10 @@ export class LegendItem extends APIScope {
         } else if (this.parent?.exclusive) {
             // toggle not visible if item is part of a exclusive set with another item's visibility already toggled on
             const siblingVisible = this.parent.children.some(
-                item => item.visibility && item !== this
+                item =>
+                    item.visibility &&
+                    item !== this &&
+                    item.type === LegendType.Item
             );
             if (siblingVisible) {
                 this.toggleVisibility(false, false);
@@ -308,34 +311,15 @@ export class LegendItem extends APIScope {
             }
         } else {
             // item in exclusive set is being turned off
-            // if this causes all items in the exclusive set to be off, we first attempt to find an item that should have been on
-            // and we turn that item on
-            // if our search is unsuccessful and all items in the set are off, turn the parent off
+            this._visibility = false;
             if (
-                this.visibility &&
-                !this.children.some(child => child.visibility)
+                this instanceof LayerItem &&
+                this.layer &&
+                this.layer.isLoaded
             ) {
-                const onChild = this.children.find(
-                    child =>
-                        child instanceof LayerItem &&
-                        child.layerControlAvailable(LayerControl.Visibility) &&
-                        child._layerInitVis
-                );
-                if (onChild) {
-                    onChild.toggleVisibility(true, false);
-                    this._lastVisible = onChild;
-                } else {
-                    this._visibility = false;
-                    if (
-                        this instanceof LayerItem &&
-                        this.layer &&
-                        this.layer.isLoaded
-                    ) {
-                        this.layer.visibility = false;
-                    }
-                    this._lastVisible = toggledChild;
-                }
+                this.layer.visibility = false;
             }
+            this._lastVisible = toggledChild;
         }
 
         // to update nested items


### PR DESCRIPTION
Closes #1433.
Closes #1436.
Closes #1437.

### Changes
* Child in visibility set can now be toggled off. Feel free to test out on any sample with a visibility set.
* Draw timer no longer incorrectly triggers on layer termination.
* Imported layers now have their layer items properly aligned with the settings panel for visibility toggling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1440)
<!-- Reviewable:end -->
