### PR TITLE
Panel Resize Fun Demo - No Pulling

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2207,6 +2207,11 @@
                     "type": "boolean",
                     "description": "Enables panel reorder controls.",
                     "default": true
+                },
+                "resizeable": {
+                    "type": "boolean",
+                    "descrription": "Enables panel resize controls.",
+                    "default": true
                 }
             },
             "additionalProperties": "false"

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -35,6 +35,8 @@ import CloseV from '@/components/panel-stack/controls/close.vue';
 import BackV from '@/components/panel-stack/controls/back.vue';
 import ExpandV from '@/components/panel-stack/controls/expand.vue';
 import MinimizeV from '@/components/panel-stack/controls/minimize.vue';
+import IncreaseV from '@/components/panel-stack/controls/increase.vue';
+import DecreaseV from '@/components/panel-stack/controls/decrease.vue';
 import RightV from '@/components/panel-stack/controls/right.vue';
 import LeftV from '@/components/panel-stack/controls/left.vue';
 import PanelOptionsMenuV from '@/components/panel-stack/controls/panel-options-menu.vue';
@@ -242,9 +244,17 @@ export class InstanceAPI {
                     });
                 }
 
-                // enable/disable reorder controls
-                const enable = langConfig.panels.reorderable ?? true;
-                this.$vApp.$store.set('panel/reorderable', enable);
+                // enable/disable reorder controls\
+                this.$vApp.$store.set(
+                    'panel/reorderable',
+                    langConfig.panels.reorderable ?? true
+                );
+
+                // enable/disable resize controls
+                this.$vApp.$store.set(
+                    'panel/resizeable',
+                    langConfig.panels.resizeable ?? true
+                );
             }
 
             // disable animations if needed
@@ -582,6 +592,8 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
     vueElement.component('minimize', MinimizeV);
     vueElement.component('right', RightV);
     vueElement.component('left', LeftV);
+    vueElement.component('increase', IncreaseV);
+    vueElement.component('decrease', DecreaseV);
 
     // ported from mapnav.vue
     vueElement.component('fullscreen-nav-button', FullscreenNavV);

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -148,11 +148,15 @@ export class PanelInstance extends APIScope {
      * @memberof PanelInstance
      */
     get width(): number | undefined {
-        if (!this.style.width || this.style.width.slice(-2) !== 'px') {
+        if (
+            this.$vApp.$store.get('panel/mobileView') ||
+            !this.style['flex-basis'] ||
+            this.style['flex-basis'].slice(-2) !== 'px'
+        ) {
             return undefined;
         }
 
-        return parseInt(this.style.width);
+        return parseInt(this.style['flex-basis']);
     }
 
     /**

--- a/src/components/panel-stack/controls/decrease.vue
+++ b/src/components/panel-stack/controls/decrease.vue
@@ -1,0 +1,46 @@
+<template>
+    <div class="relative" tabindex="-1">
+        <button
+            type="button"
+            class="p-8"
+            :class="{
+                'text-gray-500 hover:text-black focus:text-black': active,
+                'text-gray-300': !active
+            }"
+            :content="$t('panels.controls.decrease')"
+            v-tippy="{
+                placement: 'bottom',
+                theme: 'ramp4',
+                animation: 'scale'
+            }"
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="3.0"
+                stroke="currentColor"
+                class="fill-current w-16 h-16"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M19.5 13.5L12 21m0 0l-7.5-7.5M12 21V3"
+                />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'DecreaseV',
+    props: {
+        active: Boolean
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/panel-stack/controls/increase.vue
+++ b/src/components/panel-stack/controls/increase.vue
@@ -1,0 +1,46 @@
+<template>
+    <div class="relative" tabindex="-1">
+        <button
+            type="button"
+            class="p-8"
+            :class="{
+                'text-gray-500 hover:text-black focus:text-black': active,
+                'text-gray-300': !active
+            }"
+            :content="$t('panels.controls.increase')"
+            v-tippy="{
+                placement: 'bottom',
+                theme: 'ramp4',
+                animation: 'scale'
+            }"
+        >
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="3.0"
+                stroke="currentColor"
+                class="fill-current w-16 h-16"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M4.5 10.5L12 3m0 0l7.5 7.5M12 3v18"
+                />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+    name: 'IncreaseV',
+    props: {
+        active: Boolean
+    }
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -36,6 +36,8 @@ panels.controls.pin,Pin,1,Épingler,1
 panels.controls.unpin,Unpin,1,Désépingler,1
 panels.controls.back,Back,1,Retour,1
 panels.controls.optionsMenu,More,1,Plus,1
+panels.controls.increase,Increase Width,1,Augmenter la largeur,0
+panels.controls.decrease,Decrease Width,1,Diminuer la largeur,0
 panels.controls.minimize,Minimize,1,Réduire,1
 panels.controls.expand,Expand,1,Développer,1
 panels.controls.collapse,Collapse,1,Réduire,1

--- a/src/store/modules/panel/panel-state.ts
+++ b/src/store/modules/panel/panel-state.ts
@@ -85,6 +85,13 @@ export class PanelState {
      * @memberof PanelState
      */
     reorderable = true;
+
+    /**
+     * True if panels have the increase/decrease width controls enabled.
+     * @type {boolean}
+     * @memberof PanelState
+     */
+    resizeable = true;
 }
 
 // this should have been `AsyncComponentPromise` type, but something is off there

--- a/src/store/modules/panel/panel-store.ts
+++ b/src/store/modules/panel/panel-store.ts
@@ -190,6 +190,7 @@ const actions = {
             if (remainingWidth >= (context.state.pinned.width || 350)) {
                 // if theres room insert pinned element
                 nowVisible.unshift(context.state.pinned);
+                remainingWidth -= context.state.pinned.width || 350;
             } else {
                 // otherwise there is only one element in `nowVisible` (loop invariant fun)
                 // if there is no priority, the one element should be pinned
@@ -197,6 +198,8 @@ const actions = {
                 if (!context.state.priority) {
                     lastElement = nowVisible.shift()!;
                     nowVisible.unshift(context.state.pinned);
+                    remainingWidth += lastElement.width || 350;
+                    remainingWidth -= context.state.pinned.width || 350;
                 }
             }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,7 @@ export interface RampConfig {
             pin?: boolean;
         }[];
         reorderable?: boolean;
+        resizeable?: boolean;
     };
     system?: {
         proxyUrl?: string;


### PR DESCRIPTION
Relevant issue: #1178.
Relevant discussion: #1177.

This PR adds controls to the panel header that increase and decrease the width of the panel. Each click increases/decreases the width by 50px. We could make this value configurable if needed. Additionally, the width cannot be increased if there is no additional space remaining and cannot be decreased if the panel is at its minimum width (I have arbitrarily set this to 100px, the amount needed so that the resize controls aren't hidden and you aren't stuck with a potato panel forever). You can turn off this feature via the `resizeable` boolean in the config.

This PR is more for people to play around with, and if it is a desirable feature, it can be added to RAMP4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1570)
<!-- Reviewable:end -->
