### PR TITLE
Geosearch Street Address Support

### DIFF
--- a/docs/app/geosearch.md
+++ b/docs/app/geosearch.md
@@ -16,6 +16,7 @@ In the header of the Geosearch panel, there is a search bar which allows users t
 
 **Keyword search**: Type any keyword into Geosearch to display a list of results that contains the keyword.
 - each search result consists of: location name (with search keyword highlighted), location province, and location type (lake, city, town, etc.)
+- street addresses are prioritized in the list of results
 - click on any individual result to mark its coordinates and zoom the map to center around this location
 
 **FSA search**: A **forward sortation area (FSA)** is a way to designate a geographical area based on the first three characters in a Canadian postal code. All postal codes that start with the same three characters are considered an **FSA**.
@@ -33,11 +34,6 @@ In the header of the Geosearch panel, there is a search bar which allows users t
 - an NTS map number consists of a string containing a number identifying a map sheet, a letter identifying a map area, and a number identifying the scale map sheet
 - likewise, the first result will be a location of the NTS map number, click to center map on this area
 - example: type in **030M13**
-
-#### Unsupported Search Types
-
-**Street address**: Search using direct street addresses is not supported by Geosearch.
-- entering any valid street address should not return any results
 
 ### Geosearch Filters:
 

--- a/src/fixtures/geosearch/definitions.ts
+++ b/src/fixtures/geosearch/definitions.ts
@@ -66,6 +66,15 @@ export interface INTSResult {
     bbox: number[];
 }
 
