### PR TITLE
Concurrency check on detail hilight

### DIFF
--- a/demos/starter-scripts/r2-config-upgraded.js
+++ b/demos/starter-scripts/r2-config-upgraded.js
@@ -426,7 +426,7 @@ const r2config = {
                     {
                         id: 'CBMT',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
@@ -449,7 +449,7 @@ const r2config = {
                     {
                         id: 'SMR',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -464,7 +464,7 @@ const r2config = {
                     {
                         id: 'CBME_CBCE_HS_RO_3978',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -479,7 +479,7 @@ const r2config = {
                     {
                         id: 'CBMT_CBCT_GEOM_3978',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -355,7 +355,7 @@ Options parameter object, with descriptions following:
 - An optional integer number to buffer the geometry. Is generally only useful if the geometry is a point (i.e. where a mouse click / crosshair click occurred). The number represents pixels to buffer by (so 5 would be a 10x10 pixel square around the point at the current map scale level).
 - Optional result of a local hit test (a promise resolving in an array of graphic hit results). Utilized when in hybrid identify mode; will ensure any local results are excluded from the server results, avoiding duplicates.
 
-The result object of `runIdentify()` is on the fancy side, as there are a few levels identify acts upon. The topmost array of results has an entry for each logical layer involved, including the logical `uid`, a loading flag (`loaded`) and promise (`loading`), and another array of individual hits (`items`) for the logical layer. The loading properties here indicate when the items array as been populated, but be aware that individual `items` still may be downloading their own data.
+The result object of `runIdentify()` is on the fancy side, as there are a few levels identify acts upon. The topmost array of results has an entry for each logical layer involved, including the logical `uid`, a request timestamp(`requestTime`), a loading flag (`loaded`) and promise (`loading`), and another array of individual hits (`items`) for the logical layer. The loading properties here indicate when the items array as been populated, but be aware that individual `items` still may be downloading their own data.
 
 The `items` array contains a loading flag and promise to track the download of its data, a format specification and a property to contain data that aligns to the given format. Current format values include `esri` (standard attribute format), `text`, `image`, `html`, `xml`, `json`, `unknown`.
 
@@ -365,6 +365,7 @@ The `items` array contains a loading flag and promise to track the download of i
         uid,
         loaded,
         loading,
+        requestTime,
         items: [
             {
                 loaded,

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -108,6 +108,11 @@ export class DetailsState {
     activeGreedy: number = 0;
 
     /**
+     * Indicates the time of the last highlighting action (request highlights or clear highlights).
+     */
+    lastHilight: number = 0;
+
+    /**
      * Whether or not the details hilight toggle is on.
      *
      * @type boolean

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -77,6 +77,10 @@ export enum DetailsStore {
      */
     hilightToggle = 'details/hilightToggle',
     /**
+     * (State) lastHilight: number
+     */
+    lastHilight = 'details/lastHilight',
+    /**
      * (Action) setPayload: (payload: ItemResult[])
      */
     setPayload = 'details/setPayload!',

--- a/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
@@ -45,10 +45,11 @@ export class GlowHilightMode extends LiftHilightMode {
             this.$iApi.geo.map.esriView
                 ?.whenLayerView(hilightLayer.esriLayer)
                 ?.then(function (layerView) {
-                    gs.forEach((g: Graphic) => {
-                        const graphic = hilightLayer.getEsriGraphic(g.id);
-                        layerView.highlight(graphic);
-                    });
+                    layerView.highlight(
+                        gs.map(
+                            (g: Graphic) => hilightLayer.getEsriGraphic(g.id)!
+                        )
+                    );
                 });
         }
     }


### PR DESCRIPTION
Donethankses https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1604

Applies expiry logic to highlight requests in the details panel. Will prevent slow/stale highlights from being drawn on the map and then remain lurking there.

Also see https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1609 which will attempt to address the slowness of the highlighter in general.

Updates basemaps in sample, as pointed out in https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1607

Test against Sample 27.  Click the stack of CSV points, go to the "list" of results, then close the identify or pick a new detail before the highlight can draw. Ensure the highlight doesn't appear ~8 seconds later around the stack.