### PR TITLE
Improve slow feature zoom

### DIFF
--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -109,88 +109,82 @@
                             <span class="flex-grow my-auto text-lg px-8">
                                 {{ itemName }}
                             </span>
-                            <div
-                                class="flex flex-col items-center flex-shrink-0"
+                            <button
+                                type="button"
+                                :content="
+                                    t(
+                                        `details.item.zoom${
+                                            zoomStatus === 'none'
+                                                ? ''
+                                                : `.${zoomStatus}`
+                                        }`
+                                    )
+                                "
+                                v-tippy="{ placement: 'bottom' }"
+                                :aria-label="
+                                    t(
+                                        `grid.cells.zoom${
+                                            zoomStatus === 'none'
+                                                ? ''
+                                                : `.${zoomStatus}`
+                                        }`
+                                    )
+                                "
+                                ref="button"
+                                @click="zoomToFeature()"
+                                class="text-gray-600 m-8 w-24 h-24 p-2"
                             >
-                                <button
-                                    type="button"
-                                    :content="t('details.item.zoom')"
-                                    v-tippy="{ placement: 'bottom' }"
-                                    :aria-label="t('details.item.zoom')"
-                                    @click="zoomToFeature()"
-                                    class="text-gray-600 m-8 w-20 h-20"
-                                >
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        height="20"
-                                        viewBox="0 0 24 24"
-                                        width="20"
-                                    >
-                                        <path
-                                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                                        />
-                                        <path d="M0 0h24v24H0V0z" fill="none" />
-                                        <path
-                                            d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
-                                        />
-                                    </svg>
-                                </button>
                                 <div
                                     v-if="zoomStatus === 'zooming'"
-                                    class="flex items-center"
-                                >
-                                    <div
-                                        class="animate-spin spinner h-20 w-20"
-                                    ></div>
-                                    <span class="ml-4">{{
-                                        t('details.item.zoom.zooming')
-                                    }}</span>
-                                </div>
-                                <div
+                                    class="m-auto animate-spin spinner h-20 w-20"
+                                ></div>
+                                <svg
                                     v-else-if="zoomStatus === 'zoomed'"
-                                    class="flex items-center"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke-width="1.5"
+                                    stroke="green"
+                                    class="m-auto w-20 h-20"
                                 >
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke-width="1.5"
-                                        stroke="green"
-                                        class="w-20 h-20"
-                                    >
-                                        <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            d="M4.5 12.75l6 6 9-13.5"
-                                        />
-                                    </svg>
-                                    <span class="ml-4">{{
-                                        t('details.item.zoom.success')
-                                    }}</span>
-                                </div>
-                                <div
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        d="M4.5 12.75l6 6 9-13.5"
+                                    />
+                                </svg>
+                                <svg
                                     v-else-if="zoomStatus === 'error'"
-                                    class="flex items-center"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke-width="1.5"
+                                    stroke="red"
+                                    class="m-auto w-20 h-20"
                                 >
-                                    <svg
-                                        xmlns="http://www.w3.org/2000/svg"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke-width="1.5"
-                                        stroke="red"
-                                        class="w-20 h-20"
-                                    >
-                                        <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            d="M6 18L18 6M6 6l12 12"
-                                        />
-                                    </svg>
-                                    <span class="ml-4">{{
-                                        t('details.item.zoom.fail')
-                                    }}</span>
-                                </div>
-                            </div>
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        d="M6 18L18 6M6 6l12 12"
+                                    />
+                                </svg>
+                                <svg
+                                    v-else
+                                    class="m-auto"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    height="16"
+                                    viewBox="0 0 24 24"
+                                    width="16"
+                                >
+                                    <path
+                                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                    />
+                                    <path d="M0 0h24v24H0V0z" fill="none" />
+                                    <path
+                                        d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
+                                    />
+                                </svg>
+                            </button>
                         </div>
                         <component
                             :is="detailsTemplate"
@@ -234,16 +228,15 @@ import {
     onBeforeUnmount,
     onBeforeUpdate,
     onMounted,
-    ref,
-    watch,
-    type WatchStopHandle
+    ref
 } from 'vue';
 import type { PropType } from 'vue';
 import { DetailsItemInstance, useDetailsStore } from './store';
 import type { DetailsAPI } from './api/details';
 
 import { GlobalEvents, InstanceAPI } from '@/api';
