### PR TITLE
Remove terminated lifehook for fixtures

### DIFF
--- a/docs/app/fixtures.md
+++ b/docs/app/fixtures.md
@@ -4,11 +4,10 @@ This covers various ways to create fixtures.
 
 ## Interface
 
-The fixture interface has four methods, all optional. They take no parameters and return no value. If a custom fixture implements them, the RAMP instance will run them at the appropriate time.
+The fixture interface has three methods, all optional. They take no parameters and return no value. If a custom fixture implements them, the RAMP instance will run them at the appropriate time.
 
 - `added()` is run when the fixture has been added to the RAMP instance
-- `initialized()` is run when the fixture is `added` and the instance map has finished initializing
-- `terminated()` is run immediately before the fixture is removed from the RAMP instance
+- `initialized()` is run when the fixture is `added` and the instance Map has finished initializing
 - `removed()` is run after fixture is removed from the RAMP instance
 
 ## Creation

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -371,7 +371,6 @@ export class FixtureInstance extends APIScope implements FixtureBase {
     added?(): void;
     removed?(): void;
     initialized?(): void;
-    terminated?(): void;
 
     /**
      * Returns the fixture config section (JSON) taken from the global config.

--- a/src/fixtures/snowman/snowman.vue
+++ b/src/fixtures/snowman/snowman.vue
@@ -29,7 +29,6 @@ onMounted(() => {
         // NOTE: only on-map components need this relatively complicated removal process; panels are closed much easier
 
         // removes the snowman from DOM and destroys the instance
-        // TODO: this should be called in the `terminated` life hook; it's called in the timeout just for display
         // this.$destroy(); // destroy Vue component (no longer supported in Vue 3)
         el.value.parentNode!.removeChild(el.value); // remove DOM nodes
         // you can also do it like this 👉 this.$options.iApi.$vApp.$el.removeChild(this.$el.parentNode);

--- a/src/stores/fixture/fixture-state.ts
+++ b/src/stores/fixture/fixture-state.ts
@@ -31,13 +31,4 @@ export interface FixtureBase {
      * @memberof Fixture
      */
     initialized?(): void;
-
-    /**
-     * [Optional] Called before the fixture is removed from R4MP.
-     *
-     * This is a clean-up phase, and at this point, any custom content (panels, on-map components, etc.) must be removed.
-     *
-     * @memberof Fixture
-     */
-    terminated?(): void;
 }


### PR DESCRIPTION
#1665 

Terminates `terminated` lifehook for fixtures.

- Was never being called by RAMP, so any implementation already wasn't doing anything. Which technically makes this a non-breaking change 🎉 
- Along with discussion in issue couldn't see a use case that wouldn't be possible in `removed`