### PR TITLE
Fix tile layer symbology not rendering

### DIFF
--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -989,7 +989,7 @@ export class SymbologyAPI extends APIScope {
 
         const fullRenderer = {
             type: 'uniqueValue',
-            field: 'fakefield',
+            field1: 'fakefield',
             uniqueValueInfos: [].concat(...layerRenders)
         };
 


### PR DESCRIPTION
For #1703.

It turns out that we already support this. There was an error in the config object that ESRI expects that has now been fixed. Feel free to add [this layer](https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer) as a tile layer and try it out.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1705)
<!-- Reviewable:end -->
