### PR TITLE
add word-wrapping to wizard sublayer picker

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -109,7 +109,7 @@
                         "
                     >
                         <option
-                            class="p-6"
+                            class="p-6 whitespace-pre-wrap"
                             v-for="(option, idx) in options.filter(o =>
                                 o.label
                                     .toLowerCase()
@@ -118,7 +118,9 @@
                             :key="`${option.label}-${idx}`"
                             :value="option.value"
                         >
-                            {{ option.label }}
+                            <span class="whitespace-pre-wrap">{{
+                                option.label
+                            }}</span>
                         </option>
                     </select>
                     <div class="text-gray-400 text-xs mb-1">{{ help }}</div>
@@ -329,13 +331,35 @@ const checkMultiSelectError = (selected: Array<any>) => {
 };
 
 const selectSize = () => {
-    // calculates number of visible entries in multi-select list
-    const selectHeight =
-        iApi.$vApp.$el.querySelector('.stepper')?.clientHeight! - 400;
-    return Math.min(
-        props.options.length,
-        Math.max(Math.floor(selectHeight / 30), 3)
-    );
+    // Slight delay before running to ensure the component has been loaded and populated
+    setTimeout(() => {
+        // calculates number of visible entries in multi-select list
+        const selectHeight =
+            iApi.$vApp.$el.querySelector('.stepper')?.clientHeight! - 400;
+
+        // Find the sublayer selector
+        const sublayerSelector =
+            iApi.$vApp.$el.querySelectorAll('.stepper select')[1];
+
+        // determine the height of the largest entry
+        const sublayerList: HTMLElement[] = Array.from(
+            sublayerSelector.children
+        );
+
+        const maxElementHeight: number = Math.max(
+            ...sublayerList.map((item: any) => {
+                return item.clientHeight;
+            })
+        );
+
+        // determine how many options to display based on the largest option
+        sublayerSelector.size = Math.min(
+            props.options.length,
+            Math.max(Math.floor(selectHeight / maxElementHeight), 2)
+        );
+    }, 300);
+
+    return 0;
 };
 </script>
 


### PR DESCRIPTION
### Related Item(s)
#1790 

### Changes
- entries in the wizard sublayer picker will now wrap to the next line if they are too long

### Notes
![](https://camo.githubusercontent.com/45debe327a0cca3c23fba9b725d7ea0165b9c802d167b9c6bbb218163e54d32d/68747470733a2f2f692e696d6775722e636f6d2f717044656a4f682e676966)

### Testing
Steps:
1. Click the Add Layer button
2. Use the following URL to import a layer and click continue: https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer
3. Click continue again (ensure ESRI Map Image Layer is selected, it should be by default)
4. Sublayer entries should now wrap to new lines instead of being cut-off

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1791)
<!-- Reviewable:end -->
