### PR TITLE
More geosearch styling fixes

### DIFF
--- a/src/fixtures/geosearch/search-bar.vue
+++ b/src/fixtures/geosearch/search-bar.vue
@@ -2,7 +2,7 @@
     <div class="rv-geosearch-bar h-26 mb-14">
         <input
             type="search"
-            class="border-b text-base px-12 py-8 outline-none focus:shadow-outline border-gray-600 mx-8 h-full min-w-0"
+            class="border-b text-base px-12 py-8 outline-none focus:shadow-outline border-gray-600 mx-8 h-full w-11/12"
             :placeholder="$t('geosearch.searchText')"
             :value="searchVal"
             @input="onSearchTermChange($event.target.value)"

--- a/src/fixtures/geosearch/top-filters.vue
+++ b/src/fixtures/geosearch/top-filters.vue
@@ -5,13 +5,15 @@
                 class="form-select border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
                 :value="queryParams.province"
                 v-on:change="setProvince({ province: $event.target.value })"
+                v-truncate
             >
-                <option value="" disabled hidden>
+                <option value="" disabled hidden v-truncate>
                     {{ $t('geosearch.filters.province') }}
                 </option>
                 <option
                     v-for="province in provinces"
                     v-bind:key="province.code"
+                    v-truncate
                 >
                     {{ province.name }}
                 </option>
@@ -22,6 +24,7 @@
                 class="form-select border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
                 :value="queryParams.type"
                 v-on:change="setType({ type: $event.target.value })"
+                v-truncate
             >
                 <option value="" disabled hidden>
                     {{ $t('geosearch.filters.type') }}


### PR DESCRIPTION
Closes #1538.

Note: To further perfect the geosearch UI, we should use our custom dropdown menu instead of the `select` element. Since its not a critical bug fix (or at least I think it isn't), I didn't do it here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1539)
<!-- Reviewable:end -->
