### PR TITLE
Legend Search Demo

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -490,7 +490,7 @@ let config = {
                                                 name: 'Custom Info Section',
                                                 infoType: 'template',
                                                 content: `<div>
-                                                            <span>Surpise one:.</span>
+                                                            <span>Surprise one:.</span>
                                                             <img src="https://i.imgur.com/WtY0tdC.gif" />
                                                             </div>`
                                             },

--- a/schema.json
+++ b/schema.json
@@ -300,7 +300,8 @@
                         "wizard",
                         "layerReorder",
                         "groupToggle",
-                        "visibilityToggle"
+                        "visibilityToggle",
+                        "searchFilter"
                     ]
                 },
                 "panelWidth": {
@@ -448,7 +449,8 @@
                     "groupToggle",
                     "layerReorder",
                     "visibilityToggle",
-                    "wizard"
+                    "wizard",
+                    "searchFilter"
                 ]
             },
             "uniqueItems": true

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -18,7 +18,8 @@ export class LegendAPI extends FixtureInstance {
                 'wizard',
                 'layerReorder',
                 'groupToggle',
-                'visibilityToggle'
+                'visibilityToggle',
+                'searchFilter'
             ];
         useLegendStore(this.$vApp.$pinia).headerControls = controls;
 

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -1,5 +1,9 @@
 <template>
-    <div :key="legendItem.visibility" v-if="!legendItem.hidden" ref="el">
+    <div
+        :key="legendItem.visibility"
+        v-if="!legendItem.hidden && filterItem()"
+        ref="el"
+    >
         <div class="relative">
             <div
                 class="flex items-center hover:bg-gray-200"
@@ -522,11 +526,13 @@ import Checkbox from './checkbox.vue';
 import LegendOptions from './legend-options.vue';
 import SymbologyStack from './symbology-stack.vue';
 import { usePanelStore } from '@/stores/panel';
+import { useLegendStore } from '../store/legend-store';
 import { useI18n } from 'vue-i18n';
 
 import type { LegendAPI } from '../api/legend';
 import type { LegendItem } from '../store/legend-item';
 
+const legendStore = useLegendStore();
 const layerStore = useLayerStore();
 const panelStore = usePanelStore();
 const { t } = useI18n();
@@ -857,6 +863,12 @@ const hover = (t: EventTarget) => {
     setTimeout(() => {
         if (hovered.value) mobileMode.value ? null : t._tippy?.show();
     }, 300);
+};
+
+const filterItem = () => {
+    return legendStore.searchFilter !== ''
+        ? props.legendItem._matchFilter
+        : true;
 };
 </script>
 

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -1,10 +1,6 @@
 <template>
-    <div
-        :key="legendItem.visibility"
-        v-if="!legendItem.hidden && filterItem()"
-        ref="el"
-    >
-        <div class="relative">
+    <div :key="legendItem.visibility" v-if="!legendItem.hidden" ref="el">
+        <div class="relative" v-if="filterItem()">
             <div
                 class="flex items-center hover:bg-gray-200"
                 :class="[

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -127,6 +127,100 @@
                 ></path>
             </g>
         </svg>
+        <dropdown-menu
+            class="h-40 w-40"
+            :position="'bottom-end'"
+            :tooltip="t('panels.controls.optionsMenu')"
+            :centered="false"
+        >
+            <template #header
+                ><svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    class="fill-current ml-2 w-24 h-24"
+                >
+                    <path
+                        d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                    />
+                </svg>
+            </template>
+            <!-- include parent/child in search -->
+            <a
+                href="javascript:;"
+                class="flex leading-snug items-center w-256 hover:text-black"
+                @click="
+                    legendStore.searchOptions.showAncestors =
+                        !legendStore.searchOptions.showAncestors
+                "
+            >
+                <div class="md-icon-small inline items-start">
+                    {{ t('legend.header.search.showAncestors') }}
+                    <svg
+                        height="18"
+                        width="18"
+                        viewBox="0 0 24 24"
+                        class="inline float-right"
+                        v-if="legendStore.searchOptions.showAncestors"
+                    >
+                        <g id="done">
+                            <path
+                                d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+                            />
+                        </g>
+                    </svg>
+                </div>
+            </a>
+            <a
+                href="javascript:;"
+                class="flex leading-snug items-center w-256 hover:text-black"
+                @click="
+                    legendStore.searchOptions.showChildren =
+                        !legendStore.searchOptions.showChildren
+                "
+            >
+                <div class="md-icon-small inline items-start">
+                    {{ t('legend.header.search.showChildren') }}
+                    <svg
+                        height="18"
+                        width="18"
+                        viewBox="0 0 24 24"
+                        class="inline float-right"
+                        v-if="legendStore.searchOptions.showChildren"
+                    >
+                        <g id="done">
+                            <path
+                                d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+                            />
+                        </g>
+                    </svg>
+                </div>
+            </a>
+            <a
+                href="javascript:;"
+                class="flex leading-snug items-center w-256 hover:text-black"
+                @click="
+                    legendStore.searchOptions.layersOnly =
+                        !legendStore.searchOptions.layersOnly
+                "
+            >
+                <div class="md-icon-small inline items-start">
+                    {{ t('legend.header.search.showLayers') }}
+                    <svg
+                        height="18"
+                        width="18"
+                        viewBox="0 0 24 24"
+                        class="inline float-right"
+                        v-if="legendStore.searchOptions.layersOnly"
+                    >
+                        <g id="done">
+                            <path
+                                d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+                            />
+                        </g>
+                    </svg>
+                </div>
+            </a>
+        </dropdown-menu>
     </div>
 </template>
 

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -103,6 +103,31 @@
             </a>
         </dropdown-menu>
     </div>