-import type { FieldDefinition, IdentifyResult, IdentifyItem } from '@/geo/api';
+import type { FieldDefinition, IdentifyItem, IdentifyResult } from '@/geo/api';
+import { GeometryType, LayerType } from '@/geo/api';
 import type { LayerInstance, PanelInstance } from '@/api/internal';
 
 import ESRIDefault from './templates/esri-default.vue';
@@ -353,12 +346,13 @@ const detailsTemplate = computed(() => {
 });
 
 const icon = ref<string>('');
-const zoomStatus = ref<string>('');
+const zoomStatus = ref<'zooming' | 'zoomed' | 'error' | 'none'>('none');
 const currentIdx = ref<number>(0);
 const layerExists = ref<Boolean>(false);
 const handlers = ref<Array<string>>([]);
 const details = ref<DetailsAPI>(iApi.fixture.get('details'));
 const hilightToggle = ref<boolean>(true);
+const button = ref<HTMLElement>();
 
 /**
  * Clean up for when the details screen is closed.
@@ -390,7 +384,7 @@ const initDetails = () => {
  * Called whenever the displayed item changes
  */
 const itemChanged = () => {
-    zoomStatus.value = '';
+    updateZoomStatus('none');
     if (identifyItem.value.loaded) {
         const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
             props.result.uid
@@ -453,6 +447,21 @@ const seeList = () => {
     });
 };
 
+const updateZoomStatus = (value: 'zooming' | 'zoomed' | 'error' | 'none') => {
+    if (value === 'zoomed' || value === 'error') {
+        setTimeout(() => {
+            zoomStatus.value = value;
+            (button.value as any)?._tippy.show();
+            setTimeout(() => {
+                (button.value as any)?._tippy.hide();
+                zoomStatus.value = 'none';
+            }, 3000);
+        }, 300);
+    } else {
+        zoomStatus.value = value;
+    }
+};
+
 /**
  * Advance the item index by direction
  */
