### PR TITLE
add width for grid cell tooltips

### DIFF
--- a/src/fixtures/grid/templates/cell-renderer.vue
+++ b/src/fixtures/grid/templates/cell-renderer.vue
@@ -6,6 +6,7 @@
                     placement: 'top',
                     hideOnClick: false,
                     theme: 'ramp4',
+                    maxWidth: mobileMode ? 300 : 700, // remove this once scrollable tooltip option is implemented
                     animation: 'scale',
                     interactive: containsLinks
                 }
@@ -36,7 +37,9 @@ import { computed, inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import type { InstanceAPI } from '@/api';
 import linkifyHtml from 'linkify-html';
 import { useI18n } from 'vue-i18n';
+import { usePanelStore } from '@/stores/panel';
 
+const panelStore = usePanelStore();
 const iApi = inject<InstanceAPI>('iApi')!;
 const { t } = useI18n();
 const copyTooltip = ref<HTMLElement>();
@@ -44,6 +47,8 @@ const el = ref<HTMLElement>();
 const isCopied = ref<boolean>(false);
 
 const props = defineProps(['params']);
+
+const mobileMode = computed(() => panelStore.mobileView);
 
 const copy = () => {
     if (!el.value?.textContent) {


### PR DESCRIPTION
### Related Item(s)
Temp solution for #1943

### Changes
- adds more width for grid cell tooltips

### Notes
![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/31557789/9557e692-8dce-477b-9d89-d665b9d2a393)


### Testing
Steps:
1. Used [layer](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer) for testing 
2. Hover grid cells with truncated text and see tooltips

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1963)
<!-- Reviewable:end -->
