### PR TITLE
Resolve layer reload issue

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -515,9 +515,9 @@ const layerCols = ref<{
 const origLayerIds = ref(gridStore.grids[props.gridId].layerIds);
 const gridLayers = computed(() => {
     if (gridStore.grids[props.gridId]) {
-        return gridStore.grids[props.gridId].layerIds.map(
-            id => iApi.geo.layer.getLayer(id) as LayerInstance
-        );
+        return gridStore.grids[props.gridId].layerIds
+            .map(id => iApi.geo.layer.getLayer(id) as LayerInstance)
+            .filter(layer => layer !== undefined);
     } else return [];
 });
 const oidCols = ref<Set<string>>(new Set<string>());
@@ -1245,13 +1245,11 @@ const getAttrPair = (
 };
 
 const setUpColumns = () => {
-    const fancyLayers: LayerInstance[] = gridLayers.value
-        .map(layer => {
-            if (layer.supportsFeatures && layer.isLoaded) {
-                return layer;
-            }
-        })
-        .filter(fl => fl !== undefined) as LayerInstance[];
+    const fancyLayers: LayerInstance[] = gridLayers.value.map(layer => {
+        if (layer.supportsFeatures && layer.isLoaded) {
+            return layer;
+        }
+    }) as LayerInstance[];
 
     if (fancyLayers.length === 0) {
         // in the event of error'd layers, otherwise a blank datagrid will appear


### PR DESCRIPTION
### Related Item(s)
#1824 #1835

### Changes
- [FIX] Layers that had already been removed were being returned as undefined from gridLayers. This is expected as getLayer returns undefined if the layer is not found. The supportsFeatures property was then being called on an undefined layer instance thus the 💥.

### Notes
I opted to just filter the undefined layers out of gridLayers as similar behaviour is seen in setUpColumns (line 1254). It may be best to remove the layerId from the grid before its fetched by gridLayers, but I could be wrong. Wanted some extra big 🧠 opinions on this one. 

### Testing
1824 Steps:
1. Open sample 21
2. Open the Water grid
3. `debugInstance.reload();` in the console
4. No 💥 

1835 Steps:
1. Open sample 1
2. Open the WFSLayer grid
3. Switch the language
4. No 💥

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1836)
<!-- Reviewable:end -->
