### PR TITLE
Migrate to Vite 4 + Add https on local dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ npm ci
 npm run dev
 ```
 
-Open `http://localhost:3000` in your browser.
+Open `https://localhost:5173/demos/index-samples.html` in your browser.
+
+#### Serve via `http`
+
+```sh
+npm run dev-http
+```
 
 ### Build for production
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
                 "@types/node": "^16.11.26",
                 "@types/proj4": "^2.5.2",
                 "@types/throttle-debounce": "~2.1.0",
-                "@vitejs/plugin-vue": "^2.3.1",
+                "@vitejs/plugin-vue": "^4.0.0",
                 "@vue/eslint-config-prettier": "^7.0.0",
                 "@vue/eslint-config-typescript": "^11.0.2",
                 "@vue/tsconfig": "^0.1.3",
@@ -80,7 +80,8 @@
                 "tailwindcss": "^3.0.23",
                 "typedoc": "^0.22.14",
                 "typescript": "^4.6.4",
-                "vite": "^2.9.12",
+                "vite": "^4.1.4",
+                "vite-plugin-mkcert": "^1.13.3",
                 "vue-tsc": "^1.2.0"
             },
             "engines": {
@@ -336,6 +337,358 @@
             "peerDependencies": {
                 "vue": "*",
                 "vue-class-component": "*"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+            "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+            "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+            "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+            "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+            "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+            "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+            "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+            "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+            "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+            "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+            "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+            "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+            "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+            "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+            "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+            "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+            "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+            "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+            "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+            "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@eslint/eslintrc": {
@@ -609,6 +962,183 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
+            "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^9.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
+            "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/auth-token": "^3.0.0",
+                "@octokit/graphql": "^5.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
+            "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^9.0.0",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/endpoint/node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
+            "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/request": "^6.0.0",
+                "@octokit/types": "^9.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+            "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
+            "dev": true
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
+            "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^9.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=4"
+            }
+        },
+        "node_modules/@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "dev": true,
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
+            "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^9.0.0",
+                "deprecation": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
+            "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/endpoint": "^7.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/types": "^9.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/request/node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@octokit/rest": {
+            "version": "19.0.7",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
+            "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/core": "^4.1.0",
+                "@octokit/plugin-paginate-rest": "^6.0.0",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+            "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/openapi-types": "^16.0.0"
             }
         },
         "node_modules/@popperjs/core": {
@@ -1044,15 +1574,15 @@
             }
         },
         "node_modules/@vitejs/plugin-vue": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.4.tgz",
-            "integrity": "sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.0.0.tgz",
+            "integrity": "sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==",
             "dev": true,
             "engines": {
-                "node": ">=12.0.0"
+                "node": "^14.18.0 || >=16.0.0"
             },
             "peerDependencies": {
-                "vite": "^2.5.10",
+                "vite": "^4.0.0",
                 "vue": "^3.2.25"
             }
         },
@@ -1807,6 +2337,12 @@
             "dependencies": {
                 "tweetnacl": "^0.14.3"
             }
+        },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "dev": true
         },
         "node_modules/binary-extensions": {
             "version": "2.2.0",
@@ -2683,6 +3219,12 @@
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
             "optional": true
         },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "dev": true
+        },
         "node_modules/detect-libc": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -2829,9 +3371,9 @@
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
         },
         "node_modules/esbuild": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.34.tgz",
