### PR TITLE
Add ability to cancel layer load

### DIFF
--- a/demos/starter-scripts/error-layers.js
+++ b/demos/starter-scripts/error-layers.js
@@ -726,3 +726,5 @@ rInstance.fixture.add('areas-of-interest');
 
 // load map if startRequired is true
 rInstance.start();
+
+window.debugInstance = rInstance;

--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -90,7 +90,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was added to the map                   |
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
 | LAYER_RELOAD_START<br>'layer/reloadstart'          | LayerInstance object                                           | The layer started reloading                      |
-| LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |       
+| LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |
 | LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, layer: LayerInstance object           | The layer visibility changed                     |
 | MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | basemapId: string, schemaChanged: boolean                      | The basemap was changed                          |
 | MAP_BLUR<br>'map/blur'                             | KeyboardEvent object                                           | The map lost focus                               |

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -483,6 +483,7 @@ export class LegendAPI extends FixtureInstance {
             return false;
         }
 
+        item._loadCancelled = false;
         item.reload();
         return true;
     }

--- a/src/fixtures/legend/lang/lang.csv
+++ b/src/fixtures/legend/lang/lang.csv
@@ -26,6 +26,7 @@ legend.layer.controls.settings,Settings,1,Paramètres,1
 legend.layer.controls.datatable,Datatable,1,Tableau de données,1
 legend.layer.controls.symbology,Legend,1,Légende,1
 legend.layer.controls.boundaryzoom,Zoom to Layer Boundary,1,Zoomer à la limite,1
+legend.layer.controls.cancel,Cancel,1,Annuler,1
 legend.layer.controls.remove,Remove,1,Retirer,1
 legend.layer.controls.reload,Reload,1,Recharger,1
 legend.alert.symbologyExpanded,Layer legend expanded,1,Légende de la couche développée,1

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -362,22 +362,33 @@ export class CommonLayer extends LayerInstance {
     onLoad(): void {
         // magic happens here. other layers will override onLoadActions,
         // meaning this will run the function appropriate for the layer who inherited LayerBase
+        let timedOut = false;
+        const loadTimeout = setTimeout(() => {
+            timedOut = true;
+            this.onError();
+        }, 20000); // 20 second time limit for actions to execute
         const loadPromises: Array<Promise<void>> = this.onLoadActions();
         Promise.all(loadPromises)
             .then(() => {
-                // if promise was previously not in pending status, make a new one
-                // otherwise we're trying to resolve a resolved/rejected promise
-                if (this.loadPromFulfilled) {
-                    this.loadDefProm = new DefPromise();
+                clearTimeout(loadTimeout);
+                if (!timedOut) {
+                    // if promise was previously not in pending status, make a new one
+                    // otherwise we're trying to resolve a resolved/rejected promise
+                    if (this.loadPromFulfilled) {
+                        this.loadDefProm = new DefPromise();
+                    }
+                    this.loadDefProm.resolveMe();
+                    this.loadPromFulfilled = true;
+                    this.stopTimer(TimerType.LOAD);
+                    // This will just trigger the above statements for each sublayer
+                    this.sublayers.forEach(sublayer => sublayer.onLoad());
+                    this.updateLayerState(LayerState.LOADED);
+                } else {
+                    this.visibility = false;
                 }
-                this.loadDefProm.resolveMe();
-                this.loadPromFulfilled = true;
-                this.stopTimer(TimerType.LOAD);
-                // This will just trigger the above statements for each sublayer
-                this.sublayers.forEach(sublayer => sublayer.onLoad());
-                this.updateLayerState(LayerState.LOADED);
             })
             .catch(() => {
+                clearTimeout(loadTimeout);
                 this.onError();
             });
     }

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -452,9 +452,9 @@ export class MapAPI extends CommonMapAPI {
             let timeElapsed = 0;
             // Alternative to this: use event API and watch for layer initiated and layer error events??
             const layerWatcher = setInterval(() => {
-                timeElapsed += 1000;
+                timeElapsed += 250;
                 if (
-                    timeElapsed >= 600000 ||
+                    timeElapsed >= 20000 ||
                     layer.layerState === LayerState.ERROR
                 ) {
                     clearInterval(layerWatcher);
@@ -570,7 +570,6 @@ export class MapAPI extends CommonMapAPI {
         if (!layer) {
             throw new Error('Sublayer could not be found for removal.');
         }
-
         this.$iApi.event.emit(GlobalEvents.LAYER_REMOVE, sublayer);
         layer.visibility = false; // make the sublayer invisible
         layer.isRemoved = true; // mark sublayer as removed

--- a/src/store/modules/layer/layer-store.ts
+++ b/src/store/modules/layer/layer-store.ts
@@ -5,7 +5,7 @@ import { LayerState } from './layer-state';
 import type { RootState } from '@/store';
 
 import type { RampLayerConfig } from '@/geo/api';
-import type { LayerInstance } from '@/api/internal';
+import { LayerInstance } from '@/api/internal';
 
 // TODO we have "Layer" referenced as a layer baseclass in a lot of comments. Update it to whatever is appropriate and accurate.
 
@@ -185,10 +185,12 @@ const mutations = {
         });
         state.layers = filteredLayers;
     },
-    REMOVE_ERROR_LAYER: (state: LayerState, value: LayerInstance) => {
+    REMOVE_ERROR_LAYER: (state: LayerState, value: LayerInstance | string) => {
+        const layerId = value instanceof LayerInstance ? value.id : value;
+        const layerUid = value instanceof LayerInstance ? value.uid : value;
         // copy to new array so watchers will have a reference to the old value
         const filteredLayers = state.penaltyBox.filter(layer => {
-            return layer.id !== value.id || layer.uid !== value.uid;
+            return layer.id !== layerId && layer.uid !== layerUid;
         });
         state.penaltyBox = filteredLayers;
     },


### PR DESCRIPTION
Closes #1442.

On the legend, there is now a cancel button for whenever layers are in "loading" or "error" mode. Feel free to go to sample 18 (the error sample) to test out the button. 

There are a lot of different cases, and I have tried to cover as many as I thought of (see comments in code for details), however please let me know if I missed something.

In general, pressing the cancel button will remove the layer from RAMP entirely (including its config from the config store) rather than just removing the item from the legend and keeping the layer. Do we want to keep this behaviour, or simplify things to just remove the layer item from the legend? 

If we're keeping this behaviour, there is one case in particular that is giving me a headache: A MIL has a bad URL and dies. Sublayers array will be empty. User cancels sublayer in legend. We want to remove the MIL iff all other sublayers have also been cancelled. The only way I can think of to do it is a very long-winded one, where you need to loop through the MIL's config's sublayers and check if it has an entry in the legend or not. But you could have a sublayer that's only there on the map, and was never meant to be in the legend, so this "long-winded way" doesn't work either. At the moment, for this case, I've removed the sublayer from the legend and simply left the MIL as is. Would appreciate feedback/thoughts/suggestions.

**Edit**: Removing the layer in its own class seems like disrespectful coding style. If it indeed is, feel free to suggest an alternate way to handle the removal process. Since the layer could be non existent in the store at the time of removal, I couldn't figure out a different way to access the layer (outside its class).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1453)
<!-- Reviewable:end -->
