### PR TITLE
Change tailwind style scoping class

### DIFF
--- a/demos/index-teleport-wet.html
+++ b/demos/index-teleport-wet.html
@@ -325,13 +325,13 @@
             <div id="IE"></div>
             <div style="display: flex">
                 <div
-                    class="ramp-app"
+                    class="ramp-styles"
                     id="legend"
                     style="height: 70vh; width: 30%"
                 ></div>
                 <div id="app" style="height: 70vh; width: 70%"></div>
             </div>
-            <div class="ramp-app" id="grid" style="height: 70vh"></div>
+            <div class="ramp-styles" id="grid" style="height: 70vh"></div>
             <span id="ramp-version"></span>
 
             <div id="def-preFooter">

--- a/demos/index-teleport.html
+++ b/demos/index-teleport.html
@@ -52,7 +52,7 @@
             <h1 style="text-align: center">RAMP Teleportation Magic</h1>
             <div id="form">
                 <div id="ramp-instance"></div>
-                <div class="ramp-app" id="grid"></div>
+                <div class="ramp-styles" id="grid"></div>
             </div>
         </div>
 

--- a/docs/app/panels.md
+++ b/docs/app/panels.md
@@ -309,7 +309,7 @@ fixtures: {
 
 Some other important things to note include:
 
-* In order to get the regular panel styling, you will need to add the `ramp-app` class to your target element. Otherwise, things are likely to look funny.
+* In order to get the regular panel styling, you will need to add the `ramp-styles` class to your target element. Otherwise, things are likely to look funny.
 * Teleported panels by have the `focus-container` directive removed by default. If you wish to add this directive back, you can add the `inner-shell` class to your target element.
 * Unlike regular panels, teleported panels will always take up the full width of the target element. Therefore, it is not recommended to teleport multiple panels into one container.
 

--- a/src/app.vue
+++ b/src/app.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="ramp-app animation-enabled" :lang="$i18n.locale">
+    <div class="ramp-app ramp-styles animation-enabled" :lang="$i18n.locale">
         <div class="h-full" ref="app-size">
             <shell></shell>
         </div>
@@ -49,7 +49,7 @@ $font-list: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica
     Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 @use 'directives/focus-list/focus-list';
 
-.ramp-app {
+.ramp-styles {
     @include focus-list.default-focused-styling;
     height: 100%;
     font-family: $font-list;

--- a/src/fixtures/legend/components/symbology-stack.vue
+++ b/src/fixtures/legend/components/symbology-stack.vue
@@ -97,10 +97,10 @@ onMounted(() => {
         transform-origin: bottom center;
     }
 }
-.ramp-app.animation-enabled .symbol-0 {
+.ramp-styles.animation-enabled .symbol-0 {
     transition-duration: 0.2s;
 }
-.ramp-app.animation-enabled .symbol-2 {
+.ramp-styles.animation-enabled .symbol-2 {
     transition-duration: 0.2s;
 }
 </style>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,4 @@
-.ramp-app {
+.ramp-styles {
     @tailwind base;
     @tailwind components;
     @tailwind utilities;
@@ -17,7 +17,7 @@
     }
 }
 
-.ramp-app {
+.ramp-styles {
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
         Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
     font-size: 16px;
@@ -25,18 +25,18 @@
     word-wrap: break-word;
 }
 
-.ramp-app button:focus {
+.ramp-styles button:focus {
     outline: 2px solid black;
 }
 
 /* Change ag-grid theme default font (Roboto) to match the rest of the page. */
-.ramp-app .ag-theme-material * {
+.ramp-styles .ag-theme-material * {
     font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
         Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }
 
 /* styling for rectangle when Shift+Left-click+Drag zooming */
-.ramp-app .esri-zoom-box__container {
+.ramp-styles .esri-zoom-box__container {
     position: absolute;
     top: 0;
     left: 0;
@@ -44,16 +44,16 @@
     bottom: 0;
 }
 
-.ramp-app .esri-zoom-box__overlay {
+.ramp-styles .esri-zoom-box__overlay {
     width: 100%;
     height: 100%;
 }
 
-.ramp-app .esri-zoom-box__overlay-background {
+.ramp-styles .esri-zoom-box__overlay-background {
     fill: rgba(0, 0, 0, 0.1);
 }
 
-.ramp-app .esri-zoom-box__outline {
+.ramp-styles .esri-zoom-box__outline {
     fill: transparent;
     stroke: #1e90ff;
     stroke-dasharray: 1, 1;


### PR DESCRIPTION
### Related Item
#1730

### Changes
- Tailwind styles are now scoped under the `ramp-styles` class instead of the `ramp-app` class for the reasons mentioned in the issue.

### Testing
- Ensure all styling works the same as before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1782)
<!-- Reviewable:end -->
