### PR TITLE
Configurable layer load timeout

### DIFF
--- a/docs/configuration/layer-config.md
+++ b/docs/configuration/layer-config.md
@@ -24,6 +24,7 @@ Layer Configuration Properties
 - [latField](#latField)
 - [layerType](#layerType)
 - [longField](#longField)
+- [maxLoadTime](#maxLoadTime)
 - [metadata](#metadata)
 - [mouseTolerance](#mouseTolerance)
 - [name](#name)
@@ -193,6 +194,18 @@ The object structure matches the ArcGIS Server [2D Envelope](https://developers.
             wkid: 4326
         }
     }
+}
+```
+
+### maxLoadTime
+
+*integer*
+
+Defines a time limit, in milliseconds, for the max amount of time it would take for the layer load (i.e. establishing contact with a server, the fetching of metadata, the downloading of data for file or WFS type layers). If the limit is exceeded, the layer will stop loading and produce an error. If missing, a default of 20 seconds will be used. Setting to `0` will allow the layer to load forever.
+
+```js
+{
+    maxLoadTime: 10000
 }
 ```
 

--- a/schema.json
+++ b/schema.json
@@ -725,6 +725,11 @@
                     "default": 4000,
                     "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
                 },
+                "maxLoadTime": {
+                    "type": "number",
+                    "default": 20000,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
                 },
@@ -795,6 +800,11 @@
                     "type": "number",
                     "default": 4000,
                     "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                },
+                "maxLoadTime": {
+                    "type": "number",
+                    "default": 20000,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -867,6 +877,11 @@
                     "type": "number",
                     "default": 4000,
                     "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                },
+                "maxLoadTime": {
+                    "type": "number",
+                    "default": 20000,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -1067,6 +1082,11 @@
                     "default": 4000,
                     "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
                 },
+                "maxLoadTime": {
+                    "type": "number",
+                    "default": 20000,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
                 },
@@ -1186,6 +1206,11 @@
                     "type": "number",
                     "default": 4000,
                     "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                },
+                "maxLoadTime": {
+                    "type": "number",
+                    "default": 20000,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
                 },
                 "layerType": {
                     "type": "string",
@@ -1312,6 +1337,11 @@
                     "default": 4000,
                     "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
                 },
+                "maxLoadTime": {
+                    "type": "number",
+                    "default": 20000,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                },
                 "colour": {
                     "type": "string",
                     "description": "The hex code representing the layer symbology colour."
@@ -1428,6 +1458,11 @@
                     "type": "number",
                     "default": 4000,
                     "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                },
+                "maxLoadTime": {
+                    "type": "number",
+                    "default": 20000,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"

--- a/src/fixtures/help/screen.vue
+++ b/src/fixtures/help/screen.vue
@@ -62,7 +62,11 @@ onBeforeMount(() => {
                         : `${location.value}/`;
                 // make it easier to use images in markdown by prepending path to href if href is not an external source
                 // this avoids the need for ![](help/images/myimg.png) to just ![](myimg.png). This overrides the default image renderer completely.
-                renderer.image = (href: string, title: string, text: string) => {
+                renderer.image = (
+                    href: string,
+                    title: string,
+                    text: string
+                ) => {
                     if (href.indexOf('http') === -1) {
                         href = `${loc}images/` + href;
                     }

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -623,6 +623,7 @@ export interface RampLayerConfig {
     identifyMode?: LayerIdentifyMode;
     caching?: boolean; // whether to preserve raw data in file and WFS layers
     rawData?: any; // used for static data, like geojson string, shapefile guts
+    maxLoadTime?: number; // how long layer can load before error
 }
 
 export interface RampExtentConfig {

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -189,6 +189,11 @@ export class LayerInstance extends APIScope {
     legend: Array<LegendSymbology>;
 
     /**
+     * How long layer can load for before error (milliseconds)
+     */
+    maxLoadTime: number;
+
+    /**
      *  The internal ESRI API layer
      */
     esriLayer: __esri.Layer | undefined;
@@ -252,6 +257,7 @@ export class LayerInstance extends APIScope {
         this.legend = [];
         this._sublayers = [];
         this.expectedTime = { draw: 0, load: 0 };
+        this.maxLoadTime = 0;
     }
 
     /**


### PR DESCRIPTION
For #1485 

This update gives a user the option to set the time for how long a layer can load before an error using `layerLoadTime`.
If no value is specified then the default value of 0 is used and the layer can load forever.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1691)
<!-- Reviewable:end -->
