### PR TITLE
Fix grid header displaying white space when columns are shifted after being added/removed

### DIFF
--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -144,18 +144,18 @@ const moveLeft = (): void => {
 
     if (canMoveLeft.value) {
         columnApi.value.moveColumn(props.params.column, index);
+        props.params.api.ensureColumnVisible(allColumns[index]);
 
         // Focus the "move left" button on the new column
         // The same column index keeps this element so we can't just use a ref for the buttons;
         // e.g. grid is A | B | C and this is B, if B moves left so the grid B | A | C this element is now A
+
         (
             el.value
                 ?.closest('.ag-header-row')
-                ?.querySelectorAll('.ag-header-cell')
-                [index - 4].querySelector('.move-left') as HTMLElement
-        ).focus();
-
-        props.params.api.ensureColumnVisible(allColumns[index]);
+                ?.querySelector(`[col-id="${props.params.column.colId}"]`)
+                ?.querySelector('.move-left') as HTMLElement
+        )?.focus();
     }
 };
 


### PR DESCRIPTION
### Related Item(s)
#1914

### Changes
- The grid will no longer be ruined when you attempt to reorder columns after showing/hiding some of them.

### Testing
1. Open your favourite sample.
2. Follow the steps in the gif in the issue body.
3. Notice that nothing breaks.
4. Feel free to try it out with any other cases you can think of.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1941)
<!-- Reviewable:end -->
