### PR TITLE
Grid to Details Attribute Mapping Fix

### DIFF
--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -42,20 +42,19 @@ const openDetails = () => {
     delete data['rvInteractive'];
     delete data['rvSymbol'];
 
-    // similar to the sql lookup, the details panel must use the original OID field to render symbols
     const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
         data['rvUid']
     )!;
-    const oidPair = props.params.layerCols[layer.id].find(
-        (pair: AttributeMapPair) => pair.origAttr === layer.oidField
-    );
-    if (oidPair.mappedAttr) {
-        const oid = data[oidPair.mappedAttr];
-        delete data[oidPair.mappedAttr];
-        data[oidPair.origAttr] = oid;
-    }
 
     delete data['rvUid'];
+
+    // replace any mapped attributes with original attribute name for details renderer
+    props.params.layerCols[layer.id].forEach((attrPair: AttributeMapPair) => {
+        if (attrPair.mappedAttr) {
+            data[attrPair.origAttr] = data[attrPair.mappedAttr];
+            delete data[attrPair.mappedAttr];
+        }
+    });
 
     // grid only supports esri features at the moment, so we hardcode that format
     iApi.event.emit(GlobalEvents.DETAILS_TOGGLE, {


### PR DESCRIPTION
### Related Item(s)
#1917

### Changes
- Reverse-maps every attribute sent to details panel from the grid, not just `oid`

### Testing
Open the details panel via the grid in sample 41 (specifically the merge grid labelled **Homogenous Merge Grid with Map Filtering**)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1929)
<!-- Reviewable:end -->