-            "integrity": "sha512-QIWdPT/gFF6hCaf4m7kP0cJ+JIuFkdHibI7vVFvu3eJS1HpVmYHWDulyN5WXwbRA0SX/7ZDaJ/1DH8SdY9xOJg==",
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+            "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -2841,346 +3383,28 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "esbuild-android-64": "0.14.34",
-                "esbuild-android-arm64": "0.14.34",
-                "esbuild-darwin-64": "0.14.34",
-                "esbuild-darwin-arm64": "0.14.34",
-                "esbuild-freebsd-64": "0.14.34",
-                "esbuild-freebsd-arm64": "0.14.34",
-                "esbuild-linux-32": "0.14.34",
-                "esbuild-linux-64": "0.14.34",
-                "esbuild-linux-arm": "0.14.34",
-                "esbuild-linux-arm64": "0.14.34",
-                "esbuild-linux-mips64le": "0.14.34",
-                "esbuild-linux-ppc64le": "0.14.34",
-                "esbuild-linux-riscv64": "0.14.34",
-                "esbuild-linux-s390x": "0.14.34",
-                "esbuild-netbsd-64": "0.14.34",
-                "esbuild-openbsd-64": "0.14.34",
-                "esbuild-sunos-64": "0.14.34",
-                "esbuild-windows-32": "0.14.34",
-                "esbuild-windows-64": "0.14.34",
-                "esbuild-windows-arm64": "0.14.34"
-            }
-        },
-        "node_modules/esbuild-android-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-            "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-darwin-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.34.tgz",
-            "integrity": "sha512-vpidSJEBxx6lf1NWgXC+DCmGqesJuZ5Y8aQVVsaoO4i8tRXbXb0whChRvop/zd3nfNM4dIl5EXAky0knRX5I6w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-riscv64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-            "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild-linux-s390x": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-            "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-android-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-            "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-darwin-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-            "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-freebsd-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-            "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-freebsd-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-            "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-linux-32": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-            "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-linux-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-            "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-linux-arm": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-            "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-linux-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-            "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-linux-mips64le": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-            "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-linux-ppc64le": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-            "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-netbsd-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-            "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-openbsd-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-            "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-sunos-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-            "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-windows-32": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-            "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-windows-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-            "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/esbuild-windows-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-            "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
+                "@esbuild/android-arm": "0.16.17",
+                "@esbuild/android-arm64": "0.16.17",
+                "@esbuild/android-x64": "0.16.17",
+                "@esbuild/darwin-arm64": "0.16.17",
+                "@esbuild/darwin-x64": "0.16.17",
+                "@esbuild/freebsd-arm64": "0.16.17",
+                "@esbuild/freebsd-x64": "0.16.17",
+                "@esbuild/linux-arm": "0.16.17",
+                "@esbuild/linux-arm64": "0.16.17",
+                "@esbuild/linux-ia32": "0.16.17",
+                "@esbuild/linux-loong64": "0.16.17",
+                "@esbuild/linux-mips64el": "0.16.17",
+                "@esbuild/linux-ppc64": "0.16.17",
+                "@esbuild/linux-riscv64": "0.16.17",
+                "@esbuild/linux-s390x": "0.16.17",
+                "@esbuild/linux-x64": "0.16.17",
+                "@esbuild/netbsd-x64": "0.16.17",
+                "@esbuild/openbsd-x64": "0.16.17",
+                "@esbuild/sunos-x64": "0.16.17",
+                "@esbuild/win32-arm64": "0.16.17",
+                "@esbuild/win32-ia32": "0.16.17",
+                "@esbuild/win32-x64": "0.16.17"
             }
         },
         "node_modules/escalade": {
@@ -5480,7 +5704,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
             "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -5500,19 +5724,19 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/node-fetch/node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "optional": true
+            "devOptional": true
         },
         "node_modules/node-fetch/node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "optional": true,
+            "devOptional": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -5915,9 +6139,9 @@
             "dev": true
         },
         "node_modules/postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.21",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+            "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6465,15 +6689,16 @@
             }
         },
         "node_modules/rollup": {
-            "version": "2.70.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-            "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.17.3.tgz",
+            "integrity": "sha512-p5LaCXiiOL/wrOkj8djsIDFmyU9ysUxcyW+EKRLHb6TKldJzXpImjcRSR+vgo09DBdofGcOoLOsRyxxG2n5/qQ==",
             "dev": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=14.18.0",
+                "npm": ">=8.0.0"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
@@ -7445,6 +7670,12 @@
                 "node": ">=4.2.0"
             }
         },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+            "dev": true
