### PR TITLE
Merge Grid

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -213,6 +213,12 @@
                 custom fixture with an externally defined custom store.
                 <span class="tag misc">Custom Store</span>
             </li>
+            <li>
+                38.
+                <a href="index-samples.html?sample=38">Merge Grid</a>. Contains
+                layers with merged grid fixtures.
+                <span class="tag misc">Datatable</span>
+            </li>
         </ul>
 
         <h2>Simple Samples</h2>

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -92,6 +92,7 @@
                         36. Basemap fixture with configured thumbnails
                     </option>
                     <option value="custom-store">37. Custom Store</option>
+                    <option value="merge-grid">38. Merge Grid</option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/merge-grid.js
+++ b/demos/starter-scripts/merge-grid.js
@@ -1,0 +1,383 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    }
+                ],
+                initialBasemapId: 'baseNrCan'
+            },
+            layers: [
+                {
+                    id: 'NPRI',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/NPRI_INRP/NPRI_INRP/MapServer/0',
+                    fixtures: {
+                        grid: {
+                            title: 'NPRI Data'
+                        }
+                    }
+                },
+                {
+                    id: 'EcoGeo',
+                    layerType: 'esri-map-image',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/',
+                    sublayers: [{ index: 6 }, { index: 7 }, { index: 8 }]
+                },
+                {
+                    id: 'EcoGeo-9',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/9'
+                },
+                {
+                    id: 'MajorCities',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/SupportData/MapServer/1'
+                },
+                {
+                    id: 'Heroni',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/D01/456ce087-4711-442c-8445-30520f96e98e/MapServer/0'
+                },
+                {
+                    id: 'CESI',
+                    layerType: 'esri-map-image',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/',
+                    sublayers: [{ index: 22 }, { index: 24 }, { index: 26 }]
+                },
+                {
+                    id: 'ReleaseDisposals',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/2'
+                },
+                {
+                    id: 'ErroredLayer',
+                    layerType: 'esri-feature',
+                    url: 'error'
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                infoType: 'title',
+                                content: 'Single Layer Grid',
+                                controls: [],
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content:
+                                            'Represents a simple grid with a single layer.'
+                                    },
+                                    {
+                                        name: 'NPRI',
+                                        layerId: 'NPRI'
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'title',
+                                content: 'Homogenous Merge Grid',
+                                controls: [],
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content:
+                                            'Represents a grid merging 3 sublayers and a separately defined sublayer with the exact same fields.'
+                                    },
+                                    {
+                                        layerId: 'EcoGeo',
+                                        sublayerIndex: 6
+                                    },
+                                    {
+                                        layerId: 'EcoGeo',
+                                        sublayerIndex: 7
+                                    },
+                                    {
+                                        layerId: 'EcoGeo',
+                                        sublayerIndex: 8
+                                    },
+                                    {
+                                        layerId: 'EcoGeo-9'
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'title',
+                                content: 'Heterogenous Merge Grid',
+                                controls: [],
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content:
+                                            'Represents a merge grid containing layers with differing fields (including oid field).'
+                                    },
+                                    {
+                                        layerId: 'MajorCities',
+                                        name: 'Major Cities'
+                                    },
+                                    {
+                                        layerId: 'Heroni',
+                                        name: 'Heroni'
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'title',
+                                content:
+                                    'Homogenous Merge Grid with Map Filtering',
+                                controls: [],
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content:
+                                            'Represents a merge grid with similar fields whose filters can be applied to the map. The Concentration (NO2/Ozone/PM2_5) and Symbol columns are field mapped.'
+                                    },
+                                    {
+                                        layerId: 'CESI',
+                                        sublayerIndex: 22,
+                                        name: 'NO2 Concentration'
+                                    },
+                                    {
+                                        layerId: 'CESI',
+                                        sublayerIndex: 24,
+                                        name: 'Ozone Concentration'
+                                    },
+                                    {
+                                        layerId: 'CESI',
+                                        sublayerIndex: 26,
+                                        name: 'Particulate Concentration'
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'title',
+                                content: 'Merge Grid with Errored Layer',
+                                controls: [],
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content:
+                                            'A merge grid where one layer has failed to load.'
+                                    },
+                                    {
+                                        name: 'Release Disposals',
+                                        layerId: 'ReleaseDisposals'
+                                    },
+                                    {
+                                        name: 'Errored Layer',
+                                        layerId: 'ErroredLayer'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: ['legend']
+                },
+                grid: {
+                    mergeGrids: [
+                        {
+                            gridId: 'EcoGeoMergeGrid',
+                            layers: [
+                                {
+                                    layerId: 'EcoGeo',
+                                    sublayers: [6, 7, 8]
+                                },
+                                {
+                                    layerId: 'EcoGeo-9'
+                                }
+                            ],
+                            options: {
+                                title: 'EcoGeo Data',
+                                columns: [
+                                    {
+                                        field: 'OBJECTID',
+                                        sort: 'asc'
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            gridId: 'HeteroMergeGrid',
+                            layers: [
+                                {
+                                    layerId: 'MajorCities'
+                                },
+                                {
+                                    layerId: 'Heroni'
+                                }
+                            ],
+                            options: {
+                                title: 'Hetero Data',
+                                applyToMap: true
+                            }
+                        },
+                        {
+                            gridId: 'CESIMergeGrid',
+                            layers: [
+                                {
+                                    layerId: 'CESI',
+                                    sublayers: [22, 24, 26]
+                                }
+                            ],
+                            options: {
+                                title: 'CESI Data',
+                                applyToMap: true,
+                                columns: [
+                                    {
+                                        field: 'Concentration',
+                                        title: 'Concentration (NO2/Ozone/PM2_5)'
+                                    }
+                                ]
+                            },
+                            fieldMap: [
+                                {
+                                    field: 'Concentration',
+                                    sources: ['NO2', 'Ozone', 'PM2_5']
+                                },
+                                {
+                                    field: 'Symbol',
+                                    sources: [
+                                        'NO2_Symbol',
+                                        'Ozone_Symbol',
+                                        'PM2_5_Symbol'
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            gridId: 'ErrorMergeGrid',
+                            layers: [
+                                {
+                                    layerId: 'ReleaseDisposals'
+                                },
+                                {
+                                    layerId: 'ErroredLayer'
+                                }
+                            ],
+                            options: {
+                                title: 'Errored Data',
+                                columns: [
+                                    {
+                                        field: 'OBJECTID',
+                                        sort: 'asc'
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                mapnav: {
+                    items: ['fullscreen', 'help', 'home', 'legend', 'geosearch']
+                },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
+                help: {
+                    location: '../help'
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+// rInstance.fixture.addDefaultFixtures().then(() => {
+//     rInstance.panel.open('legend');
+//     rInstance.panel.pin('legend');
+// });
+
+// add export fixtures
+rInstance.fixture.add('export');
+
+// add areas of interest fixture
+rInstance.fixture.add('areas-of-interest');
+
+// load map if startRequired is true
+// rInstance.start();
+
+// function animateToggle() {
+//     if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
+//         rInstance.$vApp.$el.classList.remove('animation-enabled');
+//     } else {
+//         rInstance.$vApp.$el.classList.add('animation-enabled');
+//     }
+//     document.getElementById('animate-status').innerText =
+//         'Animate: ' + rInstance.animate;
+// }
+
+window.debugInstance = rInstance;

--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -187,7 +187,7 @@ Changes to layers causing changes to the legend
 Changes to layers causing changes in other fixtures
 
 - `ramp_layer_remove_updates_details` clear details info for layer that has been removed
-- `ramp_layer_remove_closes_grid` close grid if the grid layer is removed
+- `ramp_layer_remove_checks_grid` close and remove grid if all its layers have been removed
 
 ### Panel Handlers
 

--- a/schema.json
+++ b/schema.json
@@ -1695,6 +1695,67 @@
             },
             "additionalProperties": false
         },
+        "mergeGrid": {
+            "type": "object",
+            "description": "Specification for a single merge grid.",
+            "properties": {
+                "gridId": {
+                    "type": "string",
+                    "description": "The unique ID of the grid."
+                },
+                "layers": {
+                    "type": "array",
+                    "description": "A collection of layers present in the grid.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "layerId": {
+                                "type": "string",
+                                "description": "The layer ID."
+                            },
+                            "sublayers": {
+                                "type": "array",
+                                "description": "The IDs of the sublayers when the provided layer is a map image layer.",
+                                "items": {
+                                    "type": "number"
+                                },
+                                "minItems": 1
+                            }
+                        },
+                        "required": ["layerId"]
+                    }
+                },
+                "fieldMap": {
+                    "type": "array",
+                    "description": "Objects that define mappings between layer fields for merging layers with varying column names.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "field": {
+                                "type": "string",
+                                "description": "The name of the field the column names are mapped to."
+                            },
+                            "sources": {
+                                "type": "array",
+                                "description": "The names of the columns that are mapped to the destination field",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "options": {
+                    "type": "array",
+                    "description": "Configuration for the merge grid.",
+                    "items": {
+                        "$ref": "#/$defs/grid"
+                    }
+                }
+            },
+            "required": ["mergeGrids"],
+            "unevaluatedProperties": false
+        },
         "grid": {
             "type": "object",
             "description": "Configuration for the datatable.",
@@ -2162,6 +2223,21 @@
                         }
                     },
                     "description": "Provides configuration to geosearch. If not supplied, default geosearch services are used."
+                },
+                "grid": {
+                    "type": "object",
+                    "description": "Provides configuration to the grid fixture.",
+                    "properties": {
+                        "mergeGrids": {
+                            "type": "array",
+                            "description": "Provides specifications for merge grids. Can also be used to configure single-layer grids, but the 'gridOption' property within the layer configuration object is preferred.",
+                            "items": {
+                                "$ref": "#/$defs/mergeGrid"
+                            }
+                        }
+                    },
+                    "required": ["mergeGrids"],
+                    "unevaluatedProperties": false
                 },
                 "details": {
                     "description": "Provides default template configuration to the details fixture. If not supplied, RAMP default templates wil be used.",

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -342,7 +342,7 @@ const enum DefEH {
     LAYER_RELOAD_END_BINDS_LEGEND = 'ramp_layer_reload_end_binds_legend',
     LAYER_RELOAD_START_UPDATES_LEGEND = 'ramp_layer_reload_start_updates_legend',
     LAYER_REMOVE_UPDATES_DETAILS = 'ramp_layer_remove_updates_details',
-    LAYER_REMOVE_CLOSES_GRID = 'ramp_layer_remove_closes_grid',
+    LAYER_REMOVE_CHECKS_GRID = 'ramp_layer_remove_checks_grid',
     LAYER_REMOVE_UPDATES_LEGEND = 'ramp_layer_remove_updates_legend',
     LAYER_USERADD_UPDATES_LEGEND = 'ramp_layer_useradd_updates_legend',
     MAP_BASEMAP_UPDATES_MAP_ATTRIBS = 'ramp_map_basemap_updates_map_attribs',
@@ -614,7 +614,7 @@ export class EventAPI extends APIScope {
                 DefEH.LAYER_RELOAD_END_BINDS_LEGEND,
                 DefEH.LAYER_RELOAD_START_UPDATES_LEGEND,
                 DefEH.LAYER_REMOVE_UPDATES_DETAILS,
-                DefEH.LAYER_REMOVE_CLOSES_GRID,
+                DefEH.LAYER_REMOVE_CHECKS_GRID,
                 DefEH.LAYER_REMOVE_UPDATES_LEGEND,
                 DefEH.LAYER_USERADD_UPDATES_LEGEND,
                 DefEH.MAP_BASEMAP_UPDATES_MAP_ATTRIBS,
@@ -748,19 +748,27 @@ export class EventAPI extends APIScope {
                 );
                 break;
 
-            case DefEH.LAYER_REMOVE_CLOSES_GRID:
-                // when a layer is removed, close the standard grid if open for that layer
+            case DefEH.LAYER_REMOVE_CHECKS_GRID:
+                // when a layer is removed, remove that layer from the corresponding grid
+                // close the panel if the removed layer was the last one in the grid
                 zeHandler = (layer: LayerInstance) => {
                     if (this.$iApi.fixture.get<GridAPI>('grid')) {
                         const gridStore = useGridStore(this.$vApp.$pinia);
-                        // remove cached grid state for layer from grid store
-                        gridStore.removeGrid(layer.id);
-                        // close grid panel if open or minimized with removed layer
-                        const currentId = gridStore.currentId;
-                        if (layer.id === currentId) {
-                            const panel = this.$iApi.panel.get('grid');
-                            this.$iApi.panel.close(panel);
-                            gridStore.currentId = undefined;
+                        // fetch grid id containing layer with given id
+                        const gridId = gridStore.getGridId(layer.id);
+                        if (gridId === undefined) return;
+                        // remove layerId from grid
+                        gridStore.removeLayer(gridId, layer.id);
+                        if (gridStore.grids[gridId].layerIds.length === 0) {
+                            // remove cached grid state for layer from grid store
+                            gridStore.removeGrid(gridId);
+                            // close grid panel if open or minimized with removed layer
+                            const currentId = gridStore.currentId;
+                            if (gridId === currentId) {
+                                const panel = this.$iApi.panel.get('grid');
+                                this.$iApi.panel.close(panel);
+                                gridStore.currentId = undefined;
+                            }
                         }
                     }
                 };

--- a/src/fixtures/grid/api/grid.ts
+++ b/src/fixtures/grid/api/grid.ts
@@ -1,33 +1,31 @@
 import { FixtureInstance } from '@/api';
-import { useGridStore } from '../store';
-import type { GridConfig } from '../store';
+import { useGridStore, type MergeGridConfig } from '../store';
 import TableStateManager from '../store/table-state-manager';
 
 export class GridAPI extends FixtureInstance {
+    private gridStore = useGridStore(this.$vApp.$pinia);
     /**
-     * Open the grid for the layer with the given id.
+     * Open the grid with the given id.
      *
      * @param {string} id
      * @param {boolean} [open] force panel open or closed
      * @memberof GridAPI
      */
     toggleGrid(id: string, open?: boolean): void {
-        const gridStore = useGridStore(this.$vApp.$pinia);
-        // get GridConfig for specified id
-        let gridSettings: GridConfig | undefined = gridStore.grids[id];
+        // fetch id of grid containing layer with given id
+        const gridId = this.gridStore.getGridId(id);
 
         // if no GridConfig exists for the given id, create it.
-        if (gridSettings === undefined) {
-            gridSettings = {
+        if (!gridId) {
+            this.gridStore.addGrid({
                 id: id,
-                state: new TableStateManager({})
-            };
-
-            gridStore.addGrid(gridSettings);
+                layerIds: [id],
+                state: new TableStateManager()
+            });
         }
 
-        const prevId = gridStore.currentId;
-        gridStore.currentId = id ? id : undefined;
+        const prevId = this.gridStore.currentId;
+        this.gridStore.currentId = gridId ?? id;
 
         const panel = this.$iApi.panel.get('grid');
 
@@ -50,23 +48,61 @@ export class GridAPI extends FixtureInstance {
     /**
      * Parses the grid config JSON snippet from the config file.
      *
+     * @param {any} config
      * @memberof GridAPI
      */
-    _parseConfig() {
-        const gridStore = useGridStore(this.$vApp.$pinia);
+    _parseConfig(config?: { mergeGrids: MergeGridConfig[] }) {
         this.handlePanelWidths(['grid']);
 
         const layerGridConfigs: any = this.getLayerFixtureConfigs();
+
+        // parse merge grid configs
+        if (config) {
+            config.mergeGrids.forEach((mergeGrid: any) => {
+                const layerIds: string[] = [];
+
+                // extract grid options
+                const { gridId, layers, fieldMap, options } = mergeGrid;
+
+                // collate merged layer ids and remove them from layer specific grid configs
+                // in case they are defined in two places
+                layers.forEach((layer: any) => {
+                    if (layer.sublayers) {
+                        layer.sublayers?.forEach((sl: number) => {
+                            layerIds.push(`${layer.layerId}-${sl}`);
+                            delete layerGridConfigs[`${layer.layerId}-${sl}`];
+                        });
+                    } else {
+                        layerIds.push(layer.layerId);
+                        delete layerGridConfigs[layer.layerId];
+                    }
+                });
+
+                fieldMap?.forEach((map: any) => {
+                    map.sources.forEach((source: string) => {
+                        this.gridStore.fieldMap[source] = map.field;
+                    });
+                });
+
+                const gridConfig = {
+                    id: gridId,
+                    layerIds: layerIds,
+                    state: new TableStateManager(options)
+                };
+                this.gridStore.addGrid(gridConfig);
+            });
+        }
 
         // construct the details config from the layer fixture configs
         Object.keys(layerGridConfigs).forEach((layerId: string) => {
             const gridConfig = {
                 id: layerId,
+                layerIds: [layerId],
                 state: new TableStateManager(layerGridConfigs[layerId])
             };
 
             // save the item in the store
-            gridStore.addGrid(gridConfig);
+            this.gridStore.addGrid(gridConfig);
         });
     }
 }

--- a/src/fixtures/grid/index.ts
+++ b/src/fixtures/grid/index.ts
@@ -34,7 +34,7 @@ class GridFixture extends GridAPI {
         );
 
         // parse grid config for each layer
-        this._parseConfig();
+        this._parseConfig(this.config);
     }
 
     removed() {

--- a/src/fixtures/grid/screen.vue
+++ b/src/fixtures/grid/screen.vue
@@ -4,8 +4,7 @@
         <template #content>
             <table-component
                 class="rv-grid"
-                :layerId="currentId"
-                :layerUid="currentUid"
+                :gridId="currentId"
                 :panel="panel"
             ></table-component>
         </template>
@@ -13,8 +12,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject, onBeforeMount, ref } from 'vue';
-import { type InstanceAPI, PanelInstance } from '@/api';
+import { computed } from 'vue';
+import { PanelInstance } from '@/api';
 import TableComponent from '@/fixtures/grid/table-component.vue';
 import { useGridStore } from './store';
 import { useI18n } from 'vue-i18n';
@@ -29,16 +28,10 @@ defineProps({
     }
 });
 
-const iApi = inject<InstanceAPI>('iApi')!;
 const gridStore = useGridStore();
 const { t } = useI18n();
 
 const currentId = computed<string>(() => gridStore.currentId!);
-const currentUid = ref<string>('');
-
-onBeforeMount(() => {
-    currentUid.value = iApi.geo.layer.getLayer(currentId.value)!.uid;
-});
 </script>
 
 <style lang="scss" scoped>

--- a/src/fixtures/grid/store/grid-state.ts
+++ b/src/fixtures/grid/store/grid-state.ts
@@ -2,12 +2,20 @@ import type TableStateManager from './table-state-manager';
 
 export interface GridConfig {
     /**
-     * The id for the layer that this grid represents.
+     * The id of the grid.
      *
      * @type {String}
      * @memberof GridConfig
      */
     id: string;
+
+    /**
+     * The ids for the layers that this grid contains.
+     *
+     * @type {Array<String>}
+     * @memberof GridConfig
+     */
+    layerIds: string[];
 
     /**
      * The state manager for this grid.
@@ -16,4 +24,43 @@ export interface GridConfig {
      * @memberof GridConfig
      */
     state: TableStateManager;
+}
+
+export interface MergeGridConfig {
+    /**
+     * The id of the merge grid.
+     */
+    gridId: string;
+
+    /**
+     * Ids for layers contained in the merge grid.
+     */
+    layers: { layerId: string; subLayers: number[] };
+
+    /**
+     * The state options for the merge grid.
+     */
+    options: TableStateOptions;
+
+    /**
+     * The mapping parameters for the merge grid.
+     */
+    fieldMap: { field: string; sources: string[] };
+}
+
+export interface TableStateOptions {
+    title: string;
+    showFilter: boolean;
+    filterByExtent: boolean;
+    columns: any;
+    open: boolean;
+    filtered: boolean;
+    search: boolean;
+    searchFilter: string;
+    applyToMap: boolean;
+}
+
+export interface AttributeMapPair {
+    origAttr: string;
+    mappedAttr: string | undefined;
 }

--- a/src/fixtures/grid/store/grid-store.ts
+++ b/src/fixtures/grid/store/grid-store.ts
@@ -15,9 +15,14 @@ export const useGridStore = defineStore('grid', () => {
     const panel = ref<PanelConfig>();
 
     /**
-     * The id of the layer that is currently open in the grid.
+     * The id of the grid that is currently open.
      */
     const currentId = ref<string>();
+
+    /**
+     * A mapping of grid fields for merging columns
+     */
+    const fieldMap = ref<{ [source: string]: string }>({});
 
     function addGrid(value: GridConfig) {
         grids.value = { ...grids.value, [value.id]: value };
@@ -29,5 +34,26 @@ export const useGridStore = defineStore('grid', () => {
         }
     }
 
-    return { grids, panel, currentId, addGrid, removeGrid };
+    function getGridId(id: string) {
+        return Object.keys(grids.value).find(gid =>
+            grids.value[gid].layerIds.includes(id)
+        );
+    }
+
+    function removeLayer(gridId: string, layerId: string) {
+        grids.value[gridId].layerIds = grids.value[gridId].layerIds.filter(
+            id => id !== layerId
+        );
+    }
+
+    return {
+        grids,
+        panel,
+        currentId,
+        fieldMap,
+        addGrid,
+        removeGrid,
+        getGridId,
+        removeLayer
+    };
 });

--- a/src/fixtures/grid/store/table-state-manager.ts
+++ b/src/fixtures/grid/store/table-state-manager.ts
@@ -1,4 +1,5 @@
 import ColumnStateManager from '../store/column-state-manager';
+import type { TableStateOptions } from './grid-state';
 
 /**
  * Saves relevant enhancedTable states so that it can be reset on reload/reopen. A PanelStateManager is linked to a BaseLayer.
@@ -9,17 +10,17 @@ import ColumnStateManager from '../store/column-state-manager';
  *      - whether table maximized is in maximized or split view
  */
 export default class TableStateManager {
-    constructor(baseLayer: any) {
-        this.baseLayer = baseLayer;
-        this._title = baseLayer.title ?? '';
-        this._showFilter = baseLayer.showFilter ?? true;
-        this._filterByExtent = baseLayer.filterByExtent ?? false;
+    constructor(options?: TableStateOptions) {
+        this.state = options ?? {};
+        this._title = options?.title ?? '';
+        this._showFilter = options?.showFilter ?? true;
+        this._filterByExtent = options?.filterByExtent ?? false;
         this._columns = {};
         this._open = true;
         this._filtered = true;
-        this._search = baseLayer.search ?? true;
-        this._searchFilter = baseLayer.searchFilter ?? '';
-        this._applyToMap = baseLayer.applyToMap ?? false;
+        this._search = options?.search ?? true;
+        this._searchFilter = options?.searchFilter ?? '';
+        this._applyToMap = options?.applyToMap ?? false;
 
         this.parsecolumns();
     }
@@ -30,8 +31,8 @@ export default class TableStateManager {
      * @memberof TableStateManager
      */
     parsecolumns() {
-        if (this.baseLayer.columns) {
-            this.baseLayer.columns.forEach((columnConfig: any) => {
+        if (this.state.columns) {
+            this.state.columns.forEach((columnConfig: any) => {
                 this._columns[columnConfig.field] = new ColumnStateManager(
                     columnConfig
                 );
@@ -270,7 +271,7 @@ export default class TableStateManager {
 }
 
 export default interface TableStateManager {
-    baseLayer: any;
+    state: any;
     _title: string;
     _showFilter: boolean;
     _filterByExtent: boolean;

--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -39,11 +39,12 @@ const openDetails = () => {
     let data = Object.assign({}, props.params.data);
     delete data['rvInteractive'];
     delete data['rvSymbol'];
+    delete data['rvUid'];
 
     // grid only supports esri features at the moment, so we hardcode that format
     iApi.event.emit(GlobalEvents.DETAILS_TOGGLE, {
         data: data,
-        uid: props.params.uid,
+        uid: props.params.data.rvUid,
         format: IdentifyResultFormat.ESRI
     });
 };

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -37,11 +37,10 @@ const layerStore = useLayerStore();
 const el = ref<HTMLElement>();
 const { t } = useI18n();
 
-const getLayerByUid = (uid: string): LayerInstance | undefined =>
-    layerStore.getLayerByUid(uid);
-
 const zoomToFeature = () => {
-    const layer: LayerInstance | undefined = getLayerByUid(props.params.uid);
+    const layer: LayerInstance | undefined = layerStore.getLayerByUid(
+        props.params.data.rvUid
+    );
     if (layer === undefined) return;
     const oid = props.params.data[props.params.oidField];
     const opts = { getGeom: true };

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -41,6 +41,7 @@ import deepmerge from 'deepmerge';
 import to from 'await-to-js';
 import { markRaw, toRaw } from 'vue';
 import { EsriField, EsriRendererFromJson, EsriRequest } from '@/geo/esri';
+import { useLayerStore } from '@/stores/layer';
 
 export class AttribLayer extends CommonLayer {
     geomType: GeometryType;
@@ -420,6 +421,9 @@ export class AttribLayer extends CommonLayer {
             const att = deepmerge({}, feature);
             att.rvInteractive = '';
             att.rvSymbol = this.renderer?.getGraphicIcon(feature);
+            att.rvUid = useLayerStore(this.$vApp.$pinia).getLayerById(
+                this.id
+            )!.uid;
             return att;
         });
 


### PR DESCRIPTION
Related: #1662 #1696

### Demo sample: https://ramp4-pcar4.github.io/ramp4-pcar4/merge-grid/demos/index-samples.html?sample=38

### Changes
- the grid fixture is now equipped to display data from multiple layer sources
    - attributes that are shared are merged within their columns
    - separate attributes are simply undefined (see the **_Cities Merge Grid_** in the sample)
    - rows keep track of their related layer with the `rvUid` property in the grid
- grids with multiple layers (a.k.a merge grids) are defineable in the config
    - the old way of defining grids within the layer portion of the config is still the default way to configure a grid with a single layer 
- layer removal behavior and events are changed
   - now a grid panel is only closed when the last layer in the grid is removed
   - when a layer is removed in a grid with other remaining layers, its rows in the grid are removed and the rest of the grid remains
- grid filtering and map filtering have both been updated to account for new cases with multiple layers
- fixed a bug where the wrong `oid` was selected for zooming in
- fixed a bug where scrolling the grid would cause a filter update to fire repeatedly
- added a new sample

### Remaining work & discussion
- the new `mergeGrid` config definition needs to be defined in the schema
- #1692

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1698)
<!-- Reviewable:end -->
