### PR TITLE
Add wet teleport to samples directory page

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -312,6 +312,9 @@
             <li>
                 <a href="index-wet.html">RAMP inside the WET template</a>
             </li>
+            <li>
+                <a href="index-teleport-wet.html">RAMP inside the WET template with teleport enabled</a>
+            </li>
         </ul>
     </body>
 </html>


### PR DESCRIPTION
For #1731

Demo sample `index-teleport-wet.html` is now added to `index-all.html` in the "Various Templates" section.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1764)
<!-- Reviewable:end -->