+        },
         "node_modules/universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -7561,31 +7792,37 @@
             "dev": true
         },
         "node_modules/vite": {
-            "version": "2.9.15",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-            "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+            "integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
             "dev": true,
             "dependencies": {
-                "esbuild": "^0.14.27",
-                "postcss": "^8.4.13",
-                "resolve": "^1.22.0",
-                "rollup": ">=2.59.0 <2.78.0"
+                "esbuild": "^0.16.14",
+                "postcss": "^8.4.21",
+                "resolve": "^1.22.1",
+                "rollup": "^3.10.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": ">=12.2.0"
+                "node": "^14.18.0 || >=16.0.0"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
             },
             "peerDependencies": {
+                "@types/node": ">= 14",
                 "less": "*",
                 "sass": "*",
-                "stylus": "*"
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
             },
             "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
                 "less": {
                     "optional": true
                 },
@@ -7594,7 +7831,31 @@
                 },
                 "stylus": {
                     "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
                 }
+            }
+        },
+        "node_modules/vite-plugin-mkcert": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.13.3.tgz",
+            "integrity": "sha512-cuAbOb6bHyTMhha9YimL6ZB/WoCcFy8d3uaf5n5Ovgybix1yvEu3pxARy2HjC5LJIS1qq6fFXG0+oj6/XMUapA==",
+            "dev": true,
+            "dependencies": {
+                "@octokit/rest": "^19.0.5",
+                "axios": "^1.2.2",
+                "debug": "^4.3.4",
+                "picocolors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=v16.7.0"
+            },
+            "peerDependencies": {
+                "vite": ">=3"
             }
         },
         "node_modules/vscode-oniguruma": {
@@ -8230,6 +8491,160 @@
                 }
             }
         },
+        "@esbuild/android-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+            "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+            "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+            "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+            "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+            "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+            "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+            "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+            "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+            "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+            "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+            "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+            "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+            "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+            "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+            "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+            "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+            "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+            "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+            "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+            "dev": true,
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+            "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+            "dev": true,
+            "optional": true
+        },
         "@eslint/eslintrc": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.0.tgz",
@@ -8442,6 +8857,146 @@
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
+            }
+        },
+        "@octokit/auth-token": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
+            "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^9.0.0"
+            }
+        },
+        "@octokit/core": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
+            "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
+            "dev": true,
+            "requires": {
+                "@octokit/auth-token": "^3.0.0",
+                "@octokit/graphql": "^5.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/endpoint": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
+            "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^9.0.0",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+                    "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+                    "dev": true
+                }
+            }
+        },
+        "@octokit/graphql": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
+            "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
+            "dev": true,
+            "requires": {
+                "@octokit/request": "^6.0.0",
+                "@octokit/types": "^9.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/openapi-types": {
+            "version": "16.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
+            "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
+            "dev": true
+        },
+        "@octokit/plugin-paginate-rest": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
+            "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^9.0.0"
+            }
+        },
+        "@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "dev": true,
+            "requires": {}
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
+            "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^9.0.0",
+                "deprecation": "^2.3.1"
+            }
+        },
+        "@octokit/request": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
+            "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
+            "dev": true,
+            "requires": {
+                "@octokit/endpoint": "^7.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            },
+            "dependencies": {
+                "is-plain-object": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+                    "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+                    "dev": true
+                }
+            }
+        },
+        "@octokit/request-error": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+            "dev": true,
+            "requires": {
+                "@octokit/types": "^9.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "@octokit/rest": {
+            "version": "19.0.7",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
+            "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
+            "dev": true,
+            "requires": {
+                "@octokit/core": "^4.1.0",
+                "@octokit/plugin-paginate-rest": "^6.0.0",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+            }
+        },
+        "@octokit/types": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
+            "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+            "dev": true,
+            "requires": {
+                "@octokit/openapi-types": "^16.0.0"
             }
         },
         "@popperjs/core": {
@@ -8771,9 +9326,9 @@
             }
         },
         "@vitejs/plugin-vue": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.4.tgz",
