### PR TITLE
Added y scrolling to dropdown menu component for small devices / compact RAMP implementations.

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -36,7 +36,8 @@ import {
     onMounted,
     onBeforeUnmount
 } from 'vue';
-import { createPopper, type Placement } from '@popperjs/core';
+import type { Placement, Modifier, State } from '@popperjs/core';
+import { createPopper, detectOverflow } from '@popperjs/core';
 
 const open = ref<boolean>(false);
 const popper = ref<any>(null);
@@ -93,6 +94,26 @@ onMounted(() => {
 
     // nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
     nextTick(() => {
+        const overflowScrollModifier: Modifier<'overflowScroll', {}> = {
+            name: 'overflowScroll',
+            enabled: true,
+            phase: 'main',
+            fn({ state }: { state: State }) {
+                const { bottom } = detectOverflow(state);
+
+                if (bottom > 0) {
+                    state.styles.popper.overflowY =
+                        bottom > 100 ? 'auto' : undefined;
+                    state.styles.popper.overflowX = 'hidden';
+                    state.styles.popper.height = `${
+                        state.rects.popper.height - bottom - 8
+                    }px`;
+                } else {
+                    state.styles.popper.height = 'auto';
+                }
+            }
+        };
+
         if (dropdownTrigger.value && dropdown.value) {
             popper.value = createPopper(
                 dropdownTrigger.value as Element,
@@ -100,6 +121,7 @@ onMounted(() => {
                 {
                     placement: (props.position || 'bottom') as Placement,
                     modifiers: [
+                        overflowScrollModifier,
                         {
                             name: 'offset',
                             options: {


### PR DESCRIPTION
The dropdown menu component will now be scrollable along the y axis if the viewport height is below 700px. Not sure if this has any implications for other dropdown instances in RAMP, so yell at me if it does.

I'm also looking for feedback on whether the I should increase / decrease the viewport threshold, or max height of the scrollable menu.

Heres an example of where this may be needed: https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-form

#1670 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1675)
<!-- Reviewable:end -->
