### PR TITLE
Add ability to select/copy long text and stringify object type data in the grid

### DIFF
--- a/docs/app/grid.md
+++ b/docs/app/grid.md
@@ -19,6 +19,9 @@ Each row in the grid table contains a zoom and details button. The zoom button c
 ## Controls
 Various controls have been added to the grid for user convenience.
 
+### Copy Text
+Any cell with text in it can be copied to the clipboard by double clicking on the cell, or for keyboard users, by navigating to the cell and pressing the control and c keys. A tooltip will appear to indicate that the text has been successfully copied.
+
 ### Show/Hide Columns
 A dropdown menu located in the upper right corner of the grid panel, labeled `Columns`. This allows the user to hide unwanted columns from the table. Columns that are visible have a checkmark displayed beside them.
 

--- a/public/help/en.md
+++ b/public/help/en.md
@@ -170,6 +170,7 @@ In addition to scrolling data, it is possible to:
 - Filter the columns by numerical range, text, selection or date (if the configuration allows it). Changes in the table can also be made to reflect on the map by applying or clearing filters from map options, available in the top right corner of the data table
 - Show and/or hide columns by clicking on the *Hide Columns* icon, in the top right corner of the data table.
 - Navigate the table using a keyboard
+- Copy the text in a cell by double clicking on it, or for keyboard users, by navigating to the cell and pressing the control and c keys.
 
 The number of features in the layer is displayed in the top left corner below the layer title.
 

--- a/public/help/fr.md
+++ b/public/help/fr.md
@@ -170,6 +170,7 @@ En plus de pouvoir faire défiler les données, vous pouvez :
 - appliquer un filtre sur les colonnes selon une plage numérique, du texte, une sélection ou une date (si la configuration le permet). Vous pouvez appliquer ou supprimer les filtres à partir des options de la carte, situées dans le coin supérieur droit du tableau de données, pour que les modifications apportées au tableau s'affichent sur la carte;
 - afficher et/ou masquer les colonnes en cliquant sur l'icône _Masquer les colonnes_, située dans le coin supérieur droit du tableau de données;
 - vous déplacer dans le tableau au moyen du clavier.
+- Copiez le texte dans une cellule en double-cliquant dessus, ou pour les utilisateurs de clavier, en naviguant jusqu'à la cellule et et en appuyant sur les touches contrôle et c.
 
 Le nombre d'éléments figurant dans la couche est affiché dans le coin supérieur gauche, sous le titre de la couche.
 

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -8,6 +8,8 @@ grid.splash.cancel,Cancel,1,Annuler,1
 grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,1
 grid.layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
 grid.label.columns,Hide columns,1,Masquer les colonnes,1
+grid.label.copied,Copied,1,Copié,0
+grid.label.copy,Press ctrl + c or double click to copy,1,Appuyez sur ctrl + c ou double-cliquez pour copier,0
 grid.label.filters.show,Show filters,1,Afficher les filtres,1
 grid.label.filters.hide,Hide filters,1,Masquer les filtres,1
 grid.label.filters.apply,Apply filters to map,1,Appliquer les filtres à la carte,1

--- a/src/geo/layer/file-utils.ts
+++ b/src/geo/layer/file-utils.ts
@@ -536,7 +536,9 @@ export class FileUtils extends APIScope {
                         typeof gr.attributes[attName] === 'object') &&
                     gr.attributes[attName] != null
                 ) {
-                    gr.attributes[attName] = '[Complex Value Removed]';
+                    gr.attributes[attName] = JSON.stringify(
+                        gr.attributes[attName]
+                    );
                 }
             });
         });


### PR DESCRIPTION
For #1676, #1758. This is somewhat of a demo PR that needs feedback before it can be merged.

### Changes
* Added ability to copy and select text in the grid. There are currently two different solutions implemented for this. One is a copy dropdown in the top menu of the grid, where you can select the row and column and copy the contents inside it. The other is you can expand/collapse the contents inside the cell itself to show/truncate text via a more button, and this replaces the tooltip we currently have in place. I also tried opening a dropdown when you click more button that has all the text inside it, however it was presenting too many issues (fighting between different events, dropdown not fitting in certain situations. etc.) so I decided to not go with that.
Feel free to try both out and provide your opinions/suggestions. Personally, I like the copy dropdown better because when you click more and the text is really long, the row expands a lot and then it could be annoying to scroll down and collapse it, especially on mobile. However, my opinion comes with the grain of salt that I am a UI/UX noob. People can also propose a third solution if none of these work.

* Object type data is now stringified. Add [this layer](https://api.weather.gc.ca/collections/hydrometric-stations/items?startindex=6000) and view the links column in the grid to see this change in action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1759)
<!-- Reviewable:end -->
