### PR TITLE
Details open event is now toggle

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -128,7 +128,7 @@ TODO add stuff as we make events that core fixtures raise
 
 | Event Name                           | Payload                                                 | Event Announces                                                |
 | ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------- |
-| DETAILS_OPEN<br>'details/open'       | { data: any, uid: string, format: string }              | A feature's details was requested                              |
+| DETAILS_TOGGLE<br>'details/toggle'   | { data: any, uid: string, format: string }, boolean (optional)         | A feature's details panel toggle was requested with optional force open/close       |
 | GRID_TOGGLE<br>'grid/toggle'         | layer: LayerInstance, _open_: boolean (optional)        | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |
 | METADATA_OPEN<br>'metadata/open'     | { type: string, layerName: string, url: string, layer: LayerInstance }         | A metadata view was requested                                  |

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -50,10 +50,10 @@ export enum GlobalEvents {
     CONFIG_CHANGE = 'config/configchanged',
 
     /**
-     * Fires when a request is issued to show the details of an identify result.
-     * Payload: `({ identifyItem: IdentifyItem, uid: string })`
+     * Fires when a request is issued to toggle (show if hidden, hide if showing) the details of an identify result.
+     * Payload: `({ identifyItem: IdentifyItem, uid: string, format: string }, force?: boolean)`
      */
-    DETAILS_OPEN = 'details/open',
+    DETAILS_TOGGLE = 'details/toggle',
 
     /**
      * Fires when a filter is changed.
@@ -354,7 +354,7 @@ enum DefEH {
     MAP_UPDATE_CROSSHAIRS_COORDS = 'updates_map_crosshairs_coords',
     MAP_UPDATE_MOUSE_COORDS = 'updates_map_mouse_coords',
     MOUSE_MOVE_MAPTIP_CHECK = 'checks_maptip_mouse_move',
-    OPEN_DETAILS = 'opens_feature_details',
+    TOGGLE_DETAILS = 'toggles_feature_details',
     OPEN_METADATA = 'opens_metadata_panel',
     SHOW_DEFAULT_MAPTIP = 'show_default_maptip',
     TOGGLE_GRID = 'toggles_grid_panel',
@@ -633,7 +633,7 @@ export class EventAPI extends APIScope {
                 DefEH.MAP_UPDATE_CROSSHAIRS_COORDS,
                 DefEH.MAP_UPDATE_MOUSE_COORDS,
                 DefEH.MOUSE_MOVE_MAPTIP_CHECK,
-                DefEH.OPEN_DETAILS,
+                DefEH.TOGGLE_DETAILS,
                 DefEH.OPEN_METADATA,
                 DefEH.SHOW_DEFAULT_MAPTIP,
                 DefEH.TOGGLE_GRID,
@@ -1001,21 +1001,24 @@ export class EventAPI extends APIScope {
                     handlerName
                 );
                 break;
-            case DefEH.OPEN_DETAILS:
-                // opens the standard details panel when a show details event happens
-                zeHandler = (payload: {
-                    data: any;
-                    uid: string;
-                    format: string;
-                }) => {
+            case DefEH.TOGGLE_DETAILS:
+                // opens or closes the standard details panel when a toggle details event happens
+                zeHandler = (
+                    payload: {
+                        data: any;
+                        uid: string;
+                        format: string;
+                    },
+                    open?: boolean
+                ) => {
                     const detailsFixture =
                         this.$iApi.fixture.get<DetailsAPI>('details');
                     if (detailsFixture) {
-                        detailsFixture.openFeature(payload);
+                        detailsFixture.toggleFeature(payload, open);
                     }
                 };
                 this.$iApi.event.on(
-                    GlobalEvents.DETAILS_OPEN,
+                    GlobalEvents.DETAILS_TOGGLE,
                     zeHandler,
                     handlerName
                 );

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -38,20 +38,25 @@ export class DetailsAPI extends FixtureInstance {
     }
 
     /**
-     * Provided with the data for a single feature, open the details panel directly to the feature screen.
+     * Provided with the data for a single feature, toggles the details panel directly with the feature screen.
      *
      * @param {{data: any, uid: string, format: string}} featureData
+     * @param {boolean | undefined} open
      * @memberof DetailsAPI
      */
-    openFeature(featureData: { data: any; uid: string; format: string }): void {
+    toggleFeature(
+        featureData: { data: any; uid: string; format: string },
+        open: boolean | undefined
+    ): void {
         // Close the identified layers panel.
         const panel = this.$iApi.panel.get('details-layers');
         if (panel.isOpen) {
             this.$iApi.panel.close(panel);
         }
 
-        // Open or update the items panel
+        // Toggle or update the items panel
         const itemsPanel = this.$iApi.panel.get('details-items');
+
         // result: is IdentifyResult class
         const props: any = {
             result: {
@@ -68,19 +73,35 @@ export class DetailsAPI extends FixtureInstance {
                 loaded: true
             }
         };
-        if (!itemsPanel.isOpen) {
+
+        // feature ids are composed of the layer uid and feature object id
+        const prevFeatureId = this.$vApp.$store.get(
+            DetailsStore.currentFeatureId
+        );
+        const currFeatureId = `${featureData.uid}-${featureData.data.OBJECTID}`;
+        this.$vApp.$store.set(
+            DetailsStore.currentFeatureId,
+            featureData.data ? currFeatureId : null
+        );
+
+        // toggle rules based on last opened details panel
+        if (open === false) {
+            this.$iApi.panel!.close(itemsPanel);
+        } else if (!itemsPanel.isOpen) {
             // open the items panel
             this.$iApi.panel!.open({
                 id: 'details-items',
                 screen: 'item-screen',
                 props: props
             });
-        } else {
+        } else if (prevFeatureId !== currFeatureId || open === true) {
             // update the items screen
             itemsPanel!.show({
                 screen: 'item-screen',
                 props: props
             });
+        } else {
+            this.$iApi.panel!.close(itemsPanel);
         }
     }
 

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -87,6 +87,13 @@ export class DetailsState {
     defaultTemplates: { [type: string]: string } = {};
 
     /**
+     * The id of the feature that the current details panel is targeting.
+     *
+     * @memberof DetailsState
+     */
+    currentFeatureId: string | undefined = undefined;
+
+    /**
      * Indicates whether greedy mode is still loading for current identify request after 500ms delay.
      *
      * @memberof DetailsState

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -61,6 +61,10 @@ export enum DetailsStore {
      */
     defaultTemplates = 'details/defaultTemplates',
     /**
+     * (State) currentFeatureId: string | undefined
+     */
+    currentFeatureId = 'details/currentFeatureId',
+    /**
      * (State) slowLoadingFlag: boolean
      */
     slowLoadingFlag = 'details/slowLoadingFlag',

--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -79,7 +79,7 @@ export default defineComponent({
             delete data['rvSymbol'];
 
             // grid only supports esri features at the moment, so we hardcode that format
-            this.$iApi.event.emit(GlobalEvents.DETAILS_OPEN, {
+            this.$iApi.event.emit(GlobalEvents.DETAILS_TOGGLE, {
                 data: data,
                 uid: this.params.uid,
                 format: IdentifyResultFormat.ESRI


### PR DESCRIPTION
Closes #1514.

### Changes
- `DETAILS_OPEN` is now `DETAILS_TOGGLE`
- Updated docs

### Notes
- Currently, this change only affects the details button in the grid panel. I didn't enable force open so the details panel can be closed by clicking again on the same button. If we want the exact same behaviour as before (no toggle off), I can just set `open` to `true`.

### Testing
- You can observe the changes by fiddling about with the details buttons in a grid

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1519)
<!-- Reviewable:end -->