-            "integrity": "sha512-IfFNbtkbIm36O9KB8QodlwwYvTEsJb4Lll4c2IwB3VHc2gie2mSPtSzL0eYay7X2jd/2WX02FjSGTWR6OPr/zg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.0.0.tgz",
+            "integrity": "sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==",
             "dev": true,
             "requires": {}
         },
@@ -9362,6 +9917,12 @@
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
+        },
+        "before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "dev": true
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -10015,6 +10576,12 @@
             "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
             "optional": true
         },
+        "deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "dev": true
+        },
         "detect-libc": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -10139,174 +10706,34 @@
             }
         },
         "esbuild": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.34.tgz",
-            "integrity": "sha512-QIWdPT/gFF6hCaf4m7kP0cJ+JIuFkdHibI7vVFvu3eJS1HpVmYHWDulyN5WXwbRA0SX/7ZDaJ/1DH8SdY9xOJg==",
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+            "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
             "dev": true,
             "requires": {
-                "esbuild-android-64": "0.14.34",
-                "esbuild-android-arm64": "0.14.34",
-                "esbuild-darwin-64": "0.14.34",
-                "esbuild-darwin-arm64": "0.14.34",
-                "esbuild-freebsd-64": "0.14.34",
-                "esbuild-freebsd-arm64": "0.14.34",
-                "esbuild-linux-32": "0.14.34",
-                "esbuild-linux-64": "0.14.34",
-                "esbuild-linux-arm": "0.14.34",
-                "esbuild-linux-arm64": "0.14.34",
-                "esbuild-linux-mips64le": "0.14.34",
-                "esbuild-linux-ppc64le": "0.14.34",
-                "esbuild-linux-riscv64": "0.14.34",
-                "esbuild-linux-s390x": "0.14.34",
-                "esbuild-netbsd-64": "0.14.34",
-                "esbuild-openbsd-64": "0.14.34",
-                "esbuild-sunos-64": "0.14.34",
-                "esbuild-windows-32": "0.14.34",
-                "esbuild-windows-64": "0.14.34",
-                "esbuild-windows-arm64": "0.14.34"
-            },
-            "dependencies": {
-                "esbuild-android-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.34.tgz",
-                    "integrity": "sha512-T02+NXTmSRL1Mc6puz+R9CB54rSPICkXKq6+tw8B6vxZFnCPzbJxgwIX4kcluz9p8nYBjF3+lSilTGWb7+Xgew==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-darwin-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.34.tgz",
-                    "integrity": "sha512-pLRip2Bh4Ng7Bf6AMgCrSp3pPe/qZyf11h5Qo2mOfJqLWzSVjxrXW+CFRJfrOVP7TCnh/gmZSM2AFdCPB72vtw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-freebsd-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.34.tgz",
-                    "integrity": "sha512-m0HBjePhe0hAQJgtMRMNV9kMgIyV4/qSnzPx42kRMQBcPhgjAq1JRu4Il26czC+9FgpMbFkUktb07f/Lwnc6CA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-freebsd-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.34.tgz",
-                    "integrity": "sha512-cpRc2B94L1KvMPPYB4D6G39jLqpKlD3noAMY4/e86iXXXkhUYJJEtTuyNFTa9JRpWM0xCAp4mxjHjoIiLuoCLA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-linux-32": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.34.tgz",
-                    "integrity": "sha512-8nQaEaoW7MH/K/RlozJa+lE1ejHIr8fuPIHhc513UebRav7HtXgQvxHQ6VZRUkWtep23M6dd7UqhwO1tMOfzQQ==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-linux-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.34.tgz",
-                    "integrity": "sha512-Y3of4qQoLLlAgf042MlrY1P+7PnN9zWj8nVtw9XQG5hcLOZLz7IKpU35oeu7n4wvyaZHwvQqDJ93gRLqdJekcQ==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-linux-arm": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.34.tgz",
-                    "integrity": "sha512-9lpq1NcJqssAF7alCO6zL3gvBVVt/lKw4oetUM7OgNnRX0OWpB+ZIO9FwCrSj/dMdmgDhPLf+119zB8QxSMmAg==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-linux-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.34.tgz",
-                    "integrity": "sha512-IlWaGtj9ir7+Nrume1DGcyzBDlK8GcnJq0ANKwcI9pVw8tqr+6GD0eqyF9SF1mR8UmAp+odrx1H5NdR2cHdFHA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-linux-mips64le": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.34.tgz",
-                    "integrity": "sha512-k3or+01Rska1AjUyNjA4buEwB51eyN/xPQAoOx1CjzAQC3l8rpjUDw55kXyL63O/1MUi4ISvtNtl8gLwdyEcxw==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-linux-ppc64le": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.34.tgz",
-                    "integrity": "sha512-+qxb8M9FfM2CJaVU7GgYpJOHM1ngQOx+/VrtBjb4C8oVqaPcESCeg2anjl+HRZy8VpYc71q/iBYausPPbJ+Keg==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-netbsd-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.34.tgz",
-                    "integrity": "sha512-cfaFGXdRt0+vHsjNPyF0POM4BVSHPSbhLPe8mppDc7GDDxjIl08mV1Zou14oDWMp/XZMjYN1kWYRSfftiD0vvQ==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-openbsd-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.34.tgz",
-                    "integrity": "sha512-vmy9DxXVnRiI14s8GKuYBtess+EVcDALkbpTqd5jw4XITutIzyB7n4x0Tj5utAkKsgZJB22lLWGekr0ABnSLow==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-sunos-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.34.tgz",
-                    "integrity": "sha512-eNPVatNET1F7tRMhii7goL/eptfxc0ALRjrj9SPFNqp0zmxrehBFD6BaP3R4LjMn6DbMO0jOAnTLFKr8NqcJAA==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-windows-32": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.34.tgz",
-                    "integrity": "sha512-EFhpXyHEcnqWYe2rAHFd8dRw8wkrd9U+9oqcyoEL84GbanAYjiiIjBZsnR8kl0sCQ5w6bLpk7vCEIA2VS32Vcg==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-windows-64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.34.tgz",
-                    "integrity": "sha512-a8fbl8Ky7PxNEjf1aJmtxdDZj32/hC7S1OcA2ckEpCJRTjiKslI9vAdPpSjrKIWhws4Galpaawy0nB7fjHYf5Q==",
-                    "dev": true,
-                    "optional": true
-                },
-                "esbuild-windows-arm64": {
-                    "version": "0.14.34",
-                    "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.34.tgz",
-                    "integrity": "sha512-EYvmKbSa2B3sPnpC28UEu9jBK5atGV4BaVRE7CYGUci2Hlz4AvtV/LML+TcDMT6gBgibnN2gcltWclab3UutMg==",
-                    "dev": true,
-                    "optional": true
-                }
+                "@esbuild/android-arm": "0.16.17",
+                "@esbuild/android-arm64": "0.16.17",
+                "@esbuild/android-x64": "0.16.17",
+                "@esbuild/darwin-arm64": "0.16.17",
+                "@esbuild/darwin-x64": "0.16.17",
+                "@esbuild/freebsd-arm64": "0.16.17",
+                "@esbuild/freebsd-x64": "0.16.17",
+                "@esbuild/linux-arm": "0.16.17",
+                "@esbuild/linux-arm64": "0.16.17",
+                "@esbuild/linux-ia32": "0.16.17",
+                "@esbuild/linux-loong64": "0.16.17",
+                "@esbuild/linux-mips64el": "0.16.17",
+                "@esbuild/linux-ppc64": "0.16.17",
+                "@esbuild/linux-riscv64": "0.16.17",
+                "@esbuild/linux-s390x": "0.16.17",
+                "@esbuild/linux-x64": "0.16.17",
+                "@esbuild/netbsd-x64": "0.16.17",
+                "@esbuild/openbsd-x64": "0.16.17",
+                "@esbuild/sunos-x64": "0.16.17",
+                "@esbuild/win32-arm64": "0.16.17",
+                "@esbuild/win32-ia32": "0.16.17",
+                "@esbuild/win32-x64": "0.16.17"
             }
