### PR TITLE
Remove maptip when mouse leaves the map

### DIFF
--- a/docs/app/defaults.md
+++ b/docs/app/defaults.md
@@ -105,7 +105,8 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_IDENTIFY<br>'map/identify'                     | MapIdentifyResult object                                       | A map identify was requested                     |
 | MAP_KEYDOWN<br>'map/keydown'                       | KeyboardEvent object                                           | A key was pressed                                |
 | MAP_KEYUP<br>'map/keyup'                           | KeyboardEvent object                                           | A key was released                               |
-| MAP_MOUSEDOWN<br>'map/mousedown'                   | PointerEvent object                                            | A mouse button was depressed                     |
+| MAP_MOUSEDOWN<br>'map/mousedown'                   | PointerEvent object                                            | A mouse button was depressed
+| MAP_MOUSELEAVE<br>'map/mouseleave'             |     PointerEvent object                                            | The mouse left the map                    |
 | MAP_MOUSEMOVE<br>'map/mousemove'                   | MapMove object                                                 | The mouse moved over the map                     |
 | MAP_MOUSEMOVE_END<br>'map/mousemoveend'            | MapMove object                                                 | The mouse started moving over the map            |
 | MAP_MOUSEMOVE_START<br>'map/mousemovestart'        | MapMove object                                                 | The mouse stopped moving over the map            |
@@ -172,6 +173,7 @@ Creates or updates the feature maptip
 - `ramp_map_extent_updates_maptip` check for graphics when map extent changes
 - `ramp_map_graphichit_creates_maptip` create maptip content when a new feature is hit
 - `ramp_map_mouse_updates_maptip` check for graphics when mouse moves
+- `ramp_map_mouseleave_removes_maptip` remove the maptip when the mouse leaves the map
 
 ### Layer Handlers
 

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -223,6 +223,12 @@ export enum GlobalEvents {
     MAP_MOUSEDOWN = 'map/mousedown',
 
     /**
+     * Fires when the mouse leaves the map.
+     * Payload: `(params: PointerEvent)` (DOM Event)
+     */
+    MAP_MOUSELEAVE = 'map/mouseleave',
+
+    /**
      * Fires when the mouse moves while over the map.
      * Payload: `(params: MapMove)`
      */
@@ -357,6 +363,7 @@ const enum DefEH {
     MAP_KEYUP_UPDATES_KEY_HANDLER = 'ramp_map_keyup_updates_key_handler',
     MAP_MOUSE_UPDATES_COORDS = 'ramp_map_mouse_updates_coords',
     MAP_MOUSE_UPDATES_MAPTIP = 'ramp_map_mouse_updates_maptip',
+    MAP_MOUSELEAVE_REMOVES_MAPTIP = 'ramp_map_mouseleave_removes_maptip',
     MAP_RESIZE_UPDATES_SCALEBAR = 'ramp_map_resize_updates_scalebar',
     MAP_SCALE_UPDATES_SCALEBAR = 'ramp_map_scale_updates_scalebar',
     PANEL_CLOSE_UPDATES_APPBAR = 'ramp_panel_close_updates_appbar',
@@ -629,6 +636,7 @@ export class EventAPI extends APIScope {
                 DefEH.MAP_KEYUP_UPDATES_KEY_HANDLER,
                 DefEH.MAP_MOUSE_UPDATES_COORDS,
                 DefEH.MAP_MOUSE_UPDATES_MAPTIP,
+                DefEH.MAP_MOUSELEAVE_REMOVES_MAPTIP,
                 DefEH.MAP_RESIZE_UPDATES_SCALEBAR,
                 DefEH.MAP_SCALE_UPDATES_SCALEBAR,
                 DefEH.PANEL_CLOSE_UPDATES_APPBAR,
@@ -1025,6 +1033,14 @@ export class EventAPI extends APIScope {
                     throttle(200, (mapMove: MapMove) => zeHandler(mapMove)),
                     handlerName
                 );
+                break;
+
+            case DefEH.MAP_MOUSELEAVE_REMOVES_MAPTIP:
+                // remove the maptip when the mouse leaves the map
+                zeHandler = () => {
+                    this.$iApi.geo.map.maptip.clear();
+                };
+                this.$iApi.event.on(GlobalEvents.MAP_MOUSELEAVE, zeHandler);
                 break;
 
             case DefEH.MAP_RESIZE_UPDATES_SCALEBAR:

--- a/src/components/map/esri-map.vue
+++ b/src/components/map/esri-map.vue
@@ -5,7 +5,7 @@
         class="h-full overflow-hidden"
         v-tippy="{
             allowHTML: true,
-            zIndex: 5,
+            zIndex: 150,
             theme: 'ramp4',
             trigger: 'manual',
             appendTo: 'parent',

--- a/src/geo/map/maptip.ts
+++ b/src/geo/map/maptip.ts
@@ -51,7 +51,6 @@ export class MaptipAPI extends APIScope {
         }
 
         if (!graphicHit) {
-            this.#lastHit = undefined;
             this.clear();
             return;
         }
@@ -68,8 +67,8 @@ export class MaptipAPI extends APIScope {
             return;
         }
 
-        this.#lastHit = graphicHit;
         this.clear();
+        this.#lastHit = graphicHit;
 
         // Get the layer
         const layerInstance: LayerInstance | undefined =
@@ -134,6 +133,7 @@ export class MaptipAPI extends APIScope {
      * Clears the maptip from the map
      */
     clear(): void {
+        this.#lastHit = undefined;
         this.maptipStore.setMaptipPoint(undefined);
         this.maptipStore.setMaptipContent('');
     }

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -279,6 +279,19 @@ export class MapAPI extends CommonMapAPI {
         });
 
         this.handlers.push({
+            type: 'pointer-leave',
+            handler: this.esriView.on('pointer-leave', esriMouseLeave => {
+                // guarantee that no mouse move start/end event fires after the mouse leave event
+                setTimeout(() => {
+                    this.$iApi.event.emit(
+                        GlobalEvents.MAP_MOUSELEAVE,
+                        esriMouseLeave.native
+                    );
+                }, Math.max(this.mapMouseThrottle, 100) + 1);
+            })
+        });
+
+        this.handlers.push({
             type: 'pointer-down',
             handler: this.esriView.on('pointer-down', esriMouseDown => {
                 // .native is a DOM pointer event


### PR DESCRIPTION
For #1580.

The maptip will now correctly dissappear when you move your mouse from the feature to somewhere directly outside the map e.g. the appbar or a panel. Also, the maptip will no longer be hidden underneath the appbar/panel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1714)
<!-- Reviewable:end -->
