### PR TITLE
Select correct object ID in details panel

### DIFF
--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -77,8 +77,13 @@ export class DetailsAPI extends FixtureInstance {
         };
 
         // feature ids are composed of the layer uid and feature object id
+        const layer: LayerInstance | undefined = this.$iApi.geo.layer.getLayer(
+            featureData.uid
+        );
         const prevFeatureId = this.detailsStore.currentFeatureId;
-        const currFeatureId = `${featureData.uid}-${featureData.data.OBJECTID}`;
+        const currFeatureId = `${featureData.uid}-${
+            featureData.data[layer?.oidField ?? '']
+        }`;
         this.detailsStore.currentFeatureId = featureData.data
             ? currFeatureId
             : undefined;


### PR DESCRIPTION
For #1721 

The layer's OID field is now used to select the appropriate OID value when opening the details panel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1762)
<!-- Reviewable:end -->
