### PR TITLE
Separate messages for map scale toggle

### DIFF
--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -67,7 +67,7 @@
                 class="flex-shrink-0 mx-2 sm:mx-10 px-4 pointer-events-auto cursor-pointer border-none"
                 @click="onScaleClick"
                 :aria-pressed="scale?.isImperialScale"
-                :aria-label="t('map.toggleScaleUnits')"
+                :aria-label="changeScaleMessage(scale?.isImperialScale)"
                 v-tippy="{
                     delay: [300, 0],
                     placement: 'top',
@@ -76,7 +76,7 @@
                     animation: 'scale',
                     touch: ['hold', 200]
                 }"
-                :content="t('map.toggleScaleUnits')"
+                :content="changeScaleMessage(scale?.isImperialScale)"
             >
                 <span
                     class="border-solid border-2 border-white border-t-0 h-5 mr-4 inline-block"
@@ -193,6 +193,15 @@ const onScaleClick = () => {
     // undefined argument will toggle the scale unit
     mapCaptionStore.toggleScale();
     iApi.geo.map.caption.updateScale();
+};
+
+/**
+ * Show different scale messages based on the current scale
+ */
+const changeScaleMessage = (isImperialScale: boolean = false) => {
+    return isImperialScale
+        ? t('map.toggleScaleToMetric')
+        : t('map.toggleScaleToImperial');
 };
 </script>
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -12,7 +12,8 @@ keyboardInstructions.app,"Use 'Tab' to navigate between sections of the applicat
 keyboardInstructions.lists,"Use the arrow keys to move between items in lists. With a list item selected you can press 'Space' or 'Enter' to click the item. You can also navigate within the list item using 'Tab'.",1,"Lorsqu'un élément de la liste est sélectionné, vous pouvez appuyer sur « Espace » ou « Entrée » pour cliquer sur l'élément. Vous pouvez également vous déplacer au sein de l'élément de la liste au moyen de la touche « Tab ».",1
 keyboardInstructions.map,"When the map is selected, use the arrow keys to move around and 'Enter' to select a point.",1,"Lorsque la carte est sélectionnée, utilisez le pavé curseur pour vous déplacer et appuyez sur « Entrée »  pour sélectionner un point.",1
 keyboardInstructions.OK,OK,1,OK,1
-map.toggleScaleUnits,Toggle between imperial and metric map scale,1,Basculer entre les échelles métriques et impériales pour la carte,1
+map.toggleScaleToMetric,Switch to metric map scale,1,Passer à l'échelle métrique de la carte,0
+map.toggleScaleToImperial,Switch to imperial map scale,1,Passer à l'échelle impériale de la carte,0
 map.coordinates.east,E,1,E,1
 map.coordinates.west,W,1,O,1
 map.coordinates.north,N,1,N,1


### PR DESCRIPTION
### Related Item(s)
[#1936](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1936) 

### Changes
Show separate messages for the map scale depending on the state of the toggle:
- "Switch to imperial map scale" when the current state is metric
- "Switch to metric map scale" when the current state is imperial

Originally showed "Toggle between imperial and metric map scale" regardless of state.

### Notes
![en_to_imperial](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/e47e4734-4684-48a2-93b0-886a86b74b78)
![en_to_metric](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/0defa2cc-b74f-4419-a87e-73ea4947f14c)
![fr_to_imperial](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/4346486e-dd04-461b-81a2-254f3f5e436a)
![fr_to_metric](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/d39c0da7-f3ca-4970-b471-396b1fc1d72d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1987)
<!-- Reviewable:end -->
