### PR TITLE
Changes to samples 17, 42, and samples with prod CESI

### DIFF
--- a/demos/starter-scripts/cumulative-effects.js
+++ b/demos/starter-scripts/cumulative-effects.js
@@ -271,16 +271,16 @@ const enConfig = {
             expectedLoadTime: 20000,
             fieldMetadata: {
                 fieldInfo: [
-                    { name: 'Overarching_Initiative' },
                     { name: 'Initiative' },
+                    { name: 'Overarching_Initiative' },
                     { name: 'Description' },
-                    { name: 'Management_Assessment_or_Monitoring' },
+                    { name: 'Initiative_Type' },
                     { name: 'Departments' },
                     { name: 'Partners' },
                     { name: 'Province_or_Territory' },
                     { name: 'Relevant_Industry' },
-                    { name: 'OSDP_or_Open_Data_Links' },
                     { name: 'Further_Information' },
+                    { name: 'Related_OSDP_or_Open_Data_Links' },
                     { name: 'Related_Initiatives' }
                 ],
                 exclusiveFields: true

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -281,7 +281,7 @@ let config = {
                 {
                     id: 'BasinLine',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/2',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/2',
                     permanentFilteredQuery: `OBJECTID > 80`
                 },
                 {

--- a/demos/starter-scripts/r2-config-upgraded.js
+++ b/demos/starter-scripts/r2-config-upgraded.js
@@ -45,14 +45,14 @@ const r2config = {
         search: {
             serviceUrls: {
                 geoNames:
-                    'http://geogratis.gc.ca/services/geoname/en/geonames.json',
+                    'https://geogratis.gc.ca/services/geoname/en/geonames.json',
                 geoLocation:
-                    'http://geogratis.gc.ca/services/geolocation/en/locate?q=',
+                    'https://geogratis.gc.ca/services/geolocation/en/locate?q=',
                 geoSuggest:
-                    'http://geogratis.gc.ca/services/geolocation/en/suggest?q=',
+                    'https://geogratis.gc.ca/services/geolocation/en/suggest?q=',
                 provinces:
-                    'http://geogratis.gc.ca/services/geoname/en/codes/province.json',
-                types: 'http://geogratis.gc.ca/services/geoname/en/codes/concise.json'
+                    'https://geogratis.gc.ca/services/geoname/en/codes/province.json',
+                types: 'https://geogratis.gc.ca/services/geoname/en/codes/concise.json'
             }
         }
     },

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -284,7 +284,7 @@ let config = {
                 {
                     id: 'BasinLine',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/2',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/2',
                     permanentFilteredQuery: `OBJECTID > 80`
                 },
                 {


### PR DESCRIPTION
### Related Item(s)
[#1923](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1923), [#1988](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1988), [#1998](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1998)

### Changes
- Sample 17: changed http to https for the URLs to `geogratis.gc.ca`
![sample17](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/fadb0594-fa4b-40f5-9022-6487185c8261)

- Sample 42: changed configs to load datatable for all layers in EN
![sample42](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/3d916295-29b9-4a26-9145-2a744fa143a6)

- Removed prod CESI from popular samples by directing BasinLine layer requests to `https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/2`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2001)
<!-- Reviewable:end -->
