### PR TITLE
include layer name in tile layer mismatch warning

### DIFF
--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -76,7 +76,9 @@ export class TileLayer extends CommonLayer {
         if (!mapSR.isEqual(layerSR)) {
             this.$iApi.notify.show(
                 NotificationType.WARNING,
-                this.$iApi.$i18n.t('layer.mismatch', { id: this.id })
+                this.$iApi.$i18n.t('layer.mismatch', {
+                    name: this.name || this.id
+                })
             );
         }
     }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -47,6 +47,6 @@ panels.alert.minimize,{name} panel minimized,1,Fenêtre {name} réduite,1
 layer.error,{id} failed to load,1,Échec du chargement de {id},1
 layer.longload,{id} is taking longer than expected to load,1,Le chargement de {id} met plus de temps que prévu,1
 layer.longdraw,{id} is taking longer than expected to draw,1,{id} prend plus de temps que prévu à extraire,1
-layer.mismatch,{id} cannot be displayed in the current projection,1,{id} ne peut pas être affiché dans la projection actuelle,0
+layer.mismatch,{name} cannot be displayed in the current projection,1,{name} ne peut pas être affiché dans la projection actuelle,0
 layer.filtersdisabled,Filters have been disabled for {name},1,Les filtres ont été désactivés par {name},0
 layer.filterwarning,You are attempting to use a merge grid that contains unmodifiable layers. Filtering will be partially disabled,1,Vous tentez d'utiliser une grille de fusion contenant des calques non modifiables. Le filtrage sera partiellement désactivé,0


### PR DESCRIPTION
### Related Item(s)
#1826 

### Changes
- The tile layer mismatch notification will now display the layer name instead of the layer ID if it is available

### Testing
Steps:
1. Open sample 1.
2. Add [this layer](https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer) via the wizard.
3. Notice that the warning that pops up in the notification section shows the layer name instead of the layer ID.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1839)
<!-- Reviewable:end -->
