### PR TITLE
add support for customized grid buttons

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -239,6 +239,13 @@
                 for some columns.
                 <span class="tag misc">Datatable</span>
             </li>
+            <li>
+                43.
+                <a href="index-samples.html?sample=43"
+                    >Grid Custom Row Buttons</a
+                >. Contains some layers that have custom row buttons.
+                <span class="tag misc">Datatable</span>
+            </li>
         </ul>
 
         <h2>Simple Samples</h2>

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -103,6 +103,9 @@
                     <option value="cumulative-effects">
                         42. Cumulative Effects Mirror
                     </option>
+                    <option value="custom-grid-buttons">
+                        43. Custom Grid Row Buttons
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/custom-grid-buttons.js
+++ b/demos/starter-scripts/custom-grid-buttons.js
@@ -1,0 +1,1017 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#55ffff',
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        },
+                        grid: {
+                            controls: ['zoom']
+                        }
+                    }
+                },
+                {
+                    id: 'CESI',
+                    layerType: 'esri-map-image',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/',
+                    sublayers: [
+                        {
+                            index: 36
+                        },
+                        {
+                            index: 37,
+                            fixtures: {
+                                grid: {
+                                    controls: [
+                                        {
+                                            actionEvent: 'customSettings',
+                                            icon: '⚙️',
+                                            tooltip: 'Open settings'
+                                        },
+                                        {
+                                            actionEvent: 'hybridZoomAndDetails',
+                                            icon: '🏆',
+                                            tooltip: 'Open details and zoom'
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            index: 38
+                        }
+                    ]
+                },
+                {
+                    id: 'table',
+                    name: 'JOSM Theme Count',
+                    layerType: 'data-esri-table',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Oilsands/MapServer/5',
+                    fixtures: {
+                        grid: {
+                            controls: [
+                                {
+                                    actionEvent: 'customSettings',
+                                    icon: '⚙️',
+                                    tooltip: 'Open settings',
+                                    displayOn: 'geo'
+                                },
+                                {
+                                    actionEvent: 'hybridZoomAndDetails',
+                                    icon: '🏆',
+                                    tooltip: 'Open details and zoom'
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                name: 'Text info section',
+                                infoType: 'title',
+                                content: 'Layer with "details" button removed.'
+                            },
+                            {
+                                layerId: 'WFSLayer'
+                            },
+                            {
+                                name: 'Text info section',
+                                infoType: 'title',
+                                content: 'Data Layer'
+                            },
+                            {
+                                infoType: 'text',
+                                content:
+                                    'The "settings" button is set to only appear for map layers, so it should not appear in this table.'
+                            },
+                            {
+                                layerId: 'table'
+                            },
+                            {
+                                name: 'Custom Buttons',
+                                infoType: 'title',
+                                content: 'Custom Buttons'
+                            },
+                            {
+                                infoType: 'text',
+                                content:
+                                    'The "Releases of mercury" layer has both the "zoom" and "details" buttons disabled. It includes two custom buttons: one to open the settings for the layer, and the other opens the details and zooms into the point (combining the two default actions).'
+                            },
+                            {
+                                layerId: 'CESI',
+                                name: 'Releases of cadmium',
+                                sublayerIndex: 36,
+                                children: [
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Releases of mercury',
+                                        sublayerIndex: 37
+                                    },
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Releases of lead',
+                                        sublayerIndex: 38
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder',
+                        'areas-of-interest'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
+                export: {
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                },
+                'areas-of-interest': {
+                    areas: [
+                        {
+                            title: 'Reservoir Manicougan, Quebec, Canada',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                            altText: 'Reservoir Manicougan, Quebec, Canada',
+                            description:
+                                'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
+                            extent: {
+                                xmax: 1840000,
+                                xmin: 1750000,
+                                ymax: 682193,
+                                ymin: 583440,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Gulf of St Lawrence',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                            extent: {
+                                xmin: 2050000,
+                                xmax: 2240000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Lake Grandmesnil and surrounding lakes',
+                            extent: {
+                                xmin: 1800000,
+                                xmax: 1840000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'CN Tower',
+                            thumbnail:
+                                'https://upload.wikimedia.org/wikipedia/commons/9/9c/Toronto_-_ON_-_CN_Tower_Turmkorb.jpg',
+                            description:
+                                'The CN Tower is a 553.3 m-high concrete communications and observation tower in downtown Toronto, Ontario, Canada.',
+                            extent: {
+                                xmin: -8838051.849695725,
+                                xmax: -8836512.572464375,
+                                ymin: 5409988.501845284,
+                                ymax: 5410763.023921062,
+                                spatialReference: {
+                                    wkid: 102100,
+                                    latestWkid: 3857
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        },
+        fr: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#55ffff',
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
+                    }
+                },
+                {
+                    id: 'TerritoriesPoly',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/SupportData/MapServer/3',
+                    permanentFilteredQuery: `Name = 'Nunavut' OR Name = 'Northwest Territories' OR Name = 'Yukon Territory'`
+                },
+                {
+                    id: 'BasinLine',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/ICDE/MapServer/2',
+                    permanentFilteredQuery: `OBJECTID > 80`
+                },
+                {
+                    id: 'CESI',
+                    layerType: 'esri-map-image',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/ICDE/MapServer/',
+                    sublayers: [{ index: 36 }, { index: 37 }, { index: 38 }]
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                infoType: 'title',
+                                name: 'Couches Vectorielles',
+                                children: [
+                                    {
+                                        layerId: 'WFSLayer'
+                                    },
+                                    {
+                                        layerId: 'TerritoriesPoly',
+                                        name: 'TerritoriesPoly'
+                                    },
+                                    {
+                                        layerId: 'BasinLine',
+                                        name: 'BasinLine',
+                                        coverIcon:
+                                            'https://cdn-icons-png.flaticon.com/512/136/136893.png?w=826&t=st=1687287352~exp=1687287952~hmac=10dfcb5cc9522c65066d495e3f17973ecf30dc948bdbdfcb073c647b3b616365'
+                                    }
+                                ]
+                            },
+                            {
+                                layerId: 'CESI',
+                                name: 'Rejets de cadmium',
+                                sublayerIndex: 36,
+                                children: [
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Rejets de mercure',
+                                        sublayerIndex: 37
+                                    },
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Rejets de plomb',
+                                        sublayerIndex: 38
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'title',
+                                content: 'Ouvrez-moi pour une surprise!',
+                                expanded: false,
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content: 'Continuer à ouvrir!',
+                                        expanded: false,
+                                        children: [
+                                            {
+                                                name: 'Custom Info Section',
+                                                infoType: 'template',
+                                                content: `<div>
+                                                            <img src="https://i.imgur.com/0IcfK7s.gif" />
+                                                            </div>`
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder',
+                        'areas-of-interest'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                details: {
+                    panelWidth: {
+                        default: 350,
+                        'details-items': 400
+                    }
+                },
+                export: {
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                },
+                'areas-of-interest': {
+                    areas: [
+                        {
+                            title: 'Reservoir Manicougan, Quebec, Canada',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                            altText: 'Reservoir Manicougan, Quebec, Canada',
+                            description:
+                                'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
+                            extent: {
+                                xmax: 1840000,
+                                xmin: 1750000,
+                                ymax: 682193,
+                                ymin: 583440,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Gulf of St Lawrence',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                            extent: {
+                                xmin: 2050000,
+                                xmax: 2240000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Lake Grandmesnil and surrounding lakes',
+                            extent: {
+                                xmin: 1800000,
+                                xmax: 1840000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'CN Tower',
+                            thumbnail:
+                                'https://upload.wikimedia.org/wikipedia/commons/9/9c/Toronto_-_ON_-_CN_Tower_Turmkorb.jpg',
+                            description:
+                                'The CN Tower is a 553.3 m-high concrete communications and observation tower in downtown Toronto, Ontario, Canada.',
+                            extent: {
+                                xmin: -8838051.849695725,
+                                xmax: -8836512.572464375,
+                                ymin: 5409988.501845284,
+                                ymax: 5410763.023921062,
+                                spatialReference: {
+                                    wkid: 102100,
+                                    latestWkid: 3857
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+// rInstance.fixture.addDefaultFixtures().then(() => {
+//     rInstance.panel.open('legend');
+//     rInstance.panel.pin('legend');
+// });
+
+rInstance.$element.component('WFSLayer-Custom', {
+    props: ['identifyData'],
+    template: `
+        <div>
+            <span>This is an example template that contains an image.</span>
+            <img src="https://i.imgur.com/WtY0tdC.gif" />
+        </div>
+    `
+});
+
+// add export fixtures
+rInstance.fixture.add('export');
+
+// add areas of interest fixture
+rInstance.fixture.add('areas-of-interest');
+
+// Add some grid button events.
+rInstance.event.on('customSettings', data => {
+    const layer = rInstance.geo.layer.getLayer(data.uid);
+    rInstance.event.emit('settings/toggle', layer);
+});
+
+rInstance.event.on('hybridZoomAndDetails', result => {
+    // Only perform the zoom if the layer is not a data layer.
+    if (result.layer.mapLayer) {
+        result.layer.getGraphic(result.oid, { getGeom: true }).then(g => {
+            rInstance.geo.map.zoomMapTo(g.geometry);
+        });
+    }
+
+    // Emit the event to toggle the details panel.
+    rInstance.event.emit('details/toggle', {
+        data: result.data,
+        uid: result.uid,
+        format: 'esri'
+    });
+});
+
+// load map if startRequired is true
+// rInstance.start();
+
+// function animateToggle() {
+//     if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
+//         rInstance.$vApp.$el.classList.remove('animation-enabled');
+//     } else {
+//         rInstance.$vApp.$el.classList.add('animation-enabled');
+//     }
+//     document.getElementById('animate-status').innerText =
+//         'Animate: ' + rInstance.animate;
+// }
+
+window.debugInstance = rInstance;

--- a/schema.json
+++ b/schema.json
@@ -1926,6 +1926,45 @@
                     "default": false,
                     "description": "Specifies if the table should filter rows by extent by default."
                 },
+                "controls": {
+                    "type": "array",
+                    "description": "Which action buttons to display for each rows. Pre-defined strings are 'zoom' and 'details'. Other entries may be an object containing an event name, an icon and a tooltip.",
+                    "default": ["zoom", "details"],
+                    "items": {
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "default": "",
+                                "description": "Either 'zoom' or 'details', the default grid buttons."
+                            },
+                            {
+                                "type": "object",
+                                "description": "Specifies a custom grid row button.",
+                                "properties": {
+                                    "actionEvent": {
+                                        "type": "string",
+                                        "description": "The name of the event to raise when the button is clicked."
+                                    },
+                                    "icon": {
+                                        "type": "string",
+                                        "description": "Determines which icon to display for the button."
+                                    },
+                                    "tooltip": {
+                                        "type": "string",
+                                        "description": "The tooltip to display when the button is hovered."
+                                    },
+                                    "displayOn": {
+                                        "type": "string",
+                                        "description": "Which layer format this button should appear for. Options are 'geo' for map layers, 'data' for data layers, or 'all' for both.",
+                                        "enum": ["all", "geo", "data"],
+                                        "default": "all"
+                                    }
+                                },
+                                "required": ["actionEvent", "icon", "tooltip"]
+                            }
+                        ]
+                    }
+                },
                 "panelWidth": {
                     "$ref": "#/$defs/panelWidth"
                 }

--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -5,6 +5,7 @@
             class="text-gray-500 hover:text-black dropdown-button"
             @click="open = !open"
             :content="tooltip"
+            :aria-label="String(tooltip)"
             v-tippy="{
                 placement: tooltipPlacement,
                 theme: tooltipTheme,

--- a/src/components/notification-center/caption-button.vue
+++ b/src/components/notification-center/caption-button.vue
@@ -44,6 +44,7 @@
                                     : 'text-gray-500 hover:text-black'
                             ]"
                             :content="t('notifications.controls.clearAll')"
+                            :aria-label="t('notifications.controls.clearAll')"
                             v-tippy="{
                                 placement: 'bottom',
                                 theme: 'ramp4',

--- a/src/components/notification-center/screen.vue
+++ b/src/components/notification-center/screen.vue
@@ -17,13 +17,14 @@
                                 : 'text-gray-500 hover:text-black'
                         ]"
                         :content="t('notifications.controls.clearAll')"
+                        :aria-label="t('notifications.controls.clearAll')"
                         v-tippy="{
                             placement: 'bottom',
                             theme: 'ramp4',
                             animation: 'scale'
                         }"
                     >
-                        <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Aclear_all -->
+                        <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Aclear_allss -->
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 24 24"

--- a/src/components/panel-stack/controls/back.vue
+++ b/src/components/panel-stack/controls/back.vue
@@ -5,6 +5,7 @@
             class="text-gray-500 hover:text-black focus:text-black p-8"
             :class="{ 'text-gray-700': active }"
             :content="t('panels.controls.back')"
+            :aria-label="t('panels.controls.back')"
             v-tippy="{
                 placement: 'bottom',
                 theme: 'ramp4',

--- a/src/components/panel-stack/controls/close.vue
+++ b/src/components/panel-stack/controls/close.vue
@@ -5,6 +5,7 @@
             class="text-gray-500 hover:text-black focus:text-black p-8"
             :class="{ 'text-gray-700': active }"
             :content="t('panels.controls.close')"
+            :aria-label="t('panels.controls.close')"
             v-tippy="{
                 placement: 'bottom',
                 theme: 'ramp4',

--- a/src/fixtures/appbar/button.vue
+++ b/src/fixtures/appbar/button.vue
@@ -11,6 +11,7 @@
             "
             v-focus-item
             :content="tooltip"
+            :aria-label="String(tooltip)"
             v-tippy="{ placement: 'right' }"
         >
             <slot></slot>

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -23,6 +23,8 @@ grid.filters.column.label.text,Search {0}...,1,Rechercher {0}...,1
 grid.filters.clear,Clear filters,1,Supprimer les filtres,1
 grid.filters.number.max,Max,1,Max,1
 grid.filters.number.min,Min,1,Min,1
+grid.filters.date.max,Max Date,1,Max Date,0
+grid.filters.date.min,Min Date,1,Min Date,0
 grid.filters.label.info,{range} of {total} entries shown,1,{range} de {total} saisies affichées,1
 grid.filters.label.filtered,(filtered from {max} total entries),1,(filtré à partir d'un total de {max} saisies),1
 grid.filters.extent,Filter by extent,1,Filtrer par étendue,1

--- a/src/fixtures/grid/store/grid-state.ts
+++ b/src/fixtures/grid/store/grid-state.ts
@@ -66,9 +66,17 @@ export interface TableStateOptions {
     search: boolean;
     searchFilter: string;
     applyToMap: boolean;
+    controls: (string | ActionButtonDefinition)[];
 }
 
 export interface AttributeMapPair {
     origAttr: string;
     mappedAttr: string | undefined;
+}
+
+export interface ActionButtonDefinition {
+    actionEvent: string;
+    icon: string;
+    tooltip: string;
+    displayOn: string;
 }

--- a/src/fixtures/grid/store/table-state-manager.ts
+++ b/src/fixtures/grid/store/table-state-manager.ts
@@ -1,5 +1,5 @@
 import ColumnStateManager from '../store/column-state-manager';
-import type { TableStateOptions } from './grid-state';
+import type { ActionButtonDefinition, TableStateOptions } from './grid-state';
 
 /**
  * Saves relevant enhancedTable states so that it can be reset on reload/reopen. A PanelStateManager is linked to a BaseLayer.
@@ -21,6 +21,7 @@ export default class TableStateManager {
         this._search = options?.search ?? true;
         this._searchFilter = options?.searchFilter ?? '';
         this._applyToMap = options?.applyToMap ?? false;
+        this._controls = options?.controls ?? ['zoom', 'details'];
 
         this.parsecolumns();
     }
@@ -268,6 +269,15 @@ export default class TableStateManager {
     set columns(val) {
         this._columns = val;
     }
+
+    /**
+     * Returns an array of grid action buttons.
+     *
+     * @memberof TableStateManager
+     */
+    get controls() {
+        return this._controls;
+    }
 }
 
 export default interface TableStateManager {
@@ -281,4 +291,5 @@ export default interface TableStateManager {
     _search: boolean;
     _searchFilter: string;
     _applyToMap: boolean;
+    _controls: (string | ActionButtonDefinition)[];
 }

--- a/src/fixtures/grid/templates/custom-button-renderer.vue
+++ b/src/fixtures/grid/templates/custom-button-renderer.vue
@@ -1,0 +1,105 @@
+<template>
+    <button
+        type="button"
+        class="flex items-center justify-center w-42 h-38"
+        v-if="isButtonVisible"
+        :content="props.params.config.tooltip"
+        v-tippy="{ placement: 'top' }"
+        @click="onButtonClick"
+        tabindex="-1"
+        ref="el"
+    >
+        <span v-html="props.params.config.icon"></span>
+    </button>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, onBeforeUnmount, onMounted, ref } from 'vue';
+import type { InstanceAPI, LayerInstance } from '@/api/internal';
+import type { AttributeMapPair } from '../store';
+
+const props = defineProps(['params']);
+const iApi = inject<InstanceAPI>('iApi')!;
+const el = ref<HTMLElement>();
+
+const isButtonVisible = computed<boolean>(() => {
+    let data = Object.assign({}, props.params.data);
+
+    // Find the layer to determine whether this is a map layer or not.
+    const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
+        data['rvUid']
+    )!;
+    const visibility = props.params.config.displayOn;
+
+    // Determine whether this button should be visible. If the visibility is set to data only, don't display if this is a map layer.
+    if (
+        !layer ||
+        (visibility === 'geo' && !layer.mapLayer) ||
+        (visibility === 'data' && layer.mapLayer)
+    ) {
+        return false;
+    }
+
+    return true;
+});
+
+const onButtonClick = () => {
+    let data = Object.assign({}, props.params.data);
+
+    const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
+        data['rvUid']
+    )!;
+    const oidPair = props.params.layerCols[layer.id].find(
+        (pair: AttributeMapPair) => pair.origAttr === layer.oidField
+    );
+
+    const oid = oidPair.mappedAttr
+        ? data[oidPair.mappedAttr]
+        : data[oidPair.origAttr];
+
+    layer.getGraphic(oid, { getAttribs: true }).then(g => {
+        iApi.event.emit(props.params.config.actionEvent, {
+            data: g.attributes,
+            layer: layer,
+            uid: props.params.data.rvUid,
+            oid: oid
+        });
+    });
+};
+
+onMounted(() => {
+    // need to hoist events to top level cell wrapper to be keyboard accessible
+    props.params.eGridCell.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            onButtonClick();
+        }
+    });
+
+    props.params.eGridCell.addEventListener('focus', () => {
+        (el.value as any)._tippy.show();
+    });
+    props.params.eGridCell.addEventListener('blur', () => {
+        (el.value as any)._tippy.hide();
+    });
+});
+
+onBeforeUnmount(() => {
+    props.params.eGridCell.removeEventListener(
+        'keydown',
+        (e: KeyboardEvent) => {
+            if (e.key === 'Enter') {
+                onButtonClick();
+            }
+        }
+    );
+
+    props.params.eGridCell.removeEventListener('focus', () => {
+        (el.value as any)._tippy.show();
+    });
+    props.params.eGridCell.removeEventListener('blur', () => {
+        (el.value as any)._tippy.hide();
+    });
+});
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/fixtures/grid/templates/custom-date-filter.vue
+++ b/src/fixtures/grid/templates/custom-date-filter.vue
@@ -4,7 +4,8 @@
             class="m-0 py-1 w-1/2 rv-input bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
             :class="{ 'pointer-events-none': fixed }"
             type="date"
-            placeholder="date min"
+            :placeholder="t('grid.filters.date.min')"
+            :aria-label="t('grid.filters.date.min')"
             v-model="minVal"
             @input="minValChanged()"
             @mousedown.stop
@@ -16,12 +17,15 @@
             "
             enterkeyhint="done"
         />
+
         <span class="w-12" />
+
         <input
             class="m-0 py-1 w-1/2 rv-input bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
             :class="{ 'pointer-events-none': fixed }"
             type="date"
-            placeholder="date max"
+            :placeholder="t('grid.filters.date.max')"
+            :aria-label="t('grid.filters.date.max')"
             v-model="maxVal"
             @input="maxValChanged()"
             @mousedown.stop
@@ -38,6 +42,7 @@
 
 <script setup lang="ts">
 import { onBeforeMount, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import type { ColumnDefinition, FilterParams } from '../table-component.vue';
 import { usePanelStore } from '@/stores/panel';
 
@@ -49,7 +54,7 @@ export interface GridCustomDateFilter {
 }
 
 const panelStore = usePanelStore();
-
+const { t } = useI18n();
 const props = defineProps(['params']);
 
 const minVal = ref<string>('');

--- a/src/fixtures/grid/templates/custom-number-filter.vue
+++ b/src/fixtures/grid/templates/custom-number-filter.vue
@@ -16,8 +16,10 @@
             "
             enterkeyhint="done"
             :placeholder="t('grid.filters.number.min')"
+            :aria-label="t('grid.filters.number.min')"
         />
         <span class="w-12" />
+
         <input
             class="rv-max rv-input bg-white text-black-75 h-24 py-16 px-8 border-2 rounded"
             :class="{ 'pointer-events-none': fixed }"
@@ -34,6 +36,7 @@
             "
             enterkeyhint="done"
             :placeholder="t('grid.filters.number.max')"
+            :aria-label="t('grid.filters.number.max')"
         />
     </div>
 </template>

--- a/src/fixtures/grid/templates/custom-selector-filter.vue
+++ b/src/fixtures/grid/templates/custom-selector-filter.vue
@@ -6,6 +6,7 @@
             v-model="selectedOption"
             @change="selectionChanged()"
             @mousedown.stop
+            :aria-label="selectedOption"
         >
             <option v-for="option in options" :value="option" :key="option">
                 {{ option }}

--- a/src/fixtures/grid/templates/custom-text-filter.vue
+++ b/src/fixtures/grid/templates/custom-text-filter.vue
@@ -19,6 +19,11 @@
                     params.column.colDef.headerName
                 ])
             "
+            :aria-label="
+                t('grid.filters.column.label.text', [
+                    params.column.colDef.headerName
+                ])
+            "
         />
     </div>
 </template>

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -135,6 +135,12 @@
                                 ? t('legend.symbology.hide')
                                 : t('legend.symbology.expand')
                         "
+                        :aria-label="
+                            legendItem instanceof LayerItem &&
+                            legendItem.symbologyExpanded
+                                ? t('legend.symbology.hide')
+                                : t('legend.symbology.expand')
+                        "
                         v-tippy="{
                             placement: 'top-start'
                         }"

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -7,6 +7,7 @@
             class="relative mr-auto text-gray-500 hover:text-black mb-3"
             v-show="getWizardExists() && isControlAvailable('wizard')"
             :content="t('legend.header.addlayer')"
+            :aria-label="t('legend.header.addlayer')"
             v-tippy="{ placement: 'right' }"
         >
             <svg class="fill-current w-18 h-18 mx-8" viewBox="0 0 23 21">
@@ -22,6 +23,7 @@
                 getLayerReorderExists() && isControlAvailable('layerReorder')
             "
             :content="t('legend.header.reorderlayers')"
+            :aria-label="t('legend.header.reorderlayers')"
             v-tippy="{ placement: 'right' }"
         >
             <svg

--- a/src/fixtures/overviewmap/overviewmap.vue
+++ b/src/fixtures/overviewmap/overviewmap.vue
@@ -26,6 +26,13 @@
                                 : 'overviewmap.minimize'
                         )
                     "
+                    :aria-label="
+                        t(
+                            minimized
+                                ? 'overviewmap.expand'
+                                : 'overviewmap.minimize'
+                        )
+                    "
                     v-tippy="{ placement: 'left', hideOnClick: false }"
                 >
                     <svg


### PR DESCRIPTION
### Related Item(s)
No RAMP4 issue exists at the moment. 

This feature is pretty urgently needed for Cumulative Effects. I wrote this up in one day so I'm looking for as much feedback/suggestions as possible!

### Changes
Added a new grid config option: `controls`, which lets you customize which buttons appear in the rows of the grid. The default for this setting is ["zoom", "details"], which will display the two current buttons. 

These new custom buttons are meant to be event-driven. When you create a button, you provide an event name that is emitted when the button is clicked (event handlers should be placed on the host page).

To add a custom button to the grid, add the following object to the `controls` array:
```
{
    actionName: string; // the name of the event to call when the button is pressed
    icon: string; // the icon to display in the button. It can be an svg, an emoji, or text.
    tooltip: string;
}
```

### Notes
GIF demonstrating a grid with two custom buttons. One button opens the settings menu for the layer, and the other combines the actions of the two default buttons (zooms and displays details panel).
![](https://i.imgur.com/aKhNn3g.gif)

### Testing
Steps:
1. Open the [new sample page](https://ramp4-pcar4.github.io/ramp4-pcar4/ce-custom-buttons/demos/index-samples.html?sample=43) (sample 43)
2. Ensure the new custom buttons in the `Releases of Mercury` grid work correctly
3. Ensure only the "zoom" button displays in the `WFSLayer` grid
4. Test other samples and ensure everything still works as expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1957)
<!-- Reviewable:end -->
