### PR TITLE
Legend icons alignment and size

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -6,14 +6,13 @@
     >
         <div class="relative">
             <div
-                class="flex items-center hover:bg-gray-200"
+                class="flex items-center hover:bg-gray-200 !p-5"
                 :class="[
                     legendItem.type === LegendType.Item
                         ? 'loaded-item default-focus-style'
                         : legendItem.type === LegendType.Error
                         ? 'non-loaded-item bg-red-200'
                         : 'non-loaded-item',
-                    legendItem instanceof LayerItem ? 'p-5' : 'px-5 py-10',
                     (isGroup && controlAvailable(LegendControl.Expand)) ||
                     (!isGroup &&
                         legendItem instanceof LayerItem &&

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -1,41 +1,53 @@
 <template>
-    <div class="relative legend-header flex">
+    <div class="relative legend-header flex align-middle">
         <!-- open import wizard -->
-        <button
-            type="button"
-            @click="toggleWizard"
-            class="relative mr-auto text-gray-500 hover:text-black mb-3"
-            v-show="getWizardExists() && isControlAvailable('wizard')"
-            :content="t('legend.header.addlayer')"
-            :aria-label="t('legend.header.addlayer')"
-            v-tippy="{ placement: 'right' }"
-        >
-            <svg class="fill-current w-18 h-18 mx-8" viewBox="0 0 23 21">
-                <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path>
-            </svg>
-        </button>
-        <!-- open layer reorder -->
-        <button
-            type="button"
-            @click="toggleLayerReorder"
-            class="relative mr-auto text-gray-500 hover:text-black p-8 mb-3"
-            v-show="
-                getLayerReorderExists() && isControlAvailable('layerReorder')
-            "
-            :content="t('legend.header.reorderlayers')"
-            :aria-label="t('legend.header.reorderlayers')"
-            v-tippy="{ placement: 'right' }"
-        >
-            <svg
-                class="fill-current w-18 h-18 mx-8 mt-4 flip"
-                viewBox="0 0 23 21"
+        <div>
+            <button
+                type="button"
+                @click="toggleWizard"
+                class="relative mr-auto text-gray-500 hover:text-black"
+                v-show="getWizardExists() && isControlAvailable('wizard')"
+                :content="t('legend.header.addlayer')"
+                :aria-label="t('legend.header.addlayer')"
+                v-tippy="{ placement: 'right' }"
             >
-                <path d="M0 0h24v24H0z" fill="none" />
-                <path
-                    d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z"
-                />
-            </svg>
-        </button>
+                <div class="p-8">
+                    <svg
+                        class="fill-current w-18 h-18 flip"
+                        viewBox="0 0 23 21"
+                    >
+                        <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path>
+                    </svg>
+                </div>
+            </button>
+        </div>
+        <!-- open layer reorder -->
+        <div>
+            <button
+                type="button"
+                @click="toggleLayerReorder"
+                class="relative mr-auto text-gray-500 hover:text-black"
+                v-show="
+                    getLayerReorderExists() &&
+                    isControlAvailable('layerReorder')
+                "
+                :content="t('legend.header.reorderlayers')"
+                :aria-label="t('legend.header.reorderlayers')"
+                v-tippy="{ placement: 'right' }"
+            >
+                <div class="p-8">
+                    <svg
+                        class="fill-current w-18 h-18 flip"
+                        viewBox="0 0 23 21"
+                    >
+                        <path d="M0 0h24v24H0z" fill="none" />
+                        <path
+                            d="M14 5h8v2h-8zm0 5.5h8v2h-8zm0 5.5h8v2h-8zM2 11.5C2 15.08 4.92 18 8.5 18H9v2l3-3-3-3v2h-.5C6.02 16 4 13.98 4 11.5S6.02 7 8.5 7H12V5H8.5C4.92 5 2 7.92 2 11.5z"
+                        />
+                    </svg>
+                </div>
+            </button>
+        </div>
         <span class="flex-1"></span>
         <!-- groups toggle -->
         <dropdown-menu
@@ -47,10 +59,7 @@
         >
             <template #header>
                 <div class="p-8">
-                    <svg
-                        class="fill-current w-18 h-18 mx-8"
-                        viewBox="0 0 23 21"
-                    >
+                    <svg class="fill-current w-18 h-18" viewBox="0 0 23 21">
                         <path
                             d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
                         />


### PR DESCRIPTION
### Related Item(s)
[#1887](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1887) , [#1889](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1889) 

### Changes
- Normalized legend button sizes and padding to 34x40.4
- Legend item and icons are aligned and centered

### Notes
![legend item alignment](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/6a156573-1c2e-4c17-81b3-e3acbbdc6298)


![plus icon](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/dc3d5af5-0fc1-436e-b7ce-c49240c8c986)
![visibility](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/8350bed1-b416-4508-a36a-1ec2cf3e91d1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1993)
<!-- Reviewable:end -->
