### PR TITLE
Grid will now refresh when filters are applied

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -675,6 +675,10 @@ const updateFilterInfo = () => {
             applyFiltersToMap();
         }
         nextTick(() => {
+            let cols = columnApi.value.getAllDisplayedColumns();
+            agGridOptions.value.api.refreshCells({
+                columns: [cols[0]] // Limits the refresh action to the row number column.
+            });
             updateRowInfo();
         });
     }


### PR DESCRIPTION
### Related Item(s)
#1933 

### Changes
- Grid cells will be refreshed when filters are applied.

### Notes
- Thanks James

### Testing
Steps:
1. Open the grid and apply any filter. Both within individual cells or globally.
2. Grid numbers will properly update both on filter and when cleared.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1962)
<!-- Reviewable:end -->
