### PR TITLE
fix infinite loading spinner for symbology stacks

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -537,8 +537,8 @@
                     </div>
                 </div>
             </div>
-            <div v-else>
-                <!-- display loading text -->
+            <div v-if="!symbologyStackLoaded">
+                <!-- display loading text if the stack hasn't loaded yet -->
                 <div class="flex p-5 ml-48" v-truncate>
                     <div
                         class="relative animate-spin spinner h-20 w-20 mr-10 pt-2"
@@ -612,6 +612,7 @@ const props = defineProps({
 const mobileMode = ref(panelStore.mobileView);
 const layerConfigs = computed(() => layerStore.layerConfigs);
 const symbologyStack = ref<Array<LegendSymbology>>([]); // ref instead of reactive to maintain reactivity after promise
+const symbologyStackLoaded = ref<boolean>(false);
 const hovered = ref(false);
 
 /**
@@ -931,6 +932,9 @@ const loadSymbologyStack = () => {
                 symbologyStack.value = (
                     props.legendItem as LayerItem
                 ).symbologyStack;
+
+                // Mark the symbology stack as loaded.
+                symbologyStackLoaded.value = true;
             });
         })
         .catch(() => {});


### PR DESCRIPTION
### Related Item(s)
#2025

### Changes
- Fixes an issue where calling toggleSymbology on a layer with no symbology stack would display an infinite loading spinner.

### Testing
Steps (stole James' steps from the original issue):
1. Open [Sample 1](https://ramp4-pcar4.github.io/ramp4-pcar4/fix-2025/demos/index-samples.html?sample=1).
2. Open Wizard. Add [this service](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer) as a Map Image Layer. Choose two leaf sublayers (no groups).
3. New layer is added to Legend. Can see the parent node then the two sublayers as children.
4. Open console and run the code snippet below.
5. An infinite loading spinner should no longer appear under the `Layers` group.
```js
// get legend entry (parent) of new layer
var echoGeo = debugInstance.fixture.get('legend').getLegend()[3];

// expand it's symbology
echoGeo.toggleSymbology(true);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2028)
<!-- Reviewable:end -->
