### PR TITLE
Fully support nulls in Unique Value Renderer

### DIFF
--- a/src/geo/utils/renderer.ts
+++ b/src/geo/utils/renderer.ts
@@ -225,15 +225,19 @@ export class UniqueValueRenderer extends BaseRenderer {
                 const defClauseKeyValues: Array<string> = su.matchValue.split(
                     this.delim
                 );
+                // use operator IS NULL to account for nulls
                 const defClause: string = this.keyFields
-                    .map(
-                        (kf: string, i: number) =>
-                            `${kf} = ${fieldDelims[i]}${quoter(
-                                defClauseKeyValues[i]
-                            )}${fieldDelims[i]}`
+                    .map((kf: string, i: number) =>
+                        defClauseKeyValues[i] === '<Null>'
+                            ? `${kf} IS NULL`
+                            : `${kf} = ${fieldDelims[i]}${quoter(
+                                  defClauseKeyValues[i]
+                              )}${fieldDelims[i]}`
                     )
                     .join(' AND ');
                 su.definitionClause = `(${defClause})`;
+                // replace nulls with empty string
+                su.matchValue = su.matchValue.replace(/<Null>/g, '');
             }
 
             this.symbolUnits.push(su);
@@ -276,11 +280,10 @@ export class UniqueValueSymbolUnit extends BaseSymbolUnit {
 
         // sometimes values can be defined in number form.
         // we convert everything to strings so all other code doesn't need to worry about types
-        // put an empty string if key value is null
         if (typeof value === 'number') {
-            this.matchValue = value.toString().replace(/<Null>/g, '');
+            this.matchValue = value.toString();
         } else {
-            this.matchValue = value.replace(/<Null>/g, '');
+            this.matchValue = value;
         }
     }
 


### PR DESCRIPTION
Should fully wrap up issue #1697 
Continuation of PR #1707 

Renderer symbol lookup and symbol filtering should now properly work when nulls are introduced.

This PR removes the changes made in #1707 and solves everything in the UV renderer, also using the IS NULL operator James suggested to solve symbol filtering with nulls (PR #1707 should be ignored).

Sorry for the unnecessary PR spam, will spend some more time before putting out a PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1715)
<!-- Reviewable:end -->
