### PR TITLE
Merge Grid Fixes

### DIFF
--- a/src/fixtures/grid/api/grid.ts
+++ b/src/fixtures/grid/api/grid.ts
@@ -20,7 +20,8 @@ export class GridAPI extends FixtureInstance {
             this.gridStore.addGrid({
                 id: id,
                 layerIds: [id],
-                state: new TableStateManager()
+                state: new TableStateManager(),
+                fieldMap: {}
             });
         }
 
@@ -79,16 +80,18 @@ export class GridAPI extends FixtureInstance {
                     }
                 });
 
+                const mapping: { [source: string]: string } = {};
                 fieldMap?.forEach((map: any) => {
                     map.sources.forEach((source: string) => {
-                        this.gridStore.fieldMap[source] = map.field;
+                        mapping[source] = map.field;
                     });
                 });
 
                 const gridConfig = {
                     id: gridId,
                     layerIds: layerIds,
-                    state: new TableStateManager(options)
+                    state: new TableStateManager(options),
+                    fieldMap: mapping
                 };
                 this.gridStore.addGrid(gridConfig);
             });
@@ -99,7 +102,8 @@ export class GridAPI extends FixtureInstance {
             const gridConfig = {
                 id: layerId,
                 layerIds: [layerId],
-                state: new TableStateManager(layerGridConfigs[layerId])
+                state: new TableStateManager(layerGridConfigs[layerId]),
+                fieldMap: {}
             };
 
             // save the item in the store

--- a/src/fixtures/grid/store/grid-state.ts
+++ b/src/fixtures/grid/store/grid-state.ts
@@ -24,6 +24,14 @@ export interface GridConfig {
      * @memberof GridConfig
      */
     state: TableStateManager;
+
+    /**
+     * The field mapping for this grid.
+     *
+     * @type { [source: string]: string }
+     * @memberof GridConfig
+     */
+    fieldMap: { [source: string]: string };
 }
 
 export interface MergeGridConfig {

--- a/src/fixtures/grid/store/grid-store.ts
+++ b/src/fixtures/grid/store/grid-store.ts
@@ -19,11 +19,6 @@ export const useGridStore = defineStore('grid', () => {
      */
     const currentId = ref<string>();
 
-    /**
-     * A mapping of grid fields for merging columns
-     */
-    const fieldMap = ref<{ [source: string]: string }>({});
-
     function addGrid(value: GridConfig) {
         grids.value = { ...grids.value, [value.id]: value };
     }
@@ -50,7 +45,6 @@ export const useGridStore = defineStore('grid', () => {
         grids,
         panel,
         currentId,
-        fieldMap,
         addGrid,
         removeGrid,
         getGridId,

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -458,7 +458,8 @@ const props = defineProps({
 const config = ref<GridConfig>({
     id: 'dummy',
     layerIds: [],
-    state: new TableStateManager()
+    state: new TableStateManager(),
+    fieldMap: {}
 });
 const agGridApi = ref<GridApi>(new GridApi());
 const agGridOptions = ref();
@@ -828,7 +829,8 @@ const setUpSpecialColumns = (
             cellRenderer: DetailsButtonRendererV,
             cellRendererParams: {
                 $iApi: iApi,
-                t: t
+                t: t,
+                layerCols: layerCols.value
             }
         };
         colDef.push(detailsDef);
@@ -847,7 +849,7 @@ const setUpSpecialColumns = (
             cellRenderer: ZoomButtonRendererV,
             cellRendererParams: {
                 $iApi: iApi,
-                oidField: oidField.value
+                layerCols: layerCols.value
             }
         };
         colDef.push(zoomDef);
@@ -1266,14 +1268,18 @@ const setUpColumns = () => {
                 // merge attributes into one table
                 tableAttributes.forEach((ta, idx) => {
                     const attrMap: any = [];
+                    const id: string = fancyLayers[idx].id;
 
                     ta.columns.forEach(col => {
-                        if (gridStore.fieldMap[col.data]) {
+                        if (
+                            config.value.fieldMap &&
+                            config.value.fieldMap[col.data]
+                        ) {
                             attrMap.push({
                                 origAttr: col.data,
-                                mappedAttr: gridStore.fieldMap[col.data]
+                                mappedAttr: config.value.fieldMap[col.data]
                             });
-                            col.data = gridStore.fieldMap[col.data];
+                            col.data = config.value.fieldMap[col.data];
                         } else {
                             attrMap.push({
                                 origAttr: col.data,
@@ -1292,12 +1298,14 @@ const setUpColumns = () => {
 
                     mergedTableAttrs.rows = mergedTableAttrs.rows.concat(
                         ta.rows.map(row => {
-                            for (const [oldAttr, newAttr] of Object.entries(
-                                gridStore.fieldMap
-                            )) {
-                                if (!row[newAttr]) {
-                                    row[newAttr] = row[oldAttr];
-                                    delete row[oldAttr];
+                            if (config.value.fieldMap) {
+                                for (const [oldAttr, newAttr] of Object.entries(
+                                    config.value.fieldMap
+                                )) {
+                                    if (row[oldAttr] && !row[newAttr]) {
+                                        row[newAttr] = row[oldAttr];
+                                        delete row[oldAttr];
+                                    }
                                 }
                             }
                             return row;
@@ -1308,8 +1316,10 @@ const setUpColumns = () => {
                         ta.fields.map(field => {
                             return {
                                 name:
-                                    gridStore.fieldMap[field.name] ??
-                                    field.name,
+                                    config.value.fieldMap &&
+                                    config.value.fieldMap[field.name]
+                                        ? config.value.fieldMap[field.name]
+                                        : field.name,
                                 type: field.type,
                                 alias: field.alias ?? undefined,
                                 length: field.length ?? undefined
@@ -1318,10 +1328,13 @@ const setUpColumns = () => {
                     );
                     //TODO: the table currently relies on config author to provide correct oid mapping. maybe return to this for enchancement?
                     mergedTableAttrs.oidField =
-                        gridStore.fieldMap[ta.oidField] ?? ta.oidField;
+                        config.value.fieldMap &&
+                        config.value.fieldMap[ta.oidField]
+                            ? config.value.fieldMap[ta.oidField]
+                            : ta.oidField;
 
                     // tracking which columns correspond with which layer for applyToMap filtering
-                    layerCols.value[fancyLayers[idx].id] = attrMap;
+                    layerCols.value[id] = attrMap;
                 });
 
                 // save field that contains oid for this layer

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -30,6 +30,7 @@ import { inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import type { InstanceAPI, LayerInstance } from '@/api/internal';
 import { useI18n } from 'vue-i18n';
 import { useLayerStore } from '@/stores/layer';
+import type { AttributeMapPair } from '../store';
 
 const props = defineProps(['params']);
 const iApi = inject<InstanceAPI>('iApi')!;
@@ -42,7 +43,13 @@ const zoomToFeature = () => {
         props.params.data.rvUid
     );
     if (layer === undefined) return;
-    const oid = props.params.data[props.params.oidField];
+
+    // similar to the sql lookup, the details panel must use the original OID field to perform zoomies
+    const oidPair = props.params.layerCols[layer.id].find(
+        (pair: AttributeMapPair) => pair.origAttr === layer.oidField
+    );
+    const oid = props.params.data[oidPair.mappedAttr ?? oidPair.origAttr];
+
     const opts = { getGeom: true };
     layer.getGraphic(oid, opts).then(g => {
         if (g.geometry.invalid()) {


### PR DESCRIPTION
References #1739 

Fixes up a couple of edge cases related to the merge grid.
- Field mappings are now separated by grid, meaning that overlapping field maps won't interfere with one another. Also prevents erroneous fields sneaking in to other details panels.
- Field mapping an OID field would cause the details panel and zoom buttons to function incorrectly for features of the mapped layer. Now the OID field is 'reverse-mapped' so that the original OID of the layer is used (similar to how the reverse mapping was done for SQL filtering).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1738)
<!-- Reviewable:end -->
