### PR TITLE
Panel in external div

### DIFF
--- a/demos/index-teleport-wet.html
+++ b/demos/index-teleport-wet.html
@@ -1,0 +1,518 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" dir="ltr" lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+        <title>Wet Template</title>
+        <meta content="width=device-width,initial-scale=1" name="viewport" />
+        <!-- Meta data -->
+        <meta
+            content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities"
+            name="description"
+        />
+        <!-- Meta data-->
+
+        <!-- the host page must load Vue since RAMP doesn't bundle it -->
+        <script src="https://unpkg.com/vue@3.1.5/dist/vue.global.prod.js"></script>
+
+        <!-- Load closure template scripts -->
+        <script
+            id="CDTSsoyutils"
+            src="https://ssl-templates.services.gc.ca/app/cls/WET/gcweb/v4_0_32/cdts/compiled/soyutils.js"
+            type="text/javascript"
+        ></script>
+        <script
+            id="CDTSwet"
+            src="https://ssl-templates.services.gc.ca/app/cls/WET/gcweb/v4_0_32/cdts/compiled/wet-en.js"
+            type="text/javascript"
+        ></script>
+        <script
+            src="https://code.jquery.com/jquery-2.0.3.min.js"
+            integrity="sha384-5BJxsRUsHmz1Kk/hmquvrNXoqth2fWO8TW4G5MbuwrD7g7eyanb4SJ9KV+VGChAT"
+            crossorigin="anonymous"
+        ></script>
+
+        <noscript>
+            <!-- Write closure fall-back static file -->
+            <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/refTop.html -->
+            <!--[if gte IE 9 | !IE]><!-->
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/favicon.ico"
+                rel="icon"
+                type="image/x-icon"
+            />
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/css/theme.min.css"
+                rel="stylesheet"
+            />
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/cdts/cdtsfixes.css"
+                rel="stylesheet"
+            />
+            <!--<![endif]-->
+            <!--[if lt IE 9]>
+                <link
+                    href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/favicon.ico"
+                    rel="shortcut icon"
+                />
+                <link
+                    rel="stylesheet"
+                    href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/css/ie8-theme.min.css"
+                />
+            <![endif]-->
+            <!--[if lte IE 9]> <![endif]-->
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/css/noscript.min.css"
+                rel="stylesheet"
+            />
+        </noscript>
+
+        <!-- Write closure template -->
+        <script id="CDTSRefTopScript" type="text/javascript">
+            document.write(
+                wet.builder.refTop({
+                    cdnEnv: 'prod'
+                })
+            );
+        </script>
+    </head>
+    <body typeof="WebPage" vocab="http://schema.org/">
+        <div id="def-top">
+            <!-- Write closure fall-back static file -->
+            <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/top-en.html -->
+            <ul id="wb-tphp">
+                <li class="wb-slc">
+                    <a class="wb-sl" href="#wb-cont">Skip to main content</a>
+                </li>
+                <li class="wb-slc visible-sm visible-md visible-lg">
+                    <a class="wb-sl" href="#wb-info"
+                        >Skip to "About this site"</a
+                    >
+                </li>
+            </ul>
+            <header role="banner">
+                <div class="container" id="wb-bnr">
+                    <section
+                        class="visible-md visible-lg text-right"
+                        id="wb-lng"
+                    >
+                        <h2 class="wb-inv">Language selection</h2>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <ul class="list-inline margin-bottom-none">
+                                    <li>
+                                        <a href="javascript:;" lang="fr"
+                                            >Français</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </section>
+                    <div class="row">
+                        <div class="brand col-xs-8 col-sm-9 col-md-6">
+                            <a href="https://www.canada.ca/en.html">
+                                <img
+                                    data="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/sig-blk-en.svg"
+                                    tabindex="-1"
+                                    type="image/svg+xml"
+                                />
+                                <span class="wb-inv">
+                                    Government of Canada</span
+                                >
+                            </a>
+                        </div>
+                        <section
+                            class="wb-mb-links col-xs-4 col-sm-3 visible-sm visible-xs"
+                            id="wb-glb-mn"
+                        >
+                            <h2>Search and menus</h2>
+                            <ul class="list-inline text-right chvrn">
+                                <li>
+                                    <a
+                                        aria-controls="mb-pnl"
+                                        class="overlay-lnk"
+                                        href="#mb-pnl"
+                                        role="button"
+                                        title="Search and menus"
+                                        ><span
+                                            class="glyphicon glyphicon-search"
+                                            ><span
+                                                class="glyphicon glyphicon-th-list"
+                                                ><span class="wb-inv"
+                                                    >Search and menus</span
+                                                ></span
+                                            ></span
+                                        ></a
+                                    >
+                                </li>
+                            </ul>
+                            <div id="mb-pnl"></div>
+                        </section>
+                        <section
+                            class="col-xs-6 text-right visible-md visible-lg"
+                            id="wb-srch"
+                        >
+                            <h2>Search</h2>
+                            <form
+                                action="https://www.canada.ca/en/sr.html#wb-land"
+                                class="form-inline"
+                                method="get"
+                                name="cse-search-box"
+                                role="search"
+                            >
+                                <div class="form-group">
+                                    <label class="wb-inv" for="wb-srch-q"
+                                        >Search website</label
+                                    >
+                                    <input
+                                        name="cdn"
+                                        type="hidden"
+                                        value="canada"
+                                    />
+                                    <input name="st" type="hidden" value="s" />
+                                    <input
+                                        name="num"
+                                        type="hidden"
+                                        value="10"
+                                    />
+                                    <input
+                                        name="langs"
+                                        type="hidden"
+                                        value="en"
+                                    />
+                                    <input
+                                        name="st1rt"
+                                        type="hidden"
+                                        value="1"
+                                    />
+                                    <input
+                                        name="s5bm3ts21rch"
+                                        type="hidden"
+                                        value="x"
+                                    />
+                                    <input
+                                        class="wb-srch-q form-control"
+                                        id="wb-srch-q"
+                                        list="wb-srch-q-ac"
+                                        maxlength="150"
+                                        name="q"
+                                        placeholder="Search Canada.ca"
+                                        size="27"
+                                        type="search"
+                                        value=""
+                                    />
+                                    <input
+                                        name="_charset_"
+                                        type="hidden"
+                                        value="UTF-8"
+                                    />
+                                    <datalist id="wb-srch-q-ac">
+                                        <!--[if lte IE 9]><select><![endif]-->
+                                        <!--[if lte IE 9]></select><![endif]-->
+                                    </datalist>
+                                </div>
+                                <div class="form-group submit">
+                                    <button
+                                        class="btn btn-primary btn-small"
+                                        id="wb-srch-sub"
+                                        name="wb-srch-sub"
+                                        type="submit"
+                                    >
+                                        <span
+                                            class="glyphicon-search glyphicon"
+                                        ></span
+                                        ><span class="wb-inv">Search</span>
+                                    </button>
+                                </div>
+                            </form>
+                        </section>
+                    </div>
+                </div>
+                <nav
+                    class="wb-menu visible-md visible-lg"
+                    id="wb-sm"
+                    role="navigation"
+                    typeof="SiteNavigationElement"
+                >
+                    <div class="container nvbar">
+                        <h2>Topics menu</h2>
+                        <div class="row">
+                            <ul class="list-inline menu">
+                                <li>
+                                    <a
+                                        href="https://www.esdc.gc.ca/en/jobs/index.page"
+                                        >Jobs</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.cic.gc.ca/english/index.asp"
+                                        >Immigration</a
+                                    >
+                                </li>
+                                <li>
+                                    <a href="https://travel.gc.ca/">Travel</a>
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services/business.html"
+                                        >Business</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services/benefits.html"
+                                        >Benefits</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://healthycanadians.gc.ca/index-eng.php"
+                                        >Health</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services/taxes.html"
+                                        >Taxes</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services.html"
+                                        >More services</a
+                                    >
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
+                <nav id="wb-bc" property="breadcrumb" role="navigation">
+                    <h2>You are here:</h2>
+                    <div class="container">
+                        <div class="row">
+                            <ol class="breadcrumb">
+                                <li>
+                                    <a href="https://www.canada.ca/en.html"
+                                        >Home</a
+                                    >
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                </nav>
+            </header>
+        </div>
+        <!-- Write closure template -->
+        <script id="CDTSTopScript" type="text/javascript">
+            var defTop = document.getElementById('def-top');
+            defTop.outerHTML = wet.builder.top({
+                cdnEnv: 'prod',
+                lngLinks: [
+                    {
+                        lang: 'fr',
+                        href: '#',
+                        text: 'Français'
+                    }
+                ],
+                search: true
+            });
+        </script>
+        <main class="container" property="mainContentOfPage" role="main">
+            <div id="IE"></div>
+            <div style="display: flex">
+                <div
+                    class="ramp-app"
+                    id="legend"
+                    style="height: 70vh; width: 30%"
+                ></div>
+                <div id="app" style="height: 70vh; width: 70%"></div>
+            </div>
+            <div class="ramp-app" id="grid" style="height: 70vh"></div>
+            <span id="ramp-version"></span>
+
+            <div id="def-preFooter">
+                <!-- Write closure fall-back static file -->
+                <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/preFooter-en.html -->
+                <div class="row pagedetails">
+                    <div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+                        <a
+                            class="btn btn-default btn-block"
+                            href="https://www.canada.ca/en/report-problem.html"
+                            >Report a problem or mistake on this page</a
+                        >
+                    </div>
+                    <div class="datemod col-xs-12 mrgn-tp-lg">
+                        <dl id="wb-dtmd"></dl>
+                    </div>
+                </div>
+            </div>
+            <script>
+                $(function () {
+                    var iframeBody = $('#if-content').contents().find('body');
+                    var styleTag = iframeBody.append($('#app'));
+                });
+            </script>
+            <!-- Write closure template -->
+            <script id="CDTSPreFooterScript" type="text/javascript">
+                var defPreFooter = document.getElementById('def-preFooter');
+                defPreFooter.outerHTML = wet.builder.preFooter({
+                    cdnEnv: 'prod'
+                });
+            </script>
+
+            <script
+                type="module"
+                src="./starter-scripts/teleport-wet.js"
+            ></script>
+        </main>
+
+        <div id="def-footer">
+            <!-- Write closure fall-back static file -->
+            <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/footer-en.html -->
+            <aside class="gc-nttvs container">
+                <h2>Government of Canada activities and initiatives</h2>
+                <div class="wb-eqht row" id="gcwb_prts">
+                    <p class="mrgn-lft-md">
+                        <a href="https://www.canada.ca/activities.html"
+                            >Access Government of Canada activities and
+                            initiatives</a
+                        >
+                    </p>
+                </div>
+            </aside>
+            <footer id="wb-info" role="contentinfo">
+                <nav class="container wb-navcurr" role="navigation">
+                    <h2 class="wb-inv">About government</h2>
+                    <ul class="list-unstyled colcount-sm-2 colcount-md-3">
+                        <li>
+                            <a href="https://www.canada.ca/en/contact.html"
+                                >Contact us</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/dept.html"
+                                >Departments and agencies</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/publicservice.html"
+                                >Public service and military</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://www.servicecanada.gc.ca/gcnews"
+                                >News</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/system/laws.html"
+                                >Treaties, laws and regulations</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/transparency/reporting.html"
+                                >Government-wide reporting</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://pm.gc.ca/eng">Prime Minister</a>
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/system.html"
+                                >How government works</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://open.canada.ca/en/"
+                                >Open government</a
+                            >
+                        </li>
+                    </ul>
+                </nav>
+                <div class="brand">
+                    <div class="container">
+                        <div class="row">
+                            <nav class="col-md-10 ftr-urlt-lnk">
+                                <h2 class="wb-inv">About this site</h2>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/social.html"
+                                            >Social media</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/mobile.html"
+                                            >Mobile applications</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www1.canada.ca/en/newsite.html"
+                                            >About Canada.ca</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/transparency/terms.html"
+                                            >Terms and conditions</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/transparency/privacy.html"
+                                            >Privacy</a
+                                        >
+                                    </li>
+                                </ul>
+                            </nav>
+                            <div class="col-xs-6 visible-sm visible-xs tofpg">
+                                <a href="#wb-cont"
+                                    >Top of Page
+                                    <span
+                                        class="glyphicon glyphicon-chevron-up"
+                                    ></span
+                                ></a>
+                            </div>
+                            <div class="col-xs-6 col-md-2 text-right">
+                                <img
+                                    aria-label="Symbol of the Government of Canada"
+                                    data="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/wmms-blk.svg"
+                                    role="img"
+                                    tabindex="-1"
+                                    type="image/svg+xml"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </div>
+
+        <!-- Write closure template -->
+        <script id="CDTSDefFooterScript" type="text/javascript">
+            var defFooter = document.getElementById('def-footer');
+            defFooter.outerHTML = wet.builder.footer({
+                cdnEnv: 'prod'
+            });
+        </script>
+        <!-- Write closure template -->
+        <script id="CDTSRefFooterScript" type="text/javascript">
+            document.write(
+                wet.builder.refFooter({
+                    cdnEnv: 'prod'
+                })
+            );
+        </script>
+    </body>
+</html>

