### PR TITLE
Add CSV field filters for lat/lon

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -56,8 +56,8 @@
             <div v-if="urlError" class="text-red-900 text-xs">
                 {{
                     modelValue
-                        ? validationMessages.invalid
-                        : validationMessages.required
+                        ? validationMessages?.invalid
+                        : validationMessages?.required
                 }}
             </div>
         </div>
@@ -80,7 +80,7 @@
                         <option
                             class="p-6"
                             v-for="option in options"
-                            v-bind:key="option"
+                            v-bind:key="option.label"
                             :value="option.value"
                         >
                             {{ option.label }}
@@ -91,7 +91,7 @@
                         v-if="validation && sublayersError"
                         class="text-red-900 text-xs"
                     >
-                        {{ validationMessages.required }}
+                        {{ validationMessages?.required }}
                     </div>
                 </div>
                 <div v-else>
@@ -122,13 +122,13 @@
                         v-if="validation && formatError"
                         class="text-red-900 text-xs"
                     >
-                        {{ validationMessages.invalid }}
+                        {{ validationMessages?.invalid }}
                     </div>
                     <div
                         v-if="validation && failureError"
                         class="text-red-900 text-xs"
                     >
-                        {{ validationMessages.failure }}
+                        {{ validationMessages?.failure }}
                     </div>
                 </div>
             </div>
@@ -144,7 +144,7 @@
                 />
             </div>
             <div v-if="validation && !modelValue" class="text-red-900 text-xs">
-                {{ validationMessages.required }}
+                {{ validationMessages?.required }}
             </div>
         </div>
     </div>
@@ -155,13 +155,13 @@ import { defineComponent } from 'vue';
 import type { PropType } from 'vue';
 
 interface ValidationMsgs {
-    required: string;
-    invalid: string;
-    failure: string;
+    required?: string;
+    invalid?: string;
+    failure?: string;
 }
 
 interface SelectionOption {
-    value: string;
+    value: any;
     label: string;
 }
 

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -1,14 +1,21 @@
 import { LayerType } from '@/geo/api';
-import type { RampLayerConfig } from '@/geo/api';
+import type { FieldDefinition, RampLayerConfig } from '@/geo/api';
 import { APIScope, InstanceAPI } from '@/api/internal';
 import { UrlWrapper } from '@/geo/api';
 import axios from 'axios';
 
 export interface LayerInfo {
-    config: RampLayerConfig | null;
-    configOptions: Array<string>;
-    fields?: any;
-    layers?: any;
+    config: RampLayerConfig; // the layer's config
+    configOptions: Array<string>; // the layer's config options that will be taken from user input in the UI
+    fields?: Array<FieldDefinition>; // the fields for the layer
+    latLonFields?: { lat: Array<string>; lon: Array<string> }; // lat and lon are a list of field names that can be possible lat/lon fields
+    layers?: Array<{
+        id: number;
+        name: string;
+        parentLayerId: number;
+        defaultVisibility: boolean;
+        sublayerIds?: Array<number>;
+    }>; // a flattened list of info for the parent layer, sublayer groups, and sublayers. Only defined for MIL
 }
 
 export class LayerSource extends APIScope {
@@ -104,6 +111,8 @@ export class LayerSource extends APIScope {
             fields: [{ name: 'OBJECTID', type: 'oid' }].concat(
                 this.$iApi.geo.layer.files.extractCsvFields(fileData)
             ),
+            latLonFields:
+                this.$iApi.geo.layer.files.filterCsvLatLonFields(fileData),
             configOptions: [
                 'name',
                 'nameField',

--- a/src/fixtures/wizard/store/wizard-state.ts
+++ b/src/fixtures/wizard/store/wizard-state.ts
@@ -1,3 +1,4 @@
+import { LayerType } from '@/geo/api';
 import type { LayerSource, LayerInfo } from './layer-source';
 
 export class WizardState {
@@ -15,7 +16,7 @@ export class WizardState {
      * @type {string}
      * @memberof WizardState
      */
-    url = '';
+    url: string = '';
 
     /**
      * Raw file data
@@ -39,7 +40,10 @@ export class WizardState {
      * @type {LayerInfo}
      * @memberof WizardState
      */
-    layerInfo: LayerInfo = { config: null, configOptions: [] };
+    layerInfo: LayerInfo = {
+        config: { id: 'Placeholder', layerType: LayerType.UNKNOWN, url: '' },
+        configOptions: []
+    };
 
     /**
      * Current wizard form step

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -336,7 +336,7 @@ export interface AttributeSet {
 // https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-support-Field.html#type
 export interface FieldDefinition {
     name: string;
-    alias: string;
+    alias?: string;
     type: string;
     length?: number;
 }


### PR DESCRIPTION
Relevant issue: #958.

When you add a CSV layer via the wizard, only those fields that can be lat/lon fields will now show up in the dropdown menu.
I also attempted to fix some TS errors but then got lazy and only did a few of them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1566)
<!-- Reviewable:end -->
