### PR TITLE
Fix overview map graphic layer pinging warnings

### DIFF
--- a/src/fixtures/overviewmap/overviewmap.vue
+++ b/src/fixtures/overviewmap/overviewmap.vue
@@ -136,14 +136,19 @@ onMounted(() => {
         handlers.push(
             iApi.event.on(
                 GlobalEvents.MAP_BASEMAPCHANGE,
-                (payload: { basemapId: string; schemaChanged: boolean }) => {
+                async (payload: {
+                    basemapId: string;
+                    schemaChanged: boolean;
+                }) => {
                     if (!payload.schemaChanged && overviewMap.created) {
                         if (
                             activeBasemap.value &&
                             basemaps.value[activeBasemap.value.tileSchemaId] ===
                                 undefined
                         ) {
+                            await overviewMap.removeMapGraphicLayer();
                             overviewMap.setBasemap(payload.basemapId);
+                            await overviewMap.addMapGraphicLayer();
                         }
                     }
                 }

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -160,7 +160,7 @@ export class OverviewMapAPI extends CommonMapAPI {
         this.esriMap?.add(this.overviewGraphicLayer.esriLayer!);
     }
 
-    removeMapGraphicLayer() {
+    async removeMapGraphicLayer() {
         if (!this.esriMap) {
             this.noMapErr();
             return;
@@ -173,7 +173,7 @@ export class OverviewMapAPI extends CommonMapAPI {
         }
 
         this.overviewGraphicLayer.removeGraphic();
-        this.overviewGraphicLayer.terminate();
+        await this.overviewGraphicLayer.terminate();
         this.esriMap.remove(this.overviewGraphicLayer.esriLayer);
     }
 
@@ -187,8 +187,6 @@ export class OverviewMapAPI extends CommonMapAPI {
         this.esriView?.container.removeEventListener('touchmove', e => {
             e.preventDefault();
         });
-        // remove the extent graphic
-        this.removeMapGraphicLayer();
         super.destroyMapView();
     }
 
@@ -251,7 +249,6 @@ export class OverviewMapAPI extends CommonMapAPI {
         if (differentSchema) {
             this.destroyMapView();
             this.createMapView(bm);
-            this.addMapGraphicLayer();
         } else {
             this.applyBasemap(bm);
         }


### PR DESCRIPTION
### Related Item(s)
#1951

### Changes
- Changing the basemap no longer makes the overview map grouse that its taking too long to load.

### Notes
- This was occurring because of the layer's `.terminate()` was being called synchronously while the method is asynchronous, which resulted in race conditions when the layer's `.initiate()` was called. Will make a new discussion to consider making layers' `.terminate()` method synchronous.

### Testing
1. Open a RAMP that starts in Mercator basemap (most do).
2. Open basemap selector. Pick a Lambert basemap.
3. Wait a bit.
4. Notice that no notification appears. 
5. Try changing back to a Mercator and verify that no notification appears.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1954)
<!-- Reviewable:end -->