--- a/demos/index-teleport.html
+++ b/demos/index-teleport.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+        <title>ramp-core</title>
+    </head>
+    <body style="margin: 0">
+        <style>
+            #container {
+                display: flex;
+                flex-direction: column;
+                padding: 0 10px;
+                width: 100%;
+                align-items: center;
+                box-sizing: border-box;
+            }
+
+            #ramp-instance {
+                width: 100%;
+                height: 50vh;
+                border: 2px solid black;
+                box-sizing: border-box;
+                margin: 10px 0;
+                border-radius: 6px;
+            }
+
+            #grid {
+                width: 100%;
+                height: 50vh;
+                border: 2px solid black;
+                box-sizing: border-box;
+                margin: 10px 0;
+                border-radius: 6px;
+            }
+
+            #form {
+                width: 90vw;
+                border: 2px solid black;
+                padding: 20px;
+                box-sizing: border-box;
+            }
+        </style>
+        <noscript>
+            <strong
+                >We're sorry but ramp-core doesn't work properly without
+                JavaScript enabled. Please enable it to continue.</strong
+            >
+        </noscript>
+        <div id="container">
+            <h1 style="text-align: center">RAMP Teleportation Magic</h1>
+            <div id="form">
+                <div id="ramp-instance"></div>
+                <div class="ramp-app" id="grid"></div>
+            </div>
+        </div>
+
+        <script type="module" src="./starter-scripts/teleport.js"></script>
+    </body>
+</html>

--- a/demos/starter-scripts/teleport-wet.js
+++ b/demos/starter-scripts/teleport-wet.js
@@ -1,0 +1,593 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WaterQuantity',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 1,
+                            name: 'Water quantity child',
+                            state: {
+                                opacity: 1,
+                                visibility: true
+                            },
+                            fixtures: {
+                                details: {
+                                    template: 'Water-Quantity-Template'
+                                },
+                                settings: {
+                                    controls: ['visibility', 'opacity']
+                                }
+                            }
+                        },
+                        {
+                            index: 9,
+                            name: 'Carbon monoxide emissions by facility',
+                            state: {
+                                opacity: 0.5,
+                                visibility: true
+                            },
+                            disabledControls: ['opacity']
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md',
+                        name: 'Read Me!'
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WaterQuality',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 5,
+                            state: {}
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'CleanAir',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/9',
+                    state: {
+                        opacity: 0.8,
+                        visibility: true,
+                        hovertips: false
+                    },
+                    mouseTolerance: 10,
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    state: {
+                        visibility: true
+                    },
+                    customRenderer: {},
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md'
+                    },
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
+                    }
+                }
+            ],
+            fixtures: {
+                legend: {
+                    panelTeleport: { target: '#legend', showHeader: true },
+                    root: {
+                        children: [
+                            {
+                                name: 'Visibility Set',
+                                exclusive: true,
+                                children: [
+                                    {
+                                        layerId: 'CleanAir',
+                                        name: 'Clean Air in Set',
+                                        disabledLayerControls: ['boundaryZoom']
+                                    },
+                                    {
+                                        name: 'Group in Set',
+                                        children: [
+                                            {
+                                                layerId: 'WaterQuantity',
+                                                name: 'Water Quantity in Nested Group',
+                                                sublayerIndex: 1,
+                                                layerControls: [
+                                                    'datatable',
+                                                    'metadata',
+                                                    'reload',
+                                                    'remove',
+                                                    'settings',
+                                                    'symbology'
+                                                ]
+                                            },
+                                            {
+                                                layerId: 'WaterQuantity',
+                                                name: 'CO2 in Nested Group',
+                                                sublayerIndex: 9
+                                            },
+                                            {
+                                                layerId: 'WaterQuality',
+                                                name: 'Water Quality in Nested Group',
+                                                sublayerIndex: 5
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                layerId: 'WFSLayer',
+                                name: 'WFSLayer',
+                                layerControls: [
+                                    'metadata',
+                                    'boundaryZoom',
+                                    'refresh',
+                                    'reload',
+                                    'remove',
+                                    'datatable',
+                                    'settings',
+                                    'symbology'
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
+                export: {
+                    title: {
+                        value: 'All Your Base are Belong to Us',
+                        selectable: false
+                    },
+                    legend: {
+                        selected: false
+                    },
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                scrollguard: {
+                    enabled: true
+                },
+                help: {
+                    location: '../help'
+                },
+                grid: {
+                    panelTeleport: {
+                        target: document.getElementById('grid')
+                    }
+                }
+            },
+            panels: {
+                reorderable: false
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: false,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+rInstance.fixture.addDefaultFixtures().then(() => {
+    rInstance.panel.open('legend');
+});
+
+rInstance.$element.component('WFSLayer-Custom', {
+    props: ['identifyData'],
+    template: `
+        <div>
+            <span>This is an example template that contains an image.</span>
+            <img src="https://i.imgur.com/WtY0tdC.gif" />
+        </div>
+    `
+});
+
+rInstance.$element.component('Water-Quantity-Template', {
+    props: ['identifyData'],
+    template: `
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
+            <div v-html="renderHeader()" />
+            <div v-html="createSection('Station ID', 'StationID')" />
+            <div v-html="createSection('Province', 'E_Province')" />
+            <div v-html="createSection('Report Year', 'Report_Year')" />
+            <div v-if="this.identifyData.loaded">
+                <div style="display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;">
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        Latitude
+                    </div>
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        Longitude
+                    </div>
+                </div>
+                <div style="display: flex; flex-direction: row;">
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        {{this.identifyData.data['Latitude']}}
+                    </div>
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        {{this.identifyData.data['Longitude']}}
+                    </div>
+                </div>
+                <div style="display: flex; flex-direction: column; padding-top: 5px; color: #4299e1;">
+                    <span style="font-weight: bold; color: #a0aec0;">Links</span>
+                    <span v-html="this.identifyData.data['E_DetailPageURL']"></span>
+                    <span v-html="this.identifyData.data['E_URL_Historical']"></span>
+                    <span v-html="this.identifyData.data['E_URL_RealTime']"></span>
+                </div>
+            </div>
+        </div>
+    `,
+    methods: {
+        renderHeader() {
+            if (!this.identifyData.loaded) {
+                return `
+                <span style="display: flex; font-size: 20px; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
+                    Loading...
+                </span>
+                `;
+            } else if (this.identifyData.data['Symbol'] === '3') {
+                return `
+                    <span style="display: flex; font-size: 20px; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                        ${this.identifyData.data['StationName']}
+                    </span>
+                `;
+            } else {
+                return `
+                    <span style="display: flex; font-size: 20px; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                        ${this.identifyData.data['StationName']}
+                    </span>
+                `;
+            }
+        },
+        createSection(title, id) {
+            var val = this.identifyData.loaded
+                ? this.identifyData.data[id]
+                : 'Loading...';
+
+            return `
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
+                <span style="color: #a0aec0; font-weight: bold;">
+                    ${title}
+                </span>
+                <span>
+                    ${val}
+                </span>
+            </div>
+            `;
+        }
+    }
+});
+
+// add export fixtures
+rInstance.fixture.add('export');
+
+// load map if startRequired is true
+// rInstance.start();
+
+// function switchLang() {
+//     if (rInstance.language === 'en') {
+//         rInstance.setLanguage('fr');
+//     } else {
+//         rInstance.setLanguage('en');
+//     }
+//     document.getElementById('instance-language').innerText = rInstance.language;
+// }
+
+// function animateToggle() {
+//     if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
+//         rInstance.$vApp.$el.classList.remove('animation-enabled');
+//     } else {
+//         rInstance.$vApp.$el.classList.add('animation-enabled');
+//     }
+//     document.getElementById('animate-status').innerText =
+//         'Animate: ' + rInstance.animate;
+// }
+
+window.debugInstance = rInstance;

--- a/demos/starter-scripts/teleport.js
+++ b/demos/starter-scripts/teleport.js
@@ -1,0 +1,733 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WaterQuantity',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 1,
+                            name: 'Water quantity child',
+                            state: {
+                                opacity: 1,
+                                visibility: true
+                            },
+                            fixtures: {
+                                details: {
+                                    template: 'Water-Quantity-Template'
+                                },
+                                settings: {
+                                    controls: ['visibility', 'opacity']
+                                }
+                            }
+                        },
+                        {
+                            index: 9,
+                            name: 'Carbon monoxide emissions by facility',
+                            state: {
+                                opacity: 0.5,
+                                visibility: false
+                            },
+                            fixtures: {
+                                settings: {
+                                    disabledControls: ['opacity']
+                                },
+                                grid: {
+                                    title: 'A Custom Title',
+                                    search: false
+                                }
+                            }
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md',
+                        name: 'Read Me!'
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WaterQuality',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 5,
+                            state: {}
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'CleanAir',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/9',
+                    state: {
+                        opacity: 0.8,
+                        visibility: true,
+                        hovertips: false
+                    },
+                    fixtures: {
+                        settings: {
+                            disabledControls: [
+                                'visibility',
+                                'opacity',
+                                'identify'
+                            ]
+                        }
+                    },
+                    tolerance: 10,
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#FF5555',
+                    state: {
+                        visibility: true
+                    },
+                    customRenderer: {},
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md'
+                    },
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        },
+                        grid: {
+                            title: 'Datatable for WFS features',
+                            filterByExtent: true,
+                            showFilter: false,
+                            searchFilter: 'y',
+                            applyToMap: true
+                        }
+                    }
+                },
+                {
+                    id: 'Caribous',
+                    name: 'Caribou Layer',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/2015_Disturbance_Footprints_Boreal_Caribou_lempreinte_15m/MapServer/0',
+                    mouseTolerance: 5,
+                    identifyMode: 'hybrid',
+                    state: {
+                        opacity: 0.5,
+                        visibility: true
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'OilFacility',
+                    name: 'OilFacility',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/1',
+                    state: {
+                        opacity: 1,
+                        visibility: false
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'ReleasesDisposals',
+                    name: 'ReleaseDisposals',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/2',
+                    state: {
+                        opacity: 1,
+                        visibility: false
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                name: 'Regular Group',
+                                children: [
+                                    {
+                                        layerId: 'OilFacility',
+                                        name: 'Oil Sands Facility Locations',
+                                        disabledLayerControls: ['visibility'],
+                                        coverIcon:
+                                            'https://cdn-icons-png.flaticon.com/512/3129/3129632.png'
+                                    },
+                                    {
+                                        layerId: 'ReleasesDisposals',
+                                        name: 'Releases and Disposals by Mining Facilities',
+                                        disabledLayerControls: ['boundaryZoom'],
+                                        description:
+                                            'Symbology description for releases and disposals by mining facilities'
+                                    }
+                                ]
+                            },
+                            {
+                                name: 'Exclusive Visibility Set',
+                                disabledControls: ['visibilityButton'],
+                                exclusive: true,
+                                children: [
+                                    {
+                                        layerId: 'CleanAir',
+                                        name: 'Clean Air in Set',
+                                        disabledLayerControls: ['boundaryZoom']
+                                    },
+                                    {
+                                        layerId: 'WaterQuantity',
+                                        name: 'Water Quantity in Nested Group',
+                                        sublayerIndex: 1,
+                                        expanded: false,
+                                        children: [
+                                            {
+                                                layerId: 'WaterQuantity',
+                                                name: 'CO2 in Nested Group',
+                                                sublayerIndex: 9
+                                            },
+                                            {
+                                                layerId: 'WaterQuality',
+                                                name: 'Water Quality in Nested Group',
+                                                sublayerIndex: 5
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        layerId: 'WFSLayer',
+                                        name: 'WFSLayer'
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'text',
+                                content: 'Image info section example:'
+                            },
+                            {
+                                infoType: 'image',
+                                content:
+                                    'https://media.gettyimages.com/photos/niagara-falls-picture-id1181897622?k=20&m=1181897622&s=612x612&w=0&h=doNDR18kAA7kl7UuTZcAZdoGQxTE1UJYTzrdW1f3KcI='
+                            },
+                            {
+                                name: 'Title info section with children.',
+                                infoType: 'title',
+                                content: 'Expand me for a surprise!',
+                                expanded: false,
+                                children: [
+                                    {
+                                        name: 'text info section with children',
+                                        infoType: 'text',
+                                        content: 'Keep expanding!',
+                                        expanded: false,
+                                        children: [
+                                            {
+                                                name: 'Custom Info Section',
+                                                infoType: 'template',
+                                                content: `<div>
+                                                            <span>Surpise one:.</span>
+                                                            <img src="https://i.imgur.com/WtY0tdC.gif" />
+                                                            </div>`
+                                            },
+                                            {
+                                                name: 'Surprise 2: Secret feature layer hidden in info section with custom cover icon',
+                                                layerId: 'Caribous',
+                                                coverIcon:
+                                                    'https://cdn-icons-png.flaticon.com/512/3628/3628583.png'
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder',
+                        'areas-of-interest'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                grid: {
+                    panelTeleport: {
+                        target: document.getElementById('grid'),
+                        showHeader: true,
+                        showAppbarButton: true
+                    }
+                },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
+                export: {
+                    title: {
+                        value: 'All Your Base are Belong to Us All Your Base are Belong to Us All Your Base are Belong to Us',
+                        selectable: false
+                    },
+                    legend: {
+                        selected: false
+                    },
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                },
+                'areas-of-interest': {
+                    areas: [
+                        {
+                            title: 'Reservoir Manicougan, Quebec, Canada',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                            altText: 'Reservoir Manicougan, Quebec, Canada',
+                            description:
+                                'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
+                            extent: {
+                                xmax: 1840000,
+                                xmin: 1750000,
+                                ymax: 682193,
+                                ymin: 583440,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Gulf of St Lawrence',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                            extent: {
+                                xmin: 2050000,
+                                xmax: 2240000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Lake Grandmesnil and surrounding lakes',
+                            extent: {
+                                xmin: 1800000,
+                                xmax: 1840000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'CN Tower',
+                            thumbnail:
+                                'https://upload.wikimedia.org/wikipedia/commons/9/9c/Toronto_-_ON_-_CN_Tower_Turmkorb.jpg',
+                            description:
+                                'The CN Tower is a 553.3 m-high concrete communications and observation tower in downtown Toronto, Ontario, Canada.',
+                            extent: {
+                                xmin: -8838051.849695725,
+                                xmax: -8836512.572464375,
+                                ymin: 5409988.501845284,
+                                ymax: 5410763.023921062,
+                                spatialReference: {
+                                    wkid: 102100,
+                                    latestWkid: 3857
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('ramp-instance'),
+    config,
+    options
+);
+
+rInstance.$element.component('WFSLayer-Custom', {
+    props: ['identifyData'],
+    template: `
+        <div>
+            <span>This is an example template that contains an image.</span>
+            <img src="https://i.imgur.com/WtY0tdC.gif" />
+        </div>
+    `
+});
+
+rInstance.$element.component('Water-Quantity-Template', {
+    props: ['identifyData'],
+    template: `
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
+            <div v-html="renderHeader()" />
+            <div v-html="createSection('Station ID', 'StationID')" />
+            <div v-html="createSection('Province', 'E_Province')" />
+            <div v-html="createSection('Report Year', 'Report_Year')" />
+            <div v-if="this.identifyData.loaded">
+                <div style="display: flex; flex-direction: row; color: #a0aec0; font-weight: bold; padding-top: 5px;">
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        Latitude
+                    </div>
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        Longitude
+                    </div>
+                </div>
+                <div style="display: flex; flex-direction: row;">
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        {{this.identifyData.data['Latitude']}}
+                    </div>
+                    <div style="flex: 1 1 0%; width: 100%;">
+                        {{this.identifyData.data['Longitude']}}
+                    </div>
+                </div>
+                <div style="display: flex; flex-direction: column; padding-top: 5px; color: #4299e1;">
+                    <span style="font-weight: bold; color: #a0aec0;">Links</span>
+                    <span v-html="this.identifyData.data['E_DetailPageURL']"></span>
+                    <span v-html="this.identifyData.data['E_URL_Historical']"></span>
+                    <span v-html="this.identifyData.data['E_URL_RealTime']"></span>
+                </div>
+            </div>
+        </div>
+    `,
+    methods: {
+        renderHeader() {
+            if (!this.identifyData.loaded) {
+                return `
+                <span style="display: flex; font-size: 20px; background-color: #e21e5e; color: white; padding: 4px; text-align: center;">
+                    Loading...
+                </span>
+                `;
+            } else if (this.identifyData.data['Symbol'] === '3') {
+                return `
+                    <span style="display: flex; font-size: 20px; background-color: #e53e3e; color: white; padding: 4px; text-align: center;">
+                        ${this.identifyData.data['StationName']}
+                    </span>
+                `;
+            } else {
+                return `
+                    <span style="display: flex; font-size: 20px; background-color: #3182ce; color: white; padding: 4px; text-align: center;">
+                        ${this.identifyData.data['StationName']}
+                    </span>
+                `;
+            }
+        },
+        createSection(title, id) {
+            var val = this.identifyData.loaded
+                ? this.identifyData.data[id]
+                : 'Loading...';
+
+            return `
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
+                <span style="color: #a0aec0; font-weight: bold;">
+                    ${title}
+                </span>
+                <span>
+                    ${val}
+                </span>
+            </div>
+            `;
+        }
+    }
+});
+
+// add export fixtures
+rInstance.fixture.add('export');
+
+// add areas of interest fixture
+rInstance.fixture.add('areas-of-interest');
+
+window.debugInstance = rInstance;

--- a/docs/app/panels.md
+++ b/docs/app/panels.md
@@ -276,6 +276,44 @@ myRAMPInstance.panel.register(panelConfig);
 
 Your panel is now ready for use! You should now leverage the [API](#the-panel-api) to perform different functions of your choice. For example, you can display the panel on the screen with the `open` method, pin the panel on the screen with the `pin` method, and so on.
 
+## Teleporting panels
+
+Panels that come out of the box can also be rendered outside the panel stack, in the container of your choice. In order to do so, you must provide a teleport configuration inside the fixture config of the fixture that registers the panel. The configuration has three properties:
+
+* `target` - (required) the element where the panel will be rendered instead of its usual spot in the panel stack. The value can be the element itself or a string query selector.
+* `showHeader` - (optional) a boolean indicating whether or not to show the panel's header, defaults to `false`.
+* `showAppbarButton` - (optional) a boolean indicating whether or not opening the panel will show an appbar button for it, defaults to `false`. This only applies to temporary appbar buttons.
+
+Below is a configuration snippet that shows how to configure the legend to appear in your own `div` element:
+
+```JS
+fixtures: {
+    legend: {
+        root: {
+            children: [
+                {
+                    name: 'Keyword search',
+                    layerId: 'climateActionMap',
+                    symbologyExpanded: true
+                }
+            ]
+        },
+        panelTeleport: {
+            target: document.getElementById('legend'),
+            showHeader: true,
+            showAppbarButton: false
+        }
+    }
+}
+```
+
+Some other important things to note include:
+
+* In order to get the regular panel styling, you will need to add the `ramp-app` class to your target element. Otherwise, things are likely to look funny.
+* Teleported panels by have the `focus-container` directive removed by default. If you wish to add this directive back, you can add the `inner-shell` class to your target element.
+* Unlike regular panels, teleported panels will always take up the full width of the target element. Therefore, it is not recommended to teleport multiple panels into one container.
+
+
 ## The Panel API
 
 The API can be accessed through the RAMP Instance API:

--- a/schema.json
+++ b/schema.json
@@ -100,6 +100,9 @@
             "type": "object",
             "description": "Provides the configuration to the areas of interest fixture",
             "properties": {
+                "panelTeleport": {
+                    "$ref": "#/$defs/panelTeleport"
+                },
                 "areas": {
                     "type": "array",
                     "description": "The areas to be displayed in the areas of interest fixture",
@@ -220,6 +223,9 @@
             "type": "object",
             "description": "Provides configuration to the geosearch fixture.",
             "properties": {
+                "panelTeleport": {
+                    "$ref": "#/$defs/panelTeleport"
+                },
                 "serviceUrls": {
                     "type": "object",
                     "properties": {
@@ -306,6 +312,9 @@
                 "panelWidth": {
                     "$ref": "#/$defs/panelWidth"
                 },
+                "panelTeleport": {
+                    "$ref": "#/$defs/panelTeleport"
+                },
                 "root": {
                     "$ref": "#/$defs/sectionItem"
                 }
@@ -316,6 +325,28 @@
         "panelWidth": {
             "type": ["number", "object"],
             "description": "Determines the width of provided panels. If a number, then defaults all panels for the fixture to the number."
+        },
+        "panelTeleport": {
+            "type": "object",
+            "description": "Determines where to render the panel instead of its usual spot in the panel stack.",
+            "properties": {
+                "target": {
+                    "type": ["string", "element"],
+                    "description": "The target container where the panel will be rendered. Can be the element itself or a string query selector."
+                },
+                "showHeader": {
+                    "type": "boolean",
+                    "description": "Whether to show the panel header or not.",
+                    "default": false
+                },
+                "showAppbarButton": {
+                    "type": "boolean",
+                    "description": "Whether to show the appbar button for the panel or not. Only applies to temporary appbar buttons.",
+                    "default": false
+                }
+            },
+            "required": ["target"],
+            "unevaluatedProperties": false
         },
         "sectionItem": {
             "type": "object",
@@ -2151,6 +2182,17 @@
                         },
                         "panelWidth": {
                             "$ref": "#/$defs/panelWidth"
+                        },
+                        "panelTeleport": {
+                            "type": "object",
+                            "properties": {
+                                "details-layers": {
+                                    "$ref": "#/$defs/panelTeleport"
+                                },
+                                "details-items": {
+                                    "$ref": "#/$defs/panelTeleport"
+                                }
+                            }
                         }
                     },
                     "required": ["templates"]
@@ -2161,6 +2203,9 @@
                         "folderName": "default",
                         "panelWidth": {
                             "$ref": "#/$defs/panelWidth"
+                        },
+                        "panelTeleport": {
+                            "$ref": "#/$defs/panelTeleport"
                         }
                     },
                     "description": "Specifies details for the Help section"

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -1071,6 +1071,7 @@ export class EventAPI extends APIScope {
                     const appbarStore = useAppbarStore(this.$vApp.$pinia);
                     if (
                         this.$iApi.fixture.get<AppbarAPI>('appbar') &&
+                        (!panel.teleport || panel.teleport?.showAppbarButton) &&
                         !appbarStore.order
                             .flat()
                             .find((item: string) => item === panel.id)

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -6,6 +6,7 @@ import { useConfigStore } from '@/stores/config';
 import type { FixtureBase } from '@/stores/fixture';
 import { useFixtureStore } from '@/stores/fixture';
 import type { RampConfig } from '@/types';
+import { usePanelStore } from '@/stores/panel';
 
 const fixtureModules = import.meta.glob<{ default: typeof FixtureInstance }>(
     '../fixtures/*/index.ts'
@@ -467,6 +468,24 @@ export class FixtureInstance extends APIScope implements FixtureBase {
                     'flex-basis': `${panelWidths[item]}px`
                 });
             }
+        }
+    }
+
+    /**
+     * If the `panelTeleport` property is provided, handle specified panelTeleport for the given fixture.
+     *
+     * @param {Array<string>} panels list of panel names for the calling fixture
+     */
+    handlePanelTeleports(panels: Array<string>) {
+        if (this.config?.panelTeleport) {
+            const panelStore = usePanelStore(this.$vApp.$pinia);
+            const oneConfig = !!this.config.panelTeleport.target;
+            panels.forEach(p => {
+                panelStore.items[p].teleport = oneConfig
+                    ? this.config.panelTeleport
+                    : this.config.panelTeleport[p];
+                panelStore.items[p].style.width = '100%';
+            });
         }
     }
 }

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -6,7 +6,8 @@ import {
     InstanceAPI,
     isVueConstructor,
     isComponentOptions,
-    isTypeofImportVue
+    isTypeofImportVue,
+    type PanelTeleportObject
 } from './internal';
 
 import type {
@@ -48,6 +49,11 @@ export class PanelInstance extends APIScope {
     private readonly loadedScreens: string[] = [];
 
     readonly alertName: string;
+
+    /**
+     * The config for the element to render the panel screen in (instead of its usual spot in the panel stack).
+     */
+    teleport?: PanelTeleportObject;
 
     controls: any;
 

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -200,7 +200,7 @@ export class PanelAPI extends APIScope {
      */
     get opened(): PanelInstance[] {
         //@ts-ignore
-        return this.panelStore.orderedItems;
+        return this.panelStore.orderedItems.concat(this.panelStore.teleported);
     }
 
     /**
@@ -213,7 +213,7 @@ export class PanelAPI extends APIScope {
      */
     get visible(): PanelInstance[] {
         //@ts-ignore
-        return this.panelStore.visible;
+        return this.panelStore.visible.concat(this.panelStore.teleported);
     }
 
     /**
@@ -428,6 +428,15 @@ export class PanelAPI extends APIScope {
             panel.registerScreen(route.screen);
         }
 
+        // if this panel is going to be teleported elsewhere, turn off the header by setting the header prop,
+        // unless someone already forced the header to true.
+        if (panel.teleport) {
+            route.props = {
+                header: !!panel.teleport?.showHeader,
+                ...route.props
+            };
+        }
+
         this.panelStore.items[panel.id].route = route;
 
         return panel;
@@ -542,4 +551,35 @@ export interface PanelWidthObject {
      * @memberof PanelWidthObject
      */
     [panel: string]: number | any;
+}
+
+export type PanelTeleportConfig =
+    | PanelTeleportObject
+    | { [id: string]: PanelTeleportObject };
+
+export interface PanelTeleportObject {
+    /**
+     * The element to teleport the panel to. Can be the actual element or a query selector string.
+     *
+     * @type string | Element
+     * @memberof PanelTeleportObject
+     */
+    target?: string | Element;
+
+    /**
+     * Whether or not to show the panel header.
+     *
+     * @type boolean
+     * @memberof PanelTeleportObject
+     */
+    showHeader?: boolean;
+
+    /**
+     * Whether or not opening/closing the panel will show/hide an appbar button for it.
+     * Will only apply to temporary appbar buttons.
+     *
+     * @type boolean
+     * @memberof PanelTeleportObject
+     */
+    showAppbarButton?: boolean;
 }

--- a/src/components/panel-stack/panel-container.vue
+++ b/src/components/panel-stack/panel-container.vue
@@ -21,10 +21,12 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import type { PropType } from 'vue';
 import anime from 'animejs';
 import type { PanelInstance } from '@/api';
+// @ts-ignore
+import ro from '@/scripts/resize-observer.js';
 
 const componentEl = ref(null as unknown as Element);
 const props = defineProps({
@@ -35,6 +37,13 @@ const props = defineProps({
 });
 
 const skipTransition = ref(false);
+
+onMounted(() => {
+    // If this panel will be teleported elsewhere, apply tailwind styles directly on the panel.
+    if (props.panel.teleport) {
+        ro.observe(componentEl.value);
+    }
+});
 
 const animateTransition = (
     el: HTMLElement,

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -19,7 +19,12 @@
             class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48 overflow-hidden"
             tabindex="-1"
         >
-            <back class="block sm:display-none" @click="panel.close()"></back>
+            <back
+                :class="
+                    !!panel.teleport ? 'display-none' : 'block sm:display-none'
+                "
+                @click="panel.close()"
+            ></back>
 
             <h2 class="flex-grow text-lg py-16 pl-8 min-w-0" v-truncate>
                 <slot name="header"></slot>
@@ -29,23 +34,25 @@
                 <slot name="controls"></slot>
             </panel-options-menu>
 
-            <div class="display-none sm:flex">
-                <left
-                    v-if="reorderable"
-                    @click="move('left')"
-                    :active="!panel.isLeftMostPanel"
-                />
-                <right
-                    v-if="reorderable"
-                    @click="move('right')"
-                    :active="!panel.isRightMostPanel"
-                />
-                <pin @click="panel.pin()" :active="panel.isPinned" />
-                <expand
-                    v-if="panel.controls && panel.controls.expand"
-                    @click="panel.expand()"
-                    :active="panel.expanded"
-                />
+            <div :class="!!panel.teleport ? 'flex' : 'display-none sm:flex'">
+                <div class="flex" v-if="!panel.teleport">
+                    <left
+                        v-if="reorderable"
+                        @click="move('left')"
+                        :active="!panel.isLeftMostPanel"
+                    />
+                    <right
+                        v-if="reorderable"
+                        @click="move('right')"
+                        :active="!panel.isRightMostPanel"
+                    />
+                    <pin @click="panel.pin()" :active="panel.isPinned" />
+                    <expand
+                        v-if="panel.controls && panel.controls.expand"
+                        @click="panel.expand()"
+                        :active="panel.expanded"
+                    />
+                </div>
                 <minimize
                     v-if="panel.button && temporary?.includes(panel.id)"
                     @click="panel.minimize()"
@@ -110,7 +117,7 @@ const temporary = computed((): Array<string> | undefined =>
 const mobileView = computed(() => panelStore.mobileView);
 const reorderable = computed(() => panelStore.reorderable);
 
-const checkMode = () => !mobileView.value;
+const checkMode = () => !mobileView.value && !props.panel.teleport;
 const move = (direction: string) => {
     props.panel.move(direction);
     if (direction === 'left') {

--- a/src/components/panel-stack/panel-stack.vue
+++ b/src/components/panel-stack/panel-stack.vue
@@ -26,7 +26,7 @@ import type { ComponentPublicInstance } from 'vue';
 import { usePanelStore } from '@/stores/panel';
 
 const panelStore = usePanelStore();
-const iApi = inject<InstanceAPI>('iApi');
+const iApi = inject<InstanceAPI>('iApi')!;
 const el = ref<ComponentPublicInstance>();
 
 const mobileMode = computed(() => panelStore.mobileView);

--- a/src/components/shell.vue
+++ b/src/components/shell.vue
@@ -28,30 +28,44 @@
         <div v-else class="w-full h-full">
             <div class="spinner relative inset-x-1/2 inset-y-9/20"></div>
         </div>
+
+        <teleport v-for="panel in teleported()" :to="panel.teleport?.target">
+            <panel-container
+                :key="`${panel.id}`"
+                :panel="panel"
+            ></panel-container>
+        </teleport>
     </div>
 </template>
 
 <script setup lang="ts">
 import EsriMap from '@/components/map/esri-map.vue';
 import PanelStack from '@/components/panel-stack/panel-stack.vue';
+import PanelContainer from '@/components/panel-stack/panel-container.vue';
 import MapCaption from '@/components/map/map-caption.vue';
 import NotificationFloatingButton from '@/components/notification-center/floating-button.vue';
 import KeyboardInstructionsModal from './keyboard-instructions.vue';
 import { computed, inject } from 'vue';
-import type { InstanceAPI } from '@/api';
+import type { InstanceAPI, PanelInstance } from '@/api';
 import { useI18n } from 'vue-i18n';
 import { useFixtureStore } from '@/stores/fixture';
 import { useInstanceStore } from '@/stores/instance';
+import { usePanelStore } from '@/stores/panel';
 
 const iApi = inject<InstanceAPI>('iApi');
 const instanceStore = useInstanceStore();
 const fixtureStore = useFixtureStore();
+const panelStore = usePanelStore();
 const { t } = useI18n();
 
 const appbarFixture = computed(() => fixtureStore.items['appbar']);
 const openKeyboardInstructions = () => {
     iApi?.event.emit('openKeyboardInstructions');
 };
+
+const teleported = (): PanelInstance[] =>
+    // @ts-ignore
+    panelStore.teleported;
 </script>
 
 <style lang="scss" scoped>

--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -21,7 +21,13 @@ let managers: FocusContainerManager[] = [];
  */
 export const FocusContainer: Directive = {
     mounted(el: HTMLElement) {
-        managers.push(new FocusContainerManager(el));
+        // check whether the element is inside a RAMP app, and proceed only if it is
+        // let's hope that no one decides to use class inner-shell on their elements
+        // couldn't find a better solution since we don't have access to the vue app in here
+        const rampShells = [...document.querySelectorAll('.inner-shell')];
+        if (rampShells.some(shell => shell.contains(el))) {
+            managers.push(new FocusContainerManager(el));
+        }
     },
     beforeUnmount(el: HTMLElement) {
         // filter removes the FocusContainerManager at the same time

--- a/src/fixtures/areas-of-interest/api/areas-of-interest.ts
+++ b/src/fixtures/areas-of-interest/api/areas-of-interest.ts
@@ -19,5 +19,6 @@ export class AreasOfInterestAPI extends FixtureInstance {
         }
         const areasOfInterestStore = useAreasOfInterestStore(this.$vApp.$pinia);
         areasOfInterestStore.areas = areasOfInterest.areas;
+        this.handlePanelTeleports(['areas-of-interest']);
     }
 }

--- a/src/fixtures/basemap/index.ts
+++ b/src/fixtures/basemap/index.ts
@@ -26,6 +26,8 @@ class BasemapFixture extends FixtureInstance {
             },
             { i18n: { messages } }
         );
+
+        this.handlePanelTeleports(['basemap']);
     }
 
     removed() {

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -117,6 +117,7 @@ export class DetailsAPI extends FixtureInstance {
         }
 
         this.handlePanelWidths(['details-items', 'details-layers']);
+        this.handlePanelTeleports(['details-items', 'details-layers']);
 
         // get all layer fixture configs
         const layerDetailsConfigs: any = this.getLayerFixtureConfigs();

--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -61,6 +61,7 @@ export class ExportAPI extends FixtureInstance {
         exportStore.fileName = exportConfig.fileName || '';
 
         this.handlePanelWidths(['export']);
+        this.handlePanelTeleports(['export']);
     }
 
     /**

--- a/src/fixtures/gazebo/index.ts
+++ b/src/fixtures/gazebo/index.ts
@@ -106,6 +106,8 @@ class GazeboFixture extends FixtureInstance {
             },
             { i18n: { messages } }
         );
+
+        this.handlePanelTeleports(['p1', 'p2']);
     }
 }
 

--- a/src/fixtures/geosearch/index.ts
+++ b/src/fixtures/geosearch/index.ts
@@ -33,6 +33,8 @@ class GeosearchFixture extends GeosearchAPI {
             },
             { i18n: { messages } }
         );
+
+        this.handlePanelTeleports(['geosearch']);
     }
 
     removed() {

--- a/src/fixtures/grid/api/grid.ts
+++ b/src/fixtures/grid/api/grid.ts
@@ -55,6 +55,7 @@ export class GridAPI extends FixtureInstance {
     _parseConfig() {
         const gridStore = useGridStore(this.$vApp.$pinia);
         this.handlePanelWidths(['grid']);
+        this.handlePanelTeleports(['grid']);
 
         const layerGridConfigs: any = this.getLayerFixtureConfigs();
 

--- a/src/fixtures/grid/screen.vue
+++ b/src/fixtures/grid/screen.vue
@@ -23,9 +23,6 @@ defineProps({
     panel: {
         type: PanelInstance,
         required: true
-    },
-    header: {
-        type: String
     }
 });
 

--- a/src/fixtures/help/api/help.ts
+++ b/src/fixtures/help/api/help.ts
@@ -35,5 +35,6 @@ export class HelpAPI extends FixtureInstance {
         const helpStore = useHelpStore(this.$vApp.$pinia);
         helpStore.location = helpConfig?.location ?? './help/';
         this.handlePanelWidths(['help']);
+        this.handlePanelTeleports(['help']);
     }
 }

--- a/src/fixtures/layer-reorder/index.ts
+++ b/src/fixtures/layer-reorder/index.ts
@@ -29,6 +29,8 @@ class LayerReorderFixture extends LayerReorderAPI {
                 i18n: { messages }
             }
         );
+
+        this.handlePanelTeleports(['layer-reorder']);
     }
 
     removed() {

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -27,6 +27,7 @@ export class LegendAPI extends FixtureInstance {
         }
 
         this.handlePanelWidths(['legend']);
+        this.handlePanelTeleports(['legend']);
 
         // get all layer fixture configs to read layer-specific legend properties
         const layerLegendConfigs: { [layerId: string]: any } =

--- a/src/fixtures/metadata/index.ts
+++ b/src/fixtures/metadata/index.ts
@@ -28,6 +28,8 @@ class MetadataFixture extends MetadataAPI {
             { i18n: { messages } }
         );
 
+        this.handlePanelTeleports(['metadata']);
+
         this.removed = () => {
             // console.log(`[fixture] ${this.id} removed`);
             if (this.$iApi.fixture.get('appbar')) {

--- a/src/fixtures/settings/index.ts
+++ b/src/fixtures/settings/index.ts
@@ -27,6 +27,8 @@ class SettingsFixture extends SettingsAPI {
             },
             { i18n: { messages } }
         );
+
+        this.handlePanelTeleports(['settings']);
     }
 
     removed() {

--- a/src/fixtures/wizard/index.ts
+++ b/src/fixtures/wizard/index.ts
@@ -30,6 +30,8 @@ class WizardFixture extends WizardAPI {
             }
         );
 
+        this.handlePanelTeleports(['wizard']);
+
         let layerSource: LayerSource | undefined = new LayerSource(this.$iApi);
 
         const wizardStore = useWizardStore(this.$vApp.$pinia);

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -13,6 +13,7 @@ export const usePanelStore = defineStore('panel', () => {
     const items = ref<{ [name: string]: PanelInstance }>({});
     const regPromises = ref<{ [name: string]: DefPromise }>({});
     const orderedItems = ref<PanelInstance[]>([]);
+    const teleported = ref<PanelInstance[]>([]);
     const visible = ref<PanelInstance[]>([]);
 
     /**
@@ -191,18 +192,34 @@ export const usePanelStore = defineStore('panel', () => {
     }
 
     function open(panel: PanelInstance): void {
-        //@ts-ignore
-        orderedItems.value = [...orderedItems.value, panel];
+        if (panel.teleport) {
+            // @ts-ignore
+            teleported.value = [...teleported.value, panel];
+        } else {
+            //@ts-ignore
+            orderedItems.value = [...orderedItems.value, panel];
+        }
     }
 
     function close(panel: PanelInstance): void {
-        //@ts-ignore
-        const index = orderedItems.value.indexOf(panel);
-        if (index !== -1) {
-            orderedItems.value = [
-                ...orderedItems.value.slice(0, index),
-                ...orderedItems.value.slice(index + 1)
-            ];
+        if (panel.teleport) {
+            //@ts-ignore
+            const index = teleported.value.indexOf(panel);
+            if (index !== -1) {
+                teleported.value = [
+                    ...teleported.value.slice(0, index),
+                    ...teleported.value.slice(index + 1)
+                ];
+            }
+        } else {
+            //@ts-ignore
+            const index = orderedItems.value.indexOf(panel);
+            if (index !== -1) {
+                orderedItems.value = [
+                    ...orderedItems.value.slice(0, index),
+                    ...orderedItems.value.slice(index + 1)
+                ];
+            }
         }
     }
 
@@ -262,6 +279,7 @@ export const usePanelStore = defineStore('panel', () => {
         remWidth,
         mobileView,
         reorderable,
+        teleported,
         getRemainingWidth,
         getVisible,
         getRegPromises,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,7 +65,9 @@ export default defineConfig(({ command, mode }) => {
                         wet: '/index-wet.html',
                         samples: '/index-samples.html',
                         all: '/index-all.html',
-                        form: '/index-form.html'
+                        form: '/index-form.html',
+                        teleport: '/index-teleport.html',
+                        teleportWet: '/index-teleport-wet.html'
                     }
                 }
             });


### PR DESCRIPTION
For #1668.
Relevant discussion: #1497.

This PR is a demonstration of the Vue teleport suggestion by @milespetrov.

To test it out, go to [https://ramp4-pcar4.github.io/ramp4-pcar4/teleport/demos/index-teleport.html](https://ramp4-pcar4.github.io/ramp4-pcar4/teleport/demos/index-teleport.html) and attempt to open the grid as you normally would. Notice the grid appearing in the empty div below RAMP.

I attempted to mostly emulate the solution we have in place for handling panel widths. Here are some pontifications I have regarding the current solution:
* Are we okay with the level of modification this would require to the config as well as core? This would ideally have been something that would be done via external dev code, but since we need the `<teleport`> wrapped around the panel container component, I'm not sure how we could achieve that.
* We would also need to figure out how to address wacky behaviour that this causes. Primarily, should opening a panel elsewhere make an appbar button for it, and should it be able to be controlled via the appbar? What about the panel's header controls, do we need to change anything about them? For example, the back button in the demo above doesn't really make sense imo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1644)
<!-- Reviewable:end -->
