### PR TITLE
Fix data layers being treated as unmodifiable

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1220,19 +1220,23 @@ const cancelAttributeLoad = () => {
 };
 
 /**
- * Determine if the layer is modifiable
+ * Determine if map filtering for this grid is fully enabled, partially enabled, or disabled.
  */
 const filtersStatus = computed<'disabled' | 'partial' | 'enabled'>(() => {
-    // Check to see if all layers are consistent with their modifiability. If not, throw a warning notifiying the user that filtering has been disabled.
-    const modifiable = gridLayers.value.map(layer => {
+    const filterable = gridLayers.value.map(layer => {
         return layer.visibility && layer.canModifyLayer && layer.mapLayer;
     });
 
-    if (!modifiable.every(value => value === modifiable[0])) {
-        return 'partial';
-    }
+    const unmodifiableExists = gridLayers.value.some(
+        layer => layer.visibility && layer.mapLayer && !layer.canModifyLayer
+    );
+    const filterableExists = filterable.some(Boolean);
 
-    return modifiable.some(Boolean) ? 'enabled' : 'disabled';
+    return unmodifiableExists && filterableExists
+        ? 'partial' // we have an unmodifiable map layer and we also have >= 1 layer that can be filtered, so overall filtering is partial
+        : filterableExists
+        ? 'enabled' // we have >= 1 layer that can be filtered, anything with filtering disabled is a data layer which is not on the map anyways, so overall filtering is enabled
+        : 'disabled'; // no layers that can be filtered, so disable filtering
 });
 
 /**

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -49,4 +49,4 @@ layer.longload,{id} is taking longer than expected to load,1,Le chargement de {i
 layer.longdraw,{id} is taking longer than expected to draw,1,{id} prend plus de temps que prévu à extraire,1
 layer.mismatch,{name} cannot be displayed in the current projection,1,{name} ne peut pas être affiché dans la projection actuelle,0
 layer.filtersdisabled,Filters have been disabled for {name},1,Les filtres ont été désactivés par {name},0
-layer.filterwarning,You are attempting to use a merge grid that contains unmodifiable layers. Filtering will be partially disabled,1,Vous tentez d'utiliser une grille de fusion contenant des calques non modifiables. Le filtrage sera partiellement désactivé,0
+layer.filterwarning,You are attempting to use a grid that contains unmodifiable layers. Filtering will be partially disabled,1,Vous tentez d'utiliser une grille contenant des calques non modifiables. Le filtrage sera partiellement désactivé,0


### PR DESCRIPTION
### Related Item(s)
#1918

### Changes
- Fixed an issue where the unmodifiable layer warning was triggering for a grid with data layers.

### Testing
1. Go to sample 38.
2. Open the heterogeneous merge grid.
3. Ensure that there is no warning notification.
4. Additionally ensure that all other behaviour is the same (i.e. the apply to map and filter by extent are enabled/disabled in the correct cases).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1919)
<!-- Reviewable:end -->
