### PR TITLE
Added padding to the export scrollbar

### DIFF
--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -4,7 +4,7 @@
 
         <template #content>
             <div class="overflow-hidden border border-gray-200">
-                <canvas class="export-canvas"></canvas>
+                <canvas class="export-canvas !w-[100%]"></canvas>
             </div>
         </template>
 
@@ -111,8 +111,7 @@ const make = debounce(300, () => {
         '.export-canvas'
     ) as HTMLCanvasElement;
 
-    // TODO: detect size of the canvas container properly
-    fixture.value.make(canvasElement, el.value.clientWidth - 16);
+    fixture.value.make(canvasElement, el.value.clientWidth);
 });
 
 onMounted(() => {


### PR DESCRIPTION
### Related Item(s)
#2013 

### Changes
- [FEATURE] Added a touch of padding to the north arrow in the export

### Notes
Put your thinkin caps on for this one.

### Testing
Steps:
  1. Go to Sample 1.
  2. With all layers on, launching the export should produce the scrollbar.
  3. The north arrow should not be pushing up against the scrollbar.
  4. Turning off the "Releases of X" CESI legend group, then re-launching the export, should not have the scrollbar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2023)
<!-- Reviewable:end -->
