### PR TITLE
Disable feature highlighting for layers that do not support features

### DIFF
--- a/demos/starter-scripts/cccs.js
+++ b/demos/starter-scripts/cccs.js
@@ -12,7 +12,8 @@ let config = {
         'wizard',
         'export',
         'basemap',
-        'layer-reorder'
+        'layer-reorder',
+        'hilight'
     ],
     configs: {
         en: {

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -15,7 +15,7 @@
                 <!-- highlight toggle -->
                 <div
                     class="p-8 mb-8 bg-gray-100 flex justify-between"
-                    v-if="details.hasHilighter()"
+                    v-if="details.hasHilighter() && supportsFeatures"
                 >
                     <div>{{ t('details.togglehilight.title') }}</div>
                     <Toggle
@@ -408,11 +408,13 @@ const itemChanged = () => {
                     : ''
             }`
         );
-        if (hilightToggle.value) {
+        if (hilightToggle.value && supportsFeatures.value) {
             details.value.hilightDetailsItems(
                 props.result.items[currentIdx.value],
                 props.result.uid
             );
+        } else if (!supportsFeatures.value) {
+            details.value.removeDetailsHilight();
         }
     } else {
         // wait for load.


### PR DESCRIPTION
### Related Item(s)
#1810

### Changes
- What the title says

### Testing
- On sample 26, ensure that doing an identify and opening the details panel hides the feature highlight toggle, and there are no errors in the console. Can also test on another WMS layer sample by adding the hilight fixture.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1813)
<!-- Reviewable:end -->