+export interface IAddressResult {
+    name: string; // "123 Yonge Street"
+    city: string; // "Toronto"
+    province: string; // "ON"
+    desc: string; // "Street Address"
+    LatLon: ILatLon;
+    bbox: number[];
+}
+
 export interface ILatLongResult {
     latlong: string; // "54.54,-91.45"
     desc: string; // "Latitude/Longitude",
@@ -85,6 +94,7 @@ export interface INameResult {
 
 export interface ILocateResponse {
     title: string;
+    type?: string;
     bbox?: number[];
     geometry: { coordinates: number[] };
 }
@@ -92,8 +102,11 @@ export interface ILocateResponse {
 export type LocateResponseList = ILocateResponse[];
 export type NameResultList = INameResult[];
 export type NTSResultList = INTSResult[];
+export type AddressResultList = IAddressResult[];
+export type ResultList = (INameResult | IAddressResult)[];
 export type queryFeatureResults =
     | IFSAResult
     | INTSResult
+    | IAddressResult
     | ILatLongResult
     | undefined;

--- a/src/fixtures/geosearch/lang/lang.csv
+++ b/src/fixtures/geosearch/lang/lang.csv
@@ -6,3 +6,4 @@ geosearch.visible,Visible on map,1,Visible sur la carte,1
 geosearch.filters.province,Province,1,Province,1
 geosearch.filters.type,Type,1,Type,1
 geosearch.filters.clear,Clear filters,1,Effacer les filtres,1
+geosearch.serviceError,No response from {services},1,[fr]No response from {services},0

--- a/src/fixtures/geosearch/lang/lang.csv
+++ b/src/fixtures/geosearch/lang/lang.csv
@@ -6,4 +6,4 @@ geosearch.visible,Visible on map,1,Visible sur la carte,1
 geosearch.filters.province,Province,1,Province,1
 geosearch.filters.type,Type,1,Type,1
 geosearch.filters.clear,Clear filters,1,Effacer les filtres,1
-geosearch.serviceError,No response from {services},1,[fr]No response from {services},0
+geosearch.serviceError,No response from {services} service(s),1,[fr]No response from {services} service(s),0

--- a/src/fixtures/geosearch/screen.vue
+++ b/src/fixtures/geosearch/screen.vue
@@ -92,7 +92,7 @@ import { defineComponent } from 'vue';
 import type { PropType } from 'vue';
 
 import type { PanelInstance } from '@/api';
-import { Point } from '@/geo/api';
+import { Extent } from '@/geo/api';
 
 import { GeosearchStore } from './store';
 
@@ -129,8 +129,12 @@ export default defineComponent({
     methods: {
         // zoom in to a clicked result
         zoomIn(result: any): void {
-            let zoomPoint = new Point('zoomies', result.position);
-            this.$iApi.geo.map.zoomMapTo(zoomPoint);
+            let zoom = new Extent(
+                'zoomies',
+                [result.bbox[0], result.bbox[1]],
+                [result.bbox[2], result.bbox[3]]
+            );
+            this.$iApi.geo.map.zoomMapTo(zoom);
         },
 
         // highlight the search term in each listed geosearch result

--- a/src/fixtures/geosearch/screen.vue
+++ b/src/fixtures/geosearch/screen.vue
@@ -11,6 +11,16 @@
                     v-if="loadingResults"
                 ></loading-bar>
                 <div
+                    class="text-red-900 text-xs px-8 mb-10"
+                    v-if="failedServices.length > 0 && !loadingResults"
+                >
+                    {{
+                        $t('geosearch.serviceError', {
+                            services: failedServices.join(', ')
+                        })
+                    }}
+                </div>
+                <div
                     class="px-8 mb-10 truncate"
                     v-if="
                         searchVal &&
@@ -123,9 +133,11 @@ export default defineComponent({
         return {
             searchVal: this.get(GeosearchStore.searchVal),
             searchResults: this.get(GeosearchStore.searchResults),
-            loadingResults: this.get(GeosearchStore.loadingResults)
+            loadingResults: this.get(GeosearchStore.loadingResults),
+            failedServices: this.get(GeosearchStore.failedServices)
         };
     },
+
     methods: {
         // zoom in to a clicked result
         zoomIn(result: any): void {

--- a/src/fixtures/geosearch/search-bar.vue
+++ b/src/fixtures/geosearch/search-bar.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="rv-geosearch-bar h-26 mb-14">
+    <div class="rv-geosearch-bar h-26 mb-8 mx-8">
         <input
             type="search"
-            class="border-b text-base px-12 py-8 outline-none focus:shadow-outline border-gray-600 mx-8 h-full w-11/12"
+            class="border-b w-full text-base py-8 outline-none focus:shadow-outline border-gray-600 h-full min-w-0"
             :placeholder="$t('geosearch.searchText')"
             :value="searchVal"
             @input="onSearchTermChange($event.target.value)"

--- a/src/fixtures/geosearch/store/geosearch-state.ts
+++ b/src/fixtures/geosearch/store/geosearch-state.ts
@@ -9,6 +9,7 @@ export class GeosearchState {
     savedResults: Array<any>;
     resultsVisible: boolean;
     loadingResults: boolean;
+    failedServices: string[];
 
     // param is the fixture config from config file
     constructor(geosearchConfig: any) {
@@ -30,6 +31,7 @@ export class GeosearchState {
         this.searchResults = [];
         this.savedResults = [];
         this.loadingResults = false;
+        this.failedServices = [];
     }
 }
 

--- a/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/src/fixtures/geosearch/store/geosearch-store.ts
@@ -59,6 +59,9 @@ const mutations = {
     },
     SET_GSSERVICE: (state: GeosearchState, newGSservice: any) => {
         state.GSservice = newGSservice;
+    },
+    SET_FAILED_SERVICES: (state: GeosearchState, service: string[]) => {
+        state.failedServices = service;
     }
 };
 
@@ -94,12 +97,16 @@ const actions = {
                         context.state.GSservice.query(
                             `${context.state.searchVal}*`
                         ).then((data: any) => {
+                            context.commit(
+                                'SET_FAILED_SERVICES',
+                                data.failedServs
+                            );
                             // store data for current search term
                             context.commit(
                                 'SET_LAST_SEARCH_VAL',
                                 context.state.searchVal
                             );
-                            context.commit('SET_SAVED_RESULTS', data);
+                            context.commit('SET_SAVED_RESULTS', data.results);
 
                             // replace old saved results
                             const filteredData = filter(
@@ -265,6 +272,10 @@ export enum GeosearchStore {
      */
     loadingResults = 'geosearch/loadingResults',
     /**
+     * (State) failedServices: string[]
+     */
+    failedServices = 'geosearch/failedServices',
+    /**
      * (Action) runQuery: () => Promise
      */
     runQuery = 'geosearch/runQuery',
@@ -287,7 +298,11 @@ export enum GeosearchStore {
     /**
      * (Action) setGSserivce: (config: any)
      */
-    setGSservice = 'geosearch/setGSservice'
+    setGSservice = 'geosearch/setGSservice',
+    /**
+     * (Action) setFailedService: (service: string)
+     */
+    setFailedService = 'geosearch/setFailedService'
 }
 
 export function geosearch(config: any) {

--- a/src/fixtures/geosearch/store/geosearch.feature.ts
+++ b/src/fixtures/geosearch/store/geosearch.feature.ts
@@ -6,13 +6,14 @@ import Provinces from './provinces';
 import Types from './types';
 import * as Q from './query';
 import type { IGeosearchConfig } from '../definitions';
+import type { Query } from './query';
 
 // geosearch query services
 // note "geolocation" is a service for looking up locations in canada. It is not a geolocator for the browser's location.
 const GEO_LOCATE_URL =
-    'https://geogratis.gc.ca/services/geolocation/@{language}/locate';
+    'https://geogratis.gc.ca/services/geolocation/@{language}/locte';
 const GEO_NAMES_URL =
-    'https://geogratis.gc.ca/services/geoname/@{language}/geonames.json';
+    'https://geogratis.gc.ca/services/geoname/@{language}/geonmes.json';
 const GEO_PROVINCES_URL =
     'https://geogratis.gc.ca/services/geoname/@{language}/codes/province.json';
 const GEO_TYPES_URL =
@@ -152,55 +153,68 @@ export class GeoSearchUI {
     query(q: string) {
         // run query based on search string input
         return Q.make(this.config, q.toUpperCase()).onComplete.then(
-            (q: any) => {
+            (q: Query) => {
                 // any feature result requires a manual first entry
                 let featureResult: any[] = [];
-                if (q.featureResults) {
-                    if (q.featureResults.fsa) {
+                if (q.featureResults.length > 0) {
+                    if (q.resultType === 'fsa') {
                         // add first geosearch result as location of FSA itself
-                        featureResult = [
-                            {
-                                name: q.featureResults.fsa,
+                        featureResult = q.featureResults.map((fsa: any) => ({
+                            name: fsa.fsa,
+                            bbox: [
+                                fsa.LatLon.lon + 0.02,
+                                fsa.LatLon.lat - 0.02,
+                                fsa.LatLon.lon - 0.02,
+                                fsa.LatLon.lat + 0.02
+                            ],
+                            type: fsa.desc,
+                            position: [fsa.LatLon.lon, fsa.LatLon.lat],
+                            location: {
+                                latitude: fsa.LatLon.lat,
+                                longitude: fsa.LatLon.lon,
+                                province: this.findProvinceObj(fsa.province)
+                            }
+                        }));
+                    } else if (q.resultType === 'nts') {
+                        // add first geosearch result as location of NTS map number
+                        featureResult = q.featureResults.map((nts: any) => ({
+                            name: nts.nts,
+                            bbox: nts.bbox,
+                            type: nts.desc,
+                            position: [nts.LatLon.lon, nts.LatLon.lat],
+                            location: {
+                                city: nts.location,
+                                latitude: nts.LatLon.lat,
+                                longitude: nts.LatLon.lon
+                            }
+                        }));
+                    } else if (q.resultType === 'address') {
+                        featureResult = q.featureResults.map(
+                            (address: any) => ({
+                                name: address.name,
                                 bbox: [
-                                    q.featureResults.LatLon.lon + 0.02,
-                                    q.featureResults.LatLon.lat - 0.02,
-                                    q.featureResults.LatLon.lon - 0.02,
-                                    q.featureResults.LatLon.lat + 0.02
+                                    address.LatLon.lon + 0.002,
+                                    address.LatLon.lat - 0.002,
+                                    address.LatLon.lon - 0.002,
+                                    address.LatLon.lat + 0.002
                                 ],
-                                type: q.featureResults.desc,
+                                type: address.desc,
                                 position: [
-                                    q.featureResults.LatLon.lon,
-                                    q.featureResults.LatLon.lat
+                                    address.LatLon.lon,
+                                    address.LatLon.lat
                                 ],
                                 location: {
-                                    latitude: q.featureResults.LatLon.lat,
-                                    longitude: q.featureResults.LatLon.lon,
+                                    city: address.city,
+                                    latitude: address.LatLon.lat,
+                                    longitude: address.LatLon.lon,
                                     province: this.findProvinceObj(
-                                        q.featureResults.province
+                                        address.province
                                     )
                                 }
-                            }
-                        ];
-                    } else if (q.featureResults.nts) {
-                        // add first geosearch result as location of NTS map number
-                        featureResult = [
-                            {
-                                name: q.featureResults.nts,
-                                bbox: q.featureResults.bbox,
-                                type: q.featureResults.desc,
-                                position: [
-                                    q.featureResults.LatLon.lon,
-                                    q.featureResults.LatLon.lat
-                                ],
-                                location: {
-                                    city: q.featureResults.location,
-                                    latitude: q.featureResults.LatLon.lat,
-                                    longitude: q.featureResults.LatLon.lon
-                                }
-                            }
-                        ];
+                            })
+                        );
                     }
-                } else if (q.latLongResult !== undefined) {
+                } else if (q.resultType === 'latlong') {
                     // add first geosearch result as location of lat/lon coordinates
                     featureResult = [q.latLongResult];
                 }
@@ -208,23 +222,23 @@ export class GeoSearchUI {
                 // format returned query results appropriately to support zoom/extent functionality
                 const queryResult = q.results.map((item: any) => ({
                     name: item.name,
-                    bbox: item.bbox ?? [
-                        item.LatLon.lon + 0.002,
-                        item.LatLon.lat - 0.002,
-                        item.LatLon.lon - 0.002,
-                        item.LatLon.lat + 0.002
-                    ],
-                    type: item.type ?? item.desc,
+                    bbox: item.bbox,
+                    type: item.type,
                     position: [item.LatLon.lon, item.LatLon.lat],
                     location: {
-                        city: item.location ?? item.city,
+                        city: item.location,
                         latitude: item.LatLon.lat,
                         longitude: item.LatLon.lon,
                         province: this.findProvinceObj(item.province)
                     }
                 }));
                 // console.log("remaining query results: ", queryResult);
-                return featureResult.concat(queryResult);
+                return {
+                    results: featureResult
+                        .concat(queryResult)
+                        .slice(0, this.config.maxResults),
+                    failedServs: q.failedServs
+                };
             }
         );
     }

--- a/src/fixtures/geosearch/store/geosearch.feature.ts
+++ b/src/fixtures/geosearch/store/geosearch.feature.ts
@@ -158,15 +158,14 @@ export class GeoSearchUI {
                 if (q.featureResults) {
                     if (q.featureResults.fsa) {
                         // add first geosearch result as location of FSA itself
-                        const bboxRange = 0.02;
                         featureResult = [
                             {
                                 name: q.featureResults.fsa,
                                 bbox: [
-                                    q.featureResults.LatLon.lon + bboxRange,
-                                    q.featureResults.LatLon.lat - bboxRange,
-                                    q.featureResults.LatLon.lon - bboxRange,
-                                    q.featureResults.LatLon.lat + bboxRange
+                                    q.featureResults.LatLon.lon + 0.02,
+                                    q.featureResults.LatLon.lat - 0.02,
+                                    q.featureResults.LatLon.lon - 0.02,
+                                    q.featureResults.LatLon.lat + 0.02
                                 ],
                                 type: q.featureResults.desc,
                                 position: [
@@ -206,15 +205,19 @@ export class GeoSearchUI {
                     featureResult = [q.latLongResult];
                 }
                 // console.log("first feature result: ", featureResult);
-
                 // format returned query results appropriately to support zoom/extent functionality
                 const queryResult = q.results.map((item: any) => ({
                     name: item.name,
-                    bbox: item.bbox,
-                    type: item.type,
+                    bbox: item.bbox ?? [
+                        item.LatLon.lon + 0.002,
+                        item.LatLon.lat - 0.002,
+                        item.LatLon.lon - 0.002,
+                        item.LatLon.lat + 0.002
+                    ],
+                    type: item.type ?? item.desc,
                     position: [item.LatLon.lon, item.LatLon.lat],
                     location: {
-                        city: item.location,
+                        city: item.location ?? item.city,
                         latitude: item.LatLon.lat,
                         longitude: item.LatLon.lon,
                         province: this.findProvinceObj(item.province)

--- a/src/fixtures/geosearch/store/types.ts
+++ b/src/fixtures/geosearch/store/types.ts
@@ -4,12 +4,14 @@ import axios from 'axios';
 // TODO should these strings be in an i18n csv instead?
 const types: any = {
     en: {
+        ADDRESS: 'Street Address',
         FSA: 'Forward Sortation Area',
         NTS: 'National Topographic System',
         COORD: 'Latitude/Longitude',
         SCALE: 'Scale'
     },
     fr: {
+        ADDRESS: 'Adresse Municipale',
         FSA: "Région De Tri D'Acheminement",
         NTS: 'Système National De Référence Cartographique',
         COORD: 'Latitude/Longitude',

--- a/src/fixtures/geosearch/top-filters.vue
+++ b/src/fixtures/geosearch/top-filters.vue
@@ -1,6 +1,10 @@
 <template>
-    <div class="rv-geosearch-top-filters flex items-center w-full mx-8 mb-14">
-        <div class="inline-block w-2/5 h-26">
+    <div
+        class="rv-geosearch-top-filters sm:flex items-center w-full ml-8 mb-14"
+    >
+        <div
+            class="w-fit inline-block sm:w-1/2 h-26 mb-8 sm:mb-0 pr-16 sm:pr-0"
+        >
             <select
                 class="form-select border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
                 :value="queryParams.province"
@@ -19,9 +23,9 @@
                 </option>
             </select>
         </div>
-        <div class="inline-block w-2/5 h-26 mx-16">
+        <div class="sm:w-1/2 h-26 sm:mx-16 flex">
             <select
-                class="form-select border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
+                class="form-select border-b border-b-gray-600 w-full h-full py-0 cursor-pointer max-w-150"
                 :value="queryParams.type"
                 v-on:change="setType({ type: $event.target.value })"
                 v-truncate
@@ -33,23 +37,23 @@
                     {{ type.name }}
                 </option>
             </select>
+            <button
+                type="button"
+                class="text-gray-400 w-1/8 h-24 pl-8 pr-16 sm:pr-8 hover:text-black disabled:cursor-default disabled:text-gray-400"
+                :disabled="!queryParams.type && !queryParams.province"
+                v-on:click="clearFilters"
+                :content="$t('geosearch.filters.clear')"
+                v-tippy="{ placement: 'bottom' }"
+            >
+                <div class="rv-geosearch-icon">
+                    <svg class="fill-current w-18 h-18" viewBox="0 0 23 21">
+                        <path
+                            d="M 14.7574,20.8284L 17.6036,17.9822L 14.7574,15.1716L 16.1716,13.7574L 19.0178,16.568L 21.8284,13.7574L 23.2426,15.1716L 20.432,17.9822L 23.2426,20.8284L 21.8284,22.2426L 19.0178,19.3964L 16.1716,22.2426L 14.7574,20.8284 Z M 2,2L 19.9888,2.00001L 20,2.00001L 20,2.01122L 20,3.99999L 19.9207,3.99999L 13,10.9207L 13,22.909L 8.99999,18.909L 8.99999,10.906L 2.09405,3.99999L 2,3.99999L 2,2 Z "
+                        />
+                    </svg>
+                </div>
+            </button>
         </div>
-        <button
-            type="button"
-            class="inline-block text-gray-400 w-1/8 h-24 px-8 mr-8 float-right hover:text-black disabled:cursor-default disabled:text-gray-400"
-            :disabled="!queryParams.type && !queryParams.province"
-            v-on:click="clearFilters"
-            :content="$t('geosearch.filters.clear')"
-            v-tippy="{ placement: 'bottom' }"
-        >
-            <div class="rv-geosearch-icon">
-                <svg class="fill-current w-18 h-18" viewBox="0 0 23 21">
-                    <path
-                        d="M 14.7574,20.8284L 17.6036,17.9822L 14.7574,15.1716L 16.1716,13.7574L 19.0178,16.568L 21.8284,13.7574L 23.2426,15.1716L 20.432,17.9822L 23.2426,20.8284L 21.8284,22.2426L 19.0178,19.3964L 16.1716,22.2426L 14.7574,20.8284 Z M 2,2L 19.9888,2.00001L 20,2.00001L 20,2.01122L 20,3.99999L 19.9207,3.99999L 13,10.9207L 13,22.909L 8.99999,18.909L 8.99999,10.906L 2.09405,3.99999L 2,3.99999L 2,2 Z "
-                    />
-                </svg>
-            </div>
-        </button>
     </div>
 </template>
 


### PR DESCRIPTION
Closes #1469.

This PR can marinate until after release.

### Changes
- Geosearch now supports searching by street address (i.e. '2144 King West Street')
- The list of search results follow the third option in [my original comment](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1469#issuecomment-1342897946), where street addresses are listed above `Geoname` results
- Updated docs

### Testing
- Use the geosearch panel to search for addresses

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1544)
<!-- Reviewable:end -->
