### PR TITLE
Fix tree grow issues

### DIFF
--- a/demos/starter-scripts/tree-grow.js
+++ b/demos/starter-scripts/tree-grow.js
@@ -281,6 +281,12 @@ let config = {
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
                     sublayers: [{ index: 21 }, { index: 35 }]
+                },
+                {
+                    id: 'Cycling',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps.ottawa.ca/arcgis/rest/services/CyclingMap/MapServer',
+                    sublayers: [{ index: 0 }, { index: 27 }]
                 }
             ],
             fixtures: {
@@ -315,6 +321,10 @@ let config = {
                                 name: 'MIL group that is exclusive set',
                                 expanded: false,
                                 exclusive: true
+                            },
+                            {
+                                layerId: 'Cycling',
+                                expanded: false
                             }
                         ]
                     }

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -138,6 +138,9 @@ export class LegendAPI extends FixtureInstance {
             parent,
             layer
         );
+        // add the layer item to store
+        // will be in a placeholder state until the layer is loaded
+        this._insertItem(item as unknown as LegendItem, parent);
 
         if (layer.supportsSublayers) {
             // if layer supports sublayers, then we need to parse the
@@ -156,9 +159,6 @@ export class LegendAPI extends FixtureInstance {
 
         item.treeGrown = true;
 
-        // add the layer item to store
-        // will be in a placeholder state until the layer is loaded
-        this._insertItem(item as unknown as LegendItem, parent);
         return item;
     }
 
@@ -389,6 +389,9 @@ export class LegendAPI extends FixtureInstance {
                                 delete layerItemConf.layerId;
                                 delete layerItemConf.sublayerIndex;
                                 delete layerItemConf.children;
+                                if (!layerItemConf.name) {
+                                    delete layerItemConf.name;
+                                }
                                 const replacementConf = {
                                     ...this._treeWalker(layer, node),
                                     ...layerItemConf

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -74,7 +74,7 @@ export class LayerSource extends APIScope {
             id: `geojson#${++this.layerCount}`,
             layerType: LayerType.GEOJSON,
             url,
-            name: url.substr(url.lastIndexOf('/') + 1),
+            name: url.substring(url.lastIndexOf('/') + 1),
             state: { opacity: 1, visibility: true },
             rawData: fileData
         };
@@ -101,7 +101,7 @@ export class LayerSource extends APIScope {
             id: `csv#${++this.layerCount}`,
             layerType: LayerType.CSV,
             url,
-            name: url.substr(url.lastIndexOf('/') + 1),
+            name: url.substring(url.lastIndexOf('/') + 1),
             state: { opacity: 1, visibility: true },
             rawData: fileData
         };
@@ -199,6 +199,10 @@ export class LayerSource extends APIScope {
             configOptions: ['name', 'sublayers']
         };
 
+        /**
+         * Processes the layer's flattened layer tree to determine the level of each layer in the list.
+         * @param layers the layer's flattened tree that was retrieved from the server.
+         */
         function flattenMapImageLayerList(layers: any) {
             return layers.map((layer: any) => {
                 const level = calculateLevel(layer, layers);
@@ -210,12 +214,22 @@ export class LayerSource extends APIScope {
                 return layer;
             });
 
+            /**
+             * Calculates the level of the layer in the layer tree i.e. how many parent layers you can go up before you reach the base MIL.
+             * @param layer the layer for which the calculation is occurring.
+             * @param layers a flattened array of the layer tree.
+             */
             function calculateLevel(layer: any, layers: any): number {
                 if (layer.parentLayerId === -1) {
                     return 0;
                 } else {
                     return (
-                        calculateLevel(layers[layer.parentLayerId], layers) + 1
+                        calculateLevel(
+                            layers.find(
+                                (l: any) => l.id === layer.parentLayerId
+                            ),
+                            layers
+                        ) + 1
                     );
                 }
             }


### PR DESCRIPTION
For #1654, #1656.

MIL's with reordered indexes can now be correctly added via the wizard. Use [this service](https://maps.ottawa.ca/arcgis/rest/services/CyclingMap/MapServer) to test out. I have also added the service to sample 30 to demonstrate that reordered indexes work in the config.

Additionally, MIL groups will now use their name from the server if one is not defined in the config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1660)
<!-- Reviewable:end -->
