### PR TITLE
remove grab cursor from row numbers and disabled clear filters icon

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1628,7 +1628,9 @@ onBeforeUnmount(() => {
 </script>
 
 <style scoped>
-:deep(.ag-header-cell-sortable) {
+:deep(.ag-header-cell-sortable),
+:deep(.ag-pinned-left-header),
+:deep(.ag-pinned-left-cols-container) {
     cursor: default;
 }
 :deep(.ag-pinned-left-cols-container .ag-row) {

--- a/src/fixtures/grid/templates/clear-filter.vue
+++ b/src/fixtures/grid/templates/clear-filter.vue
@@ -1,7 +1,7 @@
 <template>
     <button
         type="button"
-        class="clearFilterButton flex items-center justify-center w-full h-full disabled:opacity-30 disabled:cursor-grab text-gray-500 hover:text-black"
+        class="clearFilterButton flex items-center justify-center w-full h-full disabled:opacity-30 disabled:cursor-default text-gray-500 hover:text-black"
         @click="clearFilters"
         :content="t('grid.filters.clear')"
         v-tippy="{ placement: 'bottom' }"


### PR DESCRIPTION
### Related Item(s)
#1828 

### Changes
- removes grab icon from disabled clear filters icon
- removes grab icon from the row number column

### Notes
I'm not sure how we want to address point 3 in the issue:
> 3. The hand scroll is now only horizontal, while vertical does text select.

A few ideas:
- If we don't like the grab function for mouse/keyboard it can be disabled and we can have users use the scroll bars to move.
- Since the user doesn't need to select text to copy it any more, maybe we can disable selecting and allow for vertical hand scrolling as well.
- We can leave it as it currently is.
- Any other ideas?

### Testing
Steps:
1. Open any data grid.
2. Hover over the row number column, notice that the grab cursor doesn't appear.
3. Hover over the disabled clear filter icon, notice that the grab cursor doesn't appear. Add a filter to one of the columns and notice it becomes a pointer as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1859)
<!-- Reviewable:end -->
