### PR TITLE
Change focus highlight on map caption buttons

### DIFF
--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -206,8 +206,12 @@ const onScaleClick = () => {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .map-caption {
     backdrop-filter: blur(5px);
+
+    button:focus {
+        outline: 2px solid #1e3a8a !important;
+    }
 }
 </style>


### PR DESCRIPTION
Addresses #1625.

The buttons in the map caption now have a blue coloured highlight, as the issue suggests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1627)
<!-- Reviewable:end -->
