### PR TITLE
Reload Caching for Non ArcGIS Layers

### DIFF
--- a/demos/starter-scripts/simple-file.js
+++ b/demos/starter-scripts/simple-file.js
@@ -273,7 +273,8 @@ let config = {
                     id: 'GeoJson',
                     name: 'GeoJson',
                     layerType: 'file-geojson',
-                    url: '../file-layers/geojson.json'
+                    url: '../file-layers/geojson.json',
+                    caching: true
                 },
                 {
                     id: 'Shape',

--- a/schema.json
+++ b/schema.json
@@ -1237,6 +1237,11 @@
                     "description": "Optional content to use as the layer source (instead of loading via the url property). GeoJSON accepts json object or stringified object. CSV accepts string. Shapefile accepts binary ArrayBuffer (runtime only).",
                     "additionalProperties": true
                 },
+                "caching": {
+                    "type": "boolean",
+                    "description": "Indicates whether to preserve the layer's raw data after initiation.",
+                    "default": "false"
+                },
                 "identifyMode": {
                     "type": "string",
                     "description": "Determines how features should be identified. By geometry, by symbol, or both.",
@@ -1349,6 +1354,11 @@
                 "drawOrder": {
                     "$ref": "#/$defs/drawOrder",
                     "default": []
+                },
+                "caching": {
+                    "type": "boolean",
+                    "description": "Indicates whether to preserve the layer's raw data after initiation. If set to true, reloading will not refresh data from the server.",
+                    "default": "false"
                 },
                 "identifyMode": {
                     "type": "string",

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -509,6 +509,9 @@ export default defineComponent({
                           this.url,
                           this.typeSelection
                       );
+                if (this.isFileLayer() && this.fileData) {
+                    delete this.layerInfo.config.url;
+                }
             } catch (_) {
                 this.failureError = true;
                 return;

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -355,7 +355,7 @@ export interface LegendSymbology {
     label: string;
     definitionClause?: string;
     svgcode: string;
-    imgUrl: string; // for custom symbology stack
+    imgUrl?: string; // for custom symbology stack
     drawPromise: Promise<string | void>;
     esriStandard: boolean; // indicates if this symbol is ESRI standard symbology or an image
     imgHeight?: string; // height of the original legend graphic (for wms layers)
@@ -605,6 +605,7 @@ export interface RampLayerConfig {
     initialFilteredQuery?: string;
     drawOrder?: Array<DrawOrder>; // feature drawing order
     identifyMode?: LayerIdentifyMode;
+    caching?: boolean; // whether to preserve raw data in file and WFS layers
     rawData?: any; // used for static data, like geojson string, shapefile guts
 }
 

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -24,6 +24,7 @@ import {
     IdentifyResultFormat,
     LayerFormat,
     LayerIdentifyMode,
+    LayerType,
     Point
 } from '@/geo/api';
 
@@ -105,6 +106,16 @@ export class FileLayer extends AttribLayer {
         }
     }
 
+    async reload(): Promise<void> {
+        if (this.origRampConfig.caching !== true && !this.origRampConfig.url) {
+            console.error(
+                'Attempted to reload file layer from non server source without caching enabled.'
+            );
+            return;
+        }
+        await super.reload();
+    }
+
     protected async onInitiate(): Promise<void> {
         // NOTE subclasses of FileLayer should do all their file data processing first,
         //      drop it in this.sourceGeoJson,
@@ -113,10 +124,14 @@ export class FileLayer extends AttribLayer {
         // TODO figure out how the geojson is supplied.
         // another protected property? a permananent property to support reloads? part of rampConfig?
 
+        if (!this.sourceGeoJson) {
+            throw new Error('File Layer is missing raw data.');
+        }
+
         const realJson: any =
             typeof this.sourceGeoJson === 'string'
                 ? JSON.parse(this.sourceGeoJson)
-                : this.sourceGeoJson;
+                : JSON.parse(JSON.stringify(this.sourceGeoJson)); // need a deep copy so that all the manipulation of realJson below does not affect sourceGeoJson
 
         // esri 4: https://developers.arcgis.com/javascript/latest/sample-code/layers-featurelayer-collection/index.html
         // might need to change our terraformer call to just create a set of graphics? need to inspect terrafomer outputs
@@ -147,6 +162,10 @@ export class FileLayer extends AttribLayer {
         );
 
         this.esriJson = undefined;
+        if (this.origRampConfig.caching !== true) {
+            delete this.origRampConfig.rawData;
+            delete this.sourceGeoJson;
+        }
 
         await super.onInitiate();
     }

--- a/src/geo/layer/wfs-layer.ts
+++ b/src/geo/layer/wfs-layer.ts
@@ -15,14 +15,17 @@ export class WfsLayer extends FileLayer {
         // get start index and limit set on the url
         const { startindex, limit } = wrapper.queryMap;
 
-        this.sourceGeoJson = await this.$iApi.geo.layer.ogc.loadWfsData(
-            this.config.url,
-            -1,
-            parseInt(startindex) || 0,
-            parseInt(limit) || 1000,
-            undefined,
-            this.config.xyInAttribs
-        );
+        // fetch data from server only if it has not been cached
+        if (!this.sourceGeoJson) {
+            this.sourceGeoJson = await this.$iApi.geo.layer.ogc.loadWfsData(
+                this.config.url,
+                -1,
+                parseInt(startindex) || 0,
+                parseInt(limit) || 1000,
+                undefined,
+                this.config.xyInAttribs
+            );
+        }
 
         // TODO error handling? set layer state to error if above call fails?
         await super.onInitiate();


### PR DESCRIPTION
Relevant issue: #504.

I basically followed the steps in the issue body. However, I realize that:
* the code then must have been different
* my expertise in this area of the codebase is very low

So feel free to provide feedback on the approach. I feel like when caching is true, we shouldn't be refetching data from the URL on reload, but I didn't implement this part as I was not sure.

For testing, on [sample 27](https://ramp4-pcar4.github.io/ramp4-pcar4/504/demos/index-samples.html?sample=27), the GeoJson layer has caching enabled, while the other layers have it disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1565)
<!-- Reviewable:end -->
