### PR TITLE
Text basemaps and composite basemap fixes

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -202,6 +202,11 @@
                 Geoseach fixture with a custom filter and sort order for
                 results.
             </li>
+            <li>
+                36.
+                <a href="index-samples.html?sample=36">Basemap Thumbnails</a>.
+                Basemap fixture with different options on thumbnails.
+            </li>
         </ul>
 
         <h2>Simple Samples</h2>

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -88,6 +88,9 @@
                     <option value="geosearch-filtered">
                         35. Geosearch with filtered results
                     </option>
+                    <option value="basemaps">
+                        36. Basemap fixture with configured thumbnails
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/basemaps.js
+++ b/demos/starter-scripts/basemaps.js
@@ -1,0 +1,328 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'transportLabels',
+                        name: 'Transport with labels',
+                        description:
+                            'This worldwide basemap provides geographic context with bilingual labels and an emphasis on transportation networks. From Natural Resources Canada.',
+                        altText: 'Transport with labels',
+                        thumbnailUrl: null,
+                        // attribution: '',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                id: 'CBMT_GEOM',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3857/MapServer'
+                            },
+                            {
+                                id: 'CBMT_TXT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_TXT_3857/MapServer'
+                            }
+                        ]
+                    },
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        hideThumbnail: true,
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        hideThumbnail: true,
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        hideThumbnail: true,
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        hideThumbnail: true,
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [],
+            fixtures: {
+                appbar: {
+                    items: ['basemap']
+                }
+            },
+            panels: {
+                open: [{ id: 'basemap', pin: false }]
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+// load map if startRequired is true
+rInstance.start();
+
+function animateToggle() {
+    if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
+        rInstance.$vApp.$el.classList.remove('animation-enabled');
+    } else {
+        rInstance.$vApp.$el.classList.add('animation-enabled');
+    }
+    document.getElementById('animate-status').innerText =
+        'Animate: ' + rInstance.animate;
+}
+
+window.debugInstance = rInstance;

--- a/schema.json
+++ b/schema.json
@@ -1840,6 +1840,11 @@
                     "default": "",
                     "description": "Alt text for the basemap thumbnail image."
                 },
+                "hideThumbnail": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When enabled, hides the basemap thumbnail image, leaving just the text component."
+                },
                 "thumbnailUrl": {
                     "type": "string",
                     "default": null,
@@ -1851,7 +1856,7 @@
                 },
                 "layers": {
                     "type": "array",
-                    "description": "A set of URLs which should be composited to form a basemap entry.",
+                    "description": "A set of URLs which should be composited to form a basemap entry. Stacked in ascending order, i.e. the first layer sits at the bottom and the last layer at the top",
                     "items": {
                         "type": "object",
                         "properties": {

--- a/src/fixtures/basemap/item.vue
+++ b/src/fixtures/basemap/item.vue
@@ -1,52 +1,65 @@
 <template>
     <div class="mb-10">
         <button
-            class="basemap-item-button bg-gray-300 h-210"
+            class="basemap-item-button bg-gray-300"
             type="button"
             :aria-label="t('basemap.select')"
             @click="selectBasemap(basemap)"
             v-focus-item
         >
+            <!-- thumbnail -->
             <div>
-                <div>
+                <div
+                    class="flex hover:opacity-50 basemap-item-image basemap-item-container"
+                    :class="!basemap.hideThumbnail ? 'h-180' : 'h-30'"
+                >
+                    <!-- text-only mode -->
+                    <img v-if="basemap.hideThumbnail" class="w-full h-30" />
+                    <!-- Else if, use basemap thumbnail url -->
+                    <img
+                        v-else-if="basemap.thumbnailUrl"
+                        class="w-full h-180"
+                        :alt="basemap.altText"
+                        :src="basemap.thumbnailUrl"
+                    />
+                    <!-- Else if, Use tileSchema tile urls -->
                     <div
-                        class="flex h-180 hover:opacity-50 basemap-item-image"
                         v-for="layer in basemap.layers"
                         :key="layer.id"
+                        v-else-if="
+                            tileSchema.thumbnailTileUrls &&
+                            tileSchema.thumbnailTileUrls.length > 0 &&
+                            basemap.layers.every(
+                                layer => layer.layerType === 'esri-tile'
+                            )
+                        "
+                        class="flex basemap-item-inner h-180"
                     >
-                        <!-- Use basemap thumbnail url -->
                         <img
-                            v-if="basemap.thumbnailUrl"
                             class="w-full"
-                            :alt="basemap.altText"
-                            :src="basemap.thumbnailUrl"
-                        />
-                        <!-- Else if, Use tileSchema tile urls -->
-                        <img
-                            v-else-if="
-                                tileSchema.thumbnailTileUrls &&
-                                tileSchema.thumbnailTileUrls.length > 0 &&
-                                layer.layerType === 'esri-tile'
-                            "
                             v-for="(url, idx) in tileSchema.thumbnailTileUrls"
-                            class="w-full"
                             :alt="basemap.altText"
                             :src="layer.url + url"
                             :key="idx"
                         />
-                        <!-- Else, Use placeholder image -->
-                        <img
-                            v-else
-                            class="w-full bg-white"
-                            :alt="basemap.altText"
-                            src="https://openclipart.org/image/800px/275366"
-                        />
                     </div>
+                    <!-- Else, Use placeholder image -->
+                    <img
+                        v-else
+                        class="w-full bg-white h-180"
+                        :alt="basemap.altText"
+                        src="https://openclipart.org/image/800px/275366"
+                    />
                 </div>
             </div>
 
             <div
-                class="absolute flex w-full bg-black opacity-75 text-white h-30 bottom-6 items-center"
+                class="absolute flex w-full bg-black text-white h-30 bottom-6 items-center"
+                :class="
+                    basemap.hideThumbnail && basemap.id === selectedBasemap.id
+                        ? 'opacity-85'
+                        : 'opacity-75'
+                "
             >
                 <div class="pl-5" v-truncate>
                     <span>{{ basemap.name }}</span>
@@ -78,7 +91,9 @@
 
             <div
                 class="rv-basemap-check absolute top-0 right-0"
-                v-if="basemap.id === selectedBasemap.id"
+                v-if="
+                    basemap.id === selectedBasemap.id && !basemap.hideThumbnail
+                "
             >
                 <svg
                     class="fill-current w-25 h-25 relative"
@@ -131,6 +146,16 @@ const selectBasemap = (basemap: any) => {
 </script>
 
 <style lang="scss" scoped>
+.basemap-item-container {
+    display: grid;
+    place-items: center;
+    grid-template-areas: 'inner-div';
+}
+
+.basemap-item-inner {
+    grid-area: inner-div;
+}
+
 [focus-list]:focus [focus-item].focused.basemap-item-button {
     border: solid black 2px;
 }

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -637,6 +637,7 @@ export interface RampBasemapConfig {
     name: string;
     description: string;
     altText: string;
+    hideThumbnail?: boolean;
     thumbnailUrl?: string;
     tileSchemaId: string;
     layers: Array<RampBasemapLayerConfig>;


### PR DESCRIPTION
Related: #1605

### Changes
- basemap thumbnails now have a `hideThumbnail` option, leaving just the basemap text
- composite basemap thumbnails now render correctly
- layer stacking will now only occur on composite basemap thumbnails
- new [sample 36](https://ramp4-pcar4.github.io/ramp4-pcar4/basemap-alt/demos/index-samples.html?sample=36) demonstrates these features

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1621)
<!-- Reviewable:end -->
