### PR TITLE
Ignore pinned panels in mobile view

### DIFF
--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -121,11 +121,12 @@ export const usePanelStore = defineStore('panel', () => {
             }
         }
 
-        // if pinned isn't visible we need to change the order of the panels (to make it visible)
+        // if pinned isn't visible and we are not in mobile mode we need to change the order of the panels (to make it visible)
         if (
             pinned.value &&
             //@ts-ignore
-            !nowVisible.includes(pinned.value)
+            !nowVisible.includes(pinned.value) &&
+            !mobileView.value
         ) {
             let lastElement: PanelInstance;
             // remove elements from visible until theres room for pinned


### PR DESCRIPTION
For #1694.

The panel stack will now ignore the pinned panel when doing its calculation kung fu in mobile view. This corrects the disrespectful behaviour described in the issue.