### PR TITLE
Remove language prefix for unofficial translations

### DIFF
--- a/scripts/vite-plugin-i18n.ts
+++ b/scripts/vite-plugin-i18n.ts
@@ -19,7 +19,6 @@ export default function vueI18nPlugin(): Plugin {
             if (!/lang\.csv/.test(id)) return;
 
             const valueField = 'Value';
-            const validField = 'Valid';
             const res: CsvRows = csvParse(
                 src
                     .replace('export default "', '')
@@ -41,11 +40,7 @@ export default function vueI18nPlugin(): Plugin {
             // fold parsed CSV into the messages object
             res.reduce((map, item) => {
                 locales.forEach(({ lang, column }) => {
-                    // prepend language code to the strings that are not yet confirmed
-                    map[lang][item.key] =
-                        (parseInt(item[`${lang}${validField}`])
-                            ? ''
-                            : `[${lang}] `) + item[column];
+                    map[lang][item.key] = item[column];
                 });
 
                 return map;


### PR DESCRIPTION
### Related Item(s)
#1830

### Changes
- Removed language prefix for unofficial translations. For example, if "bonjour" was an unofficial translation, it will now appear as "bonjour" instead of "[fr] bonjour".

### Testing
Steps:
1. Open sample 38.
2. Switch to French language.
3. Open the homogenous merge grid.
4. Then, open the notifications and ensure that the "Vous tentez d'utiliser..." notification does not have [fr] at the front. 
5. Can also be tested by examining the grid copy tooltip.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1837)
<!-- Reviewable:end -->