@@ -499,7 +508,11 @@ const fetchIcon = () => {
  * Zoom to feature on the map
  */
 const zoomToFeature = () => {
-    zoomStatus.value = 'zooming';
+    if (zoomStatus.value !== 'none') {
+        return;
+    }
+
+    updateZoomStatus('zooming');
     const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
         props.result.uid
     );
@@ -508,9 +521,7 @@ const zoomToFeature = () => {
         console.warn(
             `Could not find layer for uid ${props.result.uid} during zoom geometry lookup`
         );
-        setTimeout(() => {
-            zoomStatus.value = 'error';
-        }, 300);
+        updateZoomStatus('error');
         return;
     }
 
@@ -518,29 +529,47 @@ const zoomToFeature = () => {
         console.warn(
             'Details zoomToFeature call on item that is still loading. Should be impossible, alert the devs.'
         );
-        setTimeout(() => {
-            zoomStatus.value = 'error';
-        }, 300);
+        updateZoomStatus('error');
         return;
     }
 
     const oid = identifyItem.value.data[layer.oidField];
-    const opts = { getGeom: true };
-    layer.getGraphic(oid, opts).then(g => {
-        if (g.geometry.invalid()) {
-            console.error(`Could not find graphic for objectid ${oid}`);
-            setTimeout(() => {
-                zoomStatus.value = 'error';
-            }, 300);
-        } else {
-            iApi.geo.map.zoomMapTo(g.geometry);
-            setTimeout(() => {
-                zoomStatus.value = 'zoomed';
-            }, 300);
-        }
-    });
+    const zoomUsingGraphic = () => {
+        const opts = { getGeom: true };
+        layer
+            .getGraphic(oid, opts)
+            .then(g => {
+                if (g.geometry.invalid()) {
+                    console.error(`Could not find graphic for objectid ${oid}`);
+                    updateZoomStatus('error');
+                } else {
+                    iApi.geo.map.zoomMapTo(g.geometry);
+                    updateZoomStatus('zoomed');
+                    iApi.updateAlert(iApi.$i18n.t('details.item.alert.zoom'));
+                }
+            })
+            .catch(() => {
+                updateZoomStatus('error');
+            });
+    };
 
-    iApi.updateAlert(iApi.$i18n.t('details.item.alert.zoom'));
+    if (
+        layer.layerType === LayerType.FEATURE &&
+        layer.geomType !== GeometryType.POINT
+    ) {
+        layer
+            .getGraphicExtent(oid)
+            .then(e => {
+                iApi.geo.map.zoomMapTo(e);
+                updateZoomStatus('zoomed');
+                iApi.updateAlert(iApi.$i18n.t('details.item.alert.zoom'));
+            })
+            .catch(() => {
+                zoomUsingGraphic();
+            });
+    } else {
+        zoomUsingGraphic();
+    }
 };
 
 const onHilightToggle = (value: boolean) => {

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -92,13 +92,16 @@
                 <div v-if="layerExists">
                     <div v-if="identifyItem.loaded">
                         <!-- fancy header for esri features -->
-                        <div class="flex py-8" v-if="supportsFeatures">
+                        <div
+                            class="flex py-8 items-center"
+                            v-if="supportsFeatures"
+                        >
                             <span
                                 v-if="icon"
-                                class="flex-none m-auto symbologyIcon"
+                                class="flex-none symbologyIcon"
                                 v-html="icon"
                             ></span>
-                            <div v-else class="m-auto">
+                            <div v-else>
                                 <div
                                     class="animate-spin spinner h-20 w-20"
                                 ></div>
@@ -106,29 +109,88 @@
                             <span class="flex-grow my-auto text-lg px-8">
                                 {{ itemName }}
                             </span>
-                            <button
-                                type="button"
-                                :content="t('details.item.zoom')"
-                                v-tippy="{ placement: 'bottom' }"
-                                :aria-label="t('details.item.zoom')"
-                                @click="zoomToFeature()"
-                                class="text-gray-600 m-8"
+                            <div
+                                class="flex flex-col items-center flex-shrink-0"
                             >
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    height="20"
-                                    viewBox="0 0 24 24"
-                                    width="20"
+                                <button
+                                    type="button"
+                                    :content="t('details.item.zoom')"
+                                    v-tippy="{ placement: 'bottom' }"
+                                    :aria-label="t('details.item.zoom')"
+                                    @click="zoomToFeature()"
+                                    class="text-gray-600 m-8 w-20 h-20"
                                 >
-                                    <path
-                                        d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                                    />
-                                    <path d="M0 0h24v24H0V0z" fill="none" />
-                                    <path
-                                        d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
-                                    />
-                                </svg>
-                            </button>
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        height="20"
+                                        viewBox="0 0 24 24"
+                                        width="20"
+                                    >
+                                        <path
+                                            d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                                        />
+                                        <path d="M0 0h24v24H0V0z" fill="none" />
+                                        <path
+                                            d="M12 10h-2v2H9v-2H7V9h2V7h1v2h2v1z"
+                                        />
+                                    </svg>
+                                </button>
+                                <div
+                                    v-if="zoomStatus === 'zooming'"
+                                    class="flex items-center"
+                                >
+                                    <div
+                                        class="animate-spin spinner h-20 w-20"
+                                    ></div>
+                                    <span class="ml-4">{{
+                                        t('details.item.zoom.zooming')
+                                    }}</span>
+                                </div>
+                                <div
+                                    v-else-if="zoomStatus === 'zoomed'"
+                                    class="flex items-center"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke-width="1.5"
+                                        stroke="green"
+                                        class="w-20 h-20"
+                                    >
+                                        <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            d="M4.5 12.75l6 6 9-13.5"
+                                        />
+                                    </svg>
+                                    <span class="ml-4">{{
+                                        t('details.item.zoom.success')
+                                    }}</span>
+                                </div>
+                                <div
+                                    v-else-if="zoomStatus === 'error'"
+                                    class="flex items-center"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        fill="none"
+                                        viewBox="0 0 24 24"
+                                        stroke-width="1.5"
+                                        stroke="red"
+                                        class="w-20 h-20"
+                                    >
+                                        <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            d="M6 18L18 6M6 6l12 12"
+                                        />
+                                    </svg>
+                                    <span class="ml-4">{{
+                                        t('details.item.zoom.fail')
+                                    }}</span>
+                                </div>
+                            </div>
                         </div>
                         <component
                             :is="detailsTemplate"
@@ -172,7 +234,9 @@ import {
     onBeforeUnmount,
     onBeforeUpdate,
     onMounted,
-    ref
+    ref,
+    watch,
+    type WatchStopHandle
 } from 'vue';
 import type { PropType } from 'vue';
 import { DetailsItemInstance, useDetailsStore } from './store';
@@ -289,6 +353,7 @@ const detailsTemplate = computed(() => {
 });
 
 const icon = ref<string>('');
+const zoomStatus = ref<string>('');
 const currentIdx = ref<number>(0);
 const layerExists = ref<Boolean>(false);
 const handlers = ref<Array<string>>([]);
@@ -325,6 +390,7 @@ const initDetails = () => {
  * Called whenever the displayed item changes
  */
 const itemChanged = () => {
+    zoomStatus.value = '';
     if (identifyItem.value.loaded) {
         const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
             props.result.uid
@@ -433,6 +499,7 @@ const fetchIcon = () => {
  * Zoom to feature on the map
  */
 const zoomToFeature = () => {
+    zoomStatus.value = 'zooming';
     const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
         props.result.uid
     );
@@ -441,6 +508,9 @@ const zoomToFeature = () => {
         console.warn(
             `Could not find layer for uid ${props.result.uid} during zoom geometry lookup`
         );
+        setTimeout(() => {
+            zoomStatus.value = 'error';
+        }, 300);
         return;
     }
 
@@ -448,6 +518,9 @@ const zoomToFeature = () => {
         console.warn(
             'Details zoomToFeature call on item that is still loading. Should be impossible, alert the devs.'
         );
+        setTimeout(() => {
+            zoomStatus.value = 'error';
+        }, 300);
         return;
     }
 
@@ -456,8 +529,14 @@ const zoomToFeature = () => {
     layer.getGraphic(oid, opts).then(g => {
         if (g.geometry.invalid()) {
             console.error(`Could not find graphic for objectid ${oid}`);
+            setTimeout(() => {
+                zoomStatus.value = 'error';
+            }, 300);
         } else {
             iApi.geo.map.zoomMapTo(g.geometry);
+            setTimeout(() => {
+                zoomStatus.value = 'zoomed';
+            }, 300);
         }
     });
 

--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -9,8 +9,8 @@ details.items.title,Details,1,Détails,1
 details.item.see.list,See List,1,Voir la liste,1
 details.item.zoom,Zoom to feature,1,Zoom à l'élément,1
 details.item.zoom.zooming,Zooming...,1,Zoom...,0
-details.item.zoom.fail,Zoom failed,1,Échec du zoom,0
-details.item.zoom.success,Zoomed,1,Zoomé,0
+details.item.zoom.error,Zoom failed,1,Échec du zoom,0
+details.item.zoom.zoomed,Zoomed,1,Zoomé,0
 details.item.previous.item,Previous item,1,Élément précédent,1
 details.item.next.item,Next item,1,Élément suivant,1
 details.item.count,{0} of {1},1,{0} de {1},1

--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -8,6 +8,9 @@ details.result.default.name,Identify Item {0},1,Désigner l'élément {0},1
 details.items.title,Details,1,Détails,1
 details.item.see.list,See List,1,Voir la liste,1
 details.item.zoom,Zoom to feature,1,Zoom à l'élément,1
+details.item.zoom.zooming,Zooming...,1,Zoom...,0
+details.item.zoom.fail,Zoom failed,1,Échec du zoom,0
+details.item.zoom.success,Zoomed,1,Zoomé,0
 details.item.previous.item,Previous item,1,Élément précédent,1
 details.item.next.item,Next item,1,Élément suivant,1
 details.item.count,{0} of {1},1,{0} de {1},1

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -26,7 +26,8 @@ grid.filters.label.filtered,(filtered from {max} total entries),1,(filtré à pa
 grid.filters.extent,Filter by extent,1,Filtrer par étendue,1
 grid.cells.zoom,Zoom to feature,1,Zoom à l'élément,1
 grid.cells.zoom.zooming,Zooming...,1,Zoom...,0
-grid.cells.zoom.fail,Zoom failed,1,Échec du zoom,0
-grid.cells.zoom.success,Zoomed,1,Zoomé,0
+grid.cells.zoom.error,Zoom failed,1,Échec du zoom,0
+grid.cells.zoom.zoomed,Zoomed,1,Zoomé,0
+grid.cells.alert.zoom,Zoomed into feature,1,Zoom sur la caractéristique,1
 grid.cells.details,Details,1,Détails,1
 grid.button.title,Grid,1,Grille,1

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -25,5 +25,8 @@ grid.filters.label.info,{range} of {total} entries shown,1,{range} de {total} sa
 grid.filters.label.filtered,(filtered from {max} total entries),1,(filtré à partir d'un total de {max} saisies),1
 grid.filters.extent,Filter by extent,1,Filtrer par étendue,1
 grid.cells.zoom,Zoom to feature,1,Zoom à l'élément,1
+grid.cells.zoom.zooming,Zooming...,1,Zoom...,0
+grid.cells.zoom.fail,Zoom failed,1,Échec du zoom,0
+grid.cells.zoom.success,Zoomed,1,Zoomé,0
 grid.cells.details,Details,1,Détails,1
 grid.button.title,Grid,1,Grille,1

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -852,7 +852,7 @@ const setUpSpecialColumns = (
             filter: false,
             lockPosition: true,
             isStatic: true,
-            maxWidth: 100,
+            maxWidth: 48,
             cellStyle: () => {
                 return {
                     padding: '0px'

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -435,7 +435,7 @@ export interface SpecialColumnDefinition {
         clearFilters?: Function;
     };
     pinned?: string;
-    maxWidth: number;
+    maxWidth?: number;
     cellStyle: Function;
     cellRenderer?: Function;
     cellRendererParams?: any;
@@ -852,7 +852,7 @@ const setUpSpecialColumns = (
             filter: false,
             lockPosition: true,
             isStatic: true,
-            maxWidth: 48,
+            maxWidth: 100,
             cellStyle: () => {
                 return {
                     padding: '0px'

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -1,12 +1,60 @@
 <template>
+    <div
+        v-if="zoomStatus === 'zooming'"
+        class="flex items-center justify-center"
+    >
+        <div class="animate-spin spinner h-20 w-20"></div>
+        <span class="ml-4">{{ t('grid.cells.zoom.zooming') }}</span>
+    </div>
+    <div
+        v-else-if="zoomStatus === 'zoomed'"
+        class="flex items-center justify-center"
+    >
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="green"
+            class="w-20 h-20"
+        >
+            <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M4.5 12.75l6 6 9-13.5"
+            />
+        </svg>
+        <span class="ml-4">{{ t('grid.cells.zoom.success') }}</span>
+    </div>
+    <div
+        v-else-if="zoomStatus === 'error'"
+        class="flex items-center justify-center"
+    >
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="red"
+            class="w-20 h-20"
+        >
+            <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+            />
+        </svg>
+        <span class="ml-4">{{ t('grid.cells.zoom.fail') }}</span>
+    </div>
     <button
         type="button"
-        class="flex items-center justify-center w-46 h-44"
+        class="flex items-center justify-center w-100 h-44"
         :content="t('grid.cells.zoom')"
         v-tippy="{ placement: 'top' }"
         @click="zoomToFeature"
         tabindex="-1"
-        ref="el"
+        ref="button"
+        v-else
     >
         <svg
             class="m-auto"
@@ -25,37 +73,59 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onBeforeUnmount, onMounted, ref } from 'vue';
+import {
+    inject,
+    onBeforeUnmount,
+    onMounted,
+    ref,
+    watch,
+    type WatchStopHandle
+} from 'vue';
 
 import type { InstanceAPI, LayerInstance } from '@/api/internal';
 import { useI18n } from 'vue-i18n';
 import { useLayerStore } from '@/stores/layer';
 import type { AttributeMapPair } from '../store';
 
+const zoomStatus = ref<string>('');
 const props = defineProps(['params']);
 const iApi = inject<InstanceAPI>('iApi')!;
 const layerStore = useLayerStore();
-const el = ref<HTMLElement>();
+const button = ref<HTMLElement>();
 const { t } = useI18n();
 
+let zoomWatcher: WatchStopHandle;
+
 const zoomToFeature = () => {
+    zoomStatus.value = 'zooming';
     const layer: LayerInstance | undefined = layerStore.getLayerByUid(
         props.params.data.rvUid
     );
-    if (layer === undefined) return;
+
+    if (layer === undefined) {
+        setTimeout(() => {
+            zoomStatus.value = 'error';
+        }, 300);
+        return;
+    }
 
     // similar to the sql lookup, the details panel must use the original OID field to perform zoomies
     const oidPair = props.params.layerCols[layer.id].find(
         (pair: AttributeMapPair) => pair.origAttr === layer.oidField
     );
     const oid = props.params.data[oidPair.mappedAttr ?? oidPair.origAttr];
-
     const opts = { getGeom: true };
     layer.getGraphic(oid, opts).then(g => {
         if (g.geometry.invalid()) {
             console.error(`Could not find graphic for objectid ${oid}`);
+            setTimeout(() => {
+                zoomStatus.value = 'error';
+            }, 300);
         } else {
             iApi.geo.map.zoomMapTo(g.geometry);
+            setTimeout(() => {
+                zoomStatus.value = 'zoomed';
+            }, 300);
         }
     });
 };
@@ -63,15 +133,23 @@ const zoomToFeature = () => {
 onMounted(() => {
     // need to hoist events to top level cell wrapper to be keyboard accessible
     props.params.eGridCell.addEventListener('keydown', (e: KeyboardEvent) => {
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' && zoomStatus.value === '') {
             zoomToFeature();
         }
     });
     props.params.eGridCell.addEventListener('focus', () => {
-        (el.value as any)._tippy.show();
+        (button.value as any)?._tippy.show();
     });
     props.params.eGridCell.addEventListener('blur', () => {
-        (el.value as any)._tippy.hide();
+        (button.value as any)?._tippy.hide();
+    });
+
+    zoomWatcher = watch(zoomStatus, (newValue, oldValue) => {
+        if (newValue === 'error' || newValue === 'zoomed') {
+            setTimeout(() => {
+                zoomStatus.value = '';
+            }, 3000);
+        }
     });
 });
 
@@ -85,11 +163,13 @@ onBeforeUnmount(() => {
         }
     );
     props.params.eGridCell.removeEventListener('focus', () => {
-        (el.value as any)._tippy.show();
+        (button.value as any)?._tippy.show();
     });
     props.params.eGridCell.removeEventListener('blur', () => {
-        (el.value as any)._tippy.hide();
+        (button.value as any)?._tippy.hide();
     });
+
+    zoomWatcher();
 });
 </script>
 

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -1,16 +1,21 @@
 <template>
-    <div
-        v-if="zoomStatus === 'zooming'"
-        class="flex items-center justify-center"
+    <button
+        type="button"
+        class="flex items-center justify-center w-46 h-44"
+        :content="
+            t(`grid.cells.zoom${zoomStatus === 'none' ? '' : `.${zoomStatus}`}`)
+        "
+        v-tippy="{ placement: 'top' }"
+        @click="zoomToFeature"
+        tabindex="-1"
+        ref="button"
     >
-        <div class="animate-spin spinner h-20 w-20"></div>
-        <span class="ml-4">{{ t('grid.cells.zoom.zooming') }}</span>
-    </div>
-    <div
-        v-else-if="zoomStatus === 'zoomed'"
-        class="flex items-center justify-center"
-    >
+        <div
+            v-if="zoomStatus === 'zooming'"
+            class="m-auto animate-spin spinner h-20 w-20"
+        ></div>
         <svg
+            v-else-if="zoomStatus === 'zoomed'"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -24,13 +29,8 @@
                 d="M4.5 12.75l6 6 9-13.5"
             />
         </svg>
-        <span class="ml-4">{{ t('grid.cells.zoom.success') }}</span>
-    </div>
-    <div
-        v-else-if="zoomStatus === 'error'"
-        class="flex items-center justify-center"
-    >
         <svg
+            v-else-if="zoomStatus === 'error'"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -44,19 +44,8 @@
                 d="M6 18L18 6M6 6l12 12"
             />
         </svg>
-        <span class="ml-4">{{ t('grid.cells.zoom.fail') }}</span>
-    </div>
-    <button
-        type="button"
-        class="flex items-center justify-center w-100 h-44"
-        :content="t('grid.cells.zoom')"
-        v-tippy="{ placement: 'top' }"
-        @click="zoomToFeature"
-        tabindex="-1"
-        ref="button"
-        v-else
-    >
         <svg
+            v-else
             class="m-auto"
             xmlns="http://www.w3.org/2000/svg"
             height="16"
@@ -73,39 +62,33 @@
 </template>
 
 <script setup lang="ts">
-import {
-    inject,
-    onBeforeUnmount,
-    onMounted,
-    ref,
-    watch,
-    type WatchStopHandle
-} from 'vue';
+import { inject, onBeforeUnmount, onMounted, ref } from 'vue';
 
 import type { InstanceAPI, LayerInstance } from '@/api/internal';
 import { useI18n } from 'vue-i18n';
 import { useLayerStore } from '@/stores/layer';
 import type { AttributeMapPair } from '../store';
+import { GeometryType, LayerType } from '@/geo/api';
 
-const zoomStatus = ref<string>('');
+const zoomStatus = ref<'zooming' | 'zoomed' | 'error' | 'none'>('none');
 const props = defineProps(['params']);
 const iApi = inject<InstanceAPI>('iApi')!;
 const layerStore = useLayerStore();
 const button = ref<HTMLElement>();
 const { t } = useI18n();
 
-let zoomWatcher: WatchStopHandle;
-
 const zoomToFeature = () => {
+    if (zoomStatus.value !== 'none') {
+        return;
+    }
+
     zoomStatus.value = 'zooming';
     const layer: LayerInstance | undefined = layerStore.getLayerByUid(
         props.params.data.rvUid
     );
 
     if (layer === undefined) {
-        setTimeout(() => {
-            zoomStatus.value = 'error';
-        }, 300);
+        updateZoomStatus('error');
         return;
     }
 
@@ -114,26 +97,64 @@ const zoomToFeature = () => {
         (pair: AttributeMapPair) => pair.origAttr === layer.oidField
     );
     const oid = props.params.data[oidPair.mappedAttr ?? oidPair.origAttr];
-    const opts = { getGeom: true };
-    layer.getGraphic(oid, opts).then(g => {
-        if (g.geometry.invalid()) {
-            console.error(`Could not find graphic for objectid ${oid}`);
+
+    const zoomUsingGraphic = () => {
+        const opts = { getGeom: true };
+        layer
+            .getGraphic(oid, opts)
+            .then(g => {
+                if (g.geometry.invalid()) {
+                    console.error(`Could not find graphic for objectid ${oid}`);
+                    updateZoomStatus('error');
+                } else {
+                    iApi.geo.map.zoomMapTo(g.geometry);
+                    updateZoomStatus('zoomed');
+                    iApi.updateAlert(iApi.$i18n.t('grid.cells.alert.zoom'));
+                }
+            })
+            .catch(() => {
+                updateZoomStatus('error');
+            });
+    };
+
+    if (
+        layer.layerType === LayerType.FEATURE &&
+        layer.geomType !== GeometryType.POINT
+    ) {
+        layer
+            .getGraphicExtent(oid)
+            .then(e => {
+                iApi.geo.map.zoomMapTo(e);
+                updateZoomStatus('zoomed');
+                iApi.updateAlert(iApi.$i18n.t('grid.cells.alert.zoom'));
+            })
+            .catch(() => {
+                zoomUsingGraphic();
+            });
+    } else {
+        zoomUsingGraphic();
+    }
+};
+
+const updateZoomStatus = (value: 'zooming' | 'zoomed' | 'error' | 'none') => {
+    if (value === 'zoomed' || value === 'error') {
+        setTimeout(() => {
+            zoomStatus.value = value;
+            (button.value as any)?._tippy.show();
             setTimeout(() => {
-                zoomStatus.value = 'error';
-            }, 300);
-        } else {
-            iApi.geo.map.zoomMapTo(g.geometry);
-            setTimeout(() => {
-                zoomStatus.value = 'zoomed';
-            }, 300);
-        }
-    });
+                (button.value as any)?._tippy.hide();
+                zoomStatus.value = 'none';
+            }, 3000);
+        }, 300);
+    } else {
+        zoomStatus.value = value;
+    }
 };
 
 onMounted(() => {
     // need to hoist events to top level cell wrapper to be keyboard accessible
     props.params.eGridCell.addEventListener('keydown', (e: KeyboardEvent) => {
-        if (e.key === 'Enter' && zoomStatus.value === '') {
+        if (e.key === 'Enter' && zoomStatus.value === 'none') {
             zoomToFeature();
         }
     });
@@ -142,14 +163,6 @@ onMounted(() => {
     });
     props.params.eGridCell.addEventListener('blur', () => {
         (button.value as any)?._tippy.hide();
-    });
-
-    zoomWatcher = watch(zoomStatus, (newValue, oldValue) => {
-        if (newValue === 'error' || newValue === 'zoomed') {
-            setTimeout(() => {
-                zoomStatus.value = '';
-            }, 3000);
-        }
     });
 });
 
@@ -168,8 +181,6 @@ onBeforeUnmount(() => {
     props.params.eGridCell.removeEventListener('blur', () => {
         (button.value as any)?._tippy.hide();
     });
-
-    zoomWatcher();
 });
 </script>
 

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -879,6 +879,18 @@ export class CommonLayer extends LayerInstance {
     }
 
     /**
+     * Gets the extent where the provided object id is on the map.
+     * Can only be used on feature layers with multipoint, polyline, polygon geometry.
+     *
+     * @param objectId the object id to query
+     * @returns {Promise} resolves with the extent where the object id is present
+     */
+    getGraphicExtent(objectId: number): Promise<Extent> {
+        this.stubError();
+        return Promise.resolve(Extent.fromParams('fake', 0, 0, 0, 0));
+    }
+
+    /**
      * Applies the current filter settings to the physical map layer.
      *
      * @function applySqlFilter

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -592,6 +592,17 @@ export class LayerInstance extends APIScope {
     }
 
     /**
+     * Gets the extent where the provided object id is on the map.
+     * Can only be used on feature layers. Not applicable to point geometry.
+     *
+     * @param objectId the object id to query
+     * @returns {Promise} resolves with the extent where the object id is present
+     */
+    getGraphicExtent(objectId: number): Promise<Extent> {
+        return Promise.resolve(Extent.fromParams('fake', 0, 0, 0, 0));
+    }
+
+    /**
      * Get the parent layer for this layer
      * Only supported for sublayers
      *

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -3,6 +3,7 @@ import type {
     Attributes,
     AttributeSet,
     BaseGeometry,
+    Extent,
     GetGraphicServiceDetails,
     TabularAttributeSet
 } from '@/geo/api';
@@ -409,11 +410,15 @@ export class QuickCache {
 
     private geoms: { [key: number]: any };
 
+    // extents for feature layer graphics that do not have a point geometry
+    private extents: { [key: number]: Extent };
+
     readonly isPoint: boolean;
 
     constructor(geomType: string) {
         this.attribs = {};
         this.geoms = {};
+        this.extents = {};
         this.isPoint = geomType === 'point';
     }
 
@@ -466,8 +471,17 @@ export class QuickCache {
         store[key] = geom;
     }
 
+    getExtent(key: number): Extent {
+        return this.extents[key];
+    }
+
+    setExtent(key: number, extent: Extent) {
+        this.extents[key] = extent;
+    }
+
     clearAll(): void {
         this.attribs = {};
         this.geoms = {};
+        this.extents = {};
     }
 }


### PR DESCRIPTION
For #1720.

### Changes
* Added UI indicators when zooming starts/finishes. Feel free to try it out both in the details and the grid fixtures.
* For the `maxOffset`, it appears to be working correctly based on [this line](https://github.com/ramp4-pcar4/ramp4-pcar4/blob/main/src/geo/utils/attribute.ts#L219) of code. I attempted to change the values and increased them by as much as 1000x the original value, but I got very inconsistent results. Sometimes it would appear to zoom faster, whereas other times it would go back to the slow grind. Eventually, I gave up and left this as is.
* Added the ability to query extent on feature layers, and made zoomies for feature layers with the correct geometry use extent querying as it does appear to be consistently faster. Feel free to test the speed on this demo vs the main branch using [this layer](https://maps-cartes.ec.gc.ca/arcgis/rest/services/D01/456ce087-4711-442c-8445-30520f96e98e/MapServer/0).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1735)
<!-- Reviewable:end -->