-        },
-        "esbuild-android-64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.34.tgz",
-            "integrity": "sha512-XfxcfJqmMYsT/LXqrptzFxmaR3GWzXHDLdFNIhm6S00zPaQF1TBBWm+9t0RZ6LRR7iwH57DPjaOeW20vMqI4Yw==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-darwin-arm64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.34.tgz",
-            "integrity": "sha512-vpidSJEBxx6lf1NWgXC+DCmGqesJuZ5Y8aQVVsaoO4i8tRXbXb0whChRvop/zd3nfNM4dIl5EXAky0knRX5I6w==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-riscv64": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.34.tgz",
-            "integrity": "sha512-Y717ltBdQ5j5sZIHdy1DV9kieo0wMip0dCmVSTceowCPYSn1Cg33Kd6981+F/3b9FDMzNWldZFOBRILViENZSA==",
-            "dev": true,
-            "optional": true
-        },
-        "esbuild-linux-s390x": {
-            "version": "0.14.34",
-            "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.34.tgz",
-            "integrity": "sha512-bDDgYO4LhL4+zPs+WcBkXph+AQoPcQRTv18FzZS0WhjfH8TZx2QqlVPGhmhZ6WidrY+jKthUqO6UhGyIb4MpmA==",
-            "dev": true,
-            "optional": true
         },
         "escalade": {
             "version": "3.1.1",
@@ -12042,7 +12469,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
             "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
-            "optional": true,
+            "devOptional": true,
             "requires": {
                 "whatwg-url": "^5.0.0"
             },
@@ -12051,19 +12478,19 @@
                     "version": "0.0.3",
                     "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
                     "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-                    "optional": true
+                    "devOptional": true
                 },
                 "webidl-conversions": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
                     "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-                    "optional": true
