### PR TITLE
Experimental: Configured VS Code debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome",
+            "url": "https://localhost:5173/demos/index-samples.html", // If your vite server launches at 127.0.0.1, update the url to 127.0.0.1:5173.
+            "webRoot": "${workspaceFolder}/src",
+            "sourceMapPathOverrides": {
+                "webpack:///src/*": "$(webRoot)/*"
+            },
+            "preLaunchTask": "Start Server" // Launches the Vite server before the browser
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Start Server",
+            "type": "shell",
+            "command": "cmd",
+            "isBackground": true,
+            "args": [
+                "/c",
+                // Check to see if the server is running on port 5173 first. If the port is free then launch, otherwise exit.
+                "netstat -aon | findstr :5173 | findstr LISTENING > nul || (npm run launch && exit)"
+            ],
+            "problemMatcher": [
+                {
+                    "owner": "Start Server",
+                    "pattern": {
+                        "regexp": ".+"
+                    },
+                    "background": {
+                        "activeOnStart": true,
+                        "beginsPattern": ".+",
+                        "endsPattern": ".+"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "scripts": {
         "dev": "vite",
         "dev-http": "vite --https=false",
+        "launch": "vite --no-open",
         "build": "vite build",
         "preview": "vite preview --port 5050",
         "test:e2e": "start-server-and-test preview http://127.0.0.1:5050/ 'cypress open'",


### PR DESCRIPTION
As mentioned its still experimental, so I'll need the team to test this out and yell at me for breaking anything.

Currently chrome and edge are the only browsers that support this, and if you're still hanging onto Firefox like me we can't rely on launching the default browser.

Ideally we'll have another configuration that rewards chrome / edge users and just uses npm run dev as the launch script.

**Instructions**
Go to to the debug tab in VS code (Ctrl + Shift + D) 
Select the "Launch Chrome" configuration at the top 
Press the green play button or f5
Set breakpoints and go nuts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1632)
<!-- Reviewable:end -->
