### PR TITLE
Implement optional geometry precision

### DIFF
--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -402,6 +402,7 @@ export interface GetGraphicServiceDetails {
     serviceUrl: string; // feature layer endpoint on an arcgis server
     maxOffset?: number; // indicates detail level required of geometry. can be critical if service is in different projection than the map
     mapSR?: string; // stringified spatial reference of the map
+    geometryPrecision?: number; // number of decimal places to keep in result geometry
     oid: number; // oid of the feature to find
 }
 

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -302,12 +302,13 @@ export class AttributeAPI extends APIScope {
             params.query.outSR = details.mapSR;
         }
 
-        // TODO investigate adding `geometryPrecision` to the param.
-        //      if we have bloated decimal places, this will drop them.
-        //      need to be careful of the units of the map and the current scale.
-        //      e.g. a basemap in lat long will certainly need decimal places.
-        //      could add this to the tile schema object of our config. if missing we omit, but allow
-        //      author to define a precision for better performance. could we apply that elsewhere? (e.g. featurelayers?)
+        // set geometry precision if value is a non-negative integer
+        if (
+            typeof details.geometryPrecision !== 'undefined' &&
+            details.geometryPrecision >= 0
+        ) {
+            params.query.geometryPrecision = details.geometryPrecision;
+        }
 
         const [err, serviceResult] = await to<__esri.RequestResponse>(
             EsriRequest(details.serviceUrl + '/query', params)


### PR DESCRIPTION
### Related Item(s)
#1875

### Changes
- The `loadSingleFeature()` API method now has an optional `geometryPrecision` parameter that an API user can use to trim decimal places from the result geometries.

### Notes
- Opted not to do the configuration part of this since new services already chop off decimal places via `maxOffset` trickery. As for old services, @james-rae suggested changing the settings on the server to support the new format would be the better approach.

### Testing
1. Open your favourite sample.
2. Copy and paste the code below in the console:

```
const params1 = {
  oid: 1, 
  serviceUrl: "https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer/0", 
  mapSR: debugInstance.geo.map.getSR().wkid?.toString(), 
  includeGeometry: true
}

const params2 = {
  oid: 1, 
  serviceUrl: "https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer/0",
  includeGeometry: true
}

const params3 = {
  oid: 1, 
  serviceUrl: "https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer/0", 
  mapSR: debugInstance.geo.map.getSR().wkid?.toString(), 
  includeGeometry: true,
  geometryPrecision: 2
}

const params4 = {
  oid: 1, 
  serviceUrl: "https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer/0",
  includeGeometry: true,
  geometryPrecision: 2
}

debugInstance.geo.attributes.loadSingleFeature(params1).then(res => {
  console.log("Coordinates when projecting to map's SR with no geom precision defined:", res.geometry.rawArray)
})

debugInstance.geo.attributes.loadSingleFeature(params3).then(res => {
  console.log("Coordinates when projecting to map's SR with 2 decimal place geom precision defined:", res.geometry.rawArray)
})

debugInstance.geo.attributes.loadSingleFeature(params2).then(res => {
  console.log("Coordinates when not doing projecting and with no geom precision defined:", res.geometry.rawArray)
})

debugInstance.geo.attributes.loadSingleFeature(params4).then(res => {
  console.log("Coordinates when not doing projecting and with 2 decimal place precision defined:", res.geometry.rawArray)
})
```
3. Examine the values and ensure that everything is in order. Additionally notice that the order of operations concern mentioned in the discussion is all good since projecting to the map's spatial reference gives the same value with and without decimal chopping, so the chopping is happening at the end. Sadly no opportunity to blame ESRI for one more thing.
4. The above test uses CAM since the service is in decimal degrees. Feel free to make up your own tests using different services/parameters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1952)
<!-- Reviewable:end -->
