### PR TITLE
Fix styling conflicts between RAMP and WET

### DIFF
--- a/src/fixtures/geosearch/bottom-filters.vue
+++ b/src/fixtures/geosearch/bottom-filters.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="rv-geosearch-bottom-filters">
         <div class="bg-white">
-            <label class="ml-8 cursor-pointer"
+            <label class="ml-8 cursor-pointer font-normal"
                 ><input
                     type="checkbox"
-                    class="form-checkbox border-2 mx-8 border-gray-600 cursor-pointer"
+                    class="border-2 mx-8 border-gray-600 cursor-pointer"
                     :checked="resultsVisible"
                     @change="
                         updateMapExtent(

--- a/src/fixtures/geosearch/top-filters.vue
+++ b/src/fixtures/geosearch/top-filters.vue
@@ -6,7 +6,7 @@
             class="w-fit inline-block sm:w-1/2 h-26 mb-8 sm:mb-0 pr-16 sm:pr-0"
         >
             <select
-                class="form-select border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
+                class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
                 :value="queryParams.province"
                 v-on:change="
                     setProvince({
@@ -29,7 +29,7 @@
         </div>
         <div class="sm:w-1/2 h-26 sm:mx-16 flex">
             <select
-                class="form-select border-b border-b-gray-600 w-full h-full py-0 cursor-pointer max-w-150"
+                class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer max-w-150"
                 :value="queryParams.type"
                 v-on:change="
                     setType({

--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -2,7 +2,7 @@
     <div class="relative" @mouseover.stop>
         <!-- TODO: see if getting this to use v-model works; children wouldnt update properly on initial try -->
         <input
-            type="checkbox"
+            :type="isRadio ? 'radio' : 'checkbox'"
             :aria-label="
                 t(
                     checked
@@ -16,7 +16,6 @@
             @keypress.enter.prevent
             @keyup.enter.stop="toggleVisibility()"
             :class="[
-                isRadio ? 'form-radio' : 'form-checkbox rounded-none',
                 disabled
                     ? 'text-gray-400 border-gray-300'
                     : 'text-black cursor-pointer border-gray-500 hover:border-black'

--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -39,7 +39,7 @@
             <label class="text-base font-bold">{{ label }}</label>
             <div class="mb-0.5" data-type="url">
                 <input
-                    class="text-sm w-full border-solid border-gray-300 mb-5 leading-5 focus:border-green-500"
+                    class="text-sm w-full border-solid border-gray-300 mb-5 focus:border-green-500"
                     type="url"
                     name="url"
                     :value="modelValue"

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8,6 +8,29 @@
         .ramp-markdown :not(table, td, img) {
             all: revert;
         }
+
+        [type='text'],
+        [type='email'],
+        [type='url'],
+        [type='password'],
+        [type='number'],
+        [type='date'],
+        [type='datetime-local'],
+        [type='month'],
+        [type='search'],
+        [type='tel'],
+        [type='time'],
+        [type='week'],
+        [multiple],
+        textarea,
+        select {
+            @apply text-base pt-8 pr-12 pb-8 pl-12 font-normal;
+        }
+
+        [type='checkbox'],
+        [type='radio'] {
+            @apply h-16 w-16;
+        }
     }
 
     @layer utilities {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -100,6 +100,8 @@ module.exports = {
             addVariant('md', '.md &');
             addVariant('lg', '.lg &');
         }),
-        require('@tailwindcss/forms')
+        require('@tailwindcss/forms')({
+            strategy: 'base' // only generate global styles
+        })
     ]
 };


### PR DESCRIPTION
### Related Item(s)
#1833, #1834

### Changes
- Overwrote all tailwind styling in RAMP that was using `rem` to use the equivalent value in `px`.
- Removed class styles from the `tailwindcss/forms` plugin as I felt that they were somewhat unnecessary, given that we already have global styles applied.
- Fixed incorrect font sizes and weights within RAMP in a WET template.

### Testing
Steps:
1. Open the WET sample.
2. Open the geosearch, grid, and wizard panels (can also test others for a sanity check but these three were the ones that I found were bugged).
3. Ensure that all styling looks like a non WET sample.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1871)
<!-- Reviewable:end -->
