### PR TITLE
Added config for disabling language toggle

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -648,7 +648,7 @@
                 },
                 "footnote": {
                     "type": "object",
-                    "description": "Configuration for the footnote. Currently not supported.",
+                    "description": "Configuration for the footnote.",
                     "allOf": [
                         {
                             "$ref": "#/$defs/exportComponent"
@@ -665,7 +665,7 @@
                 },
                 "timestamp": {
                     "type": "object",
-                    "description": "Configuration for the timestamp. Currently not supported.",
+                    "description": "Configuration for the timestamp.",
                     "$ref": "#/$defs/exportComponent"
                 },
                 "fileName": {
@@ -2691,6 +2691,16 @@
                                 "imperialScale": {
                                     "type": "boolean",
                                     "description": "Use imperial scale distance units",
+                                    "default": false
+                                }
+                            }
+                        },
+                        "langToggle": {
+                            "type": "object",
+                            "description": "Allow language toggle within RAMP",
+                            "properties": {
+                                "disabled": {
+                                    "type": "boolean",
                                     "default": false
                                 }
                             }

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -90,6 +90,7 @@
             <dropdown-menu
                 class="flex-shrink-0 pointer-events-auto focus:outline-none px-4 mr-4 relative top-2"
                 position="top-end"
+                v-if="!langtoggle?.disabled"
                 v-tippy="{
                     delay: [300, 0],
                     placement: 'top-end',
@@ -154,6 +155,7 @@ const iApi = inject('iApi') as InstanceAPI;
 const scale = computed(() => mapCaptionStore.scale);
 const attribution = computed(() => mapCaptionStore.attribution);
 const coords = computed(() => mapCaptionStore.coords);
+const langtoggle = computed(() => mapCaptionStore.langtoggle);
 const mapConfig = computed(() => configStore.config.map);
 
 const lang = ref<Array<string>>([]);

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -563,6 +563,10 @@ export interface ScaleBar {
     isImperialScale?: boolean;
 }
 
+export interface LangToggle {
+    disabled?: boolean;
+}
+
 export interface RampSpatialReference {
     wkid?: number;
     latestWkid?: number;
@@ -718,6 +722,7 @@ export interface RampLodConfig {
 export interface MapCaptionConfig {
     mapCoords: { disabled?: boolean; formatter?: string };
     scaleBar: { disabled?: boolean; imperialScale?: boolean };
+    langToggle: LangToggle;
 }
 
 // actual ramp config is kinda wonky, split over lots of classes

--- a/src/geo/map/caption.ts
+++ b/src/geo/map/caption.ts
@@ -74,6 +74,11 @@ export class MapCaptionAPI extends APIScope {
                 });
             }
         }
+
+        // check if the language toggle has been disabled
+        mapCaptionStore.langtoggle = {
+            disabled: captionConfig?.langToggle?.disabled ?? false
+        };
     }
 
     /**

--- a/src/stores/map-caption/map-caption-store.ts
+++ b/src/stores/map-caption/map-caption-store.ts
@@ -1,4 +1,4 @@
-import type { Attribution, MapCoords, ScaleBar } from '@/geo/api';
+import type { Attribution, MapCoords, ScaleBar, LangToggle } from '@/geo/api';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
@@ -6,6 +6,7 @@ export const useMapCaptionStore = defineStore('map-caption', () => {
     const attribution = ref<Attribution>({ text: {}, logo: {} });
     const scale = ref<ScaleBar>({});
     const coords = ref<MapCoords>({});
+    const langtoggle = ref<LangToggle>({});
 
     function toggleScale(value?: boolean) {
         if (value !== undefined) {
@@ -15,5 +16,5 @@ export const useMapCaptionStore = defineStore('map-caption', () => {
         }
     }
 
-    return { attribution, scale, coords, toggleScale };
+    return { attribution, scale, coords, langtoggle, toggleScale };
 });


### PR DESCRIPTION
### Related Item(s)
#1985

### Changes
- The language toggle will be disabled (removed from the DOM) if `langToggle.disabled` is set to true in the config - this is for cases where RAMP is used in sites where there is external control over language
- `langToggle.disabled` is false by default

### Notes
When `langToggle.disabled = true`:
![language toggle disabled](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/ad8dd498-ed2e-4675-83ef-54c7bcbc5b94)

### Testing
1. Add the following config to any sample to `.map.caption`:
```
langToggle: {
  disabled: true
}
```

If you test this with a WET template and try to click Français at the top right of the screen (outside of RAMP), then RAMP will not switch to French because it is not configured to do so in `wet.js`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2019)
<!-- Reviewable:end -->
