### PR TITLE
Grid Column Configs

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -112,6 +112,12 @@
                 >. Layers with with a subset of their fields specified in the
                 config.
             </li>
+            <li>
+                29.
+                <a href="index-samples.html?sample=29">Grid config</a>. A layer
+                with a customized datatable.
+                <span class="tag misc">Datatable</span>
+            </li>
         </ul>
 
         Samples 5 to 14 to be added!.

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -71,6 +71,9 @@
                     <option value="exclusive-fields">
                         28. Layers with exclusive fields
                     </option>
+                    <option value="grid-config">
+                        29. Layer with configured datatable
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/grid-config.js
+++ b/demos/starter-scripts/grid-config.js
@@ -1,0 +1,209 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    }
+                ],
+                lodSets: [
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            },
+            layers: [
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#FF5555',
+                    state: {
+                        visibility: true
+                    },
+                    customRenderer: {},
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        },
+                        grid: {
+                            title: 'Datatable for WFS features',
+                            columns: [
+                                {
+                                    field: 'station_id__id_station',
+                                    title: 'Station ID',
+                                    width: 600,
+                                    filter: {
+                                        type: 'number',
+                                        value: 6020384
+                                    }
+                                },
+                                {
+                                    field: 'OBJECTID',
+                                    title: 'Object ID',
+                                    filter: {
+                                        type: 'number',
+                                        min: 3,
+                                        max: 20,
+                                        static: true
+                                    }
+                                },
+                                {
+                                    field: 'identifier__identifiant',
+                                    visible: false
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    id: 'TimeParty',
+                    layerType: 'esri-feature',
+                    fixtures: {
+                        grid: {
+                            columns: [
+                                {
+                                    field: 'ItIsPartyTime',
+                                    filter: {
+                                        type: 'date',
+                                        min: '2005-02-22'
+                                    },
+                                    sort: 'asc'
+                                },
+                                {
+                                    field: 'MyName',
+                                    filter: {
+                                        type: 'selector'
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/TimeParty/MapServer/0'
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                layerId: 'WFSLayer',
+                                name: 'WFSLayer'
+                            },
+                            {
+                                layerId: 'TimeParty',
+                                name: 'TimeParty'
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: ['legend']
+                },
+                mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] },
+                details: {
+                    templates: {
+                        esri: 'Details-Default-Template-Esri'
+                    }
+                }
+            }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: false,
+    loadDefaultEvents: true
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+rInstance.fixture
+    .addDefaultFixtures(['mapnav', 'legend', 'appbar', 'grid', 'details'])
+    .then(() => {
+        rInstance.panel.open('legend');
+    });
+
+rInstance.$element.component('Details-Default-Template-Esri', {
+    props: ['identifyData', 'fields'],
+    template: `
+        <div>
+            <div
+                class="p-5 pl-3 flex justify-end flex-wrap even:bg-green-100 border-2 border-black"
+                v-for="(val, name, itemIdx) in itemData()"
+                :key="itemIdx"
+            >
+                <span class="inline font-bold">{{ val.alias }}</span>
+                <span class="flex-auto"></span>
+                <span class="inline" v-html="val.value"></span>
+            </div>
+        </div>
+    `,
+    methods: {
+        itemData() {
+            const helper = {};
+            Object.assign(helper, this.identifyData.data);
+            if (helper.Symbol !== undefined) delete helper.Symbol;
+
+            let aliases = {};
+            this.fields.forEach(field => {
+                aliases[field.name] = field.alias || field.name;
+            });
+            Object.keys(helper).map(key => {
+                helper[key] = {
+                    value:
+                        typeof helper[key] === 'number'
+                            ? this.$iApi.$vApp.$n(helper[key], 'number')
+                            : helper[key],
+                    alias: aliases[key] || key
+                };
+            });
+
+            return helper;
+        }
+    }
+});
+
+window.debugInstance = rInstance;

--- a/docs/app/grid.md
+++ b/docs/app/grid.md
@@ -71,7 +71,7 @@ Represented by two date input fields. The date filter works in the same fashion 
 
 Like other fixtures, the grid has multiple options that can be adjusted through the configuration file. Since the grid settings are layer specific, the configuration resides in the fixtures property of layer config objects.
 - `title: string`, renders a custom title above the grid.
-- `columns: Object[]`, an array that specifies how the columns of the grid are defined. Currently not supported.
+- `columns: Object[]`, an array that specifies how the columns of the grid are defined. Its configuration is defined under [column configuration](#Column-Configuration).
 - `search: boolean`, shows/hides the [global search bar](#Global-Search).
 - `searchFilter: string`, provides an initial filter in the global search bar
 - `showFilter: boolean`, shows/hides the [column filters](#Show/Hide-Column-Filters) on grid load
@@ -90,6 +90,50 @@ const config = {
                     title: 'Datatable for this layer',
                     showFilter: false,
                     searchFilter: 'Alberta',
+                }
+            }
+        }
+    }
+}
+```
+
+### Column Configuration
+
+Every column in the datagrid can be configured separately.
+- `field: string`, a unique column identifier that aligns with attribute field name
+- `title: string`, applies a custom title to the column
+- `visible: boolean`, shows/hides the column on the grid by default
+- `width: number`, sets the width of the column
+- `sort: string`, determines the default order of the column, which can be unsorted, ascending, or descending
+- `searchable: boolean`, shows/hides the column filter
+- `filter: Object`, specifies filter values for the column
+    - `type: string`, specifies the datatype of the column (string, selector, number, date)
+    - `value: string`, specifies the default filter value for string and selector types
+    - `min: string | number`, specifies the default lower bound filter value for number and date types
+    - `max: string | number`, specifies the default upper bound filter value for number and date types
+    - `static: boolean`, enables/disables filter input
+
+An example of a datatable with a single configured column is below
+
+```text
+const config = {
+    layers: {
+        {
+            ... layer configurations
+            fixtures: {
+                grid: {
+                    columns: [
+                        {
+                            field: 'station_id__id_station',
+                            title: 'Station ID',
+                            width: 500,
+                            filter: {
+                                type: 'string',
+                                value: 6020384,
+                                static: true
+                            }
+                        }
+                    ]
                 }
             }
         }

--- a/schema.json
+++ b/schema.json
@@ -1654,15 +1654,13 @@
         "column": {
             "type": "object",
             "description": "Specifies column properties. The ordering of columns in the table header is the same as the order they appear in this array.",
-            "allOf": [
-                {
-                    "$ref": "#/$defs/fieldMetadataEntry"
-                }
-            ],
             "properties": {
+                "field": {
+                    "type": "string",
+                    "description": "Unique identifier for the column. Aligns with the layer field name."
+                },
                 "title": {
                     "type": "string",
-                    "default": "",
                     "description": "Column title, uses the layer column name or alias if missing."
                 },
                 "visible": {
@@ -1672,19 +1670,19 @@
                 },
                 "width": {
                     "type": "number",
-                    "default": 100,
-                    "description": "Specifies the column width. The minimum and default column width is set to 100px."
+                    "default": null,
+                    "description": "Specifies the column width. The default maximum column width is 400px."
                 },
                 "sort": {
                     "type": "string",
-                    "enum": ["asc", "desc"],
-                    "default": "asc",
-                    "description": "Specifies if column requires to be sorted, either in ascending or descending order."
+                    "enum": ["asc", "desc", "none"],
+                    "default": "none",
+                    "description": "Specifies if column requires to be sorted, either in ascending, descending, or no order."
                 },
                 "searchable": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Specifies if column can be filtered."
+                    "description": "Specifies if column filter is available."
                 },
                 "filter": {
                     "$ref": "#/$defs/filter"
@@ -1704,13 +1702,23 @@
                 },
                 "value": {
                     "type": "string",
+                    "default": "",
+                    "description": "Specifies the initial filter value for string or selector types."
+                },
+                "min": {
+                    "type": "string",
                     "default": null,
-                    "description": "Specifies the filter value."
+                    "description": "Specifies the initial lower bound filter value for number or date types."
+                },
+                "max": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Specifies the initial upper bound filter value for number or date types."
                 },
                 "static": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Specifies if filter is modifiable."
+                    "description": "Specifies if column filter is modifiable."
                 }
             },
             "required": ["type"],

--- a/src/fixtures/grid/store/column-state-manager.ts
+++ b/src/fixtures/grid/store/column-state-manager.ts
@@ -1,0 +1,149 @@
+/**
+ * State manager for columns in datagrid.
+ */
+export default class ColumnStateManager {
+    constructor(columnConfig: any) {
+        this.columnConfig = columnConfig;
+        this._field = columnConfig?.field;
+        this._title = columnConfig?.title;
+        this._visible = columnConfig.visible ?? true;
+        this._width = columnConfig?.width;
+        this._sort = columnConfig.sort ?? 'none';
+        this._searchable = columnConfig.searchable ?? true;
+        this._filter = {
+            type: columnConfig?.filter?.type ?? 'string',
+            value: columnConfig?.filter?.value ?? '',
+            min: columnConfig?.filter?.min ?? null,
+            max: columnConfig?.filter?.max ?? null,
+            static: columnConfig?.filter?.static ?? false
+        };
+    }
+
+    /**
+     * Returns the field of the column.
+     *
+     * @memberof ColumnStateManager
+     */
+    get field() {
+        return this._field;
+    }
+
+    /**
+     * Returns the title of the column.
+     *
+     * @memberof ColumnStateManager
+     */
+    get title() {
+        return this._title;
+    }
+
+    /**
+     * Sets the title of the column.
+     *
+     * @memberof ColumnStateManager
+     */
+    set title(val) {
+        this._title = val;
+    }
+
+    /**
+     * Returns whether column is visible.
+     *
+     * @memberof ColumnStateManager
+     */
+    get visible() {
+        return this._visible;
+    }
+
+    /**
+     * Sets column visibility.
+     *
+     * @memberof ColumnStateManager
+     */
+    set visible(val) {
+        this._visible = val;
+    }
+
+    /**
+     * Returns the column width.
+     *
+     * @memberof ColumnStateManager
+     */
+    get width() {
+        return this._width;
+    }
+
+    /**
+     * Sets the column width.
+     *
+     * @memberof ColumnStateManager
+     */
+    set width(val) {
+        this._width = val;
+    }
+
+    /**
+     * Returns whether the column is sorted.
+     *
+     * @memberof ColumnStateManager
+     */
+    get sort() {
+        return this._sort;
+    }
+
+    /**
+     * Sets the column to be sorted.
+     *
+     * @memberof ColumnStateManager
+     */
+    set sort(val) {
+        this._sort = val;
+    }
+
+    /**
+     * Returns whether the column search is currently enabled.
+     *
+     * @memberof ColumnStateManager
+     */
+    get searchable() {
+        return this._searchable;
+    }
+
+    /**
+     * Sets the column search to enabled or disabled.
+     *
+     * @memberof ColumnStateManager
+     */
+    set searchable(val) {
+        this._searchable = val;
+    }
+
+    /**
+     * Returns the filter configuration of the column.
+     *
+     * @memberof ColumnStateManager
+     */
+    get filter() {
+        return this._filter;
+    }
+
+    /**
+     * Sets the filter configuration of the column.
+     *
+     * @memberof ColumnStateManager
+     */
+    set filter(val) {
+        this._filter = val;
+    }
+}
+
+export default interface ColumnStateManager {
+    columnConfig: any;
+    _field: string;
+    _title: string;
+    _visible: boolean;
+    _width: number;
+    _sort: string;
+    _searchable: boolean;
+    _filter: any;
+}

--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -7,7 +7,7 @@
         >
             <button
                 type="button"
-                @click="onSortRequested('asc', $event)"
+                @click="onSortRequested($event)"
                 :content="$t(`grid.header.sort.${sort}`)"
                 v-tippy="{ placement: 'top', hideOnClick: false }"
                 class="customHeaderLabel hover:bg-gray-300 font-bold p-8 max-w-full"
@@ -123,6 +123,14 @@ export default defineComponent({
         this.sortable = this.params.column.colDef.sortable;
         this.columnApi = this.params.columnApi;
 
+        if (this.params.sort === 'asc') {
+            this.sort = 1;
+            this.params.setSort('asc');
+        } else if (this.params.sort === 'desc') {
+            this.sort = 2;
+            this.params.setSort('desc');
+        }
+
         this.onColumnReorder();
         // update move state when column has moved
         this.params.column.addEventListener('leftChanged', () => {
@@ -189,14 +197,14 @@ export default defineComponent({
         },
 
         // Switch between sorting the column by `ascending`, `descending` or `none`.
-        onSortRequested(order: any, event: any): void {
+        onSortRequested(event: any): void {
             this.sort = (this.sort + 1) % 3;
             if (this.sort == 1) {
                 this.params.setSort('asc', event.shiftKey);
             } else if (this.sort == 2) {
                 this.params.setSort('desc', event.shiftKey);
             } else {
-                this.params.setSort('', event.shiftKey);
+                this.params.setSort('none', event.shiftKey);
             }
         }
     }

--- a/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/src/fixtures/grid/templates/custom-number-filter.vue
@@ -2,6 +2,7 @@
     <div class="h-full flex items-center justify-center">
         <input
             class="rv-min rv-input bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
+            :class="{ 'pointer-events-none': static }"
             style="width: 45%"
             type="number"
             v-model="minVal"
@@ -17,6 +18,7 @@
         <span class="w-12" />
         <input
             class="rv-max rv-input bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
+            :class="{ 'pointer-events-none': static }"
             style="width: 45%"
             type="number"
             v-model="maxVal"
@@ -41,17 +43,22 @@ export default defineComponent({
     data() {
         return {
             minVal: '' as any,
-            maxVal: '' as any
+            maxVal: '' as any,
+            static: this.params.stateManager.columns[
+                this.params.column.colDef.field
+            ].filter.static
         };
     },
 
     beforeMount() {
         // Load previously stored values (if saved in table state manager)
-        this.minVal = this.params.stateManager.getColumnFilter(
-            this.params.column.colDef.field + ' min'
+        this.minVal = this.params.stateManager.getColumnFilterValue(
+            this.params.column.colDef.field,
+            'min'
         );
-        this.maxVal = this.params.stateManager.getColumnFilter(
-            this.params.column.colDef.field + ' max'
+        this.maxVal = this.params.stateManager.getColumnFilterValue(
+            this.params.column.colDef.field,
+            'max'
         );
 
         // Apply the default values to the column filter.
@@ -68,9 +75,10 @@ export default defineComponent({
 
                 // Save the new filter value in the state manager. Allows for quick recovery if the grid is
                 // closed and re-opened.
-                this.params.stateManager.setColumnFilter(
-                    this.params.column.colDef.field + ' min',
-                    this.minVal
+                this.params.stateManager.setColumnFilterValue(
+                    this.params.column.colDef.field,
+                    this.minVal,
+                    'min'
                 );
             });
         },
@@ -83,9 +91,10 @@ export default defineComponent({
 
                 // Save the new filter value in the state manager. Allows for quick recovery if the grid is
                 // closed and re-opened.
-                this.params.stateManager.setColumnFilter(
-                    this.params.column.colDef.field + ' max',
-                    this.maxVal
+                this.params.stateManager.setColumnFilterValue(
+                    this.params.column.colDef.field,
+                    this.maxVal,
+                    'max'
                 );
             });
         },

--- a/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -1,7 +1,8 @@
 <template>
     <div class="h-full flex items-center justify-center">
         <select
-            class="rv-input w-full bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
+            class="rv-input w-full bg-white text-black-75 h-24 py-0 px-8 border-2 rounded"
+            :class="{ 'pointer-events-none': static }"
             v-model="selectedOption"
             @change="selectionChanged()"
         >
@@ -21,13 +22,16 @@ export default defineComponent({
     data() {
         return {
             selectedOption: '' as string,
-            options: [] as Array<string>
+            options: [] as Array<string>,
+            static: this.params.stateManager.columns[
+                this.params.column.colDef.field
+            ].filter.static
         };
     },
 
     beforeMount() {
         // Load previously stored value (if saved in table state manager)
-        this.selectedOption = this.params.stateManager.getColumnFilter(
+        this.selectedOption = this.params.stateManager.getColumnFilterValue(
             this.params.column.colDef.field
         );
 
@@ -56,7 +60,6 @@ export default defineComponent({
                 if (this.selectedOption === '...') {
                     // Clear the selector filter.
                     instance.setModel(null);
-                    instance.onFilterChanged();
                     this.selectedOption = '';
                 } else {
                     // Filter by the selected option.
@@ -69,7 +72,7 @@ export default defineComponent({
 
                 // Save the new filter value in the state manager. Allows for quick recovery if the grid is
                 // closed and re-opened.
-                this.params.stateManager.setColumnFilter(
+                this.params.stateManager.setColumnFilterValue(
                     this.params.column.colDef.field,
                     this.selectedOption
                 );

--- a/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/src/fixtures/grid/templates/custom-text-filter.vue
@@ -2,6 +2,7 @@
     <div class="h-full flex items-center justify-center">
         <input
             class="rv-input w-full bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
+            :class="{ 'pointer-events-none': static }"
             type="text"
             @input="valueChanged()"
             v-model="filterValue"
@@ -21,19 +22,22 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
     name: 'GridCustomTextFilterV',
     props: ['params'],
     data() {
         return {
-            filterValue: ''
+            filterValue: '',
+            static: this.params.stateManager.columns[
+                this.params.column.colDef.field
+            ].filter.static
         };
     },
     beforeMount() {
         // Load previously stored value (if saved in table state manager)
-        this.filterValue = this.params.stateManager.getColumnFilter(
+        this.filterValue = this.params.stateManager.getColumnFilterValue(
             this.params.column.colDef.field
         );
 
@@ -54,7 +58,7 @@ export default defineComponent({
 
                 // Save the new filter value in the state manager. Allows for quick recovery if the grid is
                 // closed and re-opened.
-                this.params.stateManager.setColumnFilter(
+                this.params.stateManager.setColumnFilterValue(
                     this.params.column.colDef.field,
                     this.filterValue
                 );


### PR DESCRIPTION
Closes #1488.

EDIT: I see sample 29 is used by the auto-legend sample, I'll update it before pushing

### Changes
- Grid columns can now be individually adjusted via the config
    - This includes controls such as `visible` and `sort`, as well as the ability to provide default filter values
- Updated docs

### Notes
- Most of the features should behave the same as they did in RAMP2
- One consideration I had was that when you set a filter to `static: true`, the filter input cannot be modified by the user. However, if such a filter has a default value, hitting the 'clear all filters' button will erase the value from this column as well. Should `static` be immune to 'clear all filters'?

### Testing
- [Sample 29](https://ramp4-pcar4.github.io/ramp4-pcar4/column-config/demos/index-samples.html?sample=29) is a new config with some custom columns
- There is currently a bug where filters applied to columns with a `selector` or `date` filter type will not work with the `applyToMap` option

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1525)
<!-- Reviewable:end -->
