### PR TITLE
Prevent the user from proceeding without a layer name

### DIFF
--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -34,12 +34,7 @@
                         />
                         <wizard-form-footer
                             @submit="onUploadContinue"
-                            @cancel="
-                                () => {
-                                    goNext = false;
-                                    wizardStore.goToStep(0);
-                                }
-                            "
+                            @cancel="cancelServiceStep"
                             :disabled="!goNext"
                         />
                     </form>
@@ -143,7 +138,7 @@
                             type="text"
                             name="name"
                             v-model="layerInfo.config.name"
-                            @text="updateLayerName"
+                            @link="updateLayerName"
                             :label="t('wizard.configure.name.label')"
                             :validation="true"
                             :validation-messages="{
@@ -268,7 +263,7 @@
                         </ColorPicker>
                         <wizard-form-footer
                             @submit="onConfigureContinue"
-                            @cancel="wizardStore.goToStep(1)"
+                            @cancel="cancelNameStep"
                             :disabled="!finishStep"
                         />
                     </form>
@@ -542,9 +537,10 @@ const onSelectContinue = async () => {
 
     wizardStore.goToStep(WizardStep.CONFIGURE);
 
-    layerInfo.value.configOptions.includes(`sublayers`)
-        ? (finishStep.value = false)
-        : (finishStep.value = true);
+    finishStep.value = !(
+        layerInfo.value.configOptions.includes('sublayers') ||
+        !layerInfo.value!.config.name
+    );
 
     disabled.value = false;
     validation.value = false;
@@ -608,9 +604,9 @@ const updateTypeSelection = (type: string) => {
 };
 
 const updateLayerName = (name: string) => {
-    layerInfo.value!.config.name = name;
+    layerInfo.value!.config.name = name.trim();
     const sublayers = layerInfo.value?.config.sublayers;
-    const canFinish = sublayers ? name && sublayers.length > 0 : name;
+    const canFinish = sublayers ? name && sublayers.length > 0 : name.trim();
     canFinish ? (finishStep.value = true) : (finishStep.value = false);
 };
 
@@ -646,6 +642,16 @@ const updateColour = (eventData: any) => {
             '.vacp-copy-button'
         )!.style.backgroundColor = layerInfo.value?.config.colour;
     });
+};
+
+const cancelServiceStep = () => {
+    goNext.value = false;
+    wizardStore.goToStep(0);
+};
+
+const cancelNameStep = () => {
+    finishStep.value = false;
+    wizardStore.goToStep(1);
 };
 </script>
 


### PR DESCRIPTION
### Related Item(s)
#1909 

### Changes
- The user won't be able to proceed without a layer name. This is consistent with preventing the user from proceeding without a service url.

### Notes
Decided to just go with disabling the button to keep it consistent with the service url step. 

### Testing
Steps:
1. Open the layer wizard
2. Provide a bogus url E.g. [a ramp demo page](https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=15).
3. Select tile layer
4. Witness the disabled continue button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1969)
<!-- Reviewable:end -->
