### PR TITLE
Added search bar to Help

### DIFF
--- a/docs/using-ramp4/default-setup.md
+++ b/docs/using-ramp4/default-setup.md
@@ -199,7 +199,7 @@ var options = {
 };
 var rInstance = RAMP.createInstance(domElement, configs, options);
 rInstance.fixtures.add('help', CustomHelpFixtureClass);
-rInstance.fixtures.addDefaultFixtures(['help', 'appbar', 'mapnav']);
+rInstance.fixtures.addDefaultFixtures(['appbar', 'mapnav']);
 ```
 
 ### Specify Starting Fixtures

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp",
-    "version": "4.3.0",
+    "version": "4.4.0-beta",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp",
-            "version": "4.3.0",
+            "version": "4.4.0-beta",
             "dependencies": {
                 "@arcgis/core": "4.26.5",
                 "@ecgc/vue-slider-component": "4.0.0-beta.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ramp",
-    "version": "4.3.0",
+    "version": "4.4.0-beta",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/src/fixtures/help/lang/lang.csv
+++ b/src/fixtures/help/lang/lang.csv
@@ -1,4 +1,6 @@
 key,enValue,enValid,frValue,frValid
 help.title,Help,1,Aide,1
+help.search,Search Help,1,Rechercher aide,0
 help.section.expand,Expand section,1,Développer une section,1
 help.section.collapse,Collapse section,1,Réduire une section,1
+help.noResults,Nothing is found. Please try a different search.,1,Rien n'est trouvé. S'il vous plaît, essayez une recherche différente.,0

--- a/src/fixtures/help/screen.vue
+++ b/src/fixtures/help/screen.vue
@@ -3,8 +3,22 @@
         <template #header>
             {{ t('help.title') }}
         </template>
-
         <template #content>
+            <div class="h-26 mb-8 mx-8">
+                <input
+                    type="search"
+                    class="rv-help-search-bar border-b w-full text-base py-8 outline-none focus:shadow-outline border-gray-600 h-full min-w-0"
+                    :placeholder="t('help.search')"
+                    v-model="searchTerm"
+                    :aria-label="t('help.search')"
+                    @input="doSearch(searchTerm, helpSections)"
+                    @keypress.enter.prevent
+                    enterkeyhint="done"
+                />
+            </div>
+            <div v-if="noResults">
+                <p>{{ t('help.noResults') }}</p>
+            </div>
             <help-section
                 v-for="(section, idx) in helpSections"
                 :helpSection="section"
@@ -46,6 +60,22 @@ defineProps({
 const location = computed<string>(() => helpStore.location);
 const helpSections = ref<Array<any>>([]);
 const watchers = ref<Array<Function>>([]);
+
+const noResults = ref<boolean>(false);
+let numResults: number;
+let searchTerm: string;
+
+// find the help sections which contain the search term
+function doSearch(searchTerm: string, sections: any) {
+    numResults = 0;
+    for (let section of sections) {
+        section.drawn =
+            section.info.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1 ||
+            section.header.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1;
+        numResults = section.drawn ? numResults + 1 : numResults;
+    }
+    noResults.value = numResults === 0;
+}
 
 onBeforeMount(() => {
     // make help request when fixture loads or locale changes
@@ -96,7 +126,8 @@ onBeforeMount(() => {
                                 {
                                     renderer
                                 }
-                            )
+                            ),
+                            drawn: true
                         });
                     }
                 });

--- a/src/fixtures/help/section.vue
+++ b/src/fixtures/help/section.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-if="helpSection.drawn">
         <div>
             <button
                 type="button"


### PR DESCRIPTION
### Related Item(s)
#2012, #1970

### Changes
For #2012:
- [FEATURE] Added search bar to Help
- Does not automatically expand and highlight the search term in the content

For #1970:
- Updated confusing documentation by removing 'help' from params array

Not for an Issue:
- Updated versions to 4.4.0-beta

### Notes
When Help is first opened:
![no search term](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/54b1f0b5-fd20-493c-9fbf-fe49cae5b3ca)

With a search term:
![searchterm layer](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/0fdfbf12-01a2-459b-b251-8ce8953a7a33)

With a search term and no results:
![noresults](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/ea36b5e5-2c05-4214-abb7-9d9783b07263)

### Testing
Steps:
1. Open any sample
2. Select the Help icon (bottom right, question mark)
3. Write any search term in the search bar

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2026)
<!-- Reviewable:end -->