+                    "devOptional": true
                 },
                 "whatwg-url": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
                     "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-                    "optional": true,
+                    "devOptional": true,
                     "requires": {
                         "tr46": "~0.0.3",
                         "webidl-conversions": "^3.0.0"
@@ -12356,9 +12783,9 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.21",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+            "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
             "requires": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
@@ -12739,9 +13166,9 @@
             }
         },
         "rollup": {
-            "version": "2.70.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.1.tgz",
-            "integrity": "sha512-CRYsI5EuzLbXdxC6RnYhOuRdtz4bhejPMSWjsFLfVM/7w/85n2szZv6yExqUXsBdz5KT8eoubeyDUDjhLHEslA==",
+            "version": "3.17.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.17.3.tgz",
+            "integrity": "sha512-p5LaCXiiOL/wrOkj8djsIDFmyU9ysUxcyW+EKRLHb6TKldJzXpImjcRSR+vgo09DBdofGcOoLOsRyxxG2n5/qQ==",
             "dev": true,
             "requires": {
                 "fsevents": "~2.3.2"
@@ -13479,6 +13906,12 @@
             "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
             "devOptional": true
         },
+        "universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+            "dev": true
+        },
         "universalify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -13568,16 +14001,28 @@
             }
         },
         "vite": {
-            "version": "2.9.15",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-            "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+            "integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
             "dev": true,
             "requires": {
-                "esbuild": "^0.14.27",
+                "esbuild": "^0.16.14",
                 "fsevents": "~2.3.2",
-                "postcss": "^8.4.13",
-                "resolve": "^1.22.0",
-                "rollup": ">=2.59.0 <2.78.0"
+                "postcss": "^8.4.21",
+                "resolve": "^1.22.1",
+                "rollup": "^3.10.0"
+            }
+        },
+        "vite-plugin-mkcert": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.13.3.tgz",
+            "integrity": "sha512-cuAbOb6bHyTMhha9YimL6ZB/WoCcFy8d3uaf5n5Ovgybix1yvEu3pxARy2HjC5LJIS1qq6fFXG0+oj6/XMUapA==",
+            "dev": true,
+            "requires": {
+                "@octokit/rest": "^19.0.5",
+                "axios": "^1.2.2",
+                "debug": "^4.3.4",
+                "picocolors": "^1.0.0"
             }
         },
         "vscode-oniguruma": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
