### PR TITLE
sublayer picker size

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -97,6 +97,7 @@
             <div class="relative mb-0.5" data-type="select">
                 <div v-if="multiple">
                     <select
+                        :size="selectSize()"
                         class="block border-solid border-gray-300 w-full p-3 overflow-y-auto"
                         multiple
                         v-model="selected"
@@ -190,7 +191,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import type { InstanceAPI } from '@/api';
+import { inject, ref } from 'vue';
 import type { PropType } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -206,6 +208,7 @@ interface SelectionOption {
 }
 
 const { t } = useI18n();
+const iApi = inject('iApi') as InstanceAPI;
 
 const emit = defineEmits([
     'update:modelValue',
@@ -323,6 +326,16 @@ const checkMultiSelectError = (selected: Array<any>) => {
     selected && selected.length > 0
         ? (sublayersError.value = false)
         : (sublayersError.value = true);
+};
+
+const selectSize = () => {
+    // calculates number of visible entries in multi-select list
+    const selectHeight =
+        iApi.$vApp.$el.querySelector('.stepper')?.clientHeight! - 400;
+    return Math.min(
+        props.options.length,
+        Math.max(Math.floor(selectHeight / 30), 3)
+    );
 };
 </script>
 

--- a/src/fixtures/wizard/stepper.vue
+++ b/src/fixtures/wizard/stepper.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="py-12">
+    <div class="py-12 h-full stepper">
         <slot></slot>
     </div>
 </template>

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -208,7 +208,7 @@ export class LayerSource extends APIScope {
                 const level = calculateLevel(layer, layers);
 
                 layer.level = level;
-                layer.indent = Array.from(Array(level)).fill('-').join('');
+                layer.indent = Array.from(Array(level)).fill('- ').join('');
                 layer.index = layer.id;
 
                 return layer;
@@ -312,7 +312,7 @@ export class LayerSource extends APIScope {
                 [],
                 layers.map((layer: any) => {
                     layer.level = level;
-                    layer.indent = Array.from(Array(level)).fill('-').join('');
+                    layer.indent = Array.from(Array(level)).fill('- ').join('');
                     layer.id = layer.name;
 
                     if (layer.layers.length > 0) {


### PR DESCRIPTION
### Related Item(s)
#1779

### Changes
- Wizard sublayer picker now sizes according to panel height
- Added extra spacing to emphasize nested sublayers 

### Notes
![Screenshot 2023-07-04 134245](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/89807997/b25fb933-2170-415c-b42e-0768fe6fb2f5)

### Testing
Steps:
1. Add layers with different number of sublayers (examples with [39 layers](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer) and [2 layers](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/CanadaThings/MapServer))
2. Resize the window to observe the changes. Note that because of the way select lists are styled, the size only adapts on refreshing the component, so simply going back a step and then proceeding will show the change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1784)
<!-- Reviewable:end -->
