### PR TITLE
More geosearch fixes

### DIFF
--- a/src/fixtures/geosearch/definitions.ts
+++ b/src/fixtures/geosearch/definitions.ts
@@ -29,11 +29,13 @@ export interface INameResponse {
 export interface ITypes {
     allTypes: IGenericObjectType;
     validTypes: IGenericObjectType;
+    typesFetched: boolean;
     filterValidTypes(exclude?: string | string[]): IGenericObjectType;
 }
 
 export interface IProvinces {
     list: IGenericObjectType;
+    listFetched: boolean;
     fsaToProvinces(fsa: string): IGenericObjectType;
 }
 

--- a/src/fixtures/geosearch/index.ts
+++ b/src/fixtures/geosearch/index.ts
@@ -10,7 +10,10 @@ class GeosearchFixture extends GeosearchAPI {
     async added() {
         console.log(`[fixture] ${this.id} added`);
 
-        this.$vApp.$store.registerModule('geosearch', geosearch(this.config));
+        this.$vApp.$store.registerModule(
+            'geosearch',
+            geosearch({ ...this.config, language: this.$iApi.language })
+        );
 
         this.$iApi.component('geosearch-nav-button', GeosearchNavButtonV);
 

--- a/src/fixtures/geosearch/loading-bar.vue
+++ b/src/fixtures/geosearch/loading-bar.vue
@@ -1,5 +1,7 @@
 <template>
-    <div class="w-full h-6 relative overflow-hidden rounded-full indeterminate">
+    <div
+        class="w-full h-6 relative overflow-hidden rounded-full indeterminate mb-14"
+    >
         <div
             class="h-full progressbar bg-blue-800 rounded-full top-0"
             aria-valuemin="0"

--- a/src/fixtures/geosearch/screen.vue
+++ b/src/fixtures/geosearch/screen.vue
@@ -8,16 +8,17 @@
                 <geosearch-top-filters></geosearch-top-filters>
                 <loading-bar
                     class="flex-none"
-                    :class="{ invisible: !loadingResults }"
+                    v-if="loadingResults"
                 ></loading-bar>
-                <div class="px-5 mb-10 truncate">
-                    <span
-                        class="relative h-48"
-                        v-if="
-                            searchVal &&
-                            searchResults.length === 0 &&
-                            !loadingResults
-                        "
+                <div
+                    class="px-8 mb-10 truncate"
+                    v-if="
+                        searchVal &&
+                        searchResults.length === 0 &&
+                        !loadingResults
+                    "
+                >
+                    <span class="relative h-48"
                         >{{ $t('geosearch.noResults')
                         }}<span class="font-bold text-blue-600"
                             >"{{ searchVal }}"</span

--- a/src/fixtures/geosearch/store/geosearch-state.ts
+++ b/src/fixtures/geosearch/store/geosearch-state.ts
@@ -13,8 +13,10 @@ export class GeosearchState {
     // param is the fixture config from config file
     constructor(geosearchConfig: any) {
         // initialize geosearch feature service that contains all key geosearch functionality - running queries, fetch initial filters, update filters, etc.
-        const language = 'en';
-        this.GSservice = new GeoSearchUI(language, geosearchConfig);
+        this.GSservice = new GeoSearchUI(
+            geosearchConfig.language,
+            geosearchConfig
+        );
         // query params contains filter types
         const queryParams: QueryParams = {
             type: '',

--- a/src/fixtures/geosearch/store/geosearch.feature.ts
+++ b/src/fixtures/geosearch/store/geosearch.feature.ts
@@ -138,7 +138,7 @@ export class GeoSearchUI {
      * @return {Object}         associated province object
      */
     findProvinceObj(province: string) {
-        return this.fetchProvinces().find((p: any) => {
+        return this.provinceList.find((p: any) => {
             return p.name === province;
         });
     }
@@ -227,59 +227,72 @@ export class GeoSearchUI {
     }
 
     /**
-     * Return a list of formatted province objects
+     * Return a promise that resolves to a list of formatted province objects
      *
-     * @return {Array} list of formatted province objects
+     * @return {Promise<Array>} a promise that resolves to a list of formatted province objects
      */
-    fetchProvinces() {
-        const provinceList = [];
-        // add a '...' option as a way to clear province filter
-        const reset = {
-            code: -1,
-            abbr: '...',
-            name: '...'
-        };
-        provinceList.push(reset);
+    fetchProvinces(): Promise<Array<any>> {
+        return new Promise(resolve => {
+            const provsWatcher = setInterval(() => {
+                if (this.config.provinces.listFetched) {
+                    clearInterval(provsWatcher);
+                    const provinceList = [];
+                    // add a '...' option as a way to clear province filter
+                    const reset = {
+                        code: -1,
+                        abbr: '...',
+                        name: '...'
+                    };
+                    provinceList.push(reset);
 
-        // obtain province filters stored in config
-        const rawProvinces = this.config.provinces.list;
-        for (const code in rawProvinces) {
-            provinceList.push({
-                code: code,
-                abbr: (<any>CODE_TO_ABBR)[code],
-                name: rawProvinces[code]
+                    // obtain province filters stored in config
+                    const rawProvinces = this.config.provinces.list;
+                    for (const code in rawProvinces) {
+                        provinceList.push({
+                            code: code,
+                            abbr: (<any>CODE_TO_ABBR)[code],
+                            name: rawProvinces[code]
+                        });
+                    }
+                    this.provinceList = provinceList;
+                    resolve(this.provinceList);
+                }
             });
-        }
-        this.provinceList = provinceList;
-        return this.provinceList;
+        });
     }
 
     /**
-     * Return a list of formatted type objects
+     * Return a promise that resolves to a list of formatted type objects
      *
-     * @return {Array} a list of a formatted type objects
+     * @return {Promise<Array>} a promise that resolves to a list of formatted type objects
      */
-    fetchTypes() {
-        const typeList = [];
-        // add a '...' option as a way to clear province filter
-        const reset = {
-            code: -1,
-            name: '...'
-        };
-        typeList.push(reset);
-
-        // obtain the type filters stored in config
-        const rawTypes = this.config.types.allTypes;
-        for (const type in rawTypes) {
-            if (!(<any>this)._excludedTypes.includes(type)) {
-                typeList.push({
-                    code: type,
-                    name: rawTypes[type]
-                });
-            }
-        }
-        this.typeList = typeList;
-        return this.typeList;
+    fetchTypes(): Promise<Array<any>> {
+        return new Promise(resolve => {
+            const typesWatcher = setInterval(() => {
+                if (this.config.types.typesFetched) {
+                    clearInterval(typesWatcher);
+                    const typeList = [];
+                    // add a '...' option as a way to clear province filter
+                    const reset = {
+                        code: -1,
+                        name: '...'
+                    };
+                    typeList.push(reset);
+                    // obtain the type filters stored in config
+                    const rawTypes = this.config.types.allTypes;
+                    for (const type in rawTypes) {
+                        if (!(<any>this)._excludedTypes.includes(type)) {
+                            typeList.push({
+                                code: type,
+                                name: rawTypes[type]
+                            });
+                        }
+                    }
+                    this.typeList = typeList;
+                    resolve(this.typeList);
+                }
+            }, 250);
+        });
     }
 }
 

--- a/src/fixtures/geosearch/store/provinces.ts
+++ b/src/fixtures/geosearch/store/provinces.ts
@@ -29,6 +29,7 @@ const provs: any = {
 
 class Provinces {
     list: IGenericObjectType = {};
+    listFetched: boolean = false;
 
     constructor(language: string, url: string) {
         axios.get(url).then((res: any) => {
@@ -40,6 +41,8 @@ class Provinces {
             Object.keys(provs[language]).forEach(provKey => {
                 this.list[provKey] = (<any>provs[language])[provKey];
             });
+
+            this.listFetched = true;
         });
     }
 

--- a/src/fixtures/geosearch/store/types.ts
+++ b/src/fixtures/geosearch/store/types.ts
@@ -21,6 +21,7 @@ class Types {
     allTypes: IGenericObjectType = {};
     validTypes: IGenericObjectType = {};
     filterComplete = false;
+    typesFetched: boolean = false;
 
     constructor(language: string, url: string) {
         const fetchTypes = axios.get(url).then((res: any) => {
@@ -35,6 +36,8 @@ class Types {
                 this.allTypes[typeKey] = (<any>types[language])[typeKey];
                 this.validTypes[typeKey] = (<any>types[language])[typeKey];
             });
+
+            this.typesFetched = true;
         });
     }
 


### PR DESCRIPTION
Closes #1508.
Closes #1513.

### Changes
* Geosearch provinces, types, query results now properly react to language switch. 
* All elements in the geosearch panel now have respectful spacing between them.

Feel free to test these changes by playing around with language switching in the geosearch bar.
Please excuse the turd quality code lol.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1516)
<!-- Reviewable:end -->
