### PR TITLE
Column re-ordering fix

### DIFF
--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -152,7 +152,7 @@ const moveLeft = (): void => {
             el.value
                 ?.closest('.ag-header-row')
                 ?.querySelectorAll('.ag-header-cell')
-                [index].querySelector('.move-left') as HTMLElement
+                [index - 2].querySelector('.move-left') as HTMLElement
         ).focus();
 
         props.params.api.ensureColumnVisible(allColumns[index]);


### PR DESCRIPTION
### Related Item(s)
#1827

### Changes
- [FIX] Removed code that applied focus to moved column

### Notes
This code wasn't working to begin with, for example if you moved index 5 to the left, the focus would be applied on index 6. I opted to remove this instead of fix it because moveRight doesn't include it. Do we want this focus to be applied?

### Testing
Steps:
1. Move the right-most column in view to the left (don't horizontally scroll the grid to the right prior to this)
2. The header no longer breaks once you horizontally scroll.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1872)
<!-- Reviewable:end -->
