### PR TITLE
Added notifications in wizard

### DIFF
--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -696,7 +696,7 @@ export class EventAPI extends APIScope {
             case DefEH.LAYER_ERROR_UPDATES_LEGEND:
                 // when a layer errors, have the standard legend update in accordance to the layer
                 zeHandler = (payload: {
-                    state: String;
+                    state: string;
                     layer: LayerInstance;
                 }) => {
                     if (payload.layer.layerState === LayerState.ERROR) {

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -44,3 +44,5 @@ wizard.configure.colour.copy,Copy colour,1,Copier la couleur,1
 wizard.configure.colour.hex,Hex,1,Hex,1
 wizard.step.cancel,Cancel,1,Annuler,1
 wizard.step.continue,Continue,1,Continuer,1
+wizard.upload.success,has been uploaded successfully.,1,a été téléchargée avec succès.,0
+wizard.upload.fail,failed to upload.,1,n'a pas pu être téléchargé.,0

--- a/src/fixtures/wizard/stepper.vue
+++ b/src/fixtures/wizard/stepper.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="py-12 h-full stepper">
+    <div class="py-12 h-auto stepper">
         <slot></slot>
     </div>
 </template>


### PR DESCRIPTION
### Related Item(s)
#1867 

### Changes
- Added a notification to the top of the screen in Wizard when a user-added layer is uploaded
- If the layer is in an error state, that is shown as well
- The notification disappears when the user starts adding another layer by clicking anywhere on the form

### Notes
Successful layer upload:
![wizard upload success](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/31fe94f6-f1ea-4647-945a-3467febcbb8b)

Error layer upload:
![wizard upload fail](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/2ff73fff-c17d-4992-a3ba-1df66481a5ad)

### Testing
Steps:
1. Upload any file or URL using the Wizard.
2. See the notification.
3. To test the errored layer upload, uncomment L586 and L587 and upload a valid URL (like `https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer`) and go through the steps in Wizard. See the notification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2036)
<!-- Reviewable:end -->
