### PR TITLE
Fix details toggle bug

### DIFF
--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -82,7 +82,10 @@ export class DetailsAPI extends FixtureInstance {
         );
         const prevFeatureId = this.detailsStore.currentFeatureId;
         const currFeatureId = `${featureData.uid}-${
-            featureData.data[layer?.oidField ?? '']
+            // see https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1767 for the reasoning behind this
+            layer?.supportsFeatures
+                ? featureData.data[layer?.oidField ?? '']
+                : JSON.stringify(featureData.data)
         }`;
         this.detailsStore.currentFeatureId = featureData.data
             ? currFeatureId


### PR DESCRIPTION
### Related Item(s)
#1767

### Changes
- Went with the option 2 fix described in the issue: 
> If the incoming layer has supportsFeatures as false, stringify the featureData.data value as the currentFeatureId. This could be large but our store only tracks one at a time.
- Fixed a bug where the CCCS template would not update correctly when a different feature was toggled on while a feature was already being shown.


### Testing
Steps:
1. Go to [sample 25](https://ramp4-pcar4.github.io/ramp4-pcar4/1767/demos/index-samples?sample=25).
2. To setup testing, copy the code block below in the console.

```JS
const f1 = {
  uid: debugInstance.geo.layer.allActiveLayers()[0].uid,
  data: {
    data: {
      type: "FeatureCollection",
      layer: "DCS.TX.RCP45.YEAR.2081-2100_PCTL50",
      features: [
        {
          type: "Feature",
          id: "1134719.5/-529104.66",
          geometry: {
            type: "Point",
            coordinates: [
              -95.00111098018482,
              49.00038852404642
            ]
          },
          properties: {
            value: "3.1395652"
          }
        }
      ]
    },
    httpStatus: 200,
    requestOptions: {
      query: {
        CRS: "EPSG:3978",
        I: 649,
        J: 695,
        STYLES: "",
        FORMAT: "image/png",
        BBOX: "-4022897.663830328,-2391568.381889764,4890932.663830328,4990321.381889764",
        SERVICE: "WMS",
        REQUEST: "GetFeatureInfo",
        VERSION: "1.3.0",
        WIDTH: 1123,
        HEIGHT: 930,
        QUERY_LAYERS: "DCS.TX.RCP45.YEAR.2081-2100_PCTL50",
        LAYERS: "DCS.TX.RCP45.YEAR.2081-2100_PCTL50",
        INFO_FORMAT: "application/json"
      },
      responseType: "json"
    },
    ssl: false,
    url: "https://geo.weather.gc.ca/geomet-climate"
  },
  format: "json"
}

const f2 = {
  uid: debugInstance.geo.layer.allActiveLayers()[0].uid,
  data: {
    data: {
      type: "FeatureCollection",
      layer: "DCS.TX.RCP45.YEAR.2081-2100_PCTL50",
      features: [
        {
          type: "Feature",
          id: "482688.46/2554875.7",
          geometry: {
            type: "Point",
            coordinates: [
              100,100
            ]
          },
          properties: {
            value: "3.6415343"
          }
        }
      ]
    },
    httpStatus: 200,
    requestOptions: {
      query: {
        CRS: "EPSG:3978",
        I: 567,
        J: 306,
        STYLES: "",
        FORMAT: "image/png",
        BBOX: "-4022897.663830328,-2391568.381889764,4890932.663830328,4990321.381889764",
        SERVICE: "WMS",
        REQUEST: "GetFeatureInfo",
        VERSION: "1.3.0",
        WIDTH: 1123,
        HEIGHT: 930,
        QUERY_LAYERS: "DCS.TX.RCP45.YEAR.2081-2100_PCTL50",
        LAYERS: "DCS.TX.RCP45.YEAR.2081-2100_PCTL50",
        INFO_FORMAT: "application/json"
      },
      responseType: "json"
    },
    ssl: false,
    url: "https://geo.weather.gc.ca/geomet-climate"
  },
  format: "json"
}

const detailsAPI = debugInstance.fixture.get('details')
```
3. Now, try toggling the two features by alternately using the two lines of code below.
```JS
detailsAPI.toggleFeature(f1)
detailsAPI.toggleFeature(f2)
```
Notice that the details panel updates correctly.

You can also feel free to build your own test by getting two (or more) different features from a WMS layer (by console logging identify results) and then toggling between the features.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1805)
<!-- Reviewable:end -->
