### PR TITLE
Prevent filtering on unmodifiable layers

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -150,8 +150,12 @@
                     <!-- toggle apply to map -->
                     <a
                         href="javascript:;"
-                        class="flex leading-snug items-center w-256 hover:text-black"
-                        @click="toggleFiltersToMap()"
+                        class="flex leading-snug items-center w-256"
+                        :class="{
+                            hover: filtersEnabled ? 'none' : 'text-black',
+                            disabled: !filtersEnabled
+                        }"
+                        @click="filtersEnabled && toggleFiltersToMap()"
                     >
                         <div class="md-icon-small inline items-start">
                             <svg
@@ -169,7 +173,7 @@
                                 width="18"
                                 viewBox="0 0 24 24"
                                 class="inline float-right"
-                                v-if="config.state.applyToMap"
+                                v-if="filtersEnabled && config.state.applyToMap"
                             >
                                 <g id="done">
                                     <path
@@ -214,8 +218,12 @@
                     <!-- toggle extent filter -->
                     <a
                         href="javascript:;"
-                        class="flex leading-snug items-center w-256 hover:text-black"
-                        @click="toggleFilterByExtent()"
+                        class="flex leading-snug items-center w-256"
+                        :class="{
+                            hover: filtersEnabled ? 'none' : 'text-black',
+                            disabled: !filtersEnabled
+                        }"
+                        @click="filtersEnabled && toggleFilterByExtent()"
                     >
                         <div class="md-icon-small inline items-start">
                             <svg
@@ -233,7 +241,10 @@
                                 width="18"
                                 viewBox="0 0 24 24"
                                 class="inline float-right"
-                                v-if="config.state.filterByExtent"
+                                v-if="
+                                    filtersEnabled &&
+                                    config.state.filterByExtent
+                                "
                             >
                                 <g id="done">
                                     <path
@@ -313,6 +324,7 @@ import {
     GlobalEvents,
     InstanceAPI,
     LayerInstance,
+    NotificationType,
     PanelInstance
 } from '@/api/internal';
 
@@ -1187,6 +1199,29 @@ const cancelAttributeLoad = () => {
     }
 };
 
