### PR TITLE
Legend tree grow

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -118,6 +118,13 @@
                 with a customized datatable.
                 <span class="tag misc">Datatable</span>
             </li>
+            <li>
+                30.
+                <a href="index-samples.html?sample=30"
+                    >Map Image Layers with groups</a
+                >. Map image layers with groups specified in the config.
+                <span class="tag layer">Map Image Layer</span>
+            </li>
         </ul>
 
         Samples 5 to 14 to be added!.

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -74,6 +74,9 @@
                     <option value="grid-config">
                         29. Layer with configured datatable
                     </option>
+                    <option value="tree-grow">
+                        30. Map Image Layers with groups
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/tree-grow.js
+++ b/demos/starter-scripts/tree-grow.js
@@ -1,0 +1,388 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'CESI 1',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        { index: 0 },
+                        { index: 4 },
+                        { index: 9, state: { visibility: false } }
+                    ]
+                },
+                {
+                    id: 'CESI 2',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [{ index: 8 }]
+                },
+                {
+                    id: 'CESI 3',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [{ index: 21 }, { index: 35 }]
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                layerId: 'CESI 1',
+                                name: 'MIL Parent',
+                                expanded: false
+                            },
+                            {
+                                layerId: 'CESI 2',
+                                name: 'MIL Parent with extra children',
+                                expanded: false,
+                                children: [
+                                    {
+                                        infoType: 'title',
+                                        content: 'Random title above the group'
+                                    }
+                                ]
+                            },
+                            {
+                                layerId: 'CESI 3',
+                                sublayerIndex: 21,
+                                name: 'MIL group',
+                                expanded: false
+                            },
+                            {
+                                layerId: 'CESI 3',
+                                sublayerIndex: 35,
+                                name: 'MIL group that is exclusive set',
+                                expanded: false,
+                                exclusive: true
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
+                export: {
+                    title: {
+                        value: 'Enjoy this Export',
+                        selectable: false
+                    },
+                    legend: {
+                        selected: false
+                    },
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+// add export fixtures
+rInstance.fixture.add('export');
+
+// load map if startRequired is true
+// rInstance.start();
+
+window.debugInstance = rInstance;

--- a/src/fixtures/legend/store/legend-store.ts
+++ b/src/fixtures/legend/store/legend-store.ts
@@ -34,7 +34,10 @@ const mutations = {
                 return;
             }
 
-            value.parent.children = [...value.parent.children, value.item];
+            value.parent.children = [
+                ...value.parent.children,
+                value.item as LegendItem
+            ];
         }
     },
     REMOVE_ITEM: (state: LegendState, item: LegendItem) => {
@@ -66,6 +69,26 @@ const mutations = {
         };
 
         state.children = removeItem(state.children);
+    },
+    REPLACE_ITEM: (
+        state: LegendState,
+        value: { oldItem: LegendItem; newItem: LegendItem }
+    ) => {
+        if (value.oldItem.parent === undefined) {
+            const children = state.children;
+            const index = children.indexOf(value.oldItem);
+            if (index > -1) {
+                children[index] = value.newItem;
+            }
+            state.children = children;
+        } else {
+            const children = value.oldItem.parent.children;
+            const index = children.indexOf(value.oldItem);
+            if (index > -1) {
+                children[index] = value.newItem;
+            }
+            value.oldItem.parent.children = children;
+        }
     }
 };
 
@@ -80,6 +103,13 @@ const actions = {
     /** Remove legend item from store */
     removeItem: (context: LegendContext, item: LegendItem) => {
         context.commit('REMOVE_ITEM', item);
+    },
+    /** Replace legend item in store */
+    replaceItem: (
+        context: LegendContext,
+        value: { oldItem: LegendItem; newItem: LegendItem }
+    ) => {
+        context.commit('REPLACE_ITEM', value);
     }
 };
 
@@ -99,7 +129,11 @@ export enum LegendStore {
     /**
      * (Action) removeItem: (item: LegendItem)
      */
-    removeItem = 'legend/removeItem'
+    removeItem = 'legend/removeItem',
+    /**
+     * (Action) replaceItem:  (value: { oldItem: LegendItem; newItem: LegendItem })
+     */
+    replaceItem = 'legend/replaceItem'
 }
 
 export function legend() {


### PR DESCRIPTION
Related issue: #1046.
Related discussion: #1133.

The demo can be found on [sample 29](https://ramp4-pcar4.github.io/ramp4-pcar4/tree-grow/demos/index-samples?sample=29).

Note that this already works for the wizard. This PR adds this behaviour for the config.

Adding this behaviour introduced a lot of cases that I was not 100% sure how to handle. I will outline the behaviour in a Q & A format below. Feel free to suggest any changes in behaviour or other feedback below.

### Which implementation approach was chosen?

The config stays the same, so you still specify the group layer in the legend config like this:
```JS
{
      layerId: 'MapImageLayer'
      sublayerIndex: 5 // this is a group, not a sublayer
}
```
Once the layer is loaded, the legend will check whether the layer item corresponds to a group or a sublayer, and if it corresponds to a group, the layer item is replaced with a section item (a group) that has the full tree grown out in its children. The main downside to using this approach is that the tree can only be grown out once the layer is fully loaded. However, it doesn't feel like a big deal to me from a "how it looks on the UI" perspective.
The upside is that we can mainly copy over the logic from wizard tree grow, and configuring groups is no different to sublayers.

### What if I specify a sublayer and the group that its in in the layer/legend config? 

Here is an example:
```JS
{
      layerId: 'MapImageLayer'
      sublayerIndex: 5 // this is a group, not a sublayer
},
{
      layerId: 'MapImageLayer'
      sublayerIndex: 7 // this is a sublayer that is inside the group above
}
```

You will get a potato legend. There will be two layer items for index 7. One of those will load and the other one will be in loading state forever. 

I think leaving it up to the user to configure stuff properly sounds pretty good. But if we want an alternative, when adding an item to the legend, we could check if an item for the same layer already exists. 

### What happens if I add children to the MIL group in the config?

So something like this:
```JS
{
      layerId: 'MapImageLayer'
      sublayerIndex: 5 // this is a group, not a sublayer
      children: [
             {
                    infoType: 'title',
                    content: 'Random title above the group'
             }
       ]
}
```

Children added via the config will come first, followed by any children added because of tree grow. Another option is to switch the order of the children or be able to make the order configurable. 

### What about other legend config options?

All the layer item config options like cover icon, description, and layer controls and disabled controls will currently be ignored. Another possible option is to make these bubble down to the items for the sublayers so all the sublayers in the group have the same layer controls enabled/disabled in the legend. But this would look silly if adopted for something like the cover icon.

Other config options like expanded, hidden, etc. will work as normal.

### What stuff still doesn't work? 

Any sublayer config options on the layer config (besides the `index`) will not work for group layers. Example:
```JS
// layer config
{
      id: 'MapImageLayer',
      sublayers: [
            { 
                index: 4, // this corresponds to a group
                state: { visibility: false } 
            }
      ]
}
```
In the example above, the group will still start out as visible. If this behaviour is something that is working as intended, then great. If we want something like this to work, we will have to make the config options bubble down to all the sublayers since there's no layer object for group layers.

That's all I can think of for now. Will update this PR if there is anything else.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1520)
<!-- Reviewable:end -->
