### PR TITLE
Todo Cleanup

### DIFF
--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -2,7 +2,6 @@ import { createInstance, geo } from '@/main';
 
 window.debugInstance = null;
 
-// TODO: Location for version string needs to be finalized
 // document.getElementById('ramp-version').innerText =
 //     'v.' +
 //     RAMP.version.major +

--- a/demos/starter-scripts/sample-fixtures/iklob/main.ts
+++ b/demos/starter-scripts/sample-fixtures/iklob/main.ts
@@ -2,8 +2,6 @@ import { markRaw } from 'vue';
 import screen from './screen.vue';
 export class IklobFixture {
     added(): void {
-        const messages = {};
-        // TODO: import `FixtureInstance` types
         (this as any).$iApi.panel.register(
             {
                 id: 'iklob-p1',

--- a/docs/configuration/layer-config.md
+++ b/docs/configuration/layer-config.md
@@ -4,6 +4,7 @@
 
 Layer Configuration Properties
 
+- [caching](#caching)
 - [colour](#colour)
 - [controls](#controls)
 - [cosmetic](#cosmetic)
@@ -247,6 +248,12 @@ Defines the desired state of the layer at load time.
 ```
 
 ## Fancy Properties
+
+### caching
+
+*boolean*, only applies to file based layers that have the [rawData](#rawdata) property set
+
+Specifies if a layers raw data should be preserved after the layer is created. This type of layer does not have a server-based source to ask for the data again, so enabling caching will allow for reloads to occur. It will however double the memory footprint of the layer. If missing, defaults to `false`.
 
 ### colour
 

--- a/docs/configuration/migration.md
+++ b/docs/configuration/migration.md
@@ -1,6 +1,7 @@
 # Config Migration Guide
 
 // TODO: Update this file when we add support for anything or make changes to the schema.
+// TODO this file is significantly out of date. Consider removing now that we have converter function
 
 Listed below are breaking changes from the RAMP2 schema i.e. properties in the RAMP2 config that cannot be mapped to some part of the RAMP4 config.
 

--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -342,7 +342,6 @@ Options parameter object, with descriptions following:
 ```js
 {
     geometry,
-    returnGeometry,
     sublayerIds,
     tolerance,
     hitTest
@@ -350,7 +349,6 @@ Options parameter object, with descriptions following:
 ```
 
 - The geometry to identify against. A RAMP API [Geometry](../api/geometry.md). Intersecting features will be returned.
-- An optional boolean to indicate the geometry of the result features should also be downloaded. Defaults to `false`.
 - An optional array of sublayer uids (string) or server indicies / layer indexes (number) that indicate which sublayers to include in the request.
 - An optional integer number to buffer the geometry. Is generally only useful if the geometry is a point (i.e. where a mouse click / crosshair click occurred). The number represents pixels to buffer by (so 5 would be a 10x10 pixel square around the point at the current map scale level).
 - Optional result of a local hit test (a promise resolving in an array of graphic hit results). Utilized when in hybrid identify mode; will ensure any local results are excluded from the server results, avoiding duplicates.

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -135,8 +135,8 @@ function mapUpgrader(r2Map: any, r4c: any): void {
     }
 
     if (r2Map.components) {
-        // TODO process components
-        // TODO: handle fixture inclusion/exclusion flag in the component config. Append to fixturesEnabled if included
+        // process components
+        // handle fixture inclusion/exclusion flag in the component config. Append to fixturesEnabled if included
 
         if (r2Map.components.geoSearch) {
             if (r2Map.components.geoSearch.enabled) {
@@ -603,7 +603,7 @@ function legendEntryUpgrader(r2legendEntry: any) {
         );
     }
     // Warning party
-    // TODO: remove these warnings whenever we add support for one of these properties.
+    // remove these warnings whenever we add support for one of these properties.
     if (r2legendEntry.controlledIds) {
         console.warn(
             `controlledIds property defined in legend entry ${r2legendEntry.layerId} cannot be mapped and will be skipped.`
@@ -1110,7 +1110,7 @@ function servicesUpgrader(r2Services: any, r4c: any): void {
         r4c.system.proxyUrl = r2Services.proxyUrl;
     }
 
-    // TODO: If any of these properties get implemented/used in the future, remove them from the warning list and map them appropriately.
+    // If any of these properties get implemented/used in the future, remove them from the warning list and map them appropriately.
     const unused: String[] = [
         'corsEverywhere',
         'exportMapUrl',
@@ -1136,8 +1136,7 @@ function servicesUpgrader(r2Services: any, r4c: any): void {
  * @param r4c entire ramp4 config. param is modded in place, since ramp2 elements end up all over the new config
  */
 function uiUpgrader(r2ui: any, r4c: any): void {
-    // TODO git r done
-    // TODO: handle fixture inclusion/exclusion flag in the component config. Append to fixturesEnabled if included
+    // handle fixture inclusion/exclusion flag in the component config. Append to fixturesEnabled if included
 
     if (r2ui.navBar) {
         // process nav bar
@@ -1334,7 +1333,7 @@ function uiUpgrader(r2ui: any, r4c: any): void {
         } */
     }
 
-    // TODO: If any of these properties get implemented/used in the future, remove them from the warning list and map them appropriately.
+    // If any of these properties get implemented/used in the future, remove them from the warning list and map them appropriately.
     const unused: String[] = [
         'fullscreen',
         'theme',

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -372,7 +372,7 @@ enum DefEH {
 
 // private for EventBus internals, so don't export
 // a simple data structure for managing the Event API on fixtures.
-// TODO if we end up supporting toggle/disabled events, add an active boolean flag to the structure
+// If we end up supporting toggle/disabled events, add an active boolean flag to the structure
 class EventHandler {
     eventName: string;
     handlerName: string;
@@ -398,8 +398,7 @@ export class EventAPI extends APIScope {
     // tracks active event handlers: event name, handler name, and the actual handler function
     private readonly _eventRegister: Array<EventHandler>;
 
-    // a helpful register of event names that have been announced by the app and fixtures.
-    // TODO this is not essential. we can decide to remove the feature. would also remove .registerEventName and .eventNames
+    // a helpful register of event names that have been declared by the app and fixtures.
     private readonly _nameRegister: Array<string>;
 
     // for autonamer
@@ -510,10 +509,6 @@ export class EventAPI extends APIScope {
      */
     off(handlerName: string): void {
         // TODO support other overloads? like event name + handler function?
-        // TODO handle the "off all" scenario?
-        // TODO support "turn off all handlers for an event?".
-        //      This is a bit tricky as it also uses a 1 string param sig.
-        //      Could use a diff method, like .allOff(event)
 
         // check if name exists. if not... do nothing? console warn? error?
         const eh = this.findHandler(handlerName);
@@ -583,7 +578,7 @@ export class EventAPI extends APIScope {
      * @memberof EventAPI
      */
     activeHandlers(event = ''): Array<string> {
-        // TODO add a filter if we implement disabled events
+        // add a filter if we implement disabled events
 
         if (event === '') {
             return this._eventRegister.map(eh => eh.handlerName);
@@ -611,11 +606,7 @@ export class EventAPI extends APIScope {
             eventHandlerNames.length === 0
         ) {
             // use all the default event handlers
-            // TODO the enum-values-to-array logic we use in the event names list
-            //      fails a bit here. we could make it work if we force every default
-            //      handler name to being with a specific prefix. Alternately use object, not enum.
-            //      ---
-            //      Update (years later). We now have prefix "ramp_", but honestly not sure what orig problem was.
+
             eventHandlerNames = [
                 DefEH.CONFIG_CHANGE_UPDATES_MAP_ATTRIBS,
                 DefEH.LAYER_ERROR_UPDATES_LEGEND,

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -11,8 +11,6 @@ const fixtureModules = import.meta.glob<{ default: typeof FixtureInstance }>(
     '../fixtures/*/index.ts'
 );
 
-// TODO: implement the same `internal.ts` pattern in store, so can import from a single place;
-
 /**
  * A constructor returning an object implementing FixtureBase interface.
  */
@@ -237,7 +235,6 @@ export class FixtureAPI extends APIScope {
         this.$vApp.$store.set(ConfigStore.setStartingFixtures, fixtureNames);
         // add all the requested default promises.
         // return the promise-all of all the add fixture promises
-        // TODO alterately, don't do a promise.all, and just return the array of promises. not sure which is more useful.
         return Promise.all(fixtureNames.map(fn => this.add(fn)));
     }
 }

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -132,8 +132,6 @@ export class InstanceAPI {
      * @param {RampOptions | undefined} options startup options for this R4MP instance
      */
     private initialize(configs?: RampConfigs, options?: RampOptions): void {
-        // TODO: decide whether to move to src/main.ts:createApp
-        // TODO: store a reference to the event bus in the global store [?]
         if (configs?.configs !== undefined) {
             const langConfigs: {
                 [key: string]: RampConfig;
@@ -351,7 +349,6 @@ export class InstanceAPI {
         this.initialize(configs, options);
     }
 
-    // TODO: we probably need to expose other Vue global functions here like `set`, `use`, etc.
     /**
      * Retrieves a global Vue component by its id.
      *

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -414,7 +414,6 @@ export class PanelInstance extends APIScope {
         // use the provided value or negate the existing `isPinned` status of this panel
         value = typeof value !== 'undefined' ? value : !this.isPinned;
 
-        // TODO: change to toggle the pin status
         this.$iApi.panel.pin(this, value);
 
         return this;

--- a/src/fixtures/gazebo/index.ts
+++ b/src/fixtures/gazebo/index.ts
@@ -59,13 +59,13 @@ class GazeboFixture extends FixtureInstance {
                 config: {
                     screens: {
                         /**
-                         * // TODO: This should work:
+                         * // This should work:
                          * manually lazy-loading a screen component
                          */
                         //'p-2-screen-1': () => import(/* webpackChunkName: "p-2-screen-1" */ `./p2-screen-1.vue`),
 
                         /**
-                         * // TODO: This should work:
+                         * // This should work:
                          * for the demo purposes, delay resolution of a component by 2 seconds
                          */
                         'p-2-screen-1': () => {
@@ -83,13 +83,13 @@ class GazeboFixture extends FixtureInstance {
                         },
 
                         /**
-                         * // TODO: This should work:
+                         * // This should work:
                          * letting the core to lazy-load a screen component; need to provide a path relative to the fixtures home folder
                          */
                         'p-2-screen-2': markRaw(GazeboP2Screen2V),
 
                         /**
-                         * // TODO: This should work:
+                         * // This should work:
                          * returning a `VueConstructor` in a promise
                          */
                         'p-2-screen-3': () => {

--- a/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/src/fixtures/geosearch/store/geosearch-store.ts
@@ -186,7 +186,7 @@ const actions = {
      * Toggle map extent filter.
      *
      * @function setMapExtent
-     * @param   {any}    mapExtent   current map extent info // TODO what is this? add strong types? has .visible and .extent
+     * @param   {any}    mapExtent   current map extent info. has property .visible (boolean) and .extent (Extent)
      */
     setMapExtent: function (context: GeosearchContext, mapExtent: any): void {
         // if results should be filtered by current map view

--- a/src/fixtures/geosearch/store/types.ts
+++ b/src/fixtures/geosearch/store/types.ts
@@ -1,7 +1,6 @@
 import type { IGenericObjectType, ITypes } from '../definitions';
 import axios from 'axios';
 
-// TODO should these strings be in an i18n csv instead?
 const types: any = {
     en: {
         ADDRESS: 'Street Address',

--- a/src/fixtures/northarrow/northarrow.vue
+++ b/src/fixtures/northarrow/northarrow.vue
@@ -140,7 +140,7 @@ const updateNortharrow = async (newExtent: Extent) => {
                 let poleStyleParams;
                 if (poleIcon.value) {
                     // fixture config has provided a custom image.
-                    // TODO do we need to parmatarize the additonal options? offsets? height?
+                    // TODO do we need to parameterize the additonal options? offsets? height?
                     //      we would need to expand what our config schema accepts. Right now
                     //      you can only specify an icon image. Maybe we should allow the option
                     //      to pass any Option param object that a PointStyle class can accept.

--- a/src/fixtures/overviewmap/overviewmap.vue
+++ b/src/fixtures/overviewmap/overviewmap.vue
@@ -237,10 +237,10 @@ const _adaptBasemap = () => {
     } catch (err) {
         // if we errored above, just use the main map's basemap
 
-        // TODO: do we want this warning? will throw on every map refresh if no basemaps have been provided in the config (which is valid)
-        //       JR: no, as it made me investigate what the problem was. If we want to put a warning for an error that is not the
-        //           hardcoded one thrown above, we should compare the error text and only console if different. Can also shorten the
-        //           above to a unique key of sorts, since it wont be visibile to eyes.
+        // do we want this warning? will throw on every map refresh if no basemaps have been provided in the config (which is valid)
+        //   JR: no, as it made me investigate what the problem was. If we want to put a warning for an error that is not the
+        //       hardcoded one thrown above, we should compare the error text and only console if different. Can also shorten the
+        //       above to a unique key of sorts, since it wont be visibile to eyes.
         // console.warn(`${err}. Will default to the main map's basemap.`);
 
         // override the intial basemap id in the overview map config

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -260,14 +260,6 @@ const updateIdentify = (val: boolean) => {
 };
 
 /**
- * Toggle snapshot mode for the layer.
- */
-const toggleSnapshot = () => {
-    snapshotToggle.value = !snapshotToggle.value;
-    // TODO: make necessary changes to layer
-};
-
-/**
  * Load property data from layer.
  */
 const loadLayerProperties = () => {

--- a/src/geo/api/geo-common.ts
+++ b/src/geo/api/geo-common.ts
@@ -1,5 +1,3 @@
-// TODO I don't love this class / file name. Rename if better suggestion
-
 import { GeometryAPI, ProjectionAPI, SharedUtilsAPI } from '@/geo/api';
 
 import type { RampLodConfig } from '@/geo/api';

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -193,7 +193,7 @@ export enum LayerFormat {
 // Format indicates what form the spatial data is encoded in.
 // This refers to what the client is dealing with. So there is no "csv" format,
 // as that data gets converted into esri feature format.
-// TODO add more as we support more formats
+// Add more as we support more formats
 export enum DataFormat {
     ESRI_FEATURE = 'esriFeature',
     ESRI_RASTER = 'esriRaster',
@@ -293,9 +293,9 @@ export enum IdentifyResultFormat {
     UNKNOWN = 'unknown'
 }
 
-// TODO since MapClick and MapMove are payloads on public events, is there a proper
-//      way they should be exposed from the main app as well (like, exported? in one of those .d.ts files?)?
-//      same question probably applies to a number of other interfaces here.
+// Since MapClick and MapMove are payloads on public events, is there a proper
+// way they should be exposed from the main app as well (like, exported? in one of those .d.ts files?)?
+// same question probably applies to a number of other interfaces here.
 
 export interface MapClick {
     mapPoint: Point;
@@ -324,9 +324,6 @@ export interface Screenshot {
 }
 
 // a collection of attributes
-// TODO consider changin .features to .attributes or .attribs.
-//      features would be back-compatible, but it's confusing as we now have a Graphic class, which would be more
-//      aligned with the word "feature"
 export interface AttributeSet {
     features: Array<Attributes>;
     oidIndex: { [key: number]: number };
@@ -402,7 +399,6 @@ export interface QueryFeaturesArcServerParams extends QueryFeaturesParams {
 export interface IdentifyParameters {
     geometry: BaseGeometry;
     tolerance?: number;
-    returnGeometry?: boolean; // TODO revisit this. might make more sense to offload geom to a followup request. if we keep, we may need to add property to IdentifyItem for the geom to live in
     sublayerIds?: Array<string | number>; // Optional array of sublayer uids or server indices. When defined, the given sublayers are queried for instead of the default (visible, queryable, on-scale sublayers)
     hitTest?: Promise<Array<GraphicHitResult>>; // Optional results of local hits to incorporate in the identify
 }
@@ -476,6 +472,26 @@ export interface UrlQueryMap {
     [name: string]: string;
 }
 
+export interface GeoJsonOptions {
+    layerId?: string;
+    colour?: string;
+    fieldMetadata?: RampLayerFieldMetadataConfig;
+    sourceProjection?: string;
+    targetSR?: any; // string, number, or object with ESRI SR properties accepted
+    latField?: string;
+    lonField?: string;
+}
+
+export interface LoadLayerMetadataOptions {
+    customRenderer?: any; // valid JSON renderer. no handy typescript schema
+}
+
+export interface CsvOptions {
+    latfield?: string;
+    lonfield?: string;
+    delimiter?: string;
+}
+
 // ----------------------- CLIENT CONFIG INTERFACES -----------------------------------
 
 // TODO migrate these to /geo/api/geo-common ? if we need config interfaces before creating an instance,
@@ -543,7 +559,6 @@ export interface RampLayerMapImageSublayerConfig {
     index: number;
     name?: string;
     nameField?: string;
-    // outfields?: string; // TODO tbd if we keep this
     state?: RampLayerStateConfig;
     // following items need to be flushed out
     extent?: RampExtentConfig;
@@ -574,11 +589,11 @@ export interface RampLayerWmsSublayerConfig {
 export interface RampLayerConfig {
     id: string;
     layerType: LayerType;
-    url: string; // TODO tricky choice. really this should be optional. Graphic layers & raw geojson don't use it. But then we need undefined checks in majority of code.
+    url: string; // really this should be optional. Graphic layers & raw geojson don't use it. But then we would need undefined checks in majority of code.
     name?: string;
     state?: RampLayerStateConfig;
     customRenderer?: any;
-    // TODO revisit issue #1019 after v1.0.0
+    // NOTE would uncomment if issue #1019 gets done
     // refreshInterval?: number;
     expectedDrawTime?: number;
     expectedLoadTime?: number;
@@ -669,8 +684,8 @@ export interface MapCaptionConfig {
     scaleBar: { disabled?: boolean; imperialScale?: boolean };
 }
 
-// TODO actual ramp config is kinda wonky, split over lots of classes
-//      for now this will just serve as a nice type for the config
+// actual ramp config is kinda wonky, split over lots of classes
+// for now this will just serve as a nice type for the config
 export interface RampMapConfig {
     lodSets: Array<RampLodSetConfig>;
     extentSets: Array<RampExtentSetConfig>;

--- a/src/geo/api/graphic/geometry/base-geometry.ts
+++ b/src/geo/api/graphic/geometry/base-geometry.ts
@@ -1,12 +1,7 @@
-// TODO add proper documentation
-
 import { GeometryType, SpatialReference } from '@/geo/api';
 import type { SrDef, IdDef } from '@/geo/api';
 import type { EsriGeometry } from '@/geo/esri';
 import type GeoJson from 'geojson';
-
-// TODO since this class is often used as a parameter type (i.e. something that accepts any of our geometries),
-//      maybe pick a different name, like Geometry, AnyGeometry, RampGeometry, GeometryInstance
 
 /**
  * Baseclass of all geometries. All geometry types must derive from this class. Not intented to be instantiated on its own.

--- a/src/geo/api/graphic/geometry/extent.ts
+++ b/src/geo/api/graphic/geometry/extent.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import {
     BaseGeometry,
     GeoJsonGeomType,
@@ -45,7 +43,7 @@ export class Extent extends BaseGeometry {
         this.rawMax = Point.parseXY(maxGeometry);
     }
 
-    // TODO getter / setter for individul values? classic [x|y][min|max] set
+    // TODO setters for individul values? classic [x|y][min|max] set
 
     /** Returns the string 'Extent'. */
     get type(): GeometryType {

--- a/src/geo/api/graphic/geometry/geometry.ts
+++ b/src/geo/api/graphic/geometry/geometry.ts
@@ -1,5 +1,3 @@
-// TODO fancy up the docs
-
 import type GeoJson from 'geojson';
 import {
     BaseGeometry,

--- a/src/geo/api/graphic/geometry/linear-ring.ts
+++ b/src/geo/api/graphic/geometry/linear-ring.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import {
     GeoJsonGeomType,
     GeometryType,
@@ -58,10 +56,6 @@ export class LinearRing extends PointSet {
 
     /** Will update the n-th contained point with the values of the point parameter. It is assumed the point is in the same spatial reference as the Multipoint */
     updateAt(point: Point | Array<number> | object, n: number) {
-        // TODO question if this is good logic.
-        //      it helps a person not paying attention retain their ring.
-        //      if someone is being clever and updates both front and end, no harm i guess, will double the updates
-
         // add extra logic to ensure ring remains a ring
         const l = this.length - 1;
         if (n === 0) {

--- a/src/geo/api/graphic/geometry/multi-line-string.ts
+++ b/src/geo/api/graphic/geometry/multi-line-string.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import {
     BaseGeometry,
     GeoJsonGeomType,

--- a/src/geo/api/graphic/geometry/multi-point.ts
+++ b/src/geo/api/graphic/geometry/multi-point.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import {
     GeoJsonGeomType,
     GeometryType,

--- a/src/geo/api/graphic/geometry/multi-polygon.ts
+++ b/src/geo/api/graphic/geometry/multi-polygon.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import {
     BaseGeometry,
     GeoJsonGeomType,
@@ -156,7 +154,8 @@ export class MultiPolygon extends BaseGeometry {
         const ringMerger: Array<Array<Array<number>>> = [];
 
         // TODO is there a more efficient way to do this than with pushes? use concats?
-        // concat will keep re-copying all known rings with each new polygon encountered, so probably worse
+        // concat will keep re-copying all known rings with each new polygon encountered,
+        // so probably worse (internet tends to agree)
         this.toArray().forEach(poly => {
             poly.forEach(ring => ringMerger.push(ring));
         });

--- a/src/geo/api/graphic/geometry/point.ts
+++ b/src/geo/api/graphic/geometry/point.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import { BaseGeometry, GeoJsonGeomType, GeometryType } from '@/geo/api';
 import type { SrDef, IdDef } from '@/geo/api';
 import { EsriPoint } from '@/geo/esri';

--- a/src/geo/api/graphic/geometry/polygon.ts
+++ b/src/geo/api/graphic/geometry/polygon.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import {
     BaseGeometry,
     GeoJsonGeomType,

--- a/src/geo/api/graphic/geometry/spatial-reference.ts
+++ b/src/geo/api/graphic/geometry/spatial-reference.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 import type { SrDef } from '@/geo/api';
 import { EsriSpatialReference } from '@/geo/esri';
 import type GeoJson from 'geojson';

--- a/src/geo/api/graphic/graphic.ts
+++ b/src/geo/api/graphic/graphic.ts
@@ -1,5 +1,3 @@
-// TODO add proper documentation
-
 // this will collate:
 
 // geometry

--- a/src/geo/api/graphic/hover.ts
+++ b/src/geo/api/graphic/hover.ts
@@ -1,8 +1,8 @@
-// TODO add proper documentation
-// TODO this is sketchy for now. not sure what kind of hover magic we will support
+// This is sketchy for now. not sure what kind of hover magic we will support
 //      only on SimpleLayer type things?
 //      should Hover be a part of Graphic instead of Geometry?
-// for the time being, we are just using RAMP2 object for placeholder
+// for the time being, we are just using RAMP2 object for placeholder.
+// This class is likely not used in v4.0.0
 
 interface HovertipOptions {
     keepOpen: boolean;

--- a/src/geo/api/layer/filter.ts
+++ b/src/geo/api/layer/filter.ts
@@ -49,7 +49,7 @@ export class Filter {
      * @returns {Boolean} indicates if any non-permanent filters are active
      */
     isActive(): boolean {
-        // TODO clear up and make not of why there are no extent filters being considered here.
+        // TODO clear up and make note of why there are no extent filters being considered here.
         //      is this because extent is considered map level? anyways clarify the jsdoc once known.
         return this.sqlActiveFilters([CoreFilter.PERMANENT]).length > 0;
     }

--- a/src/geo/api/layer/scale-set.ts
+++ b/src/geo/api/layer/scale-set.ts
@@ -1,5 +1,3 @@
-// TODO add proper comments
-
 // TODO move to main gapi types file?
 interface OffScaleStatus {
     offScale: boolean;

--- a/src/geo/api/utils/projection.ts
+++ b/src/geo/api/utils/projection.ts
@@ -85,12 +85,9 @@ export class ProjectionAPI {
             const params: __esri.RequestOptions = {
                 responseType: 'text'
             };
-            const restReq: IPromise<__esri.RequestResponse> = EsriRequest(
-                epsgUrl,
-                params
-            ); // TODO since this is outside of esri api, consider using the vue web request lib here
+            const restReq = EsriRequest(epsgUrl, params); // TODO since this is outside of esri api, consider using the vue web request lib here
             restReq.then(
-                (serviceResult: __esri.RequestResponse) => {
+                serviceResult => {
                     if (serviceResult.data) {
                         resolve(serviceResult.data); // should be a string. TEST!
                     } else {

--- a/src/geo/api/utils/shared-utils.ts
+++ b/src/geo/api/utils/shared-utils.ts
@@ -12,16 +12,6 @@ export class SharedUtilsAPI {
     generateUUID(): string {
         let d = Date.now();
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-            /*
-            // TODO: Come up with cheaper solution that doesn't use the crypto API and satifies CodeQL
-            const r =
-            (d +
-                window.crypto.getRandomValues(new Uint32Array(1))[0] *
-                Math.pow(2, -32) *
-                16) %
-                16 |
-                0; */
-
             // do math!
             /*jslint bitwise: true */
             const r = (d + Math.random() * 16) % 16 | 0;
@@ -42,13 +32,10 @@ export class SharedUtilsAPI {
      */
     convertImageToCanvas(
         url: string,
-        canvas: any = null,
+        canvas: HTMLCanvasElement | undefined = undefined,
         crossOrigin = true
     ): Promise<any> {
-        // TODO canvas param was initially typed as HTMLCanvasElement
-        //      find out where that type was getting imported in old GeoAPI,
-        //      decide if we want to import and use here
-        canvas = canvas || window.document.createElement('canvas');
+        const c = canvas ?? window.document.createElement('canvas');
 
         const image = window.document.createElement('img'); // create image node
 
@@ -58,12 +45,12 @@ export class SharedUtilsAPI {
 
         const conversionPromise = new Promise((resolve, reject) => {
             image.addEventListener('load', () => {
-                canvas.width = image.width; // changing canvas size will clear all previous content
-                canvas.height = image.height;
-                canvas.getContext('2d').drawImage(image, 0, 0); // draw image onto a canvas
+                c.width = image.width; // changing canvas size will clear all previous content
+                c.height = image.height;
+                c.getContext('2d')?.drawImage(image, 0, 0); // draw image onto a canvas
 
                 // return canvas
-                resolve(canvas);
+                resolve(c);
             });
             image.addEventListener('error', error => reject(error));
         });

--- a/src/geo/layer/common-graphic-layer.ts
+++ b/src/geo/layer/common-graphic-layer.ts
@@ -1,6 +1,5 @@
 // put things here that would be common to all esri attribute layers.
 // used for layer types defined by Core RAMP.
-// TODO add proper comments
 
 import { CommonLayer, InstanceAPI } from '@/api/internal';
 import type { EsriGraphicsLayer, EsriGraphic } from '@/geo/esri';
@@ -28,7 +27,6 @@ export class CommonGraphicLayer extends CommonLayer {
      * @returns configuration object for the ESRI layer representing this layer
      */
     protected makeEsriLayerConfig(rampLayerConfig: RampLayerConfig): any {
-        // TODO flush out
         // NOTE: it would be nice to put esri.LayerProperties as the return type, but since we are cheating with refreshInterval it wont work
         //       we can make our own interface if it needs to happen (or can extent the esri one)
         const esriConfig: any = super.makeEsriLayerConfig(rampLayerConfig);
@@ -52,12 +50,6 @@ export class CommonGraphicLayer extends CommonLayer {
         return this._graphics.length;
     }
 
-    // TODO think about this name. would like to use getGraphic for consistency.
-    //      However currently there are things that would need to be re-aligned.
-    //      These graphic ids are strings, object ids are ints. Method in common layer / interface
-    //      would need to support both types and handle bad data in actual layers.
-    //      This function is synch. We could have it wrap its result in a promise to align with
-    //      the server version
     /**
      * Gets a graphic from the layer, if it exists.
      *

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -64,9 +64,6 @@ export class CommonLayer extends LayerInstance {
 
     // ----------- LAYER CONSTRUCTION AND INITIALIZAION -----------
 
-    // NOTE since constructor needs to be called first, we might want to push a lot of initialization to an .init() function
-    //      that actual implementer classes call in their constructors. e.g. for a file layer, might need to process file parts prior to running LayerBase stuff
-    // TODO if layer is now self-containing the reload stuff, we can internalize the reload tree.
     protected constructor(rampConfig: RampLayerConfig, $iApi: InstanceAPI) {
         super(rampConfig, $iApi);
 
@@ -319,8 +316,6 @@ export class CommonLayer extends LayerInstance {
         await this.initiate();
 
         if (!this.esriLayer) {
-            // TODO this might not warrent a console. A busted map server could fail, and the layer status would
-            //      already give the error indication.
             console.error('ESRI layer failed to re-create during reload.');
             return;
         }
@@ -347,8 +342,8 @@ export class CommonLayer extends LayerInstance {
             visible: rampLayerConfig?.state?.visibility ?? true
         };
 
-        // TODO careful now. seems setting this willy nilly, even if undefined value, causes layer to keep pinging the server
-        // TODO revisit issue #1018 after v1.0.0
+        // NOTE careful now. seems setting this willy nilly, even if undefined value, causes layer to keep pinging the server
+        //      revisit issue #1018 after v4.0.0
         // if (typeof rampLayerConfig.refreshInterval !== 'undefined') {
         //     esriConfig.refreshInterval = rampLayerConfig.refreshInterval;
         // }
@@ -808,8 +803,7 @@ export class CommonLayer extends LayerInstance {
             columns: [],
             rows: [],
             fields: [],
-            oidField: 'error',
-            oidIndex: 0 // TODO determine if we need this anymore
+            oidField: 'error'
         });
     }
 

--- a/src/geo/layer/csv-layer.ts
+++ b/src/geo/layer/csv-layer.ts
@@ -8,9 +8,6 @@ export class CsvLayer extends FileLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        // TODO check if .sourceGeoJson is already populated?
-        //      if this initiate is a reload, do we want to re-use it, or re-download? decide.
-
         if (!this.origRampConfig.latField || !this.origRampConfig.longField) {
             throw new Error('csv file config missing lat or long field names');
         }

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -64,7 +64,7 @@ export class FeatureLayer extends AttribLayer {
         const esriConfig: __esri.FeatureLayerProperties =
             super.makeEsriLayerConfig(rampLayerConfig);
 
-        // TODO add any extra properties for attrib-based layers here
+        // add any extra properties for attrib-based layers here
         // if we have a definition at load, apply it here to avoid cancellation errors on
         if (
             rampLayerConfig.initialFilteredQuery ||
@@ -109,8 +109,8 @@ export class FeatureLayer extends AttribLayer {
             );
         }
 
-        // TODO .url seems to not have the /index ending.  there is parsedUrl.path, but thats not on official definition
-        //      can also consider changing logic to use origRampConfig.url;
+        // .url seems to not have the /index ending.  there is parsedUrl.path, but thats not on official definition
+        // can also consider changing logic to use origRampConfig.url;
         // const layerUrl: string = (<esri.FeatureLayer>this._innerLayer).url;
         const layerUrl: string = (<any>this.esriLayer).parsedUrl.path;
         const urlData = this.$iApi.geo.shared.parseUrlIndex(layerUrl);
@@ -167,13 +167,8 @@ export class FeatureLayer extends AttribLayer {
         this.layerTree.name = this.name;
         this.layerTree.layerIdx = featIdx;
 
-        // if file based (or server extent was fried), calculate extent based on geometry
-        // TODO implement this. may need a manual loop to calculate graphicsExtent since ESRI torpedo'd the function
-        /*
-        if (!this.extent || !this.extent.xmin) {
-            this.extent = this._apiRef.proj.graphicsUtils.graphicsExtent(this._layer.graphics);
-        }
-        */
+        // Note that ESRI 4 seems to self-calculate a layer extent based on the geometry,
+        // so we no longer need to worry about generating one (graphicsUtils.graphicsExtent() is depreciated)
 
         loadPromises.push(pLD, pFC);
 

--- a/src/geo/layer/geojson-layer.ts
+++ b/src/geo/layer/geojson-layer.ts
@@ -9,9 +9,6 @@ export class GeoJsonLayer extends FileLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        // TODO check if .sourceGeoJson is already populated?
-        //      if this initiate is a reload, do we want to re-use it, or re-download? decide.
-
         // get geojson from appropriate source and set to special property.
         // then initiate the FileLayer
 

--- a/src/geo/layer/graphic-layer.ts
+++ b/src/geo/layer/graphic-layer.ts
@@ -30,7 +30,6 @@ export class GraphicLayer extends CommonGraphicLayer {
     protected makeEsriLayerConfig(
         rampLayerConfig: RampLayerConfig
     ): __esri.GraphicsLayerProperties {
-        // TODO flush out
         // NOTE: it would be nice to put esri.LayerProperties as the return type, but since we are cheating with refreshInterval it wont work
         //       we can make our own interface if it needs to happen (or can extent the esri one)
         const esriConfig: __esri.GraphicsLayerProperties =

--- a/src/geo/layer/imagery-layer.ts
+++ b/src/geo/layer/imagery-layer.ts
@@ -1,5 +1,3 @@
-// TODO add proper comments
-
 import { CommonLayer, InstanceAPI } from '@/api/internal';
 import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
@@ -33,7 +31,6 @@ export class ImageryLayer extends CommonLayer {
     protected makeEsriLayerConfig(
         rampLayerConfig: RampLayerConfig
     ): __esri.ImageryLayerProperties {
-        // TODO flush out
         const esriConfig: __esri.ImageryLayerProperties =
             super.makeEsriLayerConfig(rampLayerConfig);
 

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -222,7 +222,7 @@ export class LayerInstance extends APIScope {
         this.config = config;
 
         this.id = ''; // take from config here?
-        this.uid = ''; // shutting up typescript. will get set somewhere else. // TODO verify setting, move here if that is smarter.
+        this.uid = ''; // shutting up typescript. will get set somewhere else.
         this.name = 'error';
         this.layerState = LayerState.NEW;
         this.drawState = DrawState.NOT_LOADED;

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -190,9 +190,4 @@ export class LayerAPI extends APIScope {
             disabledControls: layer.config.disabledControls ?? []
         };
     }
-
-    // TODO consider if we need a defaulting scenario. This might tie in with
-    //      people wanting to override core layer types; they would omit then provide
-    //      the custom layer definition class.
-    //      see fixture api, addDefaultFixtures method
 }

--- a/src/geo/layer/ogc-utils.ts
+++ b/src/geo/layer/ogc-utils.ts
@@ -13,8 +13,6 @@ type WFSResponse = {
 type WFSData = { type: string; features: any[] };
 
 export class OgcUtils extends APIScope {
-    // TODO update logic in this function to get changes done in https://github.com/fgpv-vpgf/fgpv-vpgf/pull/3858
-    // TODO consider changing the long list of functon params into one options param object
     /**
      *
      * @param {string} url the current url to the wfs service

--- a/src/geo/layer/osm-tile-layer.ts
+++ b/src/geo/layer/osm-tile-layer.ts
@@ -1,5 +1,3 @@
-// TODO add proper comments
-
 import { CommonLayer, InstanceAPI } from '@/api/internal';
 import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 
@@ -39,7 +37,6 @@ export class OsmTileLayer extends CommonLayer {
     protected makeEsriLayerConfig(
         rampLayerConfig: RampLayerConfig
     ): __esri.OpenStreetMapLayerProperties {
-        // TODO flush out
         const esriConfig: __esri.OpenStreetMapLayerProperties =
             super.makeEsriLayerConfig(rampLayerConfig);
 
@@ -58,14 +55,14 @@ export class OsmTileLayer extends CommonLayer {
 
         this.layerTree.name = this.name;
 
-        // TODO what is appropriate legend? The default empty array?
-        //      OSM is not arcgis so no legend rest endpoint to scrape.
-        //      and if they host their own it's likely massive with all the possible symbols.
-        //      Right now you see nothing in the spot to the left of the layer name.
-        //      Maybe we hardcode the OSM icon? It is a map with a magnifying glass,
-        //      which might be confusing as it will look like a search icon.
-        //      For now, just using a default "O".  The odds of OSM being an active
-        //      layer in the legend is pretty low, and a config can override the symbol I believe.
+        // what is appropriate legend? The default empty array?
+        // OSM is not arcgis so no legend rest endpoint to scrape.
+        // and if they host their own it's likely massive with all the possible symbols.
+        // Right now you see nothing in the spot to the left of the layer name.
+        // Maybe we hardcode the OSM icon? It is a map with a magnifying glass,
+        // which might be confusing as it will look like a search icon.
+        // For now, just using a default "O".  The odds of OSM being an active
+        // layer in the legend is pretty low, and a config can override the symbol I believe.
 
         const legGuts = this.$iApi.geo.symbology.generatePlaceholderSymbology(
             'O',

--- a/src/geo/layer/shapefile-layer.ts
+++ b/src/geo/layer/shapefile-layer.ts
@@ -8,9 +8,6 @@ export class ShapefileLayer extends FileLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        // TODO check if .sourceGeoJson is already populated?
-        //      if this initiate is a reload, do we want to re-use it, or re-download? decide.
-
         let shapefileData: any; // data type is actually an ArrayBuffer
 
         if (this.origRampConfig.rawData) {

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -1,5 +1,3 @@
-// TODO add proper comments
-
 import { CommonLayer, InstanceAPI } from '@/api/internal';
 import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
@@ -34,7 +32,6 @@ export class TileLayer extends CommonLayer {
     protected makeEsriLayerConfig(
         rampLayerConfig: RampLayerConfig
     ): __esri.TileLayerProperties {
-        // TODO flush out
         const esriConfig: __esri.TileLayerProperties =
             super.makeEsriLayerConfig(rampLayerConfig);
 

--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -59,7 +59,6 @@ export class WmsLayer extends CommonLayer {
     protected makeEsriLayerConfig(
         rampLayerConfig: RampLayerConfig
     ): __esri.WMSLayerProperties {
-        // TODO flush out
         // NOTE: it would be nice to put esri.LayerProperties as the return type, but since we are cheating with refreshInterval it wont work
         //       we can make our own interface if it needs to happen (or can extent the esri one)
         const esriConfig: __esri.WMSLayerProperties = super.makeEsriLayerConfig(
@@ -105,29 +104,9 @@ export class WmsLayer extends CommonLayer {
         //      dont have 10+ MB capability files, and this is non-issue.
         //      the todo below is original brainstorming on the problem,
         //      not feeling hot that a good universal solution exists.
-        //
-        // TODO need to test the .suppressGetCapabilities functionality.
-        //      we no longer have .resourceInfo on the layer constructor.
-        //      first attempt would be to try and pre-populate .sublayers
-        //      and .fullExtent in the constructor config
-        //      further complicated as .sublayers is a tree whereas .resourceInfo
-        //      was a flat array.
-        //      also, the ESRI doc as of 4.14 seems to indicate it always makes
-        //      a getcapabilities call so this might be a lost cause
 
         // looks like the GetCapabilities call is always made: https://community.esri.com/t5/arcgis-api-for-javascript/create-wms-layer-without-getcapabilities-request/td-p/1002080
 
-        // old code:
-
-        /*
-        if (this.config.suppressGetCapabilities) {
-            cfg.resourceInfo = {
-                extent: new this._apiRef.Map.Extent(-141, 41, -52, 83.5, {wkid: 4326}), // TODO make this a parameter post-demo
-                layerInfos: this.config.sublayers
-                    .map(sublayer new this._apiRef.layer.WMSLayerInfo({name: sublayer.id, title: sublayer.name || ''}))
-            };
-        }
-        */
         return esriConfig;
     }
 

--- a/src/geo/map/basemap.ts
+++ b/src/geo/map/basemap.ts
@@ -23,7 +23,7 @@ export class Basemap {
             //      File based trickier but useful. Would throw asynch wrench into this.
             //      ESRI Image Server would make sense.
             baseLayers: rampConfig.layers.map(layerConfig => {
-                // TODO convert to switch statement if we add more types?
+                // convert to switch statement if we add more types?
                 if (layerConfig.layerType === LayerType.TILE) {
                     return new EsriTileLayer({
                         url: layerConfig.url,

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -3,8 +3,6 @@
 // makes it unclear how much overlap of functionality makes sense. Could be
 // we need an entirely different framework to really support 3D.
 
-// TODO add proper comments
-
 import { toRaw, markRaw } from 'vue';
 import { APIScope, Basemap, InstanceAPI } from '@/api/internal';
 import { EsriMap } from '@/geo/esri';
@@ -485,7 +483,4 @@ export class CommonMapAPI extends APIScope {
         );
         return false;
     }
-
-    // TODO shared Map (not view-based) functions could go here.
-    //      Includes passthrough things. Could also include addLayer (assuming the LayerView gets handled automagically in 3D case?)
 }

--- a/src/geo/map/maptip.ts
+++ b/src/geo/map/maptip.ts
@@ -79,7 +79,7 @@ export class MaptipAPI extends APIScope {
             return;
         }
 
-        // TODO: remove this once we support hovers on RAMP graphics
+        // remove this once we support hovers on RAMP graphics
         if (!layerInstance.hovertips) {
             // the hit layer doesn't support hovertips
             return;

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -1,5 +1,4 @@
 // wraps and represents a 2D esri map
-// TODO add proper comments
 
 import {
     Basemap,
@@ -648,20 +647,6 @@ export class MapAPI extends CommonMapAPI {
         // Fire the layer removal event
         this.$iApi.event.emit(GlobalEvents.LAYER_REMOVE, layerInstance);
     }
-
-    /**
-     * Adds a highlight layer to the map
-     *
-     * @param {HighlightLayer} highlightLayer the highlight
-     */
-    // TODO make a decision to re-add or remove after we figure out what highlight layers are dong
-    /*
-    addHighlightLayer (highlightLayer: HighlightLayer): void {
-        this.esriMap.add(highlightLayer.esriLayer);
-    }
-    */
-
-    // TODO passthrough functions, either by aly magic or make them hardcoded
 
     /**
      * Set's the map's mapMouseThrottle value to newThrottle.

--- a/src/geo/tests/e2e/shared-utils-test.js
+++ b/src/geo/tests/e2e/shared-utils-test.js
@@ -156,8 +156,6 @@ describe('GeoAPI SharedUtils', () => {
     //     });
     // });
 
-    // TODO: Add more tests for SharedUtils through adding layers through the wizard
-
     it('formatLatLongDMSString undefined point', () => {
         cy.window().then(window => {
             const sharedUtils = window.debugInstance.geo.shared;

--- a/src/geo/utils/query.ts
+++ b/src/geo/utils/query.ts
@@ -1,6 +1,3 @@
-// TODO add proper comments
-// TODO change all the 'any' in this file to more strict types if possible
-
 import { APIScope, FileLayer, InstanceAPI } from '@/api/internal';
 import {
     BaseGeometry,
@@ -86,7 +83,6 @@ export class QueryAPI extends APIScope {
             query.where = options.filterSql;
         }
 
-        // TODO check strong typing of this line (after GeoJSON layers are implemented)
         await options.layer.loadPromise();
 
         if (!options.layer.esriLayer) {
@@ -117,9 +113,6 @@ export class QueryAPI extends APIScope {
         });
     }
 
-    // TODO think about splitting up a lot of the below functions into server specific
-    //      and file specific functions.
-
     /**
      * Helper function to modify input geometries for queries. Will attempt to avoid various pitfalls,
      * usually around projections
@@ -137,7 +130,6 @@ export class QueryAPI extends APIScope {
         mapScale?: number,
         sourceSR?: SpatialReference
     ): __esri.Geometry {
-        // TODO consider casting sourceSR to our API SR class?
         let finalGeom: __esri.Geometry;
 
         if (!isFileLayer && geometry.type === GeometryType.EXTENT) {

--- a/src/geo/utils/renderer.ts
+++ b/src/geo/utils/renderer.ts
@@ -1,5 +1,3 @@
-// TODO proper doc
-
 // contains renderer classes that let us decorate and work with ESRI renderer classes.
 // we can add more classes to support more renderer types if we need to
 

--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -337,7 +337,7 @@ export class SymbologyAPI extends APIScope {
             .size(this.CONTAINER_SIZE, this.CONTAINER_SIZE)
             .viewbox(0, 0, this.CONTAINER_SIZE, this.CONTAINER_SIZE);
 
-        // TODO use enums here if we can (functions, tricky)
+        // use enums here if we can (functions, tricky)
         // functions to draw esri simple marker symbols
         // jscs doesn't like enhanced object notation
         // jscs:disable requireSpacesInAnonymousFunctionExpression
@@ -575,7 +575,7 @@ export class SymbologyAPI extends APIScope {
                 const max = _this.CONTAINER_SIZE - _this.CONTENT_PADDING;
                 draw.line(min, min, max, max).stroke(lineStroke);
             },
-            // TODO find new equivalent for this. CLS was cartographic line style. can run test using fromJSON to see what this spits out.
+            // cartographic line style. internet is hinting that it is not supported on JS API
             esriCLS() {
                 // ESRI Fancy Line Symbol
                 this['simple-line']();
@@ -698,13 +698,10 @@ export class SymbologyAPI extends APIScope {
 
         // jscs:enable requireSpacesInAnonymousFunctionExpression
 
-        // console.log(symbol.type, label, '--START--');
-        // console.log(symbol);
-
         try {
             // @ts-ignore
             await Promise.resolve(symbolTypes[symbol.type]());
-            // console.log(symbol.type, label, '--DONE--');
+
             // remove element from the page
             window.document.body.removeChild(container);
             return draw.svg();
@@ -756,15 +753,14 @@ export class SymbologyAPI extends APIScope {
      * @param {Boolean} crossOrigin [optional = true] specifies if the image should be loaded as crossOrigin
      * @return {Promise} promise resolving with the loaded image and its loader object (see svg.js http://documentup.com/wout/svg.js#image for details)
      */
-    svgDrawImage(
+    async svgDrawImage(
         draw: any,
         imageUri: string,
         width = 0,
         height = 0,
         crossOrigin = true
     ): Promise<any> {
-        // TODO enhance to some proper types? make this async?
-        const promise = new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             const image = draw
                 .image(imageUri, width, height, crossOrigin)
                 .loaded((loader: any) => resolve({ image, loader }))
@@ -773,8 +769,6 @@ export class SymbologyAPI extends APIScope {
                     console.error(err);
                 });
         });
-
-        return promise;
     }
 
     /**

--- a/src/store/modules/layer/layer-store.ts
+++ b/src/store/modules/layer/layer-store.ts
@@ -7,8 +7,6 @@ import type { RootState } from '@/store';
 import type { RampLayerConfig } from '@/geo/api';
 import { LayerInstance } from '@/api/internal';
 
-// TODO we have "Layer" referenced as a layer baseclass in a lot of comments. Update it to whatever is appropriate and accurate.
-
 // NOTE
 // on the wonkyness of new changes here.
 // in old version, layer store would take layer configs, generate layers from layer blueprints, and store the layers.
@@ -69,10 +67,6 @@ const actions = {
         context: LayerContext,
         layerConfigs: RampLayerConfig[]
     ) => {
-        // TODO we are getting frequent errors at startup; something passes in an
-        //      undefined layerConfigs. kicking out for now to make demos work.
-        //      possibly this is evil in vue state land. if so, then someone figure out
-        //      the root cause and fix that.
         if (!Array.isArray(layerConfigs)) {
             return;
         }
@@ -87,10 +81,6 @@ const actions = {
         context.commit('REORDER_LAYER', { layer, index });
     },
     addLayers: (context: LayerContext, layers: LayerInstance[]) => {
-        // TODO we are getting frequent errors at startup; something passes in an
-        //      undefined layerConfigs. kicking out for now to make demos work.
-        //      possibly this is evil in vue state land. if so, then someone figure out
-        //      the root cause and fix that.
         if (!Array.isArray(layers)) {
             return;
         }
@@ -98,38 +88,6 @@ const actions = {
         layers.forEach(l => {
             context.commit('ADD_LAYER', l);
         });
-
-        // TODO clean this up
-
-        // plan for the moment.
-        // looks like we can't access $iApi here in the store.
-        // the old code used LayerBlueprint, which is a standalone factory and didn't need the api
-        // suggesting the following:
-        // have esrimap watch the layerconfig array as well.
-        // when it sees the change, it does the layer registration and generation (might as well also add it to the map)
-        // then it puts the new layer in the layer store (and we erase the existing listener). need to figure out how to do this.
-        // something like this.$vApp.$store.set(ConfigStore.newConfig, defaultConfig !== undefined ? defaultConfig : undefined);
-
-        /*
-        const loadproms = [];
-        layerConfigs.forEach(layerConfig => {
-            if (api.)
-            loadproms.push(LayerBlueprint.makeBlueprint(layerConfig));
-        });
-        */
-
-        // old code
-        /*
-        const blueprints: any = [];
-        layerConfigs.forEach(layerConfig => {
-            blueprints.push(LayerBlueprint.makeBlueprint(layerConfig));
-        });
-        blueprints.forEach((blueprint: any) => {
-            blueprint.makeLayer().then((layer: LayerBase) => {
-                context.commit('ADD_LAYER', layer);
-            });
-        });
-        */
     },
     addErrorLayers: (context: LayerContext, layers: LayerInstance[]) => {
         if (!Array.isArray(layers)) {


### PR DESCRIPTION
Revisits a pile of questionable `TODO` markers

- removes ones that are no longer valid
- changes ones to general notes if there is no longer anything "to do"
- adds some types to fancy parameters
- cleans up some missing and incorrect documentation