### PR TITLE
Keyboard focus and alignment for legend

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -6,10 +6,10 @@
     >
         <div class="relative">
             <div
-                class="flex items-center hover:bg-gray-200 !p-5"
+                class="flex items-center hover:bg-gray-200 default-focus-style !p-5"
                 :class="[
                     legendItem.type === LegendType.Item
-                        ? 'loaded-item default-focus-style'
+                        ? 'loaded-item'
                         : legendItem.type === LegendType.Error
                         ? 'non-loaded-item bg-red-200'
                         : 'non-loaded-item',
@@ -67,7 +67,7 @@
             >
                 <!-- smiley face. very important that we migrate this -->
                 <div
-                    class="flex ml-3 mr-10"
+                    class="flex p-5"
                     v-if="legendItem.type !== LegendType.Item"
                 >
                     <svg
@@ -175,14 +175,14 @@
                 <!-- dropdown icon -->
                 <div
                     v-if="isGroup && controlAvailable(LegendControl.Expand)"
-                    class="expand-toggle mr-5 pointer-events-none"
+                    class="expand-toggle p-8 pointer-events-none"
                     :class="{ 'rotate-180': legendItem.expanded }"
                 >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
-                        height="24"
+                        height="18"
                         viewBox="0 0 24 24"
-                        width="24"
+                        width="18"
                     >
                         <path
                             d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
@@ -193,7 +193,7 @@
                 <!-- name or info section-->
                 <div
                     v-if="legendItem instanceof LayerItem"
-                    class="flex-1 pointer-events-none"
+                    class="flex-1 pointer-events-none p-5"
                     v-truncate="{ externalTrigger: true }"
                 >
                     <span>{{
@@ -304,7 +304,7 @@
                             <svg
                                 v-else
                                 class="inline-block fill-current w-18 h-18 mr-1"
-                                viewBox="0 0 23 21"
+                                viewBox="0 1 23 22"
                             >
                                 <path
                                     d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"


### PR DESCRIPTION
### Related Item(s)
#1889, #2010 

### Changes
- [FIX] Included keyboard focus for moving through legend items in an error state
- [FIX] Horizontal and vertical alignment of the legend items in an error state

### Notes
Keyboard focus:
![keyboard focus legend item](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/c23bc953-d191-4f51-a989-eb5cb44b5a1e)

Alignment:
![item size and alignment](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/e8cef093-a374-4176-892f-fb2cd1b6aa64)
![legend item alignment](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/1d327c3a-a7db-40cc-aadf-0bc69936de83)


### Testing
Keyboard Focus Testing:
1. Open Sample 18
2. In the Legend, use arrow keys to move through the all the layers
3. Observe the keyboard focus (blue outline) around the legend items, including the layers in an error state

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2014)
<!-- Reviewable:end -->
