### PR TITLE
More layer API enhancements

### DIFF
--- a/docs/api-guides/layers.md
+++ b/docs/api-guides/layers.md
@@ -178,6 +178,7 @@ The `getLayer()` method will return layers on the map, layers that have failed, 
 var allGoodLayerArray = instanceApi.geo.layer.allActiveLayers();
 var errLayerArray = instanceApi.geo.layer.allErrorLayers();
 var initiatingLayerArray = instanceApi.geo.layer.allInitiatingLayers();
+var mapLayerArray = instanceApi.geo.layer.allLayersOnMap();
 var allLayerArray = instanceApi.geo.layer.allLayers();
 ```
 

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -17,7 +17,12 @@ import {
     WfsLayer,
     WmsLayer
 } from '@/api/internal';
-import { LayerControl, LayerType, type RampLayerConfig } from '@/geo/api';
+import {
+    LayerControl,
+    LayerState,
+    LayerType,
+    type RampLayerConfig
+} from '@/geo/api';
 import { useLayerStore } from '@/stores/layer';
 
 // this class represents the functions that exist on rampApi.geo.layer
@@ -114,10 +119,20 @@ export class LayerAPI extends APIScope {
     }
 
     /**
+     * Returns all layers that have initiated successfully and that have not errored.
+     * @returns {Array<LayerInstance>} all layers that have initiated and not errored
+     */
+    allActiveLayers(): Array<LayerInstance> {
+        return this.allLayersOnMap().filter(
+            l => l.layerState !== LayerState.ERROR
+        );
+    }
+
+    /**
      * Returns all layers currently on the map.
      * @returns {Array<LayerInstance>} all layers on the map
      */
-    allActiveLayers(): Array<LayerInstance> {
+    allLayersOnMap(): Array<LayerInstance> {
         return (
             (useLayerStore(this.$vApp.$pinia)
                 .layers as unknown as Array<LayerInstance>) || []
@@ -130,8 +145,14 @@ export class LayerAPI extends APIScope {
      */
     allErrorLayers(): Array<LayerInstance> {
         return (
-            (useLayerStore(this.$vApp.$pinia)
-                .penaltyBox as unknown as Array<LayerInstance>) || []
+            (
+                useLayerStore(this.$vApp.$pinia)
+                    .penaltyBox as unknown as Array<LayerInstance>
+            ).concat(
+                this.allLayersOnMap().filter(
+                    l => l.layerState === LayerState.ERROR
+                )
+            ) || []
         );
     }
 


### PR DESCRIPTION
### Related Item(s)
*#Item 1*, *#Item 2*

### Changes
- `allActiveLayers()` gives everything in an initiated and non error state.
- `allLayersOnMap()` gives the map stack, in order, including errored layers that still lurk in the map.
- `allErrorLayers()` now tells the truth, and gives you all the errored layers (before it would not give you errored layers on the map).
- Updated docs.

### Testing
1. Go to your favourite sample (sample 18 is a good choice as it includes a mix of loaded and errored layers).
2. Try out all the layer API methods via `debugInstance.geo.layer.myLayerAPIMethod()`.
3. Ensure that no lies are being told.
