### PR TITLE
MIL Class Change

### DIFF
--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import {
-    AttribLayer,
     GlobalEvents,
     InstanceAPI,
     MapImageSublayer,
@@ -14,27 +13,22 @@ import {
     DrawState,
     Extent,
     GeometryType,
-    Graphic,
     IdentifyResultFormat,
     LayerFormat,
     LayerIdentifyMode,
     LayerState,
     LayerType,
-    NoGeometry,
     TreeNode
 } from '@/geo/api';
 
 import type {
-    AttributeSet,
-    GetGraphicParams,
     IdentifyItem,
     IdentifyParameters,
     IdentifyResult,
     Point,
     QueryFeaturesParams,
     RampLayerConfig,
-    RampLayerMapImageSublayerConfig,
-    TabularAttributeSet
+    RampLayerMapImageSublayerConfig
 } from '@/geo/api';
 
 import { EsriMapImageLayer, EsriRendererFromJson } from '@/geo/esri';
@@ -44,7 +38,7 @@ import { markRaw, reactive } from 'vue';
 /**
  * A layer class which implements an ESRI Map Image Layer.
  */
-export class MapImageLayer extends AttribLayer {
+export class MapImageLayer extends MapLayer {
     // indicates if sublayers can have opacity adjusted
     isDynamic: boolean;
     // used to remember state after load
@@ -552,139 +546,5 @@ export class MapImageLayer extends AttribLayer {
 
             return result;
         });
-    }
-
-    // TODO with the numerous refactors since this layer class was written 3 years ago,
-    //      proposing at some point we stop inheriting from AttribLayer and just
-    //      inherit from MapLayer. Can remove all these blocking overrides.
-    //      Most of the common methods should be abstracted out by now. But needs R&D
-
-    private noFeaturesErr(): void {
-        console.error(
-            'This method targets features and must be called on a Sublayer.'
-        );
-        console.trace();
-    }
-
-    /**
-     * Invokes the process to get the full set of attribute values for the layer.
-     * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
-     *
-     * @returns {Promise} resolves with set of attribute values
-     */
-    getAttributes(): Promise<AttributeSet> {
-        this.noFeaturesErr();
-        return Promise.resolve({
-            features: [],
-            oidIndex: {}
-        });
-    }
-
-    /**
-     * Requests that an attribute load request be aborted. Useful when encountering a massive dataset or a runaway process.
-     *
-     */
-    abortAttributeLoad(): void {
-        this.noFeaturesErr();
-    }
-
-    /**
-     * Requests that any downloaded attribute sets or cached geometry be removed from memory. The next requests will pull from the server again.
-     *
-     */
-    clearFeatureCache(): void {
-        this.noFeaturesErr();
-    }
-
-    downloadedAttributes(): number {
-        this.noFeaturesErr();
-        return 0;
-    }
-
-    attribLoadAborted(): boolean {
-        this.noFeaturesErr();
-        return false;
-    }
-
-    // formerly known as getFormattedAttributes
-    /**
-     * Invokes the process to get the full set of attribute values for the layer,
-     * formatted in a tabular format. Additional data properties are also included.
-     * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
-     *
-     * @returns {Promise} resolves with set of tabular attribute values
-     */
-    getTabularAttributes(): Promise<TabularAttributeSet> {
-        this.noFeaturesErr();
-
-        // nonsense to shut up typescript
-        return Promise.resolve({
-            columns: [],
-            rows: [],
-            fields: [],
-            oidField: 'error'
-        });
-    }
-
-    /**
-     * Gets information on a graphic in the most efficient way possible. Options object properties:
-     * - getGeom ; a boolean to indicate if the result should include graphic geometry
-     * - getAttribs ; a boolean to indicate if the result should include graphic attributes
-     * - unboundMap ; an optional RampMap reference. Only required if geometry was requested and the layer has not been added to a map.
-     *
-     * @param {Integer} objectId the object id of the graphic to find
-     * @param {Object} options options object for the request, see above
-     * @returns {Promise} resolves with a Graphic containing the requested information
-     */
-    getGraphic(objectId: number, options: GetGraphicParams): Promise<Graphic> {
-        this.noFeaturesErr();
-        return Promise.resolve(new Graphic(new NoGeometry()));
-    }
-
-    /**
-     * Gets the icon for a specific feature, as an SVG string.
-     *
-     * @param {Integer} objectId the object id of the feature to find
-     * @returns {Promise} resolves with an svg string encoding of the icon
-     */
-    getIcon(objectId: number): Promise<string> {
-        this.noFeaturesErr();
-        return Promise.resolve('');
-    }
-
-    /**
-     * Returns the value of a named SQL filter on the layer.
-     *
-     * @param {String} filterKey the filter key / named filter to view
-     * @returns {String} the value of the where clause for the filter. Empty string if not defined.
-     */
-    getSqlFilter(filterKey: string): string {
-        this.noFeaturesErr();
-        return '';
-    }
-
-    /**
-     * Applies the current filter settings to the physical map layer.
-     *
-     * @function applySqlFilter
-     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all keys
-     */
-    applySqlFilter(exclusions: Array<string> = []): void {
-        this.noFeaturesErr();
-    }
-
-    /**
-     * Gets array of object ids that currently pass any filters on the layer
-     *
-     * @param {Array} [exclusions] list of any filters keys to exclude from the result. omission includes all filters
-     * @param {Extent} [extent] if provided, the result list will only include features intersecting the extent
-     * @returns {Promise} resolves with array of object ids that pass the filter. if no filters are active, resolves with undefined.
-     */
-    getFilterOIDs(
-        exclusions: Array<string> = [],
-        extent: Extent | undefined = undefined
-    ): Promise<Array<number> | undefined> {
-        this.noFeaturesErr();
-        return Promise.resolve(undefined);
     }
 }


### PR DESCRIPTION
### Changes

Just an internal change. `MapImageLayer` inheriting from `AttribLayer` is a holdover from the days before the Grand Layer Refactor #741

It doesn't make sense and fixing it lets us delete a bunch of stub overrides acting as safety nets for the wrongness of the class.

### Testing

Just general sanity testing. Sample 1 has a medley of layers, including MIL (the CESI ones). Sample 16 is pure MIL goodness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2003)
<!-- Reviewable:end -->
