### PR TITLE
Image support in details panel

### DIFF
--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -62,6 +62,18 @@ export default defineComponent({
                 return html;
             }
 
+            // Check to see if url is a valid image / data url based on extension type or format
+            if (
+                !!html.trim().match(/\.(jpeg|jpg|gif|png)$/) ||
+                !!html
+                    .trim()
+                    .match(
+                        /^\s*data:([a-z]+\/[a-z]+(;[a-z\-]+\=[a-z\-]+)?)?(;base64)?,[a-z0-9\!\$\&\'\,\(\)\*\+\,\;\=\-\.\_\~\:\@\/\?\%\s]*\s*$/i
+                    )
+            ) {
+                return `<img src="${html}" />`;
+            }
+
             const classes = 'underline text-blue-600 break-all';
             const div = document.createElement('div');
             div.innerHTML = html.trim();


### PR DESCRIPTION
Closes #1461.

### Changes
- The details panel will now render links as images if it detects a valid image URL or base64 encoding.

### Testing
- [This layer](https://maps-cartes.ec.gc.ca/arcgis/rest/services/CWS_SCF/PriorityPlaces/MapServer/1) contains image links in it's details panel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1466)
<!-- Reviewable:end -->
