### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug report
+about: Submit a grouse
+title: ''
+labels: 'flavour: bug'
+assignees: ''
+
+---
+
+[ This is just a template. You can delete any section that does not apply to the issue. ]
+
+## Description
+
+[ Provide a clear and detailed explanation of the issue. ]
+
+## Environment
+
+- Browser (if applicable): [ e.g., Chrome 92, Firefox 89 ]
+- Versions (all that apply to bug):
+  - Browser: [ e.g. Chrome 99 ]
+  - RAMP Build: [ e.g. 4.0.1-beta [89b9eb544] ]
+  - NodeJS: [ e.g. 14.17.3 ]
+- Any other relevant environment details
+
+## Screenshots
+
+[ If applicable, include screenshots or gifs that help visualize the issue. ]
+
+## Steps to reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+[ Clearly describe what you expected to happen. ]
+
+## Actual behavior
+
+[ Describe what actually happened. ]
+
+## Additional information
+
+[ Include any other relevant information, such as error messages, logs, related issues, and things you've tried. ]
+
+## Possible solution
+
+[ If you have any ideas on how to solve the issue, share them here. It's okay if you don't have a solution yet. ]
+
+## Related issues
+
+[ List any related issues or pull requests that might be connected to this issue. ]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest an idea
+title: ''
+labels: 'flavour: feature'
+assignees: ''
+
+---
+
+[ This is just a template. You can delete any section that does not apply to the request. ]
+
+## Description
+
+[ Provide a detailed description of the feature you'd like to request. ]
+
+### Is your feature request related to a problem?
+
+[ Explain the problem it would solve or the value it would add to the project. E.g. "I'm always frustrated when X happens" ]
+
+## Proposed solution
+
+[ Provide a clear description of what you want to happen. ]
+
+## Alternatives considered
+
+[ If you have any ideas on how this feature could be implemented, share them here. You can also include design suggestions, technical details, or workflow considerations. ]
+
+## Additional context
+
+[ Add any other context or screenshots about the feature request here. ]
+
+## Related Issues
+
+[ List any related issues, pull requests, or discussions that might be related to this feature request. ]


### PR DESCRIPTION
I remember Matt mentioning somewhere that he would like all bug reports to have steps to reproduce listed and I thought making issue templates might be a good idea.

Please, see if these make sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1896)
<!-- Reviewable:end -->
