### PR TITLE
Add lazy loading disclaimer to fixture docs

### DIFF
--- a/docs/app/fixtures.md
+++ b/docs/app/fixtures.md
@@ -147,7 +147,9 @@ const handle = setInterval(() => {
 
 ## Lazy-Loading
 
-#### The current version of RAMP does not include code splitting in production builds. These methods will still work, however the build will not see the benefit of lazy loading. We plan to re-introduce some version of tree-shaking/lazy-loading/code-splitting in the future.
+::: Warning NOTE
+The current version of RAMP does not include code splitting in production builds. These methods will still work, however the build will not see the benefit of lazy loading. We plan to re-introduce some version of tree-shaking/lazy-loading/code-splitting in the future.
+:::
 
 It's possible to lazy-load fixture code for screen panels. This will split code for individual panel screens into separate file and will be loaded on demand. Otherwise, all fixture code is loaded right away and it defeats parts of the idea to make R4MP as flexible as possible. See `gazebo` fixture for examples.
 

--- a/docs/app/fixtures.md
+++ b/docs/app/fixtures.md
@@ -147,6 +147,8 @@ const handle = setInterval(() => {
 
 ## Lazy-Loading
 
+#### The current version of RAMP does not include code splitting in production builds. These methods will still work, however the build will not see the benefit of lazy loading. We plan to re-introduce some version of tree-shaking/lazy-loading/code-splitting in the future.
+
 It's possible to lazy-load fixture code for screen panels. This will split code for individual panel screens into separate file and will be loaded on demand. Otherwise, all fixture code is loaded right away and it defeats parts of the idea to make R4MP as flexible as possible. See `gazebo` fixture for examples.
 
 Two methods of lazy loading:


### PR DESCRIPTION
#1672 

From my testing the two methods under `Lazy Loading` appear to be functional. However, the current vite build just puts everything in one file so I've added an explanation of that to the section.

Feel free to suggest better ways to explain to readers, I leaned towards adding the explanation instead of removing all mentions of "lazy loading".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1723)
<!-- Reviewable:end -->
