### PR TITLE
Details and grid error handling

### DIFF
--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -2,6 +2,7 @@ key,enValue,enValid,frValue,frValid
 details.layers.title,Identified Layers,1,Couches désignées,1
 details.layers.found,Found {numResults} results in {numLayers} layers,1,{numResults} résultats trouvés dans {numLayers} couches,1
 details.layers.loading,The layer is loading...,1,La couche est en cours de chargement...,1
+details.layers.error,Error,1,Erreur,1
 details.layers.results.empty,No results found for the selected layer.,1,Aucun résultat trouvé pour la couche sélectionnée.,1
 details.result.default.name,Identify Item {0},1,Désigner l'élément {0},1
 details.items.title,Details,1,Détails,1

--- a/src/fixtures/details/layers-screen.vue
+++ b/src/fixtures/details/layers-screen.vue
@@ -31,6 +31,9 @@
                     <div v-if="item.loaded" class="px-5">
                         {{ item.items.length }}
                     </div>
+                    <div v-else-if="item.errored" class="px-5">
+                        {{ t('details.layers.error') }}
+                    </div>
                     <div
                         v-else
                         class="animate-spin spinner h-20 w-20 px-5"

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -1,6 +1,7 @@
 key,enValue,enValid,frValue,frValid
 grid.title,Datatable,1,Tableau de données,1
 grid.alertName,Grid,1,Grille,1
+grid.splash.error,Error: Failed to load the layer's data.,1,Erreur : Échec du chargement des données de la couche.,0
 grid.splash.loading,Loading data...,1,Chargement des données...,1
 grid.splash.building,Building table...,1,Création du tableau...,1
 grid.splash.cancel,Cancel,1,Annuler,1

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -415,6 +415,7 @@ export interface IdentifyResult {
     items: Array<IdentifyItem>;
     uid: string; // this would match to the logical layer.
     loaded: boolean;
+    errored: boolean;
     loading: Promise<void>; // represents the list of results has been found, but the content of items in the array may still be resolving
     requestTime: number; // tracks timestamp of identify request
 }


### PR DESCRIPTION
Donethankses #1685.

For layers with no query endpoints or with an endpoint that has a busted server, the grid and details will now show respectful error messages instead of loading perpetually.

To test out these changes, add [this layer](https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Testing/SLL_LandCover_Sample/MapServer) via the wizard (needs vpn). Then, attempt to open the grid and do an identify. Notice that respectful error messages appear.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1701)
<!-- Reviewable:end -->
