### PR TITLE
Add panelWidth to grid fixture schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2265,6 +2265,9 @@
                             "items": {
                                 "$ref": "#/$defs/mergeGrid"
                             }
+                        },
+                        "panelWidth": {
+                            "$ref": "#/$defs/panelWidth"
                         }
                     },
                     "required": ["mergeGrids"],


### PR DESCRIPTION
For #1733 

The grid section of the fixture schema now has the `panelWidth` property definition

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1769)
<!-- Reviewable:end -->