+/**
+ * Determine if the layer is modifiable
+ */
+const filtersEnabled = computed((): boolean | undefined => {
+    if (gridLayers.value) {
+        // // Check to see if all layers are consistent with their modifiability. If not, throw a warning notifiying the user that filtering has been disabled.
+        const modifiable = gridLayers.value.map(layer => {
+            return layer.canModifyLayer;
+        });
+
+        if (!modifiable.every(value => value === modifiable[0])) {
+            iApi.notify.show(
+                NotificationType.WARNING,
+                iApi.$i18n.t(`layer.filterwarning`)
+            );
+
+            return true;
+        }
+    }
+
+    return iApi.geo.layer.getLayer(props.gridId)?.canModifyLayer;
+});
+
 const getAttrPair = (
     id: string,
     attr: string
@@ -1565,5 +1600,9 @@ onBeforeUnmount(() => {
 .shadow-clip {
     box-shadow: 0px 0px 15px 1px rgb(0 0 0 / 75%);
     clip-path: inset(0px 0px -50px 0px);
+}
+
+.disabled {
+    @apply text-gray-400 cursor-default;
 }
 </style>

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -480,8 +480,9 @@
                         </div>
                         <checkbox
                             v-if="
-                                (!item.imgUrl && symbologyStack.length > 1) ||
-                                (item.imgUrl && item.definitionClause)
+                                modifiableLayer &&
+                                ((!item.imgUrl && symbologyStack.length > 1) ||
+                                    (item.imgUrl && item.definitionClause))
                             "
                             :value="item"
                             :legendItem="legendItem"
@@ -605,6 +606,16 @@ const layerType = computed((): string | undefined => {
     return props.legendItem instanceof LayerItem
         ? toRaw(props.legendItem!.layer)?.layerType
         : '';
+});
+
+/**
+ * Determine if the layer is modifiable
+ */
+const modifiableLayer = computed((): boolean => {
+    return (
+        props.legendItem instanceof LayerItem &&
+        toRaw(props.legendItem!.layer)?.canModifyLayer
+    );
 });
 
 /**

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -21,6 +21,7 @@ import {
     Filter,
     GeometryType,
     Graphic,
+    LayerType,
     NoGeometry
 } from '@/geo/api';
 
@@ -50,6 +51,7 @@ export class AttribLayer extends CommonLayer {
     attLoader: AttributeLoaderBase | undefined;
     renderer: BaseRenderer | undefined;
     serviceUrl: string;
+    canModifyLayer: boolean;
     protected quickCache: QuickCache | undefined;
     protected filter: Filter;
 
@@ -60,6 +62,7 @@ export class AttribLayer extends CommonLayer {
         this.serviceUrl = '';
         this.fieldList = '';
         this.esriFields = [];
+        this.canModifyLayer = true;
         this.filter = new Filter(
             rampConfig.permanentFilteredQuery || '',
             rampConfig.initialFilteredQuery || ''
@@ -136,6 +139,8 @@ export class AttribLayer extends CommonLayer {
         this.scaleSet.minScale = sData.effectiveMinScale || sData.minScale;
         this.scaleSet.maxScale = sData.effectiveMaxScale || sData.maxScale;
         this.supportsFeatures = false; // saves us from having to keep comparing type to 'Feature Layer' on the client
+        this.canModifyLayer =
+            this.layerType === LayerType.SUBLAYER ? sData.canModifyLayer : true; // Only MILs have sublayers and their filtering is exclusively impacted by the canModifyLayer server flag
         this.extent =
             this.extent ??
             (sData.extent

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -214,6 +214,11 @@ export class LayerInstance extends APIScope {
      */
     extent: Extent | undefined; // layer extent
 
+    /**
+     * Indicates if the layer can be modified with filters.
+     */
+    canModifyLayer: boolean;
+
     protected _parentLayer: LayerInstance | undefined;
     protected _sublayers: Array<LayerInstance>;
 
@@ -259,6 +264,7 @@ export class LayerInstance extends APIScope {
         this._sublayers = [];
         this.expectedTime = { draw: 0, load: 0 };
         this.maxLoadTime = 0;
+        this.canModifyLayer = true;
     }
 
     /**

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -5,7 +5,8 @@ import {
     CommonLayer,
     GlobalEvents,
     InstanceAPI,
-    MapImageSublayer
+    MapImageSublayer,
+    NotificationType
 } from '@/api/internal';
 import {
     DefPromise,
@@ -352,6 +353,16 @@ export class MapImageLayer extends AttribLayer {
                             subC.state?.opacity ?? this.origState.opacity ?? 1;
                         miSL.nameField = subC.nameField || miSL.nameField || '';
                         miSL.processFieldMetadata(subC.fieldMetadata);
+
+                        if (!miSL.canModifyLayer) {
+                            this.$iApi.notify.show(
+                                NotificationType.WARNING,
+                                this.$iApi.$i18n.t(`layer.filtersdisabled`, {
+                                    name: miSL.name || miSL.id
+                                })
+                            );
+                        }
+
                         // NOTE the miSL.identify property is currently getting set in onLoadActions() of
                         //      MapImageSublayer. This will get called by this layer's onLoad after this
                         //      function runs. Not sure why that one part is there, but suggest leave

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -48,3 +48,5 @@ layer.error,{id} failed to load,1,Échec du chargement de {id},1
 layer.longload,{id} is taking longer than expected to load,1,Le chargement de {id} met plus de temps que prévu,1
 layer.longdraw,{id} is taking longer than expected to draw,1,{id} prend plus de temps que prévu à extraire,1
 layer.mismatch,{id} cannot be displayed in the current projection,1,{id} ne peut pas être affiché dans la projection actuelle,0
+layer.filtersdisabled,Filters have been disabled for {name},1,Les filtres ont été désactivés par {name},0
+layer.filterwarning,You are attempting to use a merge grid that contains unmodifiable layers. Filtering will be partially disabled,1,Vous tentez d'utiliser une grille de fusion contenant des calques non modifiables. Le filtrage sera partiellement désactivé,0


### PR DESCRIPTION
Related to #1684 

Filters will no longer be available to any layer that has the 'canModifyLayer' flag set to false. A notification will be sent if a loaded layer is not modifiable. I decided to take a stab at the solution to get a better understanding of the issue, so I'll still look into an official workaround. 

Test Service: https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer

Couple things I'm uncertain about: 

1. Do groups contain the canModifyLayer option? I noticed when I was hiding the checkbox from the legend, that the Regular Group checkbox was being hidden. Additionally, I was uncertain whether this be added as a control? Somewhat confused by this system so please yell at me if so.

2. Should warning notifications be bilingual? If so, do I add this to lang.csv?

Lots of yelling on this one would be appreciated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1706)
<!-- Reviewable:end -->
