### PR TITLE
Data Layers Grid Integration

### DIFF
--- a/demos/starter-scripts/merge-grid.js
+++ b/demos/starter-scripts/merge-grid.js
@@ -107,6 +107,49 @@ let config = {
                     id: 'ErroredLayer',
                     layerType: 'esri-feature',
                     url: 'error'
+                },
+                {
+                    id: 'dataJson',
+                    name: 'Tasty Eats',
+                    layerType: 'data-json',
+                    rawData: {
+                        fields: [
+                            'Name',
+                            'Description',
+                            'Category',
+                            'Group_',
+                            'Year_'
+                        ],
+                        data: [
+                            [
+                                'Grouse Burgers',
+                                'A very tasty burger.',
+                                'Burger',
+                                'Fast Food',
+                                '2019'
+                            ],
+                            [
+                                'Greasy Patties',
+                                'A very greasy burger.',
+                                'Burger',
+                                'Fast Food',
+                                '2022'
+                            ],
+                            [
+                                'Big Dirty Slice',
+                                'The best pizza in the world!',
+                                'Pizza',
+                                'Fast Food',
+                                '2023'
+                            ]
+                        ]
+                    }
+                },
+                {
+                    id: 'table',
+                    name: 'OilSands',
+                    layerType: 'data-esri-table',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Oilsands/MapServer/5'
                 }
             ],
             fixtures: {
@@ -137,7 +180,11 @@ let config = {
                                     {
                                         infoType: 'text',
                                         content:
-                                            'Represents a grid merging 3 sublayers and a separately defined sublayer with the exact same fields.'
+                                            'Represents a grid merging 3 sublayers, a separately defined feature layer, and a JSON data layer with the exact same fields.'
+                                    },
+
+                                    {
+                                        layerId: 'dataJson'
                                     },
                                     {
                                         layerId: 'EcoGeo',
@@ -165,6 +212,9 @@ let config = {
                                         infoType: 'text',
                                         content:
                                             'Represents a merge grid containing layers with differing fields (including oid field).'
+                                    },
+                                    {
+                                        layerId: 'table'
                                     },
                                     {
                                         layerId: 'MajorCities',
@@ -236,6 +286,9 @@ let config = {
                             gridId: 'EcoGeoMergeGrid',
                             layers: [
                                 {
+                                    layerId: 'dataJson'
+                                },
+                                {
                                     layerId: 'EcoGeo',
                                     sublayers: [6, 7, 8]
                                 },
@@ -250,6 +303,9 @@ let config = {
                         {
                             gridId: 'HeteroMergeGrid',
                             layers: [
+                                {
+                                    layerId: 'table'
+                                },
                                 {
                                     layerId: 'MajorCities'
                                 },

--- a/demos/starter-scripts/simple-data.js
+++ b/demos/starter-scripts/simple-data.js
@@ -279,8 +279,7 @@ let config = {
                     root: {
                         children: [
                             {
-                                layerId: 'dataJson',
-                                disabledControls: ['visibilityButton']
+                                layerId: 'dataJson'
                             },
                             {
                                 layerId: 'table'

--- a/src/geo/layer/data-layer.ts
+++ b/src/geo/layer/data-layer.ts
@@ -24,6 +24,7 @@ import {
 import type {
     AttributeSet,
     CompactJson,
+    Extent,
     GetGraphicParams,
     RampLayerConfig,
     TabularAttributeSet
@@ -311,6 +312,37 @@ export class DataLayer extends CommonLayer {
         // No reason to run the same logic for every data row.
         return '<svg id="SvgjsSvg1012" width="32" height="32" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" viewBox="0 0 32 32"><defs id="SvgjsDefs1013"></defs><rect id="SvgjsRect1014" width="28" height="28" x="2" y="2" fill="#2e8b57"></rect><text id="SvgjsText1015" font-family="Roboto" font-size="23" fill="#ffffff" font-weight="bold" x="7.6875" y="-6.40000057220459" svgjs:data="{&quot;leading&quot;:&quot;1.3&quot;}"><tspan id="SvgjsTspan1016" dy="29.900000000000002" x="7.6875" svgjs:data="{&quot;newLined&quot;:true}">D</tspan></text></svg>';
     }
+
+    async getFilterOIDs(
+        exclusions: Array<string> = [],
+        extent: Extent | undefined = undefined
+    ): Promise<Array<number> | undefined> {
+        // TODO proper implementation in issue #1847 . For now, returns all
+        return undefined;
+    }
+
+    /**
+     * Since data layers (except table layers) do not have asynch attribute loading, there is nothing to do here.
+     * However, we have it there just so that calling this method for a giant list is peaceful, and filtering
+     * by layer type is not required.
+     */
+    abortAttributeLoad(): void {}
+
+    /**
+     * Since data layers (except table layers) do not have asynch attribute loading, there is nothing to do here.
+     * However, we have it there just so that calling this method for a giant list is peaceful, and filtering
+     * by layer type is not required.
+     */
+    attribLoadAborted(): boolean {
+        return false;
+    }
+
+    /**
+     * Since data layers (except table layers) do not have asynch attribute loading, there is nothing to do here.
+     * However, we have it there just so that calling this method for a giant list is peaceful, and filtering
+     * by layer type is not required.
+     */
+    clearFeatureCache(): void {}
 
     /**
      * The number of attributes currently downloaded (will update as download progresses)


### PR DESCRIPTION
### Related Item(s)
#1849

### Changes
- Data layers will now populate in the grid without the console yelling at you.
- The zoomies icon will not be shown for data layer rows.
- The apply to map and filter by extent will be disabled if the grid contains no map layers.

### Testing
1. Go to sample 38 (for merge grids with data layers) and/or sample 41(for standalone grids with data layers).
2. Ensure all grid functionality works as expected (zoomies is shown/hidden in correct cases, apply to map and filter by extent are enabled/disabled in correct cases, filtering works, toggling layer visibility and removing layer works as expected, whatever else you want to try).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1897)
<!-- Reviewable:end -->
