### PR TITLE
Fix legend infinite load 

### DIFF
--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -142,6 +142,9 @@ export class LegendAPI extends FixtureInstance {
         // will be in a placeholder state until the layer is loaded
         this._insertItem(item as unknown as LegendItem, parent);
 
+        // Updates the legend with the inserted item
+        this.updateLegend(layer);
+
         if (layer.supportsSublayers) {
             // if layer supports sublayers, then we need to parse the
             // layer tree after loading and generate the children

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -93,6 +93,7 @@ export class LayerItem extends LegendItem {
         this._layerId = layer.id;
         this._layerIdx = layer.layerIdx;
         this._layerUid = layer.uid;
+        this._name = this._name || layer.name;
         this._symbologyStack = this._customSymbology
             ? this._symbologyStack
             : layer.legend; // set this item's symbology stack to layer's default if undefined in config


### PR DESCRIPTION
### Related Item(s)
#1974

### Changes
- [FIX] Update the legend once the layer has been added to the store

### Testing
Steps:
1. Go to any sample (15 is nice)
2. Put the following code in the console.

```
var jconf = {
  id: 'Fun-Lines',
  layerType: 'esri-feature',
  url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/EPB/cumulative_effects_effets_cumulatifs/MapServer/2'
};
 
var layerObj = debugInstance.geo.layer.createLayer(jconf);
debugInstance.geo.map.addLayer(layerObj);
```

3. Wait for layer to load. This one will have a green line in British Columbia; choosing a light basemap will make it easy to see
4. Then run this in console

```
debugInstance.fixture.get('legend').addLayerItem(layerObj);
```
5. Legend item should now load correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/1994)
<!-- Reviewable:end -->
