### PR TITLE
Grid/Map parity

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1040,8 +1040,7 @@ const filterToSql = (col: string, colFilter: { [key: string]: any }): any => {
                 // can change to MOST other characters and should still work (ideally want an escape char no one will search for) - just replace all instances of ௌ
                 newVal = newVal.replace(/%/g, 'ௌ%');
                 newVal = newVal.replace(/_/g, 'ௌ_');
-                const filterVal = `*${newVal}`;
-                newVal = filterVal.split(' ').join('*');
+                newVal = `*${newVal}`;
                 // if val contains a % or _, add ESCAPE 'ௌ' at the end of the query
                 let sqlWhere = `UPPER(${col}) LIKE \'${newVal
                     .replace(/\*/g, '%')


### PR DESCRIPTION
### Related Item(s)
#1829 

### Changes
- The grid filter applied to map now matches using an exact SQL string, instead of a per-word match, which is the same way the grid filters it's own entries
    -  For example, query string `the green` is converted to `LIKE '%THE GREEN%'` instead of `LIKE '%THE%GREEN%'`

### Testing
For a quick example where the map and grid would previously show different results
1. Add the [nature layer](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/6) via the wizard.
2. Enable 'Apply to map' in the datagrid
3. Filter the datagrid with 'the green' in the Name column

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1841)
<!-- Reviewable:end -->
