### PR TITLE
Teleported panel does not impact reorder

### DIFF
--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -308,7 +308,7 @@ export class PanelInstance extends APIScope {
     }
 
     /**
-     * Checks if this panel is the leftmost visible panel.
+     * Checks if this panel is the leftmost visible and not-teleported panel.
      *
      * @readonly
      * @type {boolean}
@@ -316,13 +316,21 @@ export class PanelInstance extends APIScope {
      */
     get isLeftMostPanel(): boolean {
         if (this.$iApi.panel.visible.length > 0) {
-            return this.id === this.$iApi.panel.visible[0].id;
+            for (const panel of this.$iApi.panel.visible) {
+                if (!panel.teleport) {
+                    if (this.id === panel.id) {
+                        return true;
+                    }
+                    return false;
+                }
+            }
         }
         return false;
     }
 
     /**
-     * Checks if this panel is the rightmost visible panel.
+     * Checks if this panel is the rightmost visible and non-teleported panel.
+     * Note that a traditional for each loop is used due to reverse traversal of the array.
      *
      * @readonly
      * @type {boolean}
@@ -330,7 +338,14 @@ export class PanelInstance extends APIScope {
      */
     get isRightMostPanel(): boolean {
         if (this.$iApi.panel.visible.length > 0) {
-            return this.id === this.$iApi.panel.visible.slice(-1)[0].id;
+            for (let i = this.$iApi.panel.visible.length - 1; i >= 0; i--) {
+                if (!this.$iApi.panel.visible[i].teleport) {
+                    if (this.id === this.$iApi.panel.visible[i].id) {
+                        return true;
+                    }
+                    return false;
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
### Related Item(s)
[#1977 ](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1977)

### Changes
Original behaviour of panels: If there was a teleported panel, the rightmost panel still thought it could move right (the right arrow was still highlighted).

- The teleported panel is not registered as the rightmost or leftmost panel
- The existence of the teleported panel(s) doesn't impact reordering of panels inside of the RAMP 

### Notes
For the case of one teleported panel (grid):
![two panels](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/f0ad0513-11a2-4cc5-857f-17e86dcaf609)

For the case of multiple teleported panels (grid and legend, the width of the legend was purposefully decreased to ensure the RAMP div would allow panels to appear side-by-side):
![multiple teleported panels](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/91057964-bac0-444f-bfd4-f12ab4adb57c)

### Testing
Faster method:
1. Go to https://ramp4-pcar4.github.io/ramp4-pcar4/panel_reorder/demos/index-teleport-wet.html
2. Open Geosearch panel and pin it
3. `debugInstance.panel.pinned.isRightMostPanel` (should be true) and `debugInstance.panel.pinned.isLeftMostPanel` (should also be true)

Another method:
1. In `demos/starter-scripts/teleport-wet.js`: 
 - Comment out L353
 - In L469 set reorderable to true
2. In `demos/index-teleport-wet.html`: 
 - Remove style="display : flex" from L326
 - Comment out L327-L331
 - Set width: 100% in L332
3. Run RAMP, navigate to Catalogue
5. Choose the very last sample on the page called: "RAMP inside the WET template with teleport enabled"
6. Open lots of panels, including the grid and observe the panel reorder arrows

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2008)
<!-- Reviewable:end -->
