### PR TITLE
Initiate error state if a schema mismatch exists

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -605,28 +605,32 @@ const hovered = ref(false);
 onMounted(() => {
     if (props.legendItem instanceof LayerItem) {
         // load the symbology only when the layer is loaded
-        props.legendItem.loadPromise.then(() => {
-            symbologyStack.value = [];
-            // Wait for symbology to load
-            if (!(props.legendItem as LayerItem).layer) {
-                // This should never happen because the layer is loaded before the legend item component is mounted
-                console.warn(
-                    'Attempted to mount legend item component with undefined layer'
-                );
-                return;
-            }
-            Promise.all(
-                toRaw(
-                    (props.legendItem as LayerItem).symbologyStack.map(
-                        (item: LegendSymbology) => item.drawPromise
+        props.legendItem.loadPromise
+            .then(() => {
+                symbologyStack.value = [];
+                // Wait for symbology to load
+                if (!(props.legendItem as LayerItem).layer) {
+                    // This should never happen because the layer is loaded before the legend item component is mounted
+                    console.warn(
+                        'Attempted to mount legend item component with undefined layer'
+                    );
+                    return;
+                }
+                Promise.all(
+                    toRaw(
+                        (props.legendItem as LayerItem).symbologyStack.map(
+                            (item: LegendSymbology) => item.drawPromise
+                        )
                     )
-                )
-            ).then(() => {
-                symbologyStack.value = toRaw(
-                    (props.legendItem as LayerItem).symbologyStack
-                );
+                ).then(() => {
+                    symbologyStack.value = toRaw(
+                        (props.legendItem as LayerItem).symbologyStack
+                    );
+                });
+            })
+            .catch(() => {
+                console.warn('Error loading layer');
             });
-        });
     }
 });
 

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -1,5 +1,5 @@
 import { InstanceAPI, MapLayer, NotificationType } from '@/api/internal';
-import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
+import { DataFormat, LayerFormat, LayerState, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 import { EsriTileLayer } from '@/geo/esri';
 import { markRaw } from 'vue';
@@ -59,7 +59,7 @@ export class TileLayer extends MapLayer {
 
         loadPromises.push(legendPromise);
 
-        this.checkProj();
+        loadPromises.push(this.checkProj());
 
         // TODO once decided, might want to set a value on layer count that indicates nothing to count
 
@@ -70,19 +70,39 @@ export class TileLayer extends MapLayer {
 
     /**
      * Check if the layer's projection matches the current basemap's.
-     * If it does not match, warn the user by sending a notification.
+     * If they do not match the layer will enter the error state and the user will receive a warning notification
+     * If the layers do match and the layer was previously in the error state, it will reload.
      */
-    checkProj(): void {
+    checkProj(): Promise<void> {
         const layerSR = this.getSR();
         const mapSR = this.$iApi.geo.map.getSR();
+        const isEqual = mapSR.isEqual(layerSR);
 
-        if (!mapSR.isEqual(layerSR)) {
+        // If the layer is loaded and the projections do not match, it will enter the error state
+        if (this.layerState === LayerState.LOADED && !isEqual) {
             this.$iApi.notify.show(
                 NotificationType.WARNING,
                 this.$iApi.$i18n.t('layer.mismatch', {
                     name: this.name || this.id
                 })
             );
+
+            this.onError();
+        } // If the layer has errored and the projections now match, reload the layer
+        else if (this.layerState === LayerState.ERROR && isEqual) {
+            this.reload();
+        } // Reject the promise if the layer has not errored and the projections do not match
+        else if (this.layerState !== LayerState.ERROR && !isEqual) {
+            this.$iApi.notify.show(
+                NotificationType.WARNING,
+                this.$iApi.$i18n.t('layer.mismatch', {
+                    name: this.name || this.id
+                })
+            );
+
+            return Promise.reject();
         }
+
+        return Promise.resolve();
     }
 }


### PR DESCRIPTION
### Related Item(s)
#1855

### Changes
- [FIX] Layer will enter the error state if a schema mismatch exists 


### Notes
Figured this is the most intuitive approach until we fully introduce mini-icons

### Testing
Steps:
1. Fire up an R4 sample.
2. Make sure basemap is Mercator (usually is; Satellite tile is Mercator)
3. Open Wizard
4. Add [this url](https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer) as a Tile Layer type. This tile is in Lambert schema
5. Layer errors out and "{Layer name} cannot be displayed in the current projection", "{id} failed to load" appears in the notification tray.
6. Switch to a Lambert basemap
7. Reload the layer
8. Layer loads nicely

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1888)
<!-- Reviewable:end -->
