### PR TITLE
Imported layer tree grow fix

### DIFF
--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -150,8 +150,10 @@ export class LegendAPI extends FixtureInstance {
             layer
                 .getLayerTree()
                 .children.map(childNode => this._treeWalker(layer, childNode))
-                .map(childConf => this.addItem(childConf, parent));
+                .map(childConf => this.addItem(childConf, item as unknown as LegendItem));
         }
+
+        item.treeGrown = true
 
         // add the layer item to store
         // will be in a placeholder state until the layer is loaded


### PR DESCRIPTION
Imported layers were accidentally doing their tree grow in the root legend item rather than underneath their parent. This should now be fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1531)
<!-- Reviewable:end -->
