### PR TITLE
Fix keyboard panel navigation

### DIFF
--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -3,12 +3,13 @@
         class="h-full flex flex-col items-stretch"
         :content="t('panels.access')"
         v-tippy="{
-            trigger: 'focus',
-            appendTo: 'parent',
+            trigger: 'manual',
             onShow: checkMode,
             popperOptions: {
+                placement: 'top',
                 modifiers: [
-                    { name: 'preventOverflow', options: { altAxis: true } }
+                    { name: 'preventOverflow', options: { altAxis: true } },
+                    { name: 'flip', options: { fallbackPlacements: ['top'] } }
                 ]
             }
         }"
@@ -77,7 +78,14 @@
 
 <script setup lang="ts">
 import type { InstanceAPI, PanelInstance } from '@/api';
-import { computed, inject, nextTick, ref } from 'vue';
+import {
+    computed,
+    inject,
+    nextTick,
+    onBeforeUnmount,
+    onMounted,
+    ref
+} from 'vue';
 import type { PropType } from 'vue';
 import { usePanelStore } from '@/stores/panel';
 import { useI18n } from 'vue-i18n';
@@ -87,7 +95,7 @@ const { t } = useI18n();
 const panelStore = usePanelStore();
 const appbarStore = useAppbarStore();
 const iApi = inject<InstanceAPI>('iApi');
-const el = ref<Element>();
+const el = ref<HTMLElement>();
 
 const props = defineProps({
     // prop indicating if the `header` slot should be rendered
@@ -127,6 +135,30 @@ const move = (direction: string) => {
         });
     }
 };
+
+onMounted(() => {
+    el.value?.addEventListener('blur', () => {
+        (el.value as any)._tippy.hide();
+    });
+
+    el.value?.addEventListener('keyup', (e: KeyboardEvent) => {
+        if (e.key === 'Tab' && el.value?.matches(':focus')) {
+            (el.value as any)._tippy.show();
+        }
+    });
+});
+
+onBeforeUnmount(() => {
+    el.value?.removeEventListener('blur', () => {
+        (el.value as any)._tippy.hide();
+    });
+
+    el.value?.removeEventListener('keyup', (e: KeyboardEvent) => {
+        if (e.key === 'Tab' && el.value?.matches(':focus')) {
+            (el.value as any)._tippy.show();
+        }
+    });
+});
 </script>
 
 <style lang="scss" scoped></style>

--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -114,11 +114,7 @@ class FocusContainerManager {
             return;
         }
         if (event.key === KEYS.Enter || event.key === KEYS.Space) {
-            this.enableTabbing();
-            const first_tabbable_item = this.element.querySelector(
-                TABBABLE_TAGS
-            ) as HTMLElement;
-            first_tabbable_item.focus();
+            this.enableTabbing().focus();
         }
     }
 
@@ -164,9 +160,12 @@ class FocusContainerManager {
     }
 
     /**
-     * Sets tabindex to 0 for every VISIBLE element not under a different focus container or list
+     * Sets tabindex to 0 for every VISIBLE element not under a different focus container or list.
+     * 
+     * @return {HTMLElement} the first valid element
      */
     enableTabbing() {
+        let first_tabbable_item: any = undefined;
         Array.prototype.map.call(
             this.element.querySelectorAll(TABBABLE_TAGS),
             el => {
@@ -179,8 +178,12 @@ class FocusContainerManager {
                     !!el.offsetParent
                 ) {
                     el.tabIndex = 0;
+                    if (first_tabbable_item === undefined) {
+                        first_tabbable_item = el;
+                    }
                 }
             }
         );
+        return first_tabbable_item;
     }
 }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -30,7 +30,7 @@ notifications.controls.dismiss,Dismiss,1,Rejeter,1
 notifications.controls.expand,Expand,1,Développer,1
 notifications.controls.collapse,Collapse,1,Réduire,1
 notifications.controls.clearAll,Clear All,1,Effacer tout,1
-panels.access,Access the panel,1,Accéder à la fenêtre,1
+panels.access,Press enter or space to access the panel,1,Appuyez sur Entrée ou Espace pour accéder au panneau,0
 panels.controls.close,Close,1,Fermer,1
 panels.controls.pin,Pin,1,Épingler,1
 panels.controls.unpin,Unpin,1,Désépingler,1


### PR DESCRIPTION
### Related Item(s)
#1814 

### Changes
- Tooltip now appears when tabbing to a panel
- Focus now moves to the first element on enter or space press


### Testing
Steps:
1. Open a panel and press tab until your focused on it, notice how tooltip appears now
2. Press enter or space to see the focus shift to the first available element in the panel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1821)
<!-- Reviewable:end -->
