### PR TITLE
Notify user on tile schema mismatch

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -173,6 +173,9 @@ Creates or updates the feature maptip
 - `ramp_map_graphichit_creates_maptip` create maptip content when a new feature is hit
 - `ramp_map_mouse_updates_maptip` check for graphics when mouse moves
 
+Changes to the basemap causing tile layers to no longer be visible
+- `ramp_map_basemap_checks_proj` will notify the user if there is a projection mismatch
+
 ### Layer Handlers
 
 Changes to layers causing changes to the legend

--- a/docs/geo/layers.md
+++ b/docs/geo/layers.md
@@ -305,6 +305,12 @@ Determine if the Layer has been removed from the map / session. This also applie
 myLayer.isRemoved; // false
 ```
 
+Request the layer's spatial reference in [RAMP's format](../api/geometry.md#spatial-reference).
+
+```js
+const sr = myLayer.getSR() // { wkid: 102100, latestWkid: 3857 }
+```
+
 ## Identify
 
 **Supports:** Feature Layers, Map Image Layers, WMS Layers, WFS Layers, File-Based Layers
@@ -525,7 +531,7 @@ console.log(svg);
 
 Filters allow certain Layer features to be hidden based on the values of their attributes. Multiple filters combine together (i.e joined with `AND` logical operators).
 
-Filters use ESRI's [query expression syntax](https://desktop.arcgis.com/en/arcmap/10.3/map/working-with-layers/building-a-query-expression.htm), which is nearly identical to an SQL "WHERE" clause. A filter can be turned off using an empty string. For an absolute filter (hide everything), we recommend the filter `1=2`. 
+Filters use ESRI's [query expression syntax](https://desktop.arcgis.com/en/arcmap/10.3/map/working-with-layers/building-a-query-expression.htm), which is nearly identical to an SQL "WHERE" clause. A filter can be turned off using an empty string. For an absolute filter (hide everything), we recommend the filter `1=2`.
 
 Use `setSqlFilter()` to apply a filter on a logical layer. This will also raise the `filter/change` event. Core SQL filters include `grid`, `symbol`, `extent`, `initial`, and `permanent`. Avoid using core filter names for custom filters. If no filter name is provided, the generic `api` value will be used. Note that `permanent` cannot be changed after the Layer is created.
 

--- a/src/geo/api/graphic/geometry/spatial-reference.ts
+++ b/src/geo/api/graphic/geometry/spatial-reference.ts
@@ -45,11 +45,17 @@ export class SpatialReference {
             return true;
         }
 
-        return (
-            this.wkid === otherSR.wkid &&
-            this.wkt === otherSR.wkt &&
-            this.latestWkid === otherSR.latestWkid
-        );
+        if (
+            (this.wkid && otherSR.wkid && this.wkid !== otherSR.wkid) ||
+            (this.wkt && otherSR.wkt && this.wkt !== otherSR.wkt) ||
+            (this.latestWkid &&
+                otherSR.latestWkid &&
+                this.latestWkid !== otherSR.latestWkid)
+        ) {
+            return false;
+        }
+
+        return true;
     }
 
     clone(): SpatialReference {

--- a/src/geo/api/graphic/geometry/spatial-reference.ts
+++ b/src/geo/api/graphic/geometry/spatial-reference.ts
@@ -46,16 +46,16 @@ export class SpatialReference {
         }
 
         if (
-            (this.wkid && otherSR.wkid && this.wkid !== otherSR.wkid) ||
-            (this.wkt && otherSR.wkt && this.wkt !== otherSR.wkt) ||
+            (this.wkid && otherSR.wkid && this.wkid === otherSR.wkid) ||
+            (this.wkt && otherSR.wkt && this.wkt === otherSR.wkt) ||
             (this.latestWkid &&
                 otherSR.latestWkid &&
-                this.latestWkid !== otherSR.latestWkid)
+                this.latestWkid === otherSR.latestWkid)
         ) {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     clone(): SpatialReference {

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -22,6 +22,7 @@ import {
     LayerType,
     NoGeometry,
     ScaleSet,
+    SpatialReference,
     TreeNode
 } from '@/geo/api';
 
@@ -437,7 +438,7 @@ export class CommonLayer extends LayerInstance {
         // layer base class doesnt have spatial ref, but we will assume all our layers do.
         // consider adding fancy checks if its missing, and if so just promise.resolve
         const lookupPromise = this.$iApi.geo.proj
-            .checkProj((<any>this.esriLayer).spatialReference)
+            .checkProj(this.getSR())
             .then(goodSR => {
                 if (goodSR) {
                     return Promise.resolve();
@@ -897,6 +898,22 @@ export class CommonLayer extends LayerInstance {
      */
     setCustomParameter(key: string, value: string, forceRefresh = true): void {
         this.stubError();
+    }
+
+    /**
+     * Provides the spatial reference of the layer
+     *
+     * @returns {SpatialReference} the layer spatial reference in RAMP API format
+     */
+    getSR(): SpatialReference {
+        if (this.esriLayer) {
+            return SpatialReference.fromESRI(
+                (<any>this.esriLayer).spatialReference!
+            );
+        } else {
+            this.noLayerErr();
+            return SpatialReference.latLongSR();
+        }
     }
 
     /**

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -15,6 +15,7 @@ import {
     LayerType,
     NoGeometry,
     ScaleSet,
+    SpatialReference,
     TreeNode
 } from '@/geo/api';
 import type {
@@ -329,6 +330,15 @@ export class LayerInstance extends APIScope {
             'Fake tree',
             'getLayerTree() was not implemented in layer'
         );
+    }
+
+    /**
+     * Provides the spatial reference of the layer
+     *
+     * @returns {SpatialReference} the layer spatial reference in RAMP API format
+     */
+    getSR(): SpatialReference {
+        return SpatialReference.latLongSR(); // default fake value to shut up TS.
     }
 
     /**

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -1,5 +1,11 @@
 import { AttribLayer, InstanceAPI, type MapImageLayer } from '@/api/internal';
-import { DataFormat, InitiationState, LayerFormat, LayerType } from '@/geo/api';
+import {
+    DataFormat,
+    InitiationState,
+    LayerFormat,
+    LayerType,
+    SpatialReference
+} from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { markRaw } from 'vue';
 
@@ -240,5 +246,21 @@ export class MapImageSublayer extends AttribLayer {
         // TODO possibly check against this sublayer being a Raster Layer sublayer
         const sql = this.filter.getCombinedSql(exclusions);
         this.esriSubLayer.definitionExpression = sql;
+    }
+
+    /**
+     * Provides the spatial reference of the parent MIL.
+     *
+     * @returns {SpatialReference} the layer spatial reference in RAMP API format
+     */
+    getSR(): SpatialReference {
+        if (this.parentLayer?.esriLayer) {
+            return SpatialReference.fromESRI(
+                (<any>this._parentLayer?.esriLayer)?.spatialReference!
+            );
+        } else {
+            this.noLayerErr();
+            return SpatialReference.latLongSR();
+        }
     }
 }

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -1,7 +1,8 @@
-import { CommonLayer, InstanceAPI } from '@/api/internal';
+import { CommonLayer, InstanceAPI, NotificationType } from '@/api/internal';
 import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { EsriTileLayer } from '@/geo/esri';
+import { SpatialReference } from '@/geo/api';
 import { markRaw } from 'vue';
 
 export class TileLayer extends CommonLayer {
@@ -56,10 +57,30 @@ export class TileLayer extends CommonLayer {
 
         loadPromises.push(legendPromise);
 
+        this.checkProj();
+
         // TODO once decided, might want to set a value on layer count that indicates nothing to count
 
         // TODO check out whats going on with layer extent. is it set and donethanks?
 
         return loadPromises;
+    }
+
+    /**
+     * Check if the layer's projection matches the current basemap's.
+     * If it does not match, grouse in the notifications.
+     */
+    checkProj(): void {
+        const layerSR = SpatialReference.fromESRI(
+            this.esriLayer?.spatialReference!
+        );
+        const mapSR = this.$iApi.geo.map.getSR();
+
+        if (!mapSR.isEqual(layerSR)) {
+            this.$iApi.notify.show(
+                NotificationType.WARNING,
+                this.$iApi.$i18n.t('layer.mismatch', { id: this.id })
+            );
+        }
     }
 }

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -68,12 +68,10 @@ export class TileLayer extends CommonLayer {
 
     /**
      * Check if the layer's projection matches the current basemap's.
-     * If it does not match, grouse in the notifications.
+     * If it does not match, warn the user by sending a notification.
      */
     checkProj(): void {
-        const layerSR = SpatialReference.fromESRI(
-            this.esriLayer?.spatialReference!
-        );
+        const layerSR = this.getSR();
         const mapSR = this.$iApi.geo.map.getSR();
 
         if (!mapSR.isEqual(layerSR)) {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -47,3 +47,4 @@ panels.alert.minimize,{name} panel minimized,1,Fenêtre {name} réduite,1
 layer.error,{id} failed to load,1,{id} n'a pas pu être chargée,0
 layer.longload,{id} is taking longer than expected to load,1,Le chargement de {id} met plus de temps que prévu,1
 layer.longdraw,{id} is taking longer than expected to draw,1,{id} prend plus longtemps que prévu pour dessiner,0
+layer.mismatch,{id} cannot be displayed in the current projection,1,{id} ne peut pas être affiché dans la projection actuelle,0


### PR DESCRIPTION
For #1704.

If you attempt to add a tile layer to a basemap with a mismatching tile schema, you will now get groused at in the notifications. The grouse will be shown each time you change the basemap to a bad one.

To test this, attempt to add [this layer](https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer) as a tile layer on a Web Mercator map. Then, try switching basemaps. Notice that you get groused at but only on the Web Mercator maps and not the Lambert ones.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1709)
<!-- Reviewable:end -->
