### PR TITLE
Fix AG grid console warnings

### DIFF
--- a/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/src/fixtures/grid/templates/custom-date-filter.vue
@@ -148,6 +148,16 @@ onBeforeMount(() => {
 });
 </script>
 
+<script lang="ts">
+    // AG grid can't recognize required method using Composition API
+    // Use Options API instead, fixes console warnings
+    export default {
+        methods: {
+            onParentModelChanged(){}
+        }
+    };
+</script>
+
 <style lang="scss" scoped>
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,

--- a/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/src/fixtures/grid/templates/custom-number-filter.vue
@@ -164,6 +164,16 @@ onBeforeMount(() => {
 });
 </script>
 
+<script lang="ts">
+    // AG grid can't recognize required method using Composition API
+    // Use Options API instead, fixes console warnings
+    export default {
+        methods: {
+            onParentModelChanged(){}
+        }
+    };
+</script>
+
 <style lang="scss" scoped>
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,

--- a/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -98,6 +98,16 @@ onBeforeMount(() => {
 });
 </script>
 
+<script lang="ts">
+    // AG grid can't recognize required method using Composition API
+    // Use Options API instead, fixes console warnings
+    export default {
+        methods: {
+            onParentModelChanged(){}
+        }
+    };
+</script>
+
 <style lang="scss" scoped>
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,

--- a/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/src/fixtures/grid/templates/custom-text-filter.vue
@@ -91,6 +91,16 @@ onBeforeMount(() => {
 });
 </script>
 
+<script lang="ts">
+    // AG grid can't recognize required method using Composition API
+    // Use Options API instead, fixes console warnings
+    export default {
+        methods: {
+            onParentModelChanged(){}
+        }
+    };
+</script>
+
 <style lang="scss">
 .ag-floating-filter-full-body input,
 .ag-floating-filter-full-body select,


### PR DESCRIPTION
For #1652 

This update fixes the console warnings that appear whenever you open and use the filters for a datatable/grid.
From what I've tried, when using the Composition API and `<script setup>` it seems that AG grid can't recognize the required `onParentModelChanged()` method that we defined.
To fix this, I defined it within the component's options object. Might seem a little messy, could prefer to keep the console warnings  or attempt to find another way if possible.