### PR TITLE
Fix legend entry shimmy shake.

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -906,6 +906,7 @@ const hover = (t: EventTarget) => {
 }
 @media (hover) {
     .loaded-item {
+        @apply min-h-[39px];
         .options {
             @apply hidden;
         }


### PR DESCRIPTION
Legend entry will no long shimmy shake when hovered. 

#1689

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1693)
<!-- Reviewable:end -->
