### PR TITLE
Map peek demos

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -373,7 +373,8 @@ let config = {
                         'home',
                         'basemap',
                         'legend',
-                        'geosearch'
+                        'geosearch',
+                        'minimize'
                     ]
                 },
                 details: {

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -40,6 +40,7 @@ import DropdownMenuV from '@/components/controls/dropdown-menu.vue';
 
 import FullscreenNavV from '@/fixtures/mapnav/buttons/fullscreen-nav.vue';
 import GeolocatorNavV from '@/fixtures/mapnav/buttons/geolocator-nav.vue';
+import MinimizeNavV from '@/fixtures/mapnav/buttons/minimize-nav.vue';
 import HomeNavV from '@/fixtures/mapnav/buttons/home-nav.vue';
 import MapnavButtonV from '@/fixtures/mapnav/button.vue';
 
@@ -740,6 +741,7 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
     // ported from mapnav.vue
     vueElement.component('fullscreen-nav-button', FullscreenNavV);
     vueElement.component('geolocator-nav-button', GeolocatorNavV);
+    vueElement.component('minimize-nav-button', MinimizeNavV);
     vueElement.component('home-nav-button', HomeNavV);
     vueElement.component('mapnav-button', MapnavButtonV);
 

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -124,6 +124,11 @@
                 </a>
             </dropdown-menu>
         </div>
+        <div
+            class="w-15 border-l-2 ml-5 -my-5 border-gray-400"
+            @mouseover="panelStore.setOpacity(0.1)"
+            @mouseleave="panelStore.setOpacity(1)"
+        ></div>
     </div>
 </template>
 
@@ -145,8 +150,10 @@ import { useI18n } from 'vue-i18n';
 
 import type { InstanceAPI } from '@/api';
 import { useConfigStore } from '@/stores/config';
+import { usePanelStore } from '@/stores/panel';
 
 const mapCaptionStore = useMapCaptionStore();
+const panelStore = usePanelStore();
 const configStore = useConfigStore();
 const { t } = useI18n();
 const iApi = inject('iApi') as InstanceAPI;

--- a/src/components/panel-stack/panel-stack.vue
+++ b/src/components/panel-stack/panel-stack.vue
@@ -5,6 +5,7 @@
         name="panel-container"
         tag="div"
         ref="el"
+        class="panel-container"
     >
         <!-- TODO: pass a corresponding fixture instance to the panel component as it can be useful -->
         <panel-container
@@ -30,6 +31,9 @@ const iApi = inject<InstanceAPI>('iApi')!;
 const el = ref<ComponentPublicInstance>();
 
 const mobileMode = computed(() => panelStore.mobileView);
+const opacity = computed(() => {
+    return panelStore.opacity;
+});
 
 onMounted(() => {
     // sync the `panel-stack` width into the store so that visible can get calculated
@@ -123,5 +127,10 @@ declare class ResizeObserver {
 // https://vuejs.org/v2/guide/transitions.html#List-Move-Transitions
 .panel-container-move {
     transition: 0.3s transform cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.panel-container {
+    transition: opacity 0.5s ease-out;
+    opacity: v-bind(opacity) !important;
 }
 </style>

--- a/src/fixtures/mapnav/api/mapnav.ts
+++ b/src/fixtures/mapnav/api/mapnav.ts
@@ -62,7 +62,8 @@ export class MapnavAPI extends FixtureInstance {
             'geolocator',
             'zoom',
             'home',
-            'fullscreen'
+            'fullscreen',
+            'minimize'
         ];
 
         // get the ordered list of items and see if any of them are registered

--- a/src/fixtures/mapnav/buttons/minimize-nav.vue
+++ b/src/fixtures/mapnav/buttons/minimize-nav.vue
@@ -1,0 +1,65 @@
+<template>
+    <mapnav-button
+        :onClickFunction="hidePanels"
+        :tooltip="hidden ? t('mapnav.showAll') : t('mapnav.minimizeAll')"
+    >
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class="fill-current w-32 h-20"
+        >
+            <path
+                v-if="hidden"
+                d="M18,8H8V18H6V8A2,2 0 0,1 8,6H18V8M14,2H4A2,2 0 0,0 2,4V14H4V4H14V2M22,12V20A2,2 0 0,1 20,22H12A2,2 0 0,1 10,20V12A2,2 0 0,1 12,10H20A2,2 0 0,1 22,12M20,15H17V12H15V15H12V17H15V20H17V17H20V15Z"
+            />
+            <path
+                v-else
+                d="M14,4H4V14H2V4A2,2 0 0,1 4,2H14V4M18,6H8A2,2 0 0,0 6,8V18H8V8H18V6M22,12V20A2,2 0 0,1 20,22H12A2,2 0 0,1 10,20V12A2,2 0 0,1 12,10H20A2,2 0 0,1 22,12M20,15H12V17H20V15Z"
+            />
+        </svg>
+    </mapnav-button>
+</template>
+
+<script setup lang="ts">
+import { GlobalEvents, InstanceAPI, type PanelInstance } from '@/api';
+import { usePanelStore } from '@/stores/panel';
+import { inject, nextTick, onMounted, reactive, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+const iApi = inject('iApi') as InstanceAPI;
+
+const panelStore = usePanelStore();
+const panels = ref<Array<PanelInstance>>([]);
+const hidden = ref(false);
+const handlers = reactive<Array<string>>([]);
+
+onMounted(() => {
+    handlers.push(iApi.event.on(GlobalEvents.PANEL_OPENED, clearHiddenPanels));
+});
+
+const hidePanels = () => {
+    if (!hidden.value) {
+        panels.value = panelStore.orderedItems;
+        panels.value.forEach((panel: any) => {
+            panel.minimize();
+        });
+    } else {
+        panels.value.forEach((panel: any) => {
+            panel.open();
+        });
+    }
+    hidden.value = !hidden.value;
+};
+
+const clearHiddenPanels = () => {
+    nextTick(() => {
+        if (hidden.value) {
+            panels.value = [];
+            hidden.value = false;
+        }
+    });
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/fixtures/mapnav/lang/lang.csv
+++ b/src/fixtures/mapnav/lang/lang.csv
@@ -2,6 +2,8 @@ key,enValue,enValid,frValue,frValid
 mapnav.zoomIn,Zoom In,1,Zoom avant,1
 mapnav.zoomOut,Zoom Out,1,Zoom arrière,1
 mapnav.home,Home,1,Accueil,1
+mapnav.minimizeAll,Minimize All,1,Minimiser tous,0
+mapnav.showAll,Show All,1,Afficher tout,0
 mapnav.fullscreen,Full Screen,1,Plein Écran,1
 mapnav.geolocator,Your Location,1,Votre position,1
 mapnav.geolocator.error.permission,The location request was denied. Please check your browser permission settings.,1,Demande de localisation refusée. Veuillez vérifier les paramètres d'autorisation de votre navigateur.,1

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -15,6 +15,7 @@ export const usePanelStore = defineStore('panel', () => {
     const orderedItems = ref<PanelInstance[]>([]);
     const teleported = ref<PanelInstance[]>([]);
     const visible = ref<PanelInstance[]>([]);
+    const opacity = ref<number>(1);
 
     /**
      * Returns `remainingWidth` from the state. Displays how much space is left for panels to be displayed on the map.
@@ -61,6 +62,7 @@ export const usePanelStore = defineStore('panel', () => {
     }
 
     function closePanel(panel: PanelInstance): void {
+        console.log(orderedItems);
         close(panel);
         updateVisible();
     }
@@ -87,6 +89,10 @@ export const usePanelStore = defineStore('panel', () => {
 
     function setMobileView(value: boolean): void {
         mobileView.value = value;
+    }
+
+    function setOpacity(value: number): void {
+        opacity.value = value;
     }
 
     function updateVisible(): void {
@@ -269,6 +275,7 @@ export const usePanelStore = defineStore('panel', () => {
         regPromises,
         orderedItems,
         pinned,
+        opacity,
         priority,
         visible,
         stackWidth,
@@ -285,6 +292,7 @@ export const usePanelStore = defineStore('panel', () => {
         removePanel,
         setStackWidth,
         setMobileView,
+        setOpacity,
         updateVisible,
         registerPanel,
         addRegPromise


### PR DESCRIPTION
### Related Item(s)
#1900, #1237

### Changes
- Adds 2 demo features for peeking at the map when many panels are open and covering the screen
    - The first is a minimize/show current panels button in the mapnav stack
    - The second is basically a copy of the Windows desktop peek feature. Hovering over the bottom right of the instance (just to the right of the language change menu) will transparent-ize any open panels and reveal the map

### Notes
An example of the Windows peek:
![Screenshot 2023-08-21 132414](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/89807997/7fc1f953-6ebd-4ad8-a4eb-1f536d52e40c)

Since these are demo features, the goal was to have something to look at during the team meeting and decide if either of these options is what we're looking for. It's easy to make changes too, like having the Windows peek set the opacity to 0 on panels.

### Testing
Try the minimize/expand button and the peek hover with open panels
