### PR TITLE
Fix merge grid OID mapping edge case and remove comment

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1315,6 +1315,7 @@ const setUpColumns = () => {
                                 mappedAttr: config.value.fieldMap[col.data]
                             });
                             col.data = config.value.fieldMap[col.data];
+                            col.title = col.data;
                         } else {
                             attrMap.push({
                                 origAttr: col.data,
@@ -1361,7 +1362,7 @@ const setUpColumns = () => {
                             };
                         })
                     );
-                    //TODO: the table currently relies on config author to provide correct oid mapping. maybe return to this for enchancement?
+
                     mergedTableAttrs.oidField =
                         config.value.fieldMap &&
                         config.value.fieldMap[ta.oidField]


### PR DESCRIPTION
For #1734.

### Changes
* Removed TODO comment for badly mapped OIDs after feedback from the experts.
* Fixed an edge case where field mapping OIDs would show the title of the old attribute instead of the new one by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1768)
<!-- Reviewable:end -->
