### PR TITLE
Notification uses layer name over id if given

### DIFF
--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -939,8 +939,9 @@ export class CommonLayer extends LayerInstance {
                 () =>
                     this.$iApi.notify.show(
                         NotificationType.WARNING,
+                        // layer.longload or layer.longdraw
                         this.$iApi.$i18n.t(`layer.long${type}`, {
-                            id: this.id
+                            id: this.name || this.id
                         })
                     ),
                 this.expectedTime[type]


### PR DESCRIPTION
For #1753 

Notifications now use the layer name if provided in the config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1773)
<!-- Reviewable:end -->
