### PR TITLE
Respectful Reprojection

### DIFF
--- a/demos/starter-scripts/cumulative-effects.js
+++ b/demos/starter-scripts/cumulative-effects.js
@@ -259,23 +259,39 @@ const enConfig = {
             nameField: 'Initiative',
             layerType: 'esri-feature',
             expanded: true,
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/3',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/4',
             state: {
                 opacity: 0.6,
-                symbologyExpanded: true,
+                symbologyExpanded: false,
                 visibility: true
             },
             identifyMode: 'hybrid',
             customRenderer: {},
             expectedDrawTime: 20000,
-            expectedLoadTime: 20000
+            expectedLoadTime: 20000,
+            fieldMetadata: {
+                fieldInfo: [
+                    { name: 'Overarching_Initiative' },
+                    { name: 'Initiative' },
+                    { name: 'Description' },
+                    { name: 'Management_Assessment_or_Monitoring' },
+                    { name: 'Departments' },
+                    { name: 'Partners' },
+                    { name: 'Province_or_Territory' },
+                    { name: 'Relevant_Industry' },
+                    { name: 'OSDP_or_Open_Data_Links' },
+                    { name: 'Further_Information' },
+                    { name: 'Related_Initiatives' }
+                ],
+                exclusiveFields: true
+            }
         },
         {
             id: 'ce_multipoints',
             name: 'Initiatives - Multipoints',
             nameField: 'Initiative',
             layerType: 'esri-feature',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/2',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/3',
             state: {
                 visibility: true
             },
@@ -288,7 +304,7 @@ const enConfig = {
             name: 'Initiatives - Lines',
             nameField: 'Initiative',
             layerType: 'esri-feature',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/1',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/2',
             state: {
                 visibility: true
             },
@@ -301,7 +317,7 @@ const enConfig = {
             name: 'Initiatives - Points',
             nameField: 'Initiative',
             layerType: 'esri-feature',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/0',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/1',
             state: {
                 visibility: true
             },
@@ -312,9 +328,9 @@ const enConfig = {
         {
             id: 'ce_table',
             name: 'Initiatives - Unmapped',
-            nameField: 'Initiative__EN_',
+            nameField: 'Initiative',
             layerType: 'data-esri-table',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/4',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/10',
             state: {
                 visibility: true
             },
@@ -329,22 +345,22 @@ const enConfig = {
                     {
                         layerId: 'ce_polygons',
                         name: 'Initiatives - Polygons',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_multipoints',
                         name: 'Initiatives - Multipoints',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_lines',
                         name: 'Initiatives - Lines',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_points',
                         name: 'Initiatives - Points',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_table',
@@ -391,28 +407,9 @@ const enConfig = {
                                 title: 'Management',
                                 field: 'Management_Assessment_or_Monitoring'
                             },
-                            { width: 235, field: 'Partners' },
-                            // NOTE this only exists in the table layer. I expect it to be removed?
-                            {
-                                visible: false,
-                                field: 'Reporting_Department___Agency'
-                            }
+                            { width: 235, field: 'Partners' }
                         ]
-                    },
-                    // NOTE this is only required because our section917 table service has inconsistent field names.
-                    //      if that gets cleared up, we can drop this
-                    fieldMap: [
-                        { field: 'Initiative', sources: ['Initiative__EN_'] },
-                        { field: 'Description', sources: ['Description__EN_'] },
-                        {
-                            field: 'Management_Assessment_or_Monitoring',
-                            sources: ['Management__Assessment__or_Monitoring']
-                        },
-                        {
-                            field: 'Province_or_Territory',
-                            sources: ['Province___Territory']
-                        }
-                    ]
+                    }
                 }
             ]
         },
@@ -694,10 +691,10 @@ const frConfig = {
             nameField: 'Initiative',
             layerType: 'esri-feature',
             expanded: true,
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/2',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/9',
             state: {
                 opacity: 0.6,
-                symbologyExpanded: true,
+                symbologyExpanded: false,
                 visibility: true
             },
             identifyMode: 'hybrid',
@@ -710,7 +707,7 @@ const frConfig = {
             name: '[FR] Initiatives - Multipoints',
             nameField: 'Initiative',
             layerType: 'esri-feature',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/1',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/8',
             state: {
                 visibility: true
             },
@@ -723,7 +720,7 @@ const frConfig = {
             name: 'Initiatives - Lines',
             nameField: 'Initiative',
             layerType: 'esri-feature',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/1',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/7',
             state: {
                 visibility: true
             },
@@ -736,7 +733,7 @@ const frConfig = {
             name: '[FR] Initiatives - Points',
             nameField: 'Initiative',
             layerType: 'esri-feature',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/0',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/6',
             state: {
                 visibility: true
             },
@@ -749,7 +746,7 @@ const frConfig = {
             name: '[FR] Initiatives - Unmapped',
             nameField: 'Initiative__EN_',
             layerType: 'data-esri-table',
-            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/CE_MkIV/MapServer/4',
+            url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/11',
             state: {
                 visibility: true
             },
@@ -764,22 +761,22 @@ const frConfig = {
                     {
                         layerId: 'ce_polygons',
                         name: '[FR] Initiatives - Polygons',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_multipoints',
                         name: '[FR] Initiatives - Multipoints',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_lines',
                         name: '[FR] Initiatives - Lines',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_points',
                         name: '[FR] Initiatives - Points',
-                        symbologyExpanded: true
+                        symbologyExpanded: false
                     },
                     {
                         layerId: 'ce_table',
@@ -820,35 +817,9 @@ const frConfig = {
                         columns: [
                             { visible: false, field: 'Shape_Length' },
                             { visible: false, field: 'Shape_Area' },
-                            { visible: false, field: 'Department' },
-                            {
-                                width: 235,
-                                title: '[FR] Management',
-                                field: 'Management_Assessment_or_Monitoring'
-                            },
-                            { width: 235, field: 'Partners' },
-
-                            // NOTE this only exists in the table layer. I expect it to be removed?
-                            {
-                                visible: false,
-                                field: 'Reporting_Department___Agency'
-                            }
+                            { visible: false, field: 'Department' }
                         ]
-                    },
-                    // NOTE this is only required because our section917 table service has inconsistent field names.
-                    //      if that gets cleared up, we can drop this
-                    fieldMap: [
-                        { field: 'Initiative', sources: ['Initiative__EN_'] },
-                        { field: 'Description', sources: ['Description__EN_'] },
-                        {
-                            field: 'Management_Assessment_or_Monitoring',
-                            sources: ['Management__Assessment__or_Monitoring']
-                        },
-                        {
-                            field: 'Province_or_Territory',
-                            sources: ['Province___Territory']
-                        }
-                    ]
+                    }
                 }
             ]
         },


### PR DESCRIPTION
### Related Item(s)

Implements a first-cut of a fix for #1831

### Changes

- Adds new config flag `map.symbologyExpanded`. Defaults to false.
- Adds extent taming upon basemap reprojection if above flag is true
- Cleans up broken urls in Sample 42 (old service got nuked)

### Notes

Will be putting more analysis and future options enhancements on the issue shortly.

How this works is when the flag is on, after you reproject, if the new extent is wildly out of place due to warping, we tame it.

- If the new extent is totally outside of the `fullExtent` for the new tile schema (on either axis), we just go back to `fullExtent`. 
- If new extent is just lurking outside the boundaries, we will clip every lurking extent edge to the edge of `fullExtent`.


### Testing

Use sample 15 (Simple Feature), which has the flag turned on. Try switching basemaps between Lambert and Mercator when at various views.
There will still be some warpage and zoom level jumping. This is just natural due to the differences in Lambert & Mercator, and the tile scales that our basemaps are encoded at.  But we should no longer see wild jumps, in particular at the canada/world level. E.g. prior to this patch, going from large Canada Lambert to Mercator would center the map on Norway. The math was correct, but disrespectful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1960)
<!-- Reviewable:end -->
