### PR TITLE
Make icons accessible via keyboard

### DIFF
--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -8,8 +8,9 @@ const enum KEYS {
 
 const CONTAINER_ATTR = 'focus-container';
 const LIST_ATTR = 'focus-list';
+const ICON_ATTR = 'focus-icon';
 const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
-const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}],[${ICON_ATTR}]`;
 
 let managers: FocusContainerManager[] = [];
 
@@ -161,7 +162,6 @@ class FocusContainerManager {
 
     /**
      * Sets tabindex to 0 for every VISIBLE element not under a different focus container or list.
-     * 
      * @return {HTMLElement} the first valid element
      */
     enableTabbing() {

--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -17,12 +17,13 @@ const enum KEYS {
 
 const LIST_ATTR = 'focus-list';
 const ITEM_ATTR = 'focus-item';
+const ICON_ATTR = 'focus-icon';
 const CONTAINER_ATTR = 'focus-container';
 const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
 const TRUNCATE_ATTR = 'truncate-text';
 const SHOW_TRUNCATE = 'show-truncate';
 const FOCUSED_CLASS = 'focused';
-const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}],[${ICON_ATTR}]`;
 
 // TODO: Figure out a way to put the control scheme into the description of the focus-list for screen readers (hidden text?), or see if the help file would be sufficient.
 

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -316,7 +316,7 @@
 
                 <!-- offscale icon -->
                 <div
-                    class="relative mx-5"
+                    class="relative mx-5 cursor-default"
                     :content="t('legend.layer.offscale')"
                     v-tippy="{
                         placement: 'top-start'
@@ -328,6 +328,7 @@
                         legendItem instanceof LayerItem &&
                         legendItem.layerOffscale
                     "
+                    focus-icon
                 >
                     <svg
                         class="inline-block fill-gray-400 w-18 h-18"
@@ -341,7 +342,7 @@
 
                 <!-- data only icon -->
                 <div
-                    class="relative mx-5"
+                    class="relative mx-5 cursor-default"
                     :content="t('legend.layer.data.only')"
                     v-tippy="{
                         placement: 'top-end'
@@ -353,6 +354,7 @@
                         legendItem instanceof LayerItem &&
                         !legendItem.layer?.mapLayer
                     "
+                    focus-icon
                 >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
### Related Item(s)
#1903

### Changes
- Implemented Spencer's proposed solution to make icons in the legend accessible via keyboard.

### Testing
- On sample 32, ensure the offscale icon can be reached via the keyboard.
- On sample 41, ensure that the data layer icon can be reached via the keyboard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1911)
<!-- Reviewable:end -->
