### PR TITLE
Fix reverse order in legend for MIL groups children

### DIFF
--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -196,9 +196,11 @@ export class MapImageLayer extends AttribLayer {
                 }
 
                 // process the kids in the group.
-                subLayer.sublayers.forEach((subSubLayer: __esri.Sublayer) => {
-                    processSublayer(subSubLayer, treeGroup);
-                });
+                subLayer.sublayers
+                    .reverse() // need .reverse as MIL group objects in ESRI layer store their sublayers in reverse order
+                    .forEach((subSubLayer: __esri.Sublayer) => {
+                        processSublayer(subSubLayer, treeGroup);
+                    });
             } else {
                 // leaf sublayer. make placeholders, add leaf to the tree
                 // below will run only during first load


### PR DESCRIPTION
For #1659 

MIL groups no longer render children in reverse order in the legend

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1699)
<!-- Reviewable:end -->
