### PR TITLE
Another legend visibility bug fix

### DIFF
--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -217,10 +217,27 @@ export class LegendItem extends APIScope {
         } else {
             // for exclusive sets ensure that there is only one child item visible
             if (this.visibility) {
-                // toggle the last visible child on or by default the first child item in the set
-                this._lastVisible !== undefined
-                    ? this._lastVisible.toggleVisibility(true)
-                    : this.children[0].toggleVisibility(true);
+                // toggle the last visible child on if it is toggleable, otherwise find a toggleable child and toggle it
+                if (
+                    this._lastVisible &&
+                    (!(this._lastVisible instanceof LayerItem) ||
+                        this._lastVisible.layerControlAvailable(
+                            LayerControl.Visibility
+                        ))
+                ) {
+                    this._lastVisible.toggleVisibility(true);
+                } else {
+                    const itemToTurnOn = this.children.find(
+                        child =>
+                            !(child instanceof LayerItem) ||
+                            (
+                                child as unknown as LayerItem
+                            ).layerControlAvailable(LayerControl.Visibility)
+                    );
+                    if (itemToTurnOn) {
+                        itemToTurnOn.toggleVisibility(true);
+                    }
+                }
             } else {
                 // turn off visibility for all child items and save/update the last legend item
                 this._lastVisible = this.children.find(item => item.visibility);


### PR DESCRIPTION
Closes #1480.

In an exclusive set, turning on the last visible child can sometimes fail if the last visible child has the visibility control disabled. Now, another valid child will be turned on if the last visible one fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1482)
<!-- Reviewable:end -->
