### PR TITLE
Prevent page from reloading when pressing enter in wizard

### DIFF
--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -494,7 +494,9 @@ const onUploadContinue = (event: any) => {
     wizardStore.goToStep(WizardStep.FORMAT);
 };
 
-const onSelectContinue = async () => {
+const onSelectContinue = async (event: any) => {
+    event?.preventDefault();
+
     disabled.value = true;
     failureError.value = false;
     validation.value = true;
@@ -550,7 +552,10 @@ const onSelectContinue = async () => {
     validation.value = false;
 };
 
-const onConfigureContinue = async (data: object) => {
+const onConfigureContinue = async (data: any) => {
+    // Prevent the page from refreshing when pressing ENTER.
+    data?.preventDefault();
+
     const config: RampLayerConfig = Object.assign(
         layerInfo.value!.config,
         data


### PR DESCRIPTION
### Related Item(s)
#1944 

### Changes
- Pressing enter on an input in the wizard should now go to the next step as expected and will no longer refresh the page.

### Testing
Steps:
1. Open the wizard
2. Enter a service URL ([this one for example](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/1)) and go through to the last step.
3. At the final step, enter a layer name and press enter. The page should no longer refresh and the layer should instead be added as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1972)
<!-- Reviewable:end -->
