### PR TITLE
Fix symbology stack not rendering when layer reloads after error

### DIFF
--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -14,6 +14,7 @@ export class LayerItem extends LegendItem {
     _layerOffscale: boolean = false;
     _loadCancelled: boolean = false;
     _treeGrown: boolean = false;
+    _customSymbology: boolean = false;
 
     _coverIcon?: string;
     _description?: string;
@@ -45,6 +46,7 @@ export class LayerItem extends LegendItem {
         if (config.coverIcon) this._coverIcon = config.coverIcon;
         if (config.description) this._description = config.description;
         this._symbologyRenderStyle = config.symbologyRenderStyle ?? 'icons';
+        this._customSymbology = !!config.symbologyStack;
         this._symbologyStack = config.symbologyStack?.map((symbol: any) => {
             return {
                 uid: this.$iApi.geo.shared.generateUUID(),
@@ -91,7 +93,9 @@ export class LayerItem extends LegendItem {
         this._layerId = layer.id;
         this._layerIdx = layer.layerIdx;
         this._layerUid = layer.uid;
-        this._symbologyStack = this._symbologyStack ?? layer.legend; // set this item's symbology stack to layer's default if undefined in config
+        this._symbologyStack = this._customSymbology
+            ? this._symbologyStack
+            : layer.legend; // set this item's symbology stack to layer's default if undefined in config
         this.updateLayerControls();
     }
 


### PR DESCRIPTION
### Related Item(s)
#1915 

### Changes
- What the title says

### Testing
* Follow the instructions in [this comment](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1915#issue-1856828518) and ensure that the symbology stack is drawn and that expanding the symbology works as expected.
* You can also try adding [this tile layer](https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer) on a Mercator basemap and then switch to Lambert. Ensure that the symbology stack is drawn correctly in this case as well.
