### PR TITLE
Attribute downloader order robustness

### DIFF
--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -57,6 +57,7 @@ export class AttributeAPI extends APIScope {
             query: {
                 where: `${details.oidField}>${details.maxId}${permFilter}`,
                 outFields: details.attribs,
+                orderByFields: details.oidField,
                 returnGeometry: 'false',
                 f: 'json'
             }

--- a/src/stores/layer/layer-store.ts
+++ b/src/stores/layer/layer-store.ts
@@ -3,22 +3,6 @@ import { LayerInstance } from '@/api/internal';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
-// NOTE
-// on the wonkyness of new changes here.
-// in old version, layer store would take layer configs, generate layers from layer blueprints, and store the layers.
-// the layer blueprints were sort of stand alone hardcoded classes lurking inside the layer state folder.
-// now that layer definitions are loaded like fixtures, we can't do this.
-// also it appears we cant (or shouldn't) reference the $iApi from inside the state.
-// the new approach (which might be wrong but is working for now) is the layer state
-// handles both the layer configs and the layers.
-// the esri-map module watches the layer configs, when it sees a new config, it then instantiates the layer
-// (using $iApi), and stores the layer back into the store as well.
-// possible changes by smarter people:
-// - have the layer config store relocated to the config store
-// - have a way for the layer store to access and run the layer definitions from the iApi
-// - restructure the layer definitions manager on the iApi so that the definitions are inside the store.
-//   might be tricky, as this part also needs to know to load new definitions on demand
-
 // searches layers and sublayers using BFS and returns the first layer to satisfy the given predicate
 const bfs = (
     layers: Array<LayerInstance>,


### PR DESCRIPTION
Donethankses https://github.com/ramp4-pcar4/ramp4-pcar4/issues/843

Very minor, just adds robustness to the rare case where an ArcGIS Server is returning query results in an order that is not the object id. Currently do not have such a service to test against, but we have encountered this in the past ( https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2296 ).

For now, testing should just verify the bulk attribute loader works the same as it did before this change (i.e. load the grid, look for anything sus). You can also look at the web calls in the console and ensure the `orderBy` param is appearing on data requests when the grid opens the first time.

Also removed a large comment paragraph that was outdated and had some lies in it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1639)
<!-- Reviewable:end -->
