### PR TITLE
Fix zooming to NTS geosearch result

### DIFF
--- a/src/fixtures/geosearch/store/geosearch.feature.ts
+++ b/src/fixtures/geosearch/store/geosearch.feature.ts
@@ -215,7 +215,12 @@ export class GeoSearchUI {
                         // add first geosearch result as location of NTS map number
                         featureResult = q.featureResults.map((nts: any) => ({
                             name: nts.nts,
-                            bbox: nts.bbox,
+                            bbox: nts.bbox ?? [
+                                nts.LatLon.lon + 0.02,
+                                nts.LatLon.lat - 0.02,
+                                nts.LatLon.lon - 0.02,
+                                nts.LatLon.lat + 0.02
+                            ],
                             type: nts.desc,
                             position: [nts.LatLon.lon, nts.LatLon.lat],
                             location: {


### PR DESCRIPTION
For #1717.

In the geosearch panel, type something like 123A. Then, when the result comes up, try clicking on it to zoom to it. Notice that it now zooms to the correct location.

Geosearch experts, let me know if the `bbox` values require any tweaks. I've copied them from the FSA and address search types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1718)
<!-- Reviewable:end -->
