### PR TITLE
Use a single commit for demo branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 on:
     pull_request_target:
-        types: [opened, synchronize]
+        types: [opened, synchronize, reopened]
 
     push:
         branches:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,7 @@ jobs:
                   branch: gh-pages
                   folder: dist
                   target-folder: ${{ github.head_ref || github.ref_name }}
+                  single-commit: true
 
             - uses: actions/github-script@v6
               name: Post link to demo for PR's


### PR DESCRIPTION
To reduce the size of this repo only keep one commit for the demo branch `gh-pages`. 

I pushed a slimmed down `gh-pages` folder already. A fresh clone is looking like sub 100 mb now. For existing forks to be reduced (optional) sync changes from upstream and run:

```
git for-each-ref --format='delete %(refname)' refs/original | git update-ref --stdin
git reflog expire --expire=now --all
git gc --aggressive --prune=now
```

☝️ Forces a large git file that tracks changes to recompute.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1716)
<!-- Reviewable:end -->
