### PR TITLE
Workaround Vue Reactivity 

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -664,7 +664,13 @@ const isAnimationEnabled = computed((): boolean => {
  * Get if this item is a group (has at least one child)
  */
 const isGroup = computed((): boolean => {
-    return props.legendItem.children.length > 0;
+    return (
+        props.legendItem.children.length > 0 ||
+        // TODO: Determine why Vue reactivity isn't picking updates to the children property of the parent.
+        // isGroup is being called on the parent before the children are mapped in legend.ts. After they're mapped, isGroup isn't called again.
+        (props.legendItem instanceof LayerItem &&
+            toRaw(props.legendItem!.layer)?.sublayers.length > 0)
+    );
 });
 
 /**


### PR DESCRIPTION
### Related Item(s)
#1904 

### Changes
- [FIX] IsGroup is not updating when the children are mapped to the parent legend item. This prevents the parent MIL item from being collapsed / expanded.


### Notes
Tried to find a more suitable fix for this first, but isGroup is being called on the parent before the children are mapped in legend.ts. After they're mapped, isGroup isn't called again and I'm not sure how to force it. I tried adding a watcher to props.legendItem.children, but that wasn't sufficient. Not sure if there's a scenario where sublayers belong to a layer and are not meant to be grouped with it, but ideally some more eyes on this issue kicks up a permanent solution.

### Testing
Steps:
1. Add a [MIL service ](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer)
2. The parent should now be expandable / collapsible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1928)
<!-- Reviewable:end -->
