### PR TITLE
`OBJECTID` global flag

### DIFF
--- a/demos/starter-scripts/cam.js
+++ b/demos/starter-scripts/cam.js
@@ -311,9 +311,6 @@ let config = {
                                 {
                                     name: 'Icon',
                                     visible: false
-                                },
-                                {
-                                    name: 'OBJECTID'
                                 }
                             ]
                         }
@@ -660,10 +657,6 @@ let config = {
                                     enabled: false
                                 },
                                 columns: [
-                                    {
-                                        data: 'OBJECTID',
-                                        visible: false
-                                    },
                                     {
                                         data: 'Cat?gorie'
                                     },

--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -291,11 +291,7 @@ let config = {
                                         { name: 'CO2_eq' },
                                         { name: 'E_Units' },
                                         { name: 'Report_Year' },
-                                        { name: 'E_DetailPageURL' },
-                                        {
-                                            name: 'OBJECTID',
-                                            visible: false
-                                        }
+                                        { name: 'E_DetailPageURL' }
                                     ]
                                 }
                             }
@@ -331,8 +327,7 @@ let config = {
                                 { name: 'GridColumn5' },
                                 { name: 'Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -362,8 +357,7 @@ let config = {
                                 { name: 'PM2_5' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -393,8 +387,7 @@ let config = {
                                 { name: 'SO2' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -423,8 +416,7 @@ let config = {
                                 { name: 'GridColumn5' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     },
@@ -459,8 +451,7 @@ let config = {
                                 { name: 'Pb' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -499,11 +490,7 @@ let config = {
                                         { name: 'E_PA_Zone_Desc' },
                                         { name: 'E_URL' },
                                         { name: 'Report_Year' },
-                                        { name: 'E_DetailPageURL' },
-                                        {
-                                            name: 'OBJECTID',
-                                            visible: false
-                                        }
+                                        { name: 'E_DetailPageURL' }
                                     ]
                                 }
                             }
@@ -554,8 +541,7 @@ let config = {
                                 { name: 'E_URL_Historical' },
                                 { name: 'E_Measure' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -576,13 +562,6 @@ let config = {
                             state: {
                                 visibility: true,
                                 opacity: 1
-                            },
-                            fixtures: {
-                                grid: {
-                                    columns: [
-                                        { name: 'OBJECTID', visible: false }
-                                    ]
-                                }
                             }
                         },
                         {

--- a/demos/starter-scripts/fog-hilight.js
+++ b/demos/starter-scripts/fog-hilight.js
@@ -292,11 +292,7 @@ let config = {
                                         { name: 'CO2_eq' },
                                         { name: 'E_Units' },
                                         { name: 'Report_Year' },
-                                        { name: 'E_DetailPageURL' },
-                                        {
-                                            name: 'OBJECTID',
-                                            visible: false
-                                        }
+                                        { name: 'E_DetailPageURL' }
                                     ]
                                 }
                             }
@@ -332,8 +328,7 @@ let config = {
                                 { name: 'GridColumn5' },
                                 { name: 'Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -363,8 +358,7 @@ let config = {
                                 { name: 'PM2_5' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -394,8 +388,7 @@ let config = {
                                 { name: 'SO2' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -424,8 +417,7 @@ let config = {
                                 { name: 'GridColumn5' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     },
@@ -460,8 +452,7 @@ let config = {
                                 { name: 'Pb' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -500,11 +491,7 @@ let config = {
                                         { name: 'E_PA_Zone_Desc' },
                                         { name: 'E_URL' },
                                         { name: 'Report_Year' },
-                                        { name: 'E_DetailPageURL' },
-                                        {
-                                            name: 'OBJECTID',
-                                            visible: false
-                                        }
+                                        { name: 'E_DetailPageURL' }
                                     ]
                                 }
                             }
@@ -555,8 +542,7 @@ let config = {
                                 { name: 'E_URL_Historical' },
                                 { name: 'E_Measure' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -577,13 +563,6 @@ let config = {
                             state: {
                                 visibility: true,
                                 opacity: 1
-                            },
-                            fixtures: {
-                                grid: {
-                                    columns: [
-                                        { name: 'OBJECTID', visible: false }
-                                    ]
-                                }
                             }
                         },
                         {

--- a/demos/starter-scripts/grid-config.js
+++ b/demos/starter-scripts/grid-config.js
@@ -145,6 +145,9 @@ let config = {
                         esri: 'Details-Default-Template-Esri'
                     }
                 }
+            },
+            system: {
+                exposeOid: true
             }
         }
     }

--- a/demos/starter-scripts/merge-grid.js
+++ b/demos/starter-scripts/merge-grid.js
@@ -244,13 +244,7 @@ let config = {
                                 }
                             ],
                             options: {
-                                title: 'EcoGeo Data',
-                                columns: [
-                                    {
-                                        field: 'OBJECTID',
-                                        sort: 'asc'
-                                    }
-                                ]
+                                title: 'EcoGeo Data'
                             }
                         },
                         {
@@ -312,13 +306,7 @@ let config = {
                                 }
                             ],
                             options: {
-                                title: 'Errored Data',
-                                columns: [
-                                    {
-                                        field: 'OBJECTID',
-                                        sort: 'asc'
-                                    }
-                                ]
+                                title: 'Errored Data'
                             }
                         }
                     ]

--- a/docs/api/instance.md
+++ b/docs/api/instance.md
@@ -20,6 +20,7 @@ The Instance API provides an interface to manage all aspects of a RAMP instance.
 * `language` - a string representing the current language for the instance.
 * `screenSize` - a string representing the screen size for the app. Returns the largest tailwind screen class on the element. Possible values are 'lg', 'md', 'sm' or 'xs'.
 * `animate` - a boolean representing whether the app has animations enabled.
+* `exposeOid` - a boolean representing whether the app includes Object ID fields of a feature alongside attribute data.
 * `isFullScreen` - a boolean representing whether the app is currently fullscreen.
 * `started` - a boolean representing whether the app has been started.
 

--- a/public/starter-scripts/cam.js
+++ b/public/starter-scripts/cam.js
@@ -315,9 +315,6 @@ let config = {
                                 {
                                     name: 'Icon',
                                     visible: false
-                                },
-                                {
-                                    name: 'OBJECTID'
                                 }
                             ]
                         }
@@ -668,10 +665,6 @@ let config = {
                                     enabled: false
                                 },
                                 columns: [
-                                    {
-                                        data: 'OBJECTID',
-                                        visible: false
-                                    },
                                     {
                                         data: 'Cat?gorie'
                                     },

--- a/public/starter-scripts/cesi.js
+++ b/public/starter-scripts/cesi.js
@@ -295,11 +295,7 @@ let config = {
                                         { name: 'CO2_eq' },
                                         { name: 'E_Units' },
                                         { name: 'Report_Year' },
-                                        { name: 'E_DetailPageURL' },
-                                        {
-                                            name: 'OBJECTID',
-                                            visible: false
-                                        }
+                                        { name: 'E_DetailPageURL' }
                                     ]
                                 }
                             }
@@ -335,8 +331,7 @@ let config = {
                                 { name: 'GridColumn5' },
                                 { name: 'Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -366,8 +361,7 @@ let config = {
                                 { name: 'PM2_5' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -397,8 +391,7 @@ let config = {
                                 { name: 'SO2' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -427,8 +420,7 @@ let config = {
                                 { name: 'GridColumn5' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     },
@@ -463,8 +455,7 @@ let config = {
                                 { name: 'Pb' },
                                 { name: 'E_Units' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -503,11 +494,7 @@ let config = {
                                         { name: 'E_PA_Zone_Desc' },
                                         { name: 'E_URL' },
                                         { name: 'Report_Year' },
-                                        { name: 'E_DetailPageURL' },
-                                        {
-                                            name: 'OBJECTID',
-                                            visible: false
-                                        }
+                                        { name: 'E_DetailPageURL' }
                                     ]
                                 }
                             }
@@ -558,8 +545,7 @@ let config = {
                                 { name: 'E_URL_Historical' },
                                 { name: 'E_Measure' },
                                 { name: 'Report_Year' },
-                                { name: 'E_DetailPageURL' },
-                                { name: 'OBJECTID', visible: false }
+                                { name: 'E_DetailPageURL' }
                             ]
                         }
                     }
@@ -580,13 +566,6 @@ let config = {
                             state: {
                                 visibility: true,
                                 opacity: 1
-                            },
-                            fixtures: {
-                                grid: {
-                                    columns: [
-                                        { name: 'OBJECTID', visible: false }
-                                    ]
-                                }
                             }
                         },
                         {

--- a/schema.json
+++ b/schema.json
@@ -2525,6 +2525,11 @@
                     "type": "boolean",
                     "description": "Will enable visual animation when using the site, such as control transitions.",
                     "default": true
+                },
+                "exposeOid": {
+                    "type": "boolean",
+                    "description": "Determines whether or not to include a feature's object ID field when viewing data on the site (e.g. within the details panel when identifying a feature).",
+                    "default": false
                 }
             },
             "required": [],

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -93,7 +93,7 @@ function individualConfigUpgrader(r2c: any): any {
         layers: [],
         map: {},
         panels: { open: [] },
-        system: { animate: true },
+        system: { animate: true, exposeOid: false },
         fixturesEnabled: [] // this will be removed in the final step of configUpgrade2to4
     };
 

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -82,7 +82,7 @@ export class InstanceAPI {
     readonly event: EventAPI;
     readonly geo: GeoAPI;
     readonly notify: NotificationAPI;
-    readonly ui: { maptip: MaptipAPI };
+    readonly ui: { maptip: MaptipAPI; exposeOids: boolean };
     startRequired: boolean = false;
 
     /**
@@ -114,7 +114,7 @@ export class InstanceAPI {
         this.panel = new PanelAPI(this);
         this.geo = new GeoAPI(this);
         //TODO before 1.0: does the ui namespace still make sense, should we just leave maptip under geo.map only?
-        this.ui = { maptip: this.geo.map.maptip };
+        this.ui = { maptip: this.geo.map.maptip, exposeOids: false };
         this.notify = new NotificationAPI(this);
 
         this._isFullscreen =
@@ -272,6 +272,9 @@ export class InstanceAPI {
             // process system configurations
             if (langConfig.system?.proxyUrl) {
                 this.geo.proxy = langConfig.system.proxyUrl;
+            }
+            if (langConfig.system?.exposeOid) {
+                this.ui.exposeOids = langConfig.system.exposeOid;
             }
         }
 

--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -42,6 +42,11 @@ const props = defineProps({
 const itemData = () => {
     const helper: any = {};
     Object.assign(helper, props.identifyData.data);
+
+    if (!iApi?.ui.exposeOids) {
+        // check global oid flag
+        delete helper[props.fields.find(f => f.type === 'oid')!.name];
+    }
     if (helper.Symbol !== undefined) delete helper.Symbol;
 
     let aliases: any = {};

--- a/src/fixtures/grid/column-dropdown.vue
+++ b/src/fixtures/grid/column-dropdown.vue
@@ -28,7 +28,10 @@
         </template>
         <a
             v-for="col in columnDefs.filter(
-                c => c.headerName && c.headerName.length > 0
+                c =>
+                    c.headerName &&
+                    c.headerName.length > 0 &&
+                    !(!iApi.ui.exposeOids && oidCols?.has(c.headerName))
             )"
             :key="col.headerName"
             v-on:click="
@@ -59,13 +62,16 @@
 </template>
 
 <script setup lang="ts">
-import type { PropType } from 'vue';
+import type { InstanceAPI } from '@/api';
+import { inject, type PropType } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+const iApi = inject('iApi') as InstanceAPI;
 const { t } = useI18n();
 
 defineProps({
     columnDefs: { type: Object as PropType<Array<any>>, required: true },
-    columnApi: { type: Object }
+    columnApi: { type: Object },
+    oidCols: { type: Object as PropType<Set<string>> }
 });
 </script>

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -102,6 +102,7 @@
                 <column-dropdown
                     :columnApi="columnApi"
                     :columnDefs="columnDefs"
+                    :oidCols="oidCols"
                 ></column-dropdown>
 
                 <!-- clear all filters -->
@@ -504,6 +505,7 @@ const gridLayers = computed(() => {
         );
     } else return [];
 });
+const oidCols = ref<Set<string>>(new Set<string>());
 
 const onGridReady = (params: any) => {
     agGridApi.value = params.api;
@@ -1349,6 +1351,9 @@ const setUpColumns = () => {
 
                     mergedTableAttrs.fields = mergedTableAttrs.fields.concat(
                         ta.fields.map(field => {
+                            if (field.type === 'oid') {
+                                oidCols.value.add(field.name);
+                            }
                             return {
                                 name:
                                     config.value.fieldMap &&
@@ -1391,6 +1396,10 @@ const setUpColumns = () => {
                                 field: column.data,
                                 title: column.title
                             });
+                    }
+                    if (!iApi.ui.exposeOids && oidCols.value.has(column.data)) {
+                        // hide oid column according to global flag
+                        config.value.state.columns[column.data].visible = false;
                     }
                     let colConfig = config.value.state?.columns[column.data];
                     let col: ColumnDefinition = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,6 +20,7 @@ export interface RampConfig {
     system?: {
         proxyUrl?: string;
         animate?: boolean;
+        exposeOid?: boolean;
     };
 }
 


### PR DESCRIPTION
#1667

#### Changes

- Object ID fields are now hidden by default in the default details and grid panels
- The `exposeOid` field is available in the system config nugget, with schema docs
- Retroactively removed all specific `OBJECTID` references in the samples, since they're now redundant

#### Notes

I added `exposeOid` to the `ui` namespace in the instance, but there was this comment
> TODO before 1.0: does the ui namespace still make sense, should we just leave maptip under geo.map only?

IMO it made the most sense to chuck it in there rather than make a separate variable, but if we still want to remove `ui` it can be put somewhere else.

### Demo: https://ramp4-pcar4.github.io/ramp4-pcar4/objectid-flag/demos/index-samples.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1756)
<!-- Reviewable:end -->
