### PR TITLE
Details List Optimization

### DIFF
--- a/src/fixtures/details/result-screen.vue
+++ b/src/fixtures/details/result-screen.vue
@@ -38,6 +38,7 @@
                             class="w-full flex px-16 py-10 text-md hover:bg-gray-200 cursor-pointer"
                             v-for="(item, idx) in result.items"
                             :key="idx"
+                            v-memo="[icon[idx]]"
                             @click="item.loaded && openResult(idx)"
                             :disabled="!item.loaded"
                             v-focus-item


### PR DESCRIPTION
Related issue: #1609 

Items in the details list are now memoized to reduce the number of `getIcon()` calls. I tested the time to render the stack of 163 CSV points on Chrome 110: it measured roughly `26000ms` before the change (163<sup>2</sup> calls), and around`50ms` after (326 calls).
 
