### PR TITLE
fix duplicate sublayers appearing when filtering

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -109,12 +109,12 @@
                     >
                         <option
                             class="p-6"
-                            v-for="option in options.filter(o =>
+                            v-for="(option, idx) in options.filter(o =>
                                 o.label
                                     .toLowerCase()
                                     .includes(filter.toLowerCase().trim())
                             )"
-                            v-bind:key="option.label"
+                            :key="`${option.label}-${idx}`"
                             :value="option.value"
                         >
                             {{ option.label }}


### PR DESCRIPTION
### Related Item(s)
#1785 

### Changes
- When filtering sublayers in the wizard, entries will no longer duplicate and will disappear properly when the filter is cleared

### Notes
![](https://i.imgur.com/UfudZEP.gif)

### Testing
Steps:
1. Click the `Add Layer` button
2. Use the following URL to import a layer and click continue: https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer
3. Click continue again (ensure ESRI Map Image Layer is selected, it should be by default)
4. Try to filter a few sublayers on the next screen (enter things like `basin`, `emissions`, etc.) and ensure that nothing is duplicated (NOTE: `Basin Borders` and `River Basin Labels` have two entries, so they should appear twice. Ensure they don't appear more than that though)
5. Try to clear the filter and ensure the list doesn't have any new duplicates

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1788)
<!-- Reviewable:end -->
