### PR TITLE
Error Layers in grid

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1244,11 +1244,9 @@ const getAttrPair = (
 };
 
 const setUpColumns = () => {
-    const fancyLayers: LayerInstance[] = gridLayers.value.map(layer => {
-        if (layer.supportsFeatures && layer.isLoaded) {
-            return layer;
-        }
-    }) as LayerInstance[];
+    const fancyLayers: LayerInstance[] = gridLayers.value.filter(
+        layer => layer && layer.supportsFeatures && layer.isLoaded
+    ) as LayerInstance[];
 
     if (fancyLayers.length === 0) {
         // in the event of error'd layers, otherwise a blank datagrid will appear

--- a/src/geo/layer/data-layer.ts
+++ b/src/geo/layer/data-layer.ts
@@ -290,6 +290,6 @@ export class DataLayer extends CommonLayer {
      */
     downloadedAttributes(): number {
         // non-table data layer has downloaded everything after initialize.
-        return this.featureCount < 0 ? 0 : this.featureCount;
+        return this.featureCount;
     }
 }

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -112,7 +112,7 @@ export class LayerInstance extends APIScope {
     mapLayer: boolean;
 
     /**
-     * Feature count (-1 represents undefined / unknown)
+     * Feature count
      */
     featureCount: number;
 
@@ -258,7 +258,7 @@ export class LayerInstance extends APIScope {
         this.identifyMode = LayerIdentifyMode.NONE;
         this.supportsFeatures = false;
         this.mapLayer = true;
-        this.featureCount = -1;
+        this.featureCount = 0;
         this.fields = [];
         this.fieldList = '';
         this.nameField = '';

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -426,10 +426,10 @@ export class LayerAPI extends APIScope {
             // case where a non-server subclass ends up calling this via .super magic.
             // will avoid failed attempts at reading a non-existing service.
             // class should implement their own logic to load feature count (e.g. scrape from file layer)
-            console.warn(
+            console.error(
                 'A layer without a url attempted to run the server based feature count routine.'
             );
-            return -1;
+            return 0;
         }
 
         // TODO detect when we are in Raster Layer case? if we do this, we would need the caller of this
@@ -452,18 +452,25 @@ export class LayerAPI extends APIScope {
         // Throw console warnings, don't crash the app
         if (!serviceResult) {
             // case where service request was unsuccessful
-            console.warn(
+            console.error(
                 `Feature count request unsuccessful: ${serviceUrl}`,
                 err
             );
-            return -1;
+            return 0;
         }
         if (!serviceResult.data) {
             // case where service request was successful but no data appeared in result
-            console.warn(`Unable to load feature count: ${serviceUrl}`);
-            return -1;
+            console.error(`Unable to load feature count: ${serviceUrl}`);
+            return 0;
         }
 
-        return serviceResult.data.count;
+        if (Number.isInteger(serviceResult.data.count))
+            return serviceResult.data.count;
+        else {
+            console.error(
+                `Funny result (${serviceResult.data.count}) during feature count: ${serviceUrl}`
+            );
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
### Related Item(s)

Donethankses #1881

### Changes

- Stops `undefined` layers objects from being processed by the grid.
- Changes the layer count properties to no longer be `-1` in error states, as this would falsify merge grid row totals.
- Add extra check on feature count service call, on the chance something non-integer gets returned.

### Notes

Not actually sure what changed to cause this error. Looking at the code an error'd layer would always become an `undefined` (due to the `.map()` method), though in this case it was `undefined` in the grid store so the `map()` was irrelevant.

Will also open a new discussion Soon™ to figure out best way to deal with a failing feature count call. Something that has been ignored (since it rarely happens unless the service is dead and layer errors out before it can ask for feature counts).

### Testing

Main scenario:

1. Open Sample 38 (Merge Grid).
2. Scroll down in legend to `Merge Grid with Errored Layer`; click the legend layer that is not in error state.
3. Ensure the grid opens, shows rows from the not-dead layer.

Alternate scenarios

1. Open Sample 38 (Merge Grid).
2. Open one of the other merge grids. Ensure you see a medley of rows from the layers in that legend group.
3. Open Sample 1
4. Open a standard single-layer grid. Ensure nothing seems amiss.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1883)
<!-- Reviewable:end -->