+        "dev-http": "vite --https=false",
         "build": "vite build",
         "preview": "vite preview --port 5050",
         "test:e2e": "start-server-and-test preview http://127.0.0.1:5050/ 'cypress open'",
@@ -86,7 +87,7 @@
         "@types/node": "^16.11.26",
         "@types/proj4": "^2.5.2",
         "@types/throttle-debounce": "~2.1.0",
-        "@vitejs/plugin-vue": "^2.3.1",
+        "@vitejs/plugin-vue": "^4.0.0",
         "@vue/eslint-config-prettier": "^7.0.0",
         "@vue/eslint-config-typescript": "^11.0.2",
         "@vue/tsconfig": "^0.1.3",
@@ -105,7 +106,8 @@
         "tailwindcss": "^3.0.23",
         "typedoc": "^0.22.14",
         "typescript": "^4.6.4",
-        "vite": "^2.9.12",
+        "vite": "^4.1.4",
+        "vite-plugin-mkcert": "^1.13.3",
         "vue-tsc": "^1.2.0"
     }
 }

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -8,7 +8,7 @@ import type { FixtureBase, FixtureBaseSet } from '@/store/modules/fixture';
 import type { RampConfig } from '@/types';
 
 const fixtureModules = import.meta.glob<{ default: typeof FixtureInstance }>(
-    '@/fixtures/*/index.ts'
+    '../fixtures/*/index.ts'
 );
 
 // TODO: implement the same `internal.ts` pattern in store, so can import from a single place;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, type UserConfigExport } from 'vite';
+import mkcert from 'vite-plugin-mkcert';
 import vue from '@vitejs/plugin-vue';
 import VitePluginI18n from './scripts/vite-plugin-i18n';
 import VitePluginVersion from './scripts/vite-plugin-version';
@@ -7,7 +8,10 @@ import { resolve } from 'path';
 const distName = resolve(__dirname, process.env.DIST_NAME || 'dist');
 
 const baseConfig: UserConfigExport = {
-    plugins: [vue(), VitePluginI18n(), VitePluginVersion()],
+    plugins: [vue(), VitePluginI18n(), VitePluginVersion(), mkcert()],
+    define: {
+        'process.env': process.env
+    },
     base: './',
     resolve: {
         alias: {
@@ -19,7 +23,8 @@ const baseConfig: UserConfigExport = {
         target: 'esnext'
     },
     server: {
-        open: '/demos/index-samples.html'
+        open: '/demos/index-samples.html',
+        https: true
     }
 };
 
@@ -27,21 +32,21 @@ export default defineConfig(({ command, mode }) => {
     if (command == 'build') {
         if (mode === 'production') {
             Object.assign(baseConfig.build!, {
-                outDir: `${distName}`,
+                outDir: distName,
                 lib: {
                     entry: resolve(__dirname, 'src/main.ts'),
                     name: 'RAMP',
                     fileName: (format: string) =>
-                        `ramp${format == 'iife' ? '' : '.esm'}.js`,
+                        `lib/ramp${format == 'iife' ? '' : '.esm'}.js`,
                     formats: ['es', 'iife']
                 },
                 rollupOptions: {
                     output: {
                         inlineDynamicImports: true,
-                        dir: `${distName}/lib`,
+                        dir: distName,
                         assetFileNames: (assetInfo: any) => {
                             return assetInfo.name === 'style.css'
-                                ? 'ramp.css'
+                                ? 'lib/ramp.css'
                                 : assetInfo.name;
                         }
                     }


### PR DESCRIPTION
### Changes
* Migrated `vite` from 2.9.15 to 4.1.4.
* Added the ability to run the local dev server on `https`. This can be done by doing `npm run dev -- --https` locally. Note that `npm run dev` will still run the app on `http`.

### Note
* This PR should be tested both on the demo builds as well as locally to ensure that everything works as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1616)
<!-- Reviewable:end -->
