### PR TITLE
Data Layers Details Panel Integration

### DIFF
--- a/demos/starter-scripts/simple-data.js
+++ b/demos/starter-scripts/simple-data.js
@@ -265,7 +265,12 @@ let config = {
                     name: 'Tasty Eats',
                     layerType: 'data-json',
                     rawData:
-                        '{"fields":["Resto Name","Resto Type","Stars"],"data":[["Grouse Burgers","Burger",5],["Greasy Patties","Burger",2],["Big Dirty Slice","Pizza",3]]}'
+                        '{"fields":["Resto Name","Resto Type","Stars"],"data":[["Grouse Burgers","Burger",5],["Greasy Patties","Burger",2],["Big Dirty Slice","Pizza",3]]}',
+                    fixtures: {
+                        details: {
+                            template: 'Tasty-Template'
+                        }
+                    }
                 },
                 {
                     id: 'table',
@@ -350,6 +355,57 @@ const rInstance = createInstance(
 
 // add export fixtures
 rInstance.fixture.add('export');
+
+rInstance.$element.component('Tasty-Template', {
+    props: ['identifyData'],
+    template: `
+        <div style="align-items: center; justify-content: center; font-size: 14px; font-family: Arial, sans-serif;">
+            <div v-html="createSection('Restaurant', 'Resto-Name')" />
+            <div v-html="createSection('Type', 'Resto-Type')" />
+            <div v-html="createStars('Stars')" />
+        </div>
+    `,
+    methods: {
+        createSection(title, id) {
+            var val = this.identifyData.loaded
+                ? this.identifyData.data[id]
+                : 'Loading...';
+
+            return `
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
+                <span style="color: #a0aec0; font-weight: bold;">
+                    ${title}
+                </span>
+                <span>
+                    ${val}
+                </span>
+            </div>
+            `;
+        },
+        createStars(n) {
+            var stars =
+                '<img width="24" height="24" src="https://img.icons8.com/material-sharp/24/star--v1.png" alt="star--v1"/>\n'.repeat(
+                    parseInt(this.identifyData.data[n])
+                );
+            var remaining =
+                '<img width="24" height="24" src="https://img.icons8.com/material-sharp/24/b0b0b0/star--v1.png" alt="star--v1"/>'.repeat(
+                    5 - this.identifyData.data[n]
+                );
+
+            return `
+            <div style="display: flex; flex-direction: column; padding-top: 5px;">
+                <span style="color: #a0aec0; font-weight: bold;">
+                    Stars
+                </span>
+                <div style="display: flex; flex-direction: row;">
+                    ${stars}
+                    ${remaining}
+                </div>
+            </div>
+            `;
+        }
+    }
+});
 
 // load map if startRequired is true
 // rInstance.start();

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -15,7 +15,9 @@
                 <!-- highlight toggle -->
                 <div
                     class="p-8 mb-8 bg-gray-100 flex justify-between"
-                    v-if="details.hasHilighter() && supportsFeatures"
+                    v-if="
+                        details.hasHilighter() && supportsFeatures && isMapLayer
+                    "
                 >
                     <div>{{ t('details.togglehilight.title') }}</div>
                     <Toggle
@@ -133,6 +135,7 @@
                                 ref="button"
                                 @click="zoomToFeature()"
                                 class="text-gray-600 m-8 w-24 h-24 p-2"
+                                v-if="isMapLayer"
                             >
                                 <div
                                     v-if="zoomStatus === 'zooming'"
@@ -303,6 +306,12 @@ const supportsFeatures = computed<Boolean>(() => {
     );
     return layer?.supportsFeatures ?? false;
 });
+const isMapLayer = computed<Boolean>(() => {
+    const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
+        props.result.uid
+    );
+    return layer?.mapLayer ?? false;
+});
 const fieldsList = computed<Array<FieldDefinition>>(() => {
     // wms layers do not support fields
     if (!supportsFeatures.value) {
@@ -408,12 +417,12 @@ const itemChanged = () => {
                     : ''
             }`
         );
-        if (hilightToggle.value && supportsFeatures.value) {
+        if (hilightToggle.value && supportsFeatures.value && isMapLayer.value) {
             details.value.hilightDetailsItems(
                 props.result.items[currentIdx.value],
                 props.result.uid
             );
-        } else if (!supportsFeatures.value) {
+        } else if (!supportsFeatures.value || !isMapLayer.value) {
             details.value.removeDetailsHilight();
         }
     } else {


### PR DESCRIPTION
### Related Item(s)
#1850, #1744

### Changes
- Data layers are now compatible with single item details panels
- Removes highlight toggle and zoomies button
- Added a custom details template for data layer in sample 41

### Notes
- Since data layers don't exist on the map, the only way to bring up the details panel is via the datatable
- Until #1897 is merged, there will still be console errors upon opening the datatable

### Testing
Open sample 41 and access the details panels via the datatable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1905)
<!-- Reviewable:end -->
