### PR TITLE
Datagrid Accepts Negative Values

### DIFF
--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -25,6 +25,11 @@
 
         <div v-if="sortable" class="flex">
             <span
+                v-if="params.enableSorting && sort === 0"
+                class="w-24 inline-block"
+            >
+            </span>
+            <span
                 v-if="params.enableSorting && sort === 1"
                 class="customSortDownLabel"
             >

--- a/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/src/fixtures/grid/templates/custom-number-filter.vue
@@ -3,7 +3,7 @@
         <input
             class="rv-min rv-input bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
             style="width: 45%"
-            type="text"
+            type="number"
             v-model="minVal"
             @input="minValChanged()"
             @keyup.enter="
@@ -18,7 +18,7 @@
         <input
             class="rv-max rv-input bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
             style="width: 45%"
-            type="text"
+            type="number"
             v-model="maxVal"
             @input="maxValChanged()"
             @keyup.enter="


### PR DESCRIPTION
Closes #1456.

### Changes
- Datagrid filters that accept numerical values now accept negative values as well
- The sort ascending and sort descending arrows no longer resize the column header when toggled on and off

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1470)
<!-- Reviewable:end -->
