### PR TITLE
Fix unexpected focus jump when clicking on legend

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -683,9 +683,6 @@ const toggleExpand = () => {
         return;
     }
     props.legendItem.toggleExpanded();
-    nextTick(() =>
-        el.value.querySelector('.legend-group')?.scrollIntoView(false)
-    );
     iApi.updateAlert(
         t(
             `legend.alert.group${
@@ -700,9 +697,6 @@ const toggleExpand = () => {
 const toggleSymbology = (): void => {
     if (controlAvailable(LayerControl.Symbology)) {
         const expanded = (props.legendItem as LayerItem).toggleSymbology();
-        nextTick(() =>
-            el.value.querySelector('.symbology-stack')?.scrollIntoView(false)
-        );
         iApi.updateAlert(
             t(`legend.alert.symbology${expanded ? 'Expanded' : 'Collapsed'}`)
         );


### PR DESCRIPTION
### Related Item(s)
For #1968

### Changes
- Clicking on a legend icon to expand it or trying to expand a group in the legend will no longer jump so that the bottom of the expandable content is at the bottom of your screen

### Notes
Bug could be replicated in storylines as well, settled for creating a PR here instead of the marketing site as this seemed to be an issue with RAMP.

### Testing

- To see the bug in action for storylines, go to [this](https://github.com/ramp4-pcar4/story-ramp/pull/377) PR that uses RAMP4 and use the demo link

- To see in the marketing site, go to [this](https://ramp4-pcar4.github.io/ramp-pcar/#/?lang=en) 

To see the bug with RAMP4
1. Go to the [samples catalogue](https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-all.html) page and find the "RAMP inside the WET template with teleport enabled" template.
2. Scroll down (can't be scrolled to the top of the page or won't notice the bug) and click the WFSLayer icon (screen will flick up)
3. Scroll down again and expand the visibility set group (screen will flick up)

Should be fixed now when trying to do the same thing using this demo's catalogue link.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1971)
<!-- Reviewable:end -->
