### PR TITLE
Added timestamp fixture to export

### DIFF
--- a/src/fixtures/export-timestamp/index.ts
+++ b/src/fixtures/export-timestamp/index.ts
@@ -1,0 +1,42 @@
+import { fabric } from 'fabric';
+import merge from 'deepmerge';
+
+import { FixtureInstance } from '@/api/internal';
+import type { ExportAPI, ExportSubFixture } from '@/fixtures/export/api/export';
+import type { ExportConfig } from '../export/store';
+
+class ExportTimestampFixture
+    extends FixtureInstance
+    implements ExportSubFixture
+{
+    get config(): any {
+        const fixtureConfig: ExportConfig | undefined =
+            this.$iApi.fixture.get<ExportAPI>('export').config;
+        return fixtureConfig?.timestamp;
+    }
+
+    make(options?: any): Promise<fabric.Object> {
+        const timestampFixtureConfig: any = this.config;
+
+        const fabricTextConfig: any = {
+            text: new Date().toLocaleString('en-CA'),
+            fontFamily:
+                'Montserrat, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif',
+            fill: '#000',
+            fontSize: 20,
+            top: 0,
+            left: 0,
+            originX: 'left'
+        };
+
+        if (timestampFixtureConfig) {
+            fabricTextConfig.text = timestampFixtureConfig.value;
+        }
+
+        const config: any = merge(fabricTextConfig, options || {});
+        const fbTimestamp = new fabric.Textbox(config.text, config);
+        return Promise.resolve(fbTimestamp);
+    }
+}
+
+export default ExportTimestampFixture;

--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -108,12 +108,15 @@ export class ExportAPI extends FixtureInstance {
             this.getSubFixture('export-northarrow');
         const exportLegendFixture: ExportSubFixture =
             this.getSubFixture('export-legend');
+        const exportTimestampFixture: ExportSubFixture =
+            this.getSubFixture('export-timestamp');
 
         let fbTitle: fabric.Object | undefined;
         let fbMap: fabric.Object | undefined;
         let fbScaleBar: fabric.Object | undefined;
         let fbNorthArrow: fabric.Object | undefined;
         let fbLegend: fabric.Object | undefined;
+        let fbTimestamp: fabric.Object | undefined;
         const selectedExportComponents: Array<fabric.Object> = [];
 
         if (selectedState.title) {
@@ -186,6 +189,15 @@ export class ExportAPI extends FixtureInstance {
             fbLegend.top = this.options.runningHeight;
             this.options.runningHeight += fbLegend.height!;
             selectedExportComponents.push(fbLegend);
+        }
+
+        if (selectedState.timestamp) {
+            fbTimestamp = await exportTimestampFixture.make({
+                top: this.options.runningHeight + 20,
+                width: panelWidth
+            });
+            this.options.runningHeight += fbTimestamp.height! + 20;
+            selectedExportComponents.push(fbTimestamp);
         }
 
         const fbGroup = new fabric.Group(selectedExportComponents, {

--- a/src/fixtures/export/index.ts
+++ b/src/fixtures/export/index.ts
@@ -6,6 +6,7 @@ import messages from './lang/lang.csv?raw';
 /* import sub fixtures */
 import type ExportLegendFixture from '../export-legend';
 import type ExportMapFixture from '../export-map';
+import type ExportTimestampFixture from '../export-timestamp';
 import type ExportTitleFixture from '../export-title';
 import type ExportNorthArrowFixture from '../export-northarrow';
 import type ExportScalebarFixture from '../export-scalebar';
@@ -20,6 +21,7 @@ class ExportFixture extends ExportAPI {
         this.$iApi.fixture.add('export-legend');
         this.$iApi.fixture.add('export-northarrow');
         this.$iApi.fixture.add('export-scalebar');
+        this.$iApi.fixture.add('export-timestamp');
     }
 
     added(): void {
@@ -70,6 +72,9 @@ class ExportFixture extends ExportAPI {
                 ?.remove();
             this.$iApi.fixture
                 .get<ExportScalebarFixture>('export-scalebar')
+                ?.remove();
+            this.$iApi.fixture
+                .get<ExportTimestampFixture>('export-timestamp')
                 ?.remove();
 
             if (this.$iApi.fixture.get('appbar')) {


### PR DESCRIPTION
### Related Item(s)
#1980 

### Changes
- [FIX] Added a timestamp fixture to the export (do we need seconds?). Not sure if this was refactored at one point and the timestamp was missed, or if it was just never implemented. 

### Notes
 I also noticed the footnote fixture doesn't exist, so we should either implement it or remove the option. If anyone has details on what should be contained in the footnote that would be appreciated. 

### Testing
Steps:
1. Open the export tab
2. Witness the timestamp
3. Toggle the timestamp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2002)
<!-- Reviewable:end -->
