### PR TITLE
Grid Custom Cell Template

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -231,6 +231,14 @@
                 ><span class="tag legend">Exclusive Set</span
                 ><span class="tag legend">Info Sections</span>
             </li>
+            <li>
+                40.
+                <a href="index-samples.html?sample=40"
+                    >Grid Custom Cell Template</a
+                >. Contains a layer with a grid that has a custom cell template
+                for some columns.
+                <span class="tag misc">Datatable</span>
+            </li>
         </ul>
 
         <h2>Simple Samples</h2>
@@ -313,7 +321,9 @@
                 <a href="index-wet.html">RAMP inside the WET template</a>
             </li>
             <li>
-                <a href="index-teleport-wet.html">RAMP inside the WET template with teleport enabled</a>
+                <a href="index-teleport-wet.html"
+                    >RAMP inside the WET template with teleport enabled</a
+                >
             </li>
         </ul>
     </body>

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -94,6 +94,9 @@
                     <option value="custom-store">37. Custom Store</option>
                     <option value="merge-grid">38. Merge Grid</option>
                     <option value="old-main">39. Old Default Sample</option>
+                    <option value="grid-custom-template">
+                        40. Grid Custom Cell Template
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/grid-custom-template.js
+++ b/demos/starter-scripts/grid-custom-template.js
@@ -1,0 +1,152 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    }
+                ],
+                lodSets: [
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'esriImagery',
+                        tileSchemaId: 'DEFAULT_ESRI_World_AuxMerc_3857',
+                        layers: [
+                            {
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ]
+                    }
+                ],
+                initialBasemapId: 'esriImagery'
+            },
+            layers: [
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca/collections/hydrometric-stations/items?startindex=6000',
+                    xyInAttribs: true,
+                    colour: '#FF5555',
+                    customRenderer: {},
+                    fixtures: {
+                        grid: {
+                            title: 'Datatable for WFS features',
+                            columns: [
+                                {
+                                    field: 'links',
+                                    title: 'Links',
+                                    width: 600,
+                                    template: 'links-template'
+                                },
+                                {
+                                    field: 'STATION_NAME',
+                                    title: 'Station Name',
+                                    template: 'station-name-template'
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                layerId: 'WFSLayer',
+                                name: 'WFSLayer'
+                            },
+                            {
+                                infoType: 'text',
+                                content:
+                                    "The above layer's grid has custom templating for the links and station name columns."
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: ['legend']
+                },
+                mapnav: { items: ['fullscreen', 'legend', 'home', 'basemap'] }
+            },
+            system: {
+                exposeOid: true
+            }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: false,
+    loadDefaultEvents: true
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+rInstance.fixture
+    .addDefaultFixtures([
+        'mapnav',
+        'legend',
+        'appbar',
+        'grid',
+        'details',
+        'wizard'
+    ])
+    .then(() => {
+        rInstance.panel.open('legend');
+    });
+
+rInstance.$element.component('links-template', {
+    props: ['params'],
+    mounted() {},
+    template: `<div class="my-4" v-focus-list >
+        <p v-for="(val, idx) in JSON.parse(params.value)" :key="idx" class="whitespace-pre-wrap leading-none mb-8">
+            <a v-focus-item target="_blank" :href="val.href">{{ val.title }}</a>
+        </p>
+    </div>`
+});
+
+rInstance.$element.component('station-name-template', {
+    props: ['params'],
+    template: `
+        <div class="mb-8">
+            <span>Surprise!</span>
+            <img src="https://i.imgur.com/WtY0tdC.gif" />
+        </div>
+    `
+});
+
+window.debugInstance = rInstance;

--- a/docs/app/grid.md
+++ b/docs/app/grid.md
@@ -112,6 +112,7 @@ Every column in the datagrid can be configured separately.
     - `min: string | number`, specifies the default lower bound filter value for number and date types
     - `max: string | number`, specifies the default upper bound filter value for number and date types
     - `static: boolean`, enables/disables filter input
+- `template: string`, specifies a custom Vue component name to use as the cell renderer for the column. Does not apply to the OBJECTID column.
 
 An example of a datatable with a single configured column is below
 

--- a/schema.json
+++ b/schema.json
@@ -1873,6 +1873,10 @@
                 },
                 "filter": {
                     "$ref": "#/$defs/filter"
+                },
+                "template": {
+                    "type": "string",
+                    "description": "Custom Vue component name to render as cell renderer."
                 }
             },
             "unevaluatedProperties": false

--- a/src/fixtures/grid/store/column-state-manager.ts
+++ b/src/fixtures/grid/store/column-state-manager.ts
@@ -17,6 +17,7 @@ export default class ColumnStateManager {
             max: columnConfig?.filter?.max ?? null,
             static: columnConfig?.filter?.static ?? false
         };
+        this._template = columnConfig.template ?? '';
     }
 
     /**
@@ -135,6 +136,18 @@ export default class ColumnStateManager {
     set filter(val) {
         this._filter = val;
     }
+
+    /**
+     * Sets the vue template of the column
+     * @memberof ColumnStateManager
+     */
+    set template(val: string) {
+        this._template = val;
+    }
+
+    get template(): string {
+        return this._template;
+    }
 }
 
 export default interface ColumnStateManager {
@@ -146,4 +159,5 @@ export default interface ColumnStateManager {
     _sort: string;
     _searchable: boolean;
     _filter: any;
+    _template: string;
 }

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -418,6 +418,7 @@ export interface ColumnDefinition {
     isSelector: boolean;
     lockPosition: boolean;
     suppressHeaderKeyboardEvent: Function;
+    autoHeight?: boolean;
 }
 // column definition for specialized columns (index, symbols, etc.)
 export interface SpecialColumnDefinition {
@@ -1463,15 +1464,23 @@ const setUpColumns = () => {
                         if (NUM_TYPES.indexOf(fieldInfo!.type) > -1) {
                             setUpNumberFilter(col, config.value.state);
                             col.filter = 'agNumberColumnFilter';
-                            col.cellRenderer = CellRendererV;
+                            col.autoHeight = true;
+                            col.cellRenderer =
+                                colConfig.template === ''
+                                    ? CellRendererV
+                                    : iApi.component(colConfig.template);
                             col.cellRendererParams = {
                                 type: 'number'
                             };
                         } else if (fieldInfo!.type === FieldType.DATE) {
                             setUpDateFilter(col, config.value.state);
                             col.filter = 'agDateColumnFilter';
+                            col.autoHeight = true;
                             col.minWidth = 400;
-                            col.cellRenderer = CellRendererV;
+                            col.cellRenderer =
+                                colConfig.template === ''
+                                    ? CellRendererV
+                                    : iApi.component(colConfig.template);
                             col.cellRendererParams = {
                                 type: 'date'
                             };
@@ -1487,7 +1496,11 @@ const setUpColumns = () => {
                                 setUpTextFilter(col, config.value.state);
                             }
                             col.filter = 'agTextColumnFilter';
-                            col.cellRenderer = CellRendererV;
+                            col.autoHeight = true;
+                            col.cellRenderer =
+                                colConfig.template === ''
+                                    ? CellRendererV
+                                    : iApi.component(colConfig.template);
                             col.cellRendererParams = {
                                 type: 'string'
                             };

--- a/src/geo/layer/file-utils.ts
+++ b/src/geo/layer/file-utils.ts
@@ -536,7 +536,9 @@ export class FileUtils extends APIScope {
                         typeof gr.attributes[attName] === 'object') &&
                     gr.attributes[attName] != null
                 ) {
-                    gr.attributes[attName] = '[Complex Value Removed]';
+                    gr.attributes[attName] = JSON.stringify(
+                        gr.attributes[attName]
+                    );
                 }
             });
         });


### PR DESCRIPTION
### Related Item(s)
#1786

### Changes
- Added custom cell templating for the grid. The template is configured on a per column basis rather than across all columns. [Sample 40](https://ramp4-pcar4.github.io/ramp4-pcar4/1786/demos/index-samples?sample=40) shows this off in the station name and links columns.

### Notes
* One point to consider is accessibility. For example, our current accessibility handler causes the first link to be clicked when you press enter on the cell in the links column, and you can't navigate through all the links. Are we changing anything about our internal event handlers, or are we relying on the template author to add event listeners and define their own custom behaviour? Being an accessibility noob, I was not sure what to do so I left as is.
* Another point is big templates cause the grid to expand. Are we ok with this? Perhaps we leave it up to template author to add some sort of expand/collapse toggle?

GIF for QA team:
![grid-template](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/76517921/c9a9e7dc-b261-4465-a1fb-a853b00a0cf4)

### Testing
Steps:
1. Go to the new [sample 40](https://ramp4-pcar4.github.io/ramp4-pcar4/1786/demos/index-samples?sample=40).
2. Open the grid.
3. Witness the magic in the links and station name columns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1793)
<!-- Reviewable:end -->
