### PR TITLE
Overview Map Improvements

### DIFF
--- a/src/fixtures/overviewmap/overviewmap.vue
+++ b/src/fixtures/overviewmap/overviewmap.vue
@@ -75,12 +75,14 @@ export default defineComponent({
     },
 
     mounted() {
-        this.$iApi.geo.map.viewPromise.then(() => {
+        this.$iApi.geo.map.viewPromise.then(async () => {
             this._adaptBasemap();
             this.overviewMap.createMap(
                 this.mapConfig,
                 this.$el.querySelector('.overviewmap') as HTMLDivElement
             );
+
+            await this.overviewMap.addMapGraphicLayer();
 
             this.minimized = this.startMinimized;
 

--- a/src/geo/api/graphic/style/colour.ts
+++ b/src/geo/api/graphic/style/colour.ts
@@ -21,7 +21,9 @@ export class Colour {
                 this.c = [0, 0, 0, 1];
                 return;
             }
-            this.c = (<Array<any>>colour).map(n => parseInt(n));
+            this.c = (<Array<any>>colour).map((n, i) =>
+                i === 3 ? n : parseInt(n)
+            );
             if (l === 3) {
                 this.c.push(1); // no opacity given. make opaque
             }


### PR DESCRIPTION
Closes #856.
Closes #1492.
Closes #1493.

### Changes
* The overview map now draws its area of view rectangle using a RAMP `GraphicLayer` instead of dropping it on the map's ESRI view.
* Added a red border to the area of view rectangle.
* Fixed a bug where multiple area of view rectangles would appear on the map sometimes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1501)
<!-- Reviewable:end -->