+    <div class="flex" v-show="isControlAvailable('searchFilter')">
+        <input
+            @keypress.enter.prevent
+            enterkeyhint="done"
+            v-model="legendStore.searchFilter"
+            class="rv-global-search rv-input mx-8 min-w-0 w-full"
+            aria-invalid="false"
+            :aria-label="t('legend.header.search')"
+            :placeholder="t('legend.header.search')"
+        />
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fit=""
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 24 24"
+            focusable="false"
+            class="fill-current w-24 h-24 flex-shrink-0"
+        >
+            <g id="search_cache224">
+                <path
+                    d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                ></path>
+            </g>
+        </svg>
+    </div>
 </template>
 
 <script setup lang="ts">

--- a/src/fixtures/legend/lang/lang.csv
+++ b/src/fixtures/legend/lang/lang.csv
@@ -9,6 +9,9 @@ legend.header.visible,Toggle Visibility,1,Basculer la Visibilité,1
 legend.header.visible.show,Show All,1,Montrer tout,1
 legend.header.visible.hide,Hide All,1,Cacher tout,1
 legend.header.search,Search layers,1,Couches de recherche,0
+legend.header.search.showAncestors,Include ancestor items,1,Inclure les éléments des ancêtres,0
+legend.header.search.showChildren,Include child items,1,Inclure les éléments de l'enfant,0
+legend.header.search.showLayers,Search only layers,1,recherche uniquement dans les couches,0
 legend.group.expand,Expand Group,1,Développer un groupe,1
 legend.group.collapse,Collapse Group,1,Réduire un groupe,1
 legend.visibility.showLayer,Show layer,1,Afficher la couche,1

--- a/src/fixtures/legend/lang/lang.csv
+++ b/src/fixtures/legend/lang/lang.csv
@@ -8,6 +8,7 @@ legend.header.groups.collapse,Collapse All,1,Réduire les groupes,1
 legend.header.visible,Toggle Visibility,1,Basculer la Visibilité,1
 legend.header.visible.show,Show All,1,Montrer tout,1
 legend.header.visible.hide,Hide All,1,Cacher tout,1
+legend.header.search,Search layers,1,Couches de recherche,0
 legend.group.expand,Expand Group,1,Développer un groupe,1
 legend.group.collapse,Collapse Group,1,Réduire un groupe,1
 legend.visibility.showLayer,Show layer,1,Afficher la couche,1

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -25,12 +25,14 @@ import type { InstanceAPI, PanelInstance } from '@/api';
 import type { PropType } from 'vue';
 import type { LegendAPI } from './api/legend';
 import type { LegendItem } from './store/legend-item';
+import { useLegendStore } from './store';
 
 const legendHeader = defineAsyncComponent(() => import('./header.vue'));
 const legendItem = defineAsyncComponent(() => import('./components/item.vue'));
 
 const { t } = useI18n();
 const iApi = inject('iApi') as InstanceAPI;
+const legendStore = useLegendStore();
 
 defineProps({
     panel: {
@@ -42,6 +44,9 @@ defineProps({
 const children = computed<Array<LegendItem>>(() => {
     let legendApi = iApi.fixture.get<LegendAPI>('legend');
     if (legendApi) {
+        if (legendStore.searchFilter) {
+            legendStore.filterLegend([...legendApi.getLegend()]);
+        }
         return [...legendApi.getLegend()];
     }
     return [];

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -31,6 +31,7 @@ export class LegendItem extends APIScope {
     _expanded: boolean; // expanded state of item
     _visibility: boolean; // visibility state of item
     _exclusive: boolean; // indicates if children should follow 'exclusive set' behavior (à la radio buttons)
+    _matchFilter: boolean; // if item matches current search string
 
     _controls: Array<LegendControl> | undefined; // will use layer controls if undefined
     _disabledControls: Array<LegendControl> | undefined; // will use layer's disabled controls if undefined
@@ -66,6 +67,8 @@ export class LegendItem extends APIScope {
         this._disabledControls = config.disabledControls?.slice();
         this._lastVisible;
         this._visibleChildren = [];
+
+        this._matchFilter = false;
     }
 
     /** Returns the item's uid */

--- a/src/fixtures/legend/store/legend-state.ts
+++ b/src/fixtures/legend/store/legend-state.ts
@@ -5,5 +5,6 @@ export interface LegendConfig {
     isPinned: boolean;
     root: { name: string; children: Array<any> };
     headerControls: Array<string>;
+    searchFilter: string;
     panelWidth: PanelWidthObject | number;
 }

--- a/src/fixtures/legend/store/legend-state.ts
+++ b/src/fixtures/legend/store/legend-state.ts
@@ -8,3 +8,9 @@ export interface LegendConfig {
     searchFilter: string;
     panelWidth: PanelWidthObject | number;
 }
+
+export interface LegendSearchOptions {
+    showAncestors: boolean;
+    showChildren: boolean;
+    layersOnly: boolean;
+}


### PR DESCRIPTION
This adds a search bar to the legend panel that can be used to filter out layers/sublayers from the legend. The search bar can be enabled/disabled via the `headerControls` property in the config.

Since this isn't a strictly necessary feature for RAMP4, this feature can be approved/changed/denied as the team sees fit.

Sample 30 is good to test this on since it has a pretty large amount of layers: https://ramp4-pcar4.github.io/ramp4-pcar4/legend-search/demos/index-samples.html?sample=30

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1642)
<!-- Reviewable:end -->
