### PR TITLE
Merge Grid Fix

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1337,7 +1337,10 @@ const setUpColumns = () => {
                                 for (const [oldAttr, newAttr] of Object.entries(
                                     config.value.fieldMap
                                 )) {
-                                    if (row[oldAttr] && !row[newAttr]) {
+                                    if (
+                                        row[oldAttr] !== undefined &&
+                                        row[newAttr] === undefined
+                                    ) {
                                         row[newAttr] = row[oldAttr];
                                         delete row[oldAttr];
                                     }


### PR DESCRIPTION
#1771

Row data is now checked as `undefined` rather than falsy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1772)
<!-- Reviewable:end -->
