### PR TITLE
Layer reorder fix

### DIFF
--- a/src/fixtures/layer-reorder/definitions.ts
+++ b/src/fixtures/layer-reorder/definitions.ts
@@ -4,6 +4,7 @@ export interface LayerModel {
     uid: string;
     name: string;
     orderIdx: number;
+    componentIdx: number;
     isExpanded: boolean;
     isLoaded: boolean;
     supportsSublayers: boolean;

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -376,7 +376,7 @@
 <script lang="ts">
 import { GlobalEvents, LayerInstance } from '@/api';
 import type { LegendSymbology, RampLayerConfig } from '@/geo/api';
-import { DrawState, LayerControl, LayerState } from '@/geo/api';
+import { DrawState, LayerControl } from '@/geo/api';
 import { LayerStore } from '@/store/modules/layer';
 import to from 'await-to-js';
 import { marked } from 'marked';
@@ -558,7 +558,8 @@ export default defineComponent({
                 setTimeout(() => {
                     // call reload on layer if it exists
                     if (this.legendItem.layer !== undefined) {
-                        this.legendItem!.layer!.reload()
+                        toRaw(this.legendItem!.layer!)
+                            .reload()
                             .then(() =>
                                 this.$iApi.$vApp.$store.set(
                                     LayerStore.removeErrorLayer,
@@ -648,7 +649,6 @@ export default defineComponent({
             // load the symbology only when the layer is loaded
             this.legendItem.loadPromise.then(() => {
                 this.symbologyStack = [];
-
                 // Wait for symbology to load
                 if (!this.legendItem!.layer) {
                     // This should never happen because the layer is loaded before the legend item component is mounted
@@ -657,29 +657,6 @@ export default defineComponent({
                     );
                     return;
                 }
-
-                // watch for when layer state turns to ERROR
-                this.handlers.push(
-                    this.$iApi.event.on(
-                        GlobalEvents.LAYER_LAYERSTATECHANGE,
-                        (payload: { layer: LayerInstance; state: string }) => {
-                            // sync legend item state with layer state if errors
-                            if (
-                                payload.state === LayerState.ERROR &&
-                                payload.layer.uid ===
-                                    this.legendItem!.layer!.uid
-                            ) {
-                                this.legendItem.error();
-                            } else if (
-                                payload.state === LayerState.LOADED &&
-                                payload.layer.uid ===
-                                    this.legendItem!.layer!.uid
-                            ) {
-                                this.legendItem.checkVisibilityRules();
-                            }
-                        }
-                    )
-                );
 
                 // watch for the layer's drawstate
                 this.handlers.push(

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -1,5 +1,6 @@
 import { GlobalEvents, LayerInstance, type InstanceAPI } from '@/api';
-import { LayerControl, LayerType, type LegendSymbology } from '@/geo/api';
+import { LayerControl, LayerState, LayerType } from '@/geo/api';
+import type { LegendSymbology } from '@/geo/api';
 import { LegendItem, LegendType } from './legend-item';
 
 export class LayerItem extends LegendItem {
@@ -141,7 +142,7 @@ export class LayerItem extends LegendItem {
         super.toggleVisibility(visible, updateParent);
 
         // LayerItem additionally deals with symbology and layers
-        if (this.layer && this.layer.isLoaded) {
+        if (this.layer && this.layer.layerExists) {
             this.layer.visibility = this.visibility;
 
             // check child symobls for visibility
@@ -248,6 +249,26 @@ export class LayerItem extends LegendItem {
                 .catch(() => {
                     this.error();
                 });
+            // watch for when layer state turns to ERROR
+            /* this.handlers.push(
+                this.$iApi.event.on(
+                    GlobalEvents.LAYER_LAYERSTATECHANGE,
+                    (payload: { layer: LayerInstance; state: string }) => {
+                        // sync legend item state with layer state if errors
+                        if (
+                            payload.state === LayerState.ERROR &&
+                            payload.layer.uid === this.layer.uid
+                        ) {
+                            this.error();
+                        } else if (
+                            payload.state === LayerState.LOADED &&
+                            payload.layer.uid === this.layer.uid
+                        ) {
+                            this.load(payload.layer);
+                        }
+                    }
+                )
+            ); */
         }
     }
 

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -278,7 +278,7 @@ export class LegendItem extends APIScope {
                 if (
                     this instanceof LayerItem &&
                     this.layer &&
-                    this.layer.isLoaded
+                    this.layer.layerExists
                 ) {
                     this.layer.visibility = true;
                 }
@@ -288,7 +288,7 @@ export class LegendItem extends APIScope {
                 if (
                     this instanceof LayerItem &&
                     this.layer &&
-                    this.layer.isLoaded
+                    this.layer.layerExists
                 ) {
                     this.layer.visibility = false;
                 }
@@ -305,7 +305,7 @@ export class LegendItem extends APIScope {
             if (
                 this instanceof LayerItem &&
                 this.layer &&
-                this.layer.isLoaded
+                this.layer.layerExists
             ) {
                 this.layer.visibility = true;
             }
@@ -315,7 +315,7 @@ export class LegendItem extends APIScope {
             if (
                 this instanceof LayerItem &&
                 this.layer &&
-                this.layer.isLoaded
+                this.layer.layerExists
             ) {
                 this.layer.visibility = false;
             }

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -303,6 +303,13 @@ export class LayerInstance extends APIScope {
     }
 
     /**
+     * Indicates if the Esri map layer exists.
+     */
+    get layerExists(): boolean {
+        return false;
+    }
+
+    /**
      * Provides a tree structure describing the layer and any sublayers,
      * including uid values. Should only be called after loadPromise resolves.
      *

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -107,6 +107,13 @@ export class MapImageSublayer extends AttribLayer {
     }
 
     /**
+     * Indicates if the Esri map sublayer and the parent's Esri map layer exist.
+     */
+    get layerExists(): boolean {
+        return this.parentLayer?.esriLayer && this.esriSubLayer ? true : false;
+    }
+
+    /**
      * Returns the visibility of the sublayer.
      *
      * @function getVisibility


### PR DESCRIPTION
Closes #1416.
Closes #1447.

I went with the solution to exclude all error'd layers, and just tweaked/corrected the boundary calculation to be based on layers displayed in the component rather than layers on the map. Let me know if this is ok.

For testing, I have temporarily added an error'd layer to [sample 15](https://ramp4-pcar4.github.io/ramp4-pcar4/1416/demos/index-samples.html?sample=15). I would recommend testing there as well as in a normal case of no error'd layers (pick any other sample you like) that all layer-reorder magic is working well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1445)
<!-- Reviewable:end -->
