### PR TITLE
Loading bar nows displays until initial draw is complete

### DIFF
--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -272,6 +272,7 @@ export class LayerItem extends LegendItem {
                           this._layerId ?? this._layerUid
                       );
             this.layer = layer;
+            this._layerRedrawing = layer.drawState !== DrawState.UP_TO_DATE;
             if (this._loadCancelled) {
                 this.toggleVisibility(false, true, true);
                 return;


### PR DESCRIPTION
#1728 

The loading bar will now remain until the initial draw is complete. To test, load this [service ](https://maps-cartes.ec.gc.ca/arcgis/rest/services/D01/456ce087-4711-442c-8445-30520f96e98e/MapServer/0) and witness a loading bar on the legend persist until the draw is complete. (Layer draws on the west coast)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1742)
<!-- Reviewable:end -->
