### PR TITLE
Legend controls defaulting fix

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -332,8 +332,7 @@
                     "$ref": "#/$defs/layerControls"
                 },
                 "layerDisabledControls": {
-                    "$ref": "#/$defs/layerControls",
-                    "default": []
+                    "$ref": "#/$defs/layerControls"
                 },
                 "coverIcon": {
                     "type": "string",
@@ -435,7 +434,7 @@
         },
         "layerControls": {
             "type": "array",
-            "description": "All possible controls to be enabled/disabled on a single legend layer item.",
+            "description": "All possible controls to be enabled/disabled on a single legend layer item. Defaults to controls/disabledControls defined in layer config if missing.",
             "items": {
                 "type": "string",
                 "enum": [

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -15,8 +15,8 @@ export class LayerItem extends LegendItem {
     _coverIcon?: string;
     _description?: string;
     _symbologyExpanded: boolean;
-    _layerControls: Array<LayerControl> = [];
-    _layerDisabledControls: Array<LayerControl> = [];
+    _layerControls: Array<LayerControl> | undefined;
+    _layerDisabledControls: Array<LayerControl> | undefined;
 
     handlers: Array<string> = [];
 
@@ -33,8 +33,8 @@ export class LayerItem extends LegendItem {
         this._type = LegendType.Placeholder;
         this._layerId = config.layerId;
         this._layerIdx = config.sublayerIndex;
-        this._layerControls = config.layerControls ?? [];
-        this._layerDisabledControls = config.disabledLayerControls ?? [];
+        this._layerControls = config.layerControls;
+        this._layerDisabledControls = config.disabledLayerControls;
         this._layerRedrawing = false;
         this._symbologyExpanded = config.symbologyExpanded || false;
         if (config.coverIcon) this._coverIcon = config.coverIcon;
@@ -287,7 +287,7 @@ export class LayerItem extends LegendItem {
     layerControlAvailable(control: LayerControl): boolean {
         return this._layerDisabledControls?.includes(control)
             ? false
-            : this._layerControls?.includes(control);
+            : !!this._layerControls?.includes(control);
     }
 
     // Update layer controls and disabled controls for this layer item.
@@ -295,9 +295,8 @@ export class LayerItem extends LegendItem {
         const cont =
             this.$iApi.geo.layer.getLayerControls(this.layerId) ??
             this.$iApi.geo.layer.getLayerControls(this.parentLayerId ?? '');
-        if (this._layerControls.length === 0)
-            this._layerControls = cont?.controls ?? [];
-        if (this._layerDisabledControls.length === 0)
+        if (!this._layerControls) this._layerControls = cont?.controls ?? [];
+        if (!this._layerDisabledControls)
             this._layerDisabledControls = cont?.disabledControls ?? [];
     }
 }


### PR DESCRIPTION
Closes #1486.

Layer controls for the legend will now be fetched from the layer's config only when they are undefined in the legend's config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1487)
<!-- Reviewable:end -->
