### PR TITLE
Overview Map Configs

### DIFF
--- a/demos/starter-scripts/custom-overviewmap.js
+++ b/demos/starter-scripts/custom-overviewmap.js
@@ -65,7 +65,11 @@ let config = {
                         }
                     },
                     startMinimized: false,
-                    expandFactor: 3
+                    expandFactor: 3,
+                    areaOpacity: 0.5,
+                    areaColour: '#5D591F',
+                    borderColour: '#00FF00',
+                    borderWidth: 2
                 }
             }
         }

--- a/schema.json
+++ b/schema.json
@@ -62,6 +62,26 @@
                     "type": "number",
                     "default": 1.5,
                     "description": "The ratio of the overview map's extent size compared to the main map's extent size"
+                },
+                "borderColour": {
+                    "type": "string",
+                    "default": "#FF0000",
+                    "description": "The colour of the area rectangle border."
+                },
+                "borderWidth": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "The width of the area rectangle border"
+                },
+                "areaColour": {
+                    "type": "string",
+                    "default": "#000000",
+                    "description": "The colour of the area rectangle."
+                },
+                "areaOpacity": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "The opacity value of the area rectangle. Accepts decimal values between 0 and 1."
                 }
             }
         },

--- a/src/fixtures/overviewmap/api/overviewmap.ts
+++ b/src/fixtures/overviewmap/api/overviewmap.ts
@@ -27,6 +27,22 @@ export class OverviewmapAPI extends FixtureInstance {
             OverviewmapStore.expandFactor,
             overviewmapConfig?.expandFactor ?? 1.5
         );
+        this.$vApp.$store.set(
+            OverviewmapStore.borderColour,
+            overviewmapConfig?.borderColour ?? '#FF0000'
+        );
+        this.$vApp.$store.set(
+            OverviewmapStore.borderWidth,
+            overviewmapConfig?.borderWidth ?? 1
+        );
+        this.$vApp.$store.set(
+            OverviewmapStore.areaColour,
+            overviewmapConfig?.areaColour ?? '#000000'
+        );
+        this.$vApp.$store.set(
+            OverviewmapStore.areaOpacity,
+            overviewmapConfig?.areaOpacity ?? 0.25
+        );
     }
 
     get config(): OverviewmapConfig {

--- a/src/fixtures/overviewmap/store/overviewmap-state.ts
+++ b/src/fixtures/overviewmap/store/overviewmap-state.ts
@@ -1,14 +1,77 @@
 import type { RampBasemapConfig } from '@/geo/api';
 
 export class OverviewmapState {
+    /**
+     * The map configuration
+     *
+     * @type {RampMapConfig}
+     * @memberof OverviewmapState
+     */
     mapConfig: any = undefined;
+
+    /**
+     * A list of basemaps
+     *
+     * @type {{ [key: string]: RampBasemapConfig }}
+     * @memberof OverviewmapState
+     */
     basemaps: { [key: string]: RampBasemapConfig } = {};
+
+    /**
+     * Initial state of the overview map
+     *
+     * @type {boolean}
+     * @memberof OverviewmapState
+     */
     startMinimized = true;
+
+    /**
+     * Ratio of the overview map's extent size compared to the main map's extent size
+     *
+     * @type {number}
+     * @memberof OverviewmapState
+     */
     expandFactor = 1.5;
+
+    /**
+     * Colour of the area border
+     *
+     * @type {string}
+     * @memberof OverviewmapState
+     */
+    borderColour = '#FF0000';
+
+    /**
+     * Width of the area border
+     *
+     * @type {number}
+     * @memberof OverviewmapState
+     */
+    borderWidth = 1;
+
+    /**
+     * Colour of the area rectangle
+     *
+     * @type {string}
+     * @memberof OverviewmapState
+     */
+    areaColour = '#000000';
+
+    /**
+     * Opacity of the area rectangle
+     *
+     * @type {number}
+     * @memberof OverviewmapState
+     */
+    areaOpacity = 0.25;
 }
 
 export interface OverviewmapConfig {
     basemaps: { [key: string]: RampBasemapConfig };
     startMinimized: boolean;
     expandFactor: number;
+    borderColour: string;
+    borderWidth: number;
+    areaColour: string;
+    areaOpacity: number;
 }

--- a/src/fixtures/overviewmap/store/overviewmap-store.ts
+++ b/src/fixtures/overviewmap/store/overviewmap-store.ts
@@ -38,6 +38,22 @@ export enum OverviewmapStore {
      */
     expandFactor = 'overviewmap/expandFactor',
     /**
+     * (State) borderColour: string
+     */
+    borderColour = 'overviewmap/borderColour',
+    /**
+     * (State) borderWidth: number
+     */
+    borderWidth = 'overviewmap/borderWidth',
+    /**
+     * (State) areaColour: string
+     */
+    areaColour = 'overviewmap/areaColour',
+    /**
+     * (State) areaOpacity: number
+     */
+    areaOpacity = 'overviewmap/areaOpacity',
+    /**
      * (Action) updateIntialBasemap: (basemapId: string)
      */
     updateIntialBasemap = 'overviewmap/updateIntialBasemap!'

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -131,9 +131,35 @@ export class OverviewMapAPI extends CommonMapAPI {
             this.$iApi.geo.map.getExtent(),
             'overview-graphic'
         );
+
+        const borderColour =
+            (this.$iApi.$vApp.$store.get(
+                OverviewmapStore.borderColour
+            ) as string) ?? '#FF0000';
+        const borderWidth =
+            (this.$iApi.$vApp.$store.get(
+                OverviewmapStore.borderWidth
+            ) as number) ?? 1;
+        const areaColour =
+            (this.$iApi.$vApp.$store.get(
+                OverviewmapStore.areaColour
+            ) as string) ?? '#000000';
+        const areaOpacity =
+            (this.$iApi.$vApp.$store.get(
+                OverviewmapStore.areaOpacity
+            ) as number) ?? 0.25;
+
+        // generate hex colour with alpha
+        const areaFill = `${areaColour}${Math.round(areaOpacity * 255).toString(
+            16
+        )}`;
+
         overviewGraphic.style = new PolygonStyle({
-            fill: { colour: [0, 0, 0, 0.25] },
-            outline: { colour: '#FF0000' }
+            fill: { colour: areaFill },
+            outline: {
+                colour: borderColour,
+                width: borderWidth
+            }
         });
 
         await this.overviewGraphicLayer.initiate();


### PR DESCRIPTION
Closes #1512.

### Changes
- The overview map now has additional config settings
    - `borderColour`: colour of the area rectangle border
    - `borderWidth`: width of the area rectangle border
    - `areaColour`: colour of the area rectangle interior
    - `areaOpacity`: opacity of the area rectangle interior

### Notes
- Changes can be observed on sample 08.
- Suggestions for any other config settings are welcome