### PR TITLE
Fix adding WMS layer via wizard

### DIFF
--- a/src/fixtures/details/templates/html-default.vue
+++ b/src/fixtures/details/templates/html-default.vue
@@ -2,7 +2,7 @@
     <div
         class="whitespace-pre-wrap break-words h-full overflow-auto"
         v-if="identifyData"
-        v-html="identifyData.data"
+        v-html="identifyData.data.data ?? identifyData.data"
     ></div>
     <div v-else>{{ t('details.layers.results.empty') }}</div>
 </template>

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -590,7 +590,12 @@ const latLonOptions = (fieldName: 'lat' | 'lon') => {
 const sublayerOptions = () => {
     return layerInfo.value?.layers!.map((layer: any, idx: number) => {
         return {
-            label: `${layer.indent}${layer.name}`,
+            // set sublayer option properties based on whether its a map image or WMS layer
+            label: `${layer.indent}${
+                typeSelection.value === LayerType.MAPIMAGE
+                    ? layer.name
+                    : layer.title
+            }`,
             value:
                 typeSelection.value === LayerType.MAPIMAGE
                     ? {

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -308,7 +308,7 @@ export class LayerSource extends APIScope {
         };
 
         function flattenWmsLayerList(layers: any, level = 0) {
-            const layerList = [
+            return [].concat.apply(
                 [],
                 layers.map((layer: any) => {
                     layer.level = level;
@@ -330,8 +330,7 @@ export class LayerSource extends APIScope {
                         return layer.id ? layer : [];
                     }
                 })
-            ];
-            return [].concat(...layerList);
+            );
         }
     }
 

--- a/src/geo/layer/ogc-utils.ts
+++ b/src/geo/layer/ogc-utils.ts
@@ -247,8 +247,12 @@ export class OgcUtils extends APIScope {
                         }
                     });
                 }
+
                 return {
-                    name: nameNode ? nameNode : null,
+                    // typecast to string as number IDs need to be stringified in the wms sublayer config
+                    // TODO: What if this ends up being null? Does layer explode?
+                    // If yes, consider adding a warning or notification of some sort.
+                    name: nameNode?.toString() ?? null,
                     title: titleNode,
                     queryable: layer['@_queryable'] === '1',
                     layers: getLayers(layer),


### PR DESCRIPTION
### Related Item(s)
#1802 

### Changes
- Fixed adding WMS layer via the wizard.

### Testing
Use [this layer](http://geo.weather.gc.ca/geomet/?lang=E&service=WMS&request=GetCapabilities) or [this layer](http://maps.geogratis.gc.ca/wms/railway_en) for testing. Surprisingly, when you test with the [cam wms](https://section917.canadacentral.cloudapp.azure.com/arcgis/services/CAM/MapServer/WMSServer?request=GetCapabilities&service=WMS), the layer adds fine but nothing shows up on the map. However, if you do an identify request anywhere on the map, you get a hit for the layer. I'm blaming the service for this, but WMS experts can feel free to correct me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1809)
<!-- Reviewable:end -->
