### PR TITLE
add alt tags to details template image

### DIFF
--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -16,4 +16,5 @@ details.item.no.data,No data to show because the layer has been removed,1,Aucune
 details.item.alert.zoom,Zoomed into feature,1,Zoom sur la caractéristique,1
 details.item.alert.show.item,Showing result {itemName},1,Affichage du résultat {itemName},1
 details.item.alert.show.list,Showing all results for {layerName},1,Affichage de tous les résultats pour {layerName},1
+details.item.alert.defaultAltText,Image associated with {alias} field,1,Image associée au champ {alias},0
 details.togglehilight.title,Toggle Highlight,1,Basculer vers l'élément principal,1

--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -7,7 +7,10 @@
         >
             <span class="inline font-bold">{{ val.alias }}</span>
             <span class="flex-auto"></span>
-            <span class="inline" v-html="makeHtmlLink(val.value)"></span>
+            <span
+                class="inline"
+                v-html="makeHtmlLink(val.value, val.alias)"
+            ></span>
         </div>
     </div>
 </template>
@@ -18,6 +21,9 @@ import type { PropType } from 'vue';
 import type { FieldDefinition, IdentifyItem } from '@/geo/api';
 import linkifyHtml from 'linkify-html';
 import type { InstanceAPI } from '@/api';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 const iApi = inject<InstanceAPI>('iApi');
 
@@ -56,7 +62,7 @@ const itemData = () => {
 };
 
 // make links look like links and work like links
-const makeHtmlLink = (html: string): string => {
+const makeHtmlLink = (html: string, alias: string): string => {
     if (!html) {
         return html;
     }
@@ -68,7 +74,10 @@ const makeHtmlLink = (html: string): string => {
             /^\s*data:([a-z]+\/[a-z]+(;[a-z\-]+\=[a-z\-]+)?)?(;base64)?,[a-z0-9\!\$\&\'\,\(\)\*\+\,\;\=\-\.\_\~\:\@\/\?\%\s]*\s*$/i //eslint-disable-line
         )
     ) {
-        return `<img src="${html}" />`;
+        return `<img src="${html}" alt="${t(
+            'details.item.alert.defaultAltText',
+            { alias: alias }
+        )}" />`;
     }
 
     const classes = 'underline text-blue-600 break-all';


### PR DESCRIPTION
Related to #1467 

This PR adds an alt tag to images in the details template. According to [these guidelines](https://html.spec.whatwg.org/multipage/images.html#unknown-images), we can't omit the alt tag because we don't meet any of the conditions to allow leaving it out. 

To fix this, I've added a basic string to the image so that we can adhere to the guidelines. If anyone has a better idea or recommendation for what to use as the alt tag feel free to let me know!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1736)
<!-- Reviewable:end -->
