### PR TITLE
Canvas Colour Config

### DIFF
--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -87,7 +87,8 @@ let config = {
                             }
                         ],
                         tileSchemaId:
-                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        backgroundColour: '#BFE8FE'
                     },
                     {
                         id: 'baseSimple',
@@ -134,7 +135,8 @@ let config = {
                             }
                         ],
                         tileSchemaId:
-                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        backgroundColour: '#BFE8FE'
                     },
                     {
                         id: 'baseEsriWorld',

--- a/schema.json
+++ b/schema.json
@@ -1967,6 +1967,11 @@
                     "default": "",
                     "description": "Alt text for the basemap thumbnail image."
                 },
+                "backgroundColour": {
+                    "type": "string",
+                    "default": "#FFFFFF",
+                    "description": "The hex code representing the background colour of the basemap."
+                },
                 "hideThumbnail": {
                     "type": "boolean",
                     "default": false,

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -659,6 +659,7 @@ export interface RampBasemapConfig {
     tileSchemaId: string;
     layers: Array<RampBasemapLayerConfig>;
     attribution?: Attribution;
+    backgroundColour?: string;
 }
 
 export interface RampTileSchemaConfig {

--- a/src/geo/map/basemap.ts
+++ b/src/geo/map/basemap.ts
@@ -120,4 +120,11 @@ export class Basemap {
     set attribution(value: Attribution | undefined) {
         this.config.attribution = value;
     }
+
+    /**
+     * Get this basemap's background colour
+     */
+    get backgroundColour(): string {
+        return this.config.backgroundColour ?? '#FFFFFF';
+    }
 }

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -39,6 +39,7 @@ import { MapCaptionAPI } from './caption';
 import { markRaw, toRaw } from 'vue';
 import { useConfigStore } from '@/stores/config';
 import { debounce, throttle } from 'throttle-debounce';
+import { Colour } from '@/geo/api';
 
 export class MapAPI extends CommonMapAPI {
     // API for managing the maptip
@@ -173,7 +174,8 @@ export class MapAPI extends CommonMapAPI {
                 extent: this._rampExtentSet.defaultExtent.toESRI(),
                 navigation: {
                     browserTouchPanEnabled: false
-                }
+                },
+                background: { color: bm.backgroundColour }
             })
         );
 
@@ -437,6 +439,10 @@ export class MapAPI extends CommonMapAPI {
         } else {
             // change the basemap
             this.applyBasemap(bm);
+            this.esriView.set(
+                'background.color',
+                new Colour(bm.backgroundColour).toESRI()
+            );
         }
 
         // fire the basemap change event


### PR DESCRIPTION
#1746

Adds the `backgroundColour` parameter to the basemap config nugget, meaning that custom background canvas colours can be set per basemap.

The [WET sample](https://ramp4-pcar4.github.io/ramp4-pcar4/canvas-colour/demos/index-wet.html) gives a good demonstration of this; set the basemap to either of the **Canada Base Map - Transportation** sets.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1765)
<!-- Reviewable:end -->
