### PR TITLE
Added highlight and automatic expansion for help

### DIFF
--- a/src/fixtures/help/section.vue
+++ b/src/fixtures/help/section.vue
@@ -4,10 +4,10 @@
             <button
                 type="button"
                 class="help-section-header flex items-center py-15 px-25 hover:bg-gray-200 cursor-pointer select-none w-full"
-                @click="toggleExpanded()"
+                @click="$emit('expand')"
                 :content="
                     t(
-                        expanded
+                        helpSection.expanded
                             ? 'help.section.collapse'
                             : 'help.section.expand'
                     )
@@ -22,7 +22,7 @@
                 <!-- dropdown icon -->
                 <div
                     class="dropdown-icon"
-                    :class="{ 'transform -rotate-180': expanded }"
+                    :class="{ 'transform -rotate-180': helpSection.expanded }"
                 >
                     <svg
                         xmlns="http://www.w3.org/2000/svg"
@@ -39,7 +39,7 @@
             </button>
             <transition name="help-item" mode="out-in">
                 <div
-                    v-show="expanded"
+                    v-show="helpSection.expanded"
                     v-html="helpSection.info"
                     class="ramp-markdown section-body px-20 pt-5 ml-10 overflow-hidden"
                 ></div>
@@ -60,11 +60,6 @@ defineProps({
         required: true
     }
 });
-
-const expanded = ref<boolean>(false);
-const toggleExpanded = () => {
-    expanded.value = !expanded.value;
-};
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
### Related Item(s)
#2012

### Changes
- Added automatic expansion for help sections based on the search
- Added highlighting of search term in each section

### Notes
![highlight help search](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/3d2b32d6-86eb-4b01-8f12-39d3f09f4b23)

### Testing
Steps:
1. Open Help (bottom-right of screen)
2. Type anything in the search bar

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2032)
<!-- Reviewable:end -->
