### PR TITLE
Geosearch Enhancements

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -196,6 +196,12 @@
                 Only data matching the filter will get downloaded to the client
                 (e.g. in the grid).
             </li>
+            <li>
+                35.
+                <a href="index-samples.html?sample=35">Filtered Geosearch</a>.
+                Geoseach fixture with a custom filter and sort order for
+                results.
+            </li>
         </ul>
 
         <h2>Simple Samples</h2>

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -85,6 +85,9 @@
                     <option value="perm-filter">
                         34. Permanent Layer Filters
                     </option>
+                    <option value="geosearch-filtered">
+                        35. Geosearch with filtered results
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/geosearch-filtered.js
+++ b/demos/starter-scripts/geosearch-filtered.js
@@ -1,0 +1,86 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    }
+                ],
+                lodSets: [
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            },
+            layers: [],
+            fixtures: {
+                appbar: {
+                    items: ['geosearch']
+                },
+                geosearch: {
+                    settings: {
+                        categories: ['CITY', 'TOWN', 'VILG', 'HAM', 'UNP'],
+                        sortOrder: ['HAM', 'CITY'],
+                        disabledSearchTypes: ['FSA'],
+                        maxResults: 30
+                    }
+                }
+            }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: false,
+    loadDefaultEvents: true
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+rInstance.fixture.addDefaultFixtures(['appbar', 'geosearch']).then(() => {
+    rInstance.panel.open('geosearch');
+});
+
+window.debugInstance = rInstance;

--- a/docs/app/geosearch.md
+++ b/docs/app/geosearch.md
@@ -50,3 +50,33 @@ Near the bottom of the Geosearch panel, there is a checkbox labeled **visible on
 When searching for a location, a list of matched results with all appropriate filters applied (map extent, province, type) will be displayed. This takes up the main body of the Geosearch panel. There is an upper limit of 100 results possible to be displayed. If no matching results are found, then a message will appear in place of the results to inform the users.
 
 ![](./images/geosearch-results.png)
