### PR TITLE
Log RAMP version only once per page

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -102,14 +102,6 @@ export class InstanceAPI {
         configs?: RampConfigs,
         options?: RampOptions
     ) {
-        console.log(
-            `RAMP v${__RAMP_VERSION__.major}.${__RAMP_VERSION__.minor}.${
-                __RAMP_VERSION__.patch
-            } [${__RAMP_VERSION__.hash.slice(0, 9)}] (Built on ${new Date(
-                __RAMP_VERSION__.timestamp.toString()
-            ).toLocaleString()})`
-        );
-
         this.event = new EventAPI(this);
 
         const appInstance = createApp(element, this);

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,14 @@ import type { RampOptions } from '@/api/instance';
 import type { RampConfigs } from './types';
 import type { RampLayerConfig } from './geo/api';
 
+console.log(
+    `RAMP v${__RAMP_VERSION__.major}.${__RAMP_VERSION__.minor}.${
+        __RAMP_VERSION__.patch
+    } [${__RAMP_VERSION__.hash.slice(0, 9)}] (Built on ${new Date(
+        __RAMP_VERSION__.timestamp.toString()
+    ).toLocaleString()})`
+);
+
 export const version = __RAMP_VERSION__;
 export function configUpgrade(ramp2Config: any | Array<any>): any {
     return configUpgrade2to4(ramp2Config);


### PR DESCRIPTION
For #1600.

The RAMP version will now be logged once per page instead of once per instance.

I tried this out on many different pages and it seemed to work, including on a storylines product that has RAMP4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1649)
<!-- Reviewable:end -->
