### PR TITLE
Fix items in visibility sets not turning off

### DIFF
--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -10,9 +10,8 @@
                         : `legend.visibility.show${label}`
                 )
             "
-            @click.stop
+            @click.stop="toggleVisibility()"
             :checked="checked && initialChecked"
-            @change.stop="toggleVisibility()"
             @keypress.enter.prevent
             @keyup.enter.stop="toggleVisibility()"
             :class="[

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -1,5 +1,9 @@
 <template>
-    <div :key="legendItem.uid" v-if="!legendItem.hidden" ref="el">
+    <div
+        :key="`${legendItem.uid}-${legendItem.visibility}`"
+        v-if="!legendItem.hidden"
+        ref="el"
+    >
         <div class="relative">
             <div
                 class="flex items-center hover:bg-gray-200"


### PR DESCRIPTION
### Related Item(s)
#1894

### Changes
- Items in visibility sets can now be toggled off again.

### Testing
- Ensure that items in visibility sets can be toggled off by trying it on sample 17 or sample 39.
- Would appreciate a quick sanity check to ensure I didn't ruin any of the current visibility functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1913)
<!-- Reviewable:end -->
