### PR TITLE
clear filters icon colour change

### DIFF
--- a/src/fixtures/geosearch/top-filters.vue
+++ b/src/fixtures/geosearch/top-filters.vue
@@ -47,7 +47,7 @@
             </select>
             <button
                 type="button"
-                class="text-gray-400 w-1/8 h-24 pl-8 pr-16 sm:pr-8 hover:text-black disabled:cursor-default disabled:text-gray-400"
+                class="text-gray-500 w-1/8 h-24 pl-8 pr-16 sm:pr-8 hover:text-black disabled:cursor-default disabled:text-gray-300"
                 :disabled="!queryParams.type && !queryParams.province"
                 v-on:click="clearFilters"
                 :content="t('geosearch.filters.clear')"


### PR DESCRIPTION
### Related Item(s)
[#1893](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1893) 

### Changes
- In button for Clear Filters in the Geosearch panel, changed the disabled colour to gray-300 and enabled colour to gray-500, no changes to the hover colour

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1984)
<!-- Reviewable:end -->
