### PR TITLE
Export will no longer :boom: when a sub fixture is missing

### DIFF
--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -69,11 +69,11 @@ export class ExportAPI extends FixtureInstance {
      *
      * @private
      * @param {string} name
-     * @returns {ExportSubFixture}
+     * @returns {ExportSubFixture | undefined}
      * @memberof ExportAPI
      */
-    private getSubFixture(name: string): ExportSubFixture {
-        return this.$iApi.fixture.get(name);
+    private getSubFixture(name: string): ExportSubFixture | undefined {
+        return this.$iApi.fixture.get(name) as ExportSubFixture | undefined;
     }
 
     /**
@@ -98,20 +98,13 @@ export class ExportAPI extends FixtureInstance {
 
         const selectedState = exportStore.componentSelectedState;
 
-        const exportTitleFixture: ExportSubFixture =
-            this.getSubFixture('export-title');
-        const exportMapFixture: ExportSubFixture =
-            this.getSubFixture('export-map');
-        const exportScaleBarFixture: ExportSubFixture =
-            this.getSubFixture('export-scalebar');
-        const exportNorthArrowFixture: ExportSubFixture =
-            this.getSubFixture('export-northarrow');
-        const exportLegendFixture: ExportSubFixture =
-            this.getSubFixture('export-legend');
-        const exportFootnoteFixture: ExportSubFixture =
-            this.getSubFixture('export-footnote');
-        const exportTimestampFixture: ExportSubFixture =
-            this.getSubFixture('export-timestamp');
+        const exportTitleFixture = this.getSubFixture('export-title');
+        const exportMapFixture = this.getSubFixture('export-map');
+        const exportScaleBarFixture = this.getSubFixture('export-scalebar');
+        const exportNorthArrowFixture = this.getSubFixture('export-northarrow');
+        const exportLegendFixture = this.getSubFixture('export-legend');
+        const exportFootnoteFixture = this.getSubFixture('export-footnote');
+        const exportTimestampFixture = this.getSubFixture('export-timestamp');
 
         let fbTitle: fabric.Object | undefined;
         let fbMap: fabric.Object | undefined;
@@ -122,7 +115,7 @@ export class ExportAPI extends FixtureInstance {
         let fbTimestamp: fabric.Object | undefined;
         const selectedExportComponents: Array<fabric.Object> = [];
 
-        if (selectedState.title) {
+        if (selectedState.title && exportTitleFixture) {
             fbTitle = await exportTitleFixture.make({
                 /* text: '😸🤖🧙‍♂️🤦‍♀️🎶', */
                 top: this.options.runningHeight,
@@ -135,7 +128,7 @@ export class ExportAPI extends FixtureInstance {
             selectedExportComponents.push(fbTitle);
         }
 
-        if (selectedState.map) {
+        if (selectedState.map && exportMapFixture) {
             fbMap = await exportMapFixture.make({
                 top: this.options.runningHeight
             });
@@ -161,7 +154,7 @@ export class ExportAPI extends FixtureInstance {
                 GLOBAL_MARGIN.LEFT +
                 GLOBAL_MARGIN.RIGHT);
 
-        if (selectedState.mapElements) {
+        if (selectedState.mapElements && exportScaleBarFixture) {
             fbScaleBar = await exportScaleBarFixture.make({
                 top: this.options.runningHeight,
                 left: 0
@@ -169,20 +162,22 @@ export class ExportAPI extends FixtureInstance {
             this.options.runningHeight += fbScaleBar.height! + 40;
             selectedExportComponents.push(fbScaleBar);
 
-            // keep it inline with the scale bar if scalebar is selected
-            fbNorthArrow = await exportNorthArrowFixture.make({
-                top: fbScaleBar.top,
-                left: panelWidth / this.options.scale
-            });
+            if (exportNorthArrowFixture) {
+                // keep it inline with the scale bar.
+                fbNorthArrow = await exportNorthArrowFixture.make({
+                    top: fbScaleBar.top,
+                    left: panelWidth / this.options.scale
+                });
 
-            // adjust position for height and width so it is properly centered
-            fbNorthArrow.top! += fbNorthArrow.height! / 2 - 20;
-            fbNorthArrow.left! += -fbNorthArrow.width! * 2;
+                // adjust position for height and width so it is properly centered
+                fbNorthArrow.top! += fbNorthArrow.height! / 2 - 20;
+                fbNorthArrow.left! += -fbNorthArrow.width! * 2;
 
-            selectedExportComponents.push(fbNorthArrow);
+                selectedExportComponents.push(fbNorthArrow);
+            }
         }
 
-        if (selectedState.legend) {
+        if (selectedState.legend && exportLegendFixture) {
             fbLegend = await exportLegendFixture.make({
                 width:
                     exportLegendFixture.config?.columnWidth ??
@@ -194,7 +189,7 @@ export class ExportAPI extends FixtureInstance {
             selectedExportComponents.push(fbLegend);
         }
 
-        if (selectedState.timestamp) {
+        if (selectedState.timestamp && exportTimestampFixture) {
             fbTimestamp = await exportTimestampFixture.make({
                 top: this.options.runningHeight + 20,
                 width: panelWidth
@@ -203,7 +198,7 @@ export class ExportAPI extends FixtureInstance {
             selectedExportComponents.push(fbTimestamp);
         }
 
-        if (selectedState.footnote) {
+        if (selectedState.footnote && exportFootnoteFixture) {
             fbFootnote = await exportFootnoteFixture.make({
                 top: this.options.runningHeight,
                 left: panelWidth / this.options.scale + 40


### PR DESCRIPTION
### Related Item(s)
#1995 

### Changes
- [FIX] The export now loads if any of the subfixtures returned by getSubFixture are undefined

### Notes
Instead of making a mess of getSubFixture I'm checking to make sure the subfixture exists before adding it to the canvas.

### Testing
Steps:
1. I tested this locally by providing a junk value to getSubFixture for each ExportSubFixture.
2. Ensure the export is working as expected.
3. There may be some API wizardry available that I'm unaware of. If you have a way of testing this in the console please mention it below.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2029)
<!-- Reviewable:end -->
