### PR TITLE
Remove cosmetic layers from legend in export

### DIFF
--- a/src/fixtures/export-legend/index.ts
+++ b/src/fixtures/export-legend/index.ts
@@ -55,8 +55,10 @@ class ExportLegendFixture extends FixtureInstance implements ExportSubFixture {
     }
 
     async make(options: any): Promise<fabric.Group> {
-        // filter out loading/errored and invisible layers
-        const layers = useLayerStore(this.$vApp.$pinia).layers;
+        // filter out loading/errored, invisible, and cosmetic layers
+        const layers = useLayerStore(this.$vApp.$pinia).layers.filter(
+            layer => !layer.isCosmetic
+        );
 
         if (layers.length === 0) {
             // return an empty group


### PR DESCRIPTION
### Related Item(s)
[#1981](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1981)

### Changes
- When the export canvas is created, the layers array, which composes the legend, is altered to remove any cosmetic layers

### Notes
![export_no_cosmetic](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/b6d88054-6761-456b-a2a3-f2ea307d73f1)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2005)
<!-- Reviewable:end -->