+
+## Configuration
+
+The Geosearch panel has multiple options that can be adjusted through the configuration file. Though the Geosearch fixture is designed with the GeoGratis API in mind, a `serviceUrls` object with the following properties can define alternate URLs for the lookup service:
+
+- `geoLocateUrl: string`, endpoint for the Geolocation service
+- `geoNameUrl: string`, endpoint for the Geoname service
+- `geoProvinceUrl: string`, endpoint for province codes provided by the Geoname service
+- `geoTypesUrl: string`, endpoint for type codes provided by the Geoname service
+
+Also, a `settings` object enables additional fixture customization: 
+
+- `categories: string[]`, filter by [concise type](https://geogratis.gc.ca/services/geoname/en/codes/concise.json) or street address ('ADDR') when using the Geoname service
+- `sortOrder: string[]`, order search results based on category types, where missing types are appended to the bottom of the sorted list
+- `disabledSearchTypes: string[]`, omit results for given [search types](#Supported-Search-Types) (`LAT/LNG`, `FSA`, and `NTS`)
+- `maxResults: number`, specifies the maximum number of results from a query
+- `officialOnly: boolean`, results only use official names for geographic names
+
+An example of a configured Geosearch panel is below
+
+```text
+geosearch: {
+    settings: {
+        categories: ['CITY', 'TOWN', 'VILG', 'ADDR'],
+        sortOrder: ['TOWN', 'CITY'],
+        disabledSearchTypes: ['FSA'],
+        maxResults: 20
+    }
+}
+```

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -22,6 +22,7 @@ The [Startup](api/startup.md) page provides examples of how to instantiate a RAM
 - Configuration for various fixtures
   - [Appbar](app/appbar.md#configuration)
   - [Details Custom Templating](app/details.md#creating-a-custom-template)
+  - [Geosearch](app/geosearch.md#configuration) 
   - [Grid](app/grid.md#configuration)
   - [Layer Settings](app/settings.md#configuration)
   - [Legend](app/legend.md#components) (configuration snippets are embedded in functional descriptions)  

--- a/public/help/en.md
+++ b/public/help/en.md
@@ -102,6 +102,11 @@ __Keyword search__: Type any keyword into geosearch to display a list of results
 - each search result consists of: location name (with keyword highlighted), location province, and location type (lake, city, town, etc.)
 - click on any individual result to mark its coordinates and zoom the map to center around this location
 
+__Street address__: Search using direct street addresses to display a list of results related to the search term
+
+- addresses can be located by street name, or more precisely by place number and street name
+- results are sorted in order of how closely the address matches the search term
+
 __FSA search__: A __forward sortation area (FSA)__ is a way to designate a geographical area based on the first three characters in a Canadian postal code. All postal codes that start with the same three characters are considered an __FSA__.
 
 - a search using FSA will display a list of results in the vicinity of that area
@@ -120,12 +125,6 @@ __NTS search__: __National Topographic System (NTS)__ is a system used for provi
 - an NTS map number consists of a string containing a number identifying a map sheet, a letter identifying a map area, and a number identifying the scale map sheet
 - likewise, the first result will be a location of the NTS map number, click to center map on this area
 - example: type in __030M13__
-
-#### Unsupported Search Types
-
-__Street address__: Search using direct street addresses is not supported by geosearch.
-
-- entering any valid street address should not return any results
 
 ### Geosearch Filtering
 

--- a/public/help/fr.md
+++ b/public/help/fr.md
@@ -102,6 +102,11 @@ La fonction de recherche géolocalisée permet aux utilisateurs de rechercher de
 - Chaque résultat de recherche comprend les éléments suivants : le nom du lieu (mot‑clé en surbrillance), la province du lieu et le type de lieu (lac, ville, village, etc.).
 - Cliquez sur un résultat distinct pour saisir les coordonnées et faire un zoom sur la carte de façon à ce qu'elle soit centrée sur le lieu souhaité.
 
+**Adresse de rue**: Effectuer une recherche en utilisant les adresses de rue directes pour afficher une liste de résultats liés au terme recherché
+
+- les adresses peuvent être localisées par nom de rue, ou plus précisément par numéro de lieu et nom de rue
+- les résultats sont triés en fonction du degré de correspondance entre l'adresse et le terme recherché.
+
 **Recherche par région de tri d'acheminement (RTA)** : une **région de tri d'acheminement (RTA)** est une façon de désigner une zone géographique en fonction des trois premiers caractères d'un code postal canadien. Tous les codes postaux qui commencent par les trois mêmes caractères font partie d'une même **RTA**.
 
 - Une recherche par RTA permet d'afficher une liste de résultats à proximité de cette région.
@@ -120,12 +125,6 @@ La fonction de recherche géolocalisée permet aux utilisateurs de rechercher de
 - Le numéro d'une carte du SNRC consiste en une chaîne contenant un nombre désignant une feuille de carte, une lettre désignant une zone de carte et un nombre désignant la feuille de carte à l'échelle.
 - De même, le premier résultat désignera un emplacement du numéro de carte SNRC, cliquez pour centrer la carte sur cette zone.
 - Par exemple : saisissez **030M13**.
-
-#### Types de recherche non pris en charge
-
-**Adresse municipale**  : l'outil de recherche géolocalisée ne prend pas en charge la recherche par adresse municipale.
-
-- La saisie d'une adresse valide ne devrait donner aucun résultat.
 
 ### Filtres de la recherche géolocalisée
 

--- a/schema.json
+++ b/schema.json
@@ -255,7 +255,7 @@
                                 "type": "string"
                             },
                             "default": [],
-                            "description": "Filter the search results based on the type of the geographical names. Allowed values can be found here (if using the Canadian GeoNames Search Service API): http://geogratis.gc.ca/services/geoname/en/codes/concise."
+                            "description": "Filter the search results based on the type of the geographical names. Allowed values can be found here (if using the Canadian GeoNames Search Service API): http://geogratis.gc.ca/services/geoname/en/codes/concise. Street address type ('ADDR') is also valid."
                         },
                         "sortOrder": {
                             "type": "array",
@@ -264,6 +264,16 @@
                             },
                             "default": [],
                             "description": "The sort order of the defined 'categories'. Any missing categories are appended to the bottom of the sorted list. The results can still be sorted through this option even if there are no categories being filtered."
+                        },
+                        "disabledSearchTypes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["NTS", "FSA", "LAT/LNG"]
+                            },
+                            "uniqueItems": true,
+                            "default": [],
+                            "description": "Disable specific types of searches (NTS, FSA, or LAT/LNG)."
                         },
                         "maxResults": {
                             "type": "number",

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -1001,9 +1001,10 @@ function servicesUpgrader(r2Services: any, r4c: any): void {
         }
 
         if (r2Services.search.disabledSearches) {
-            console.warn(
-                `disabledSearches property provided in search service cannot be mapped and will be skipped.`
-            );
+            r4c.fixtures.geosearch.settings.disabledSearchTypes =
+                r2Services.search.disabledSearches.filter(
+                    (s: string) => s !== 'SCALE'
+                );
         }
     }
 

--- a/src/fixtures/geosearch/definitions.ts
+++ b/src/fixtures/geosearch/definitions.ts
@@ -9,6 +9,7 @@ export interface IGeosearchConfig {
     geoLocateUrl: string;
     categories: string[];
     sortOrder: string[];
+    disabledSearchTypes: string[];
     maxResults: number;
     officialOnly: boolean;
     language: string;
@@ -90,6 +91,7 @@ export interface INameResult {
     type: string; // "Lake"
     LatLon: ILatLon;
     bbox: number[];
+    order: number;
 }
 
 export interface ILocateResponse {


### PR DESCRIPTION
Addresses #1576, #1577, #1584

### Changes
- the Geosearch fixture can now leverage the `categories`, `sortOrder`, `disabledSearchTypes`, and `officialOnly` config options from RAMP2
    - as talked about in #1591, the street address type is treated as a concise type with the code `ADDR` , meaning that street addresses can be filtered and sorted alongside the other Geoname types.
    - if a custom sort order is defined, only street addresses are sorted by Levenshtein distance, and if no sort order is defined, all results are sorted by Lev by default (previous behaviour)
    - the schema was updated to reflect the changes. I opted to briefly explain the street address type instead of making a new definition for the codes, but if the doc isn't verbose enough this definition can be added
- added a [new sample](https://ramp4-pcar4.github.io/ramp4-pcar4/geosearch-enhancements/demos/index-samples.html?sample=35) with a custom sort order
- added documentation for street address search and the new config options

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1593)
<!-- Reviewable:end -->
