### PR TITLE
Add loading animation and VPN error message to wizard

### DIFF
--- a/src/fixtures/wizard/form-footer.vue
+++ b/src/fixtures/wizard/form-footer.vue
@@ -9,27 +9,87 @@
         </button>
 
         <button
-            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16 m-2 disabled:bg-gray-200 disabled:cursor-default disabled:text-gray-400"
+            class="button bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16 m-2 disabled:bg-gray-200 disabled:cursor-default disabled:text-gray-400"
+            ref="submitButton"
             type="button"
             :disabled="disabled"
-            @click="$emit('submit')"
+            :animation="animation"
+            @click="
+                $emit('submit');
+                loadButton();
+            "
         >
-            {{ t('wizard.step.continue') }}
+            <span class="button-text">{{ t('wizard.step.continue') }}</span>
         </button>
     </div>
 </template>
 
 <script setup lang="ts">
+import { ref, toRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 
-defineProps({
+const props = defineProps({
+    animation: {
+        type: Boolean,
+        default: false
+    },
     disabled: {
         type: Boolean,
         default: true
     }
 });
+
+const submitButton = ref<HTMLButtonElement>();
+
+watch(toRef(props, 'disabled'), disabled => {
+    if (
+        !disabled &&
+        submitButton.value!.classList.contains('button--loading')
+    ) {
+        submitButton.value!.classList.remove('button--loading');
+    }
+});
+
+const loadButton = () => {
+    if (props.animation)
+        submitButton.value!.classList.toggle('button--loading');
+};
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.button {
+    position: relative;
+    &.button--loading .button-text {
+        visibility: hidden;
+        opacity: 0;
+    }
+
+    &.button--loading::after {
+        content: '';
+        position: absolute;
+        width: 22px;
+        height: 22px;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        margin: auto;
+        border: 4px solid transparent;
+        border-top-color: #ffffff;
+        border-radius: 50%;
+        animation: button-loading-spinner 1s ease infinite;
+    }
+
+    @keyframes button-loading-spinner {
+        from {
+            transform: rotate(0turn);
+        }
+
+        to {
+            transform: rotate(1turn);
+        }
+    }
+}
+</style>

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -16,6 +16,7 @@ wizard.format.type.error.invalid,Invalid file or service type,1,Type de fichier 
 wizard.format.type.error.failure,Failed to load data from file/service,1,Échec du chargement des données à partir du fichier/service,1
 wizard.format.info.cors,Service needs to be CORS enabled,1,Le service doit être compatible CORS.,1
 wizard.format.warn.cors,Service may not support CORS,1,Le service ne pend peut-être pas en charge CORS.,1
+wizard.format.warn.vpn,Service may require a VPN connection,1,Le service peut nécessiter une connexion VPN,0
 wizard.fileType.csv,CSV,1,CSV,1
 wizard.fileType.shapefile,zipped Shapefile,1,Shapefile zippé,1
 wizard.fileType.geojson,GeoJSON,1,GeoJSON,1

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -95,7 +95,7 @@
                             "
                             :formatError="formatError"
                             :failureError="failureError"
-                            :validation="true"
+                            :validation="validation"
                             :validation-messages="{
                                 required: t(
                                     'wizard.format.type.error.required'
@@ -109,7 +109,7 @@
                                           t('wizard.format.warn.cors') +
                                           '.'
                                         : ''
-                                }`
+                                }${' ' + t('wizard.format.warn.vpn') + '.'}`
                             }"
                             @keydown.stop
                         />
@@ -117,13 +117,16 @@
                             @submit="onSelectContinue"
                             @cancel="
                                 () => {
+                                    disabled = false;
                                     formatError = false;
                                     failureError = false;
                                     url ? (goNext = true) : (goNext = false);
+                                    validation = false;
                                     wizardStore.goToStep(0);
                                 }
                             "
-                            :disabled="false"
+                            :animation="true"
+                            :disabled="disabled"
                         />
                     </form>
                 </stepper-item>
@@ -320,11 +323,13 @@ const step = computed(() => wizardStore.currStep);
 
 const colour = ref();
 const colourPickerId = ref();
+const disabled = ref(false);
 
 const formatError = ref(false);
 const failureError = ref(false);
 const goNext = ref(false);
 const finishStep = ref(false);
+const validation = ref(false);
 
 // service layer formats
 const serviceTypeOptions = reactive([
@@ -490,7 +495,9 @@ const onUploadContinue = (event: any) => {
 };
 
 const onSelectContinue = async () => {
+    disabled.value = true;
     failureError.value = false;
+    validation.value = true;
 
     try {
         layerInfo.value = isFileLayer()
@@ -507,6 +514,7 @@ const onSelectContinue = async () => {
             layerInfo.value.config.url = '';
         }
     } catch (_) {
+        disabled.value = false;
         failureError.value = true;
         return;
     }
@@ -526,6 +534,7 @@ const onSelectContinue = async () => {
             },
             configOptions: []
         };
+        disabled.value = false;
         return;
     }
 
@@ -536,6 +545,9 @@ const onSelectContinue = async () => {
     layerInfo.value.configOptions.includes(`sublayers`)
         ? (finishStep.value = false)
         : (finishStep.value = true);
+
+    disabled.value = false;
+    validation.value = false;
 };
 
 const onConfigureContinue = async (data: object) => {


### PR DESCRIPTION
For #1708 

When adding a layer that requires a VPN through the wizard, if no VPN is used a warning message will now appear after trying to continue step 2.

Also, during the time when the wizard sends the request to the server, the wizard will now display a loading animation over the button.

Feel free to try both using this [layer](https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/Testing/SLL_LandCover_Sample/MapServer) that requires a VPN

Lots of feedback on this one would be appreciated 👍

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1747)
<!-- Reviewable:end -->
