### PR TITLE
Fix north pole icon config

### DIFF
--- a/src/fixtures/northarrow/api/northarrow.ts
+++ b/src/fixtures/northarrow/api/northarrow.ts
@@ -14,7 +14,7 @@ export class NortharrowAPI extends FixtureInstance {
 
         if (!northarrowConfig) return;
         northarrowStore.arrowIcon = northarrowConfig.arrowIcon;
-        northarrowStore.poleIcon, northarrowConfig.poleIcon;
+        northarrowStore.poleIcon = northarrowConfig.poleIcon;
     }
 
     get config(): NortharrowConfig {


### PR DESCRIPTION
### Related Item(s)
#1992 

### Changes
- [FIX] `northarrow` `poleIcon` config setting now properly changes the north pole icon

### Testing
Steps:
1. Open sample 4, observe normal north pole icon
2. Open sample 10, observe changed north pole icon

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1991)
<!-- Reviewable:end -->
