### PR TITLE
Fix duplicate tree grow for MILs

### DIFF
--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -143,24 +143,8 @@ export class LegendAPI extends FixtureInstance {
         this._insertItem(item as unknown as LegendItem, parent);
 
         // Updates the legend with the inserted item
+        // tree growing magic also takes place here for MILs
         this.updateLegend(layer);
-
-        if (layer.supportsSublayers) {
-            // if layer supports sublayers, then we need to parse the
-            // layer tree after loading and generate the children
-
-            await layer.loadPromise();
-
-            // for each child node -> parse & create item config -> create child legend item and append to this item
-            layer
-                .getLayerTree()
-                .children.map(childNode => this._treeWalker(layer, childNode))
-                .map(childConf =>
-                    this.addItem(childConf, item as unknown as LegendItem)
-                );
-        }
-
-        item.treeGrown = true;
 
         return item;
     }


### PR DESCRIPTION
### Related Item(s)
#2007

### Changes
- Fixed an issue where adding an MIL via the wizard or API would create two legend entries instead of one.

### Testing
1. Open the wizard fixture.
2. Try to load a map image layer URL. [Here's a link to one.](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer)
3. Select a sublayer and press 'Continue'.
4. Notice that only one entry is added to the legend.
5. Feel free to try adding an MIL via the API if you'd like.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2021)
<!-- Reviewable:end -->
