### PR TITLE
Enable unpinning of special columns

### DIFF
--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -6,6 +6,7 @@ grid.splash.loading,Loading data...,1,Chargement des données...,1
 grid.splash.building,Building table...,1,Création du tableau...,1
 grid.splash.cancel,Cancel,1,Annuler,1
 grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,1
+grid.pinColumns,Pin columns,1,Épingler les colonnes,0
 grid.layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
 grid.label.columns,Hide columns,1,Masquer les colonnes,1
 grid.label.copied,Copied,1,Copié,0

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -301,6 +301,47 @@
                                 </svg>
                             </div>
                         </a>
+                        <a
+                            href="javascript:;"
+                            class="flex leading-snug items-center w-256"
+                            :class="{ hover: 'text-black' }"
+                            @click="togglePinned()"
+                        >
+                            <svg
+                                v-if="pinned"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 24 24"
+                                class="fill-current inline w-20 h-20 mr-2 text-gray-500"
+                            >
+                                <path
+                                    d="M18,8H17V6A5,5 0 0,0 12,1A5,5 0 0,0 7,6V8H6A2,2 0 0,0 4,10V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V10A2,2 0 0,0 18,8M12,3A3,3 0 0,1 15,6V8H9V6A3,3 0 0,1 12,3Z"
+                                />
+                            </svg>
+                            <svg
+                                v-else-if="!pinned"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 24 24"
+                                class="fill-current inline w-20 h-20 mr-2 text-gray-500"
+                            >
+                                <path
+                                    d="M18 1.5c2.9 0 5.25 2.35 5.25 5.25v3.75a.75.75 0 01-1.5 0V6.75a3.75 3.75 0 10-7.5 0v3a3 3 0 013 3v6.75a3 3 0 01-3 3H3.75a3 3 0 01-3-3v-6.75a3 3 0 013-3h9v-3c0-2.9 2.35-5.25 5.25-5.25z"
+                                />
+                            </svg>
+                            {{ t('grid.pinColumns') }}
+                            <svg
+                                height="18"
+                                width="18"
+                                viewBox="0 0 24 24"
+                                class="inline float-right"
+                                v-if="pinned"
+                            >
+                                <g id="done">
+                                    <path
+                                        d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"
+                                    />
+                                </g>
+                            </svg>
+                        </a>
                     </dropdown-menu>
                 </div>
             </div>
@@ -474,6 +515,8 @@ const NUM_TYPES: string[] = [
 const iApi = inject<InstanceAPI>('iApi')!;
 const gridStore = useGridStore();
 const panelStore = usePanelStore();
+const mobileView = computed(() => panelStore.mobileView);
+const pinned = ref<Boolean>(!mobileView.value);
 const el = ref<HTMLElement>();
 const { t } = useI18n();
 const forceUpdate = () => getCurrentInstance()?.proxy?.$forceUpdate();
@@ -707,6 +750,16 @@ const clearFilters = () => {
     agGridApi.value.refreshHeader();
 };
 
+const togglePinned = () => {
+    pinned.value = !pinned.value;
+
+    let cols = columnApi.value.getAllDisplayedColumns();
+    columnApi.value.setColumnsPinned(
+        cols.slice(1, 3),
+        pinned.value ? 'left' : ''
+    );
+};
+
 const setUpDateFilter = (
     colDef: ColumnDefinition,
     state: TableStateManager
@@ -860,7 +913,7 @@ const setUpSpecialColumns = (
 
         let detailsDef = {
             sortable: false,
-            pinned: 'left',
+            pinned: mobileView.value ? '' : 'left',
             filter: false,
             lockPosition: true,
             isStatic: true,
@@ -888,7 +941,7 @@ const setUpSpecialColumns = (
         if (hasMapLayers.value) {
             let zoomDef = {
                 sortable: false,
-                pinned: 'left',
+                pinned: mobileView.value ? '' : 'left',
                 filter: false,
                 lockPosition: true,
                 isStatic: true,
@@ -920,7 +973,7 @@ const setUpSpecialColumns = (
 
                 let buttonDef = {
                     sortable: false,
-                    pinned: 'left',
+                    pinned: mobileView.value ? '' : 'left',
                     filter: false,
                     lockPosition: true,
                     isStatic: true,


### PR DESCRIPTION
### Related Item(s)
#1942 

### Changes
The special columns in the grid can now be unpinned for mobile users (Is this something we want for desktop as well?). This PR should be considered experimental as the change introduces an issue. When no columns are pinned, ag-grid adds the ag-hidden class to the ag-pinned-left-header section. This is where the "Clear Filters" button resides so the user can no longer select it unless they pin the columns again. 

I wasn't able to find a way to prevent ag-hidden from being applied but I'm hoping the UI wizards may have some suggestions. We could move the button outside of the pinned panel, but from a UI perspective I think it makes sense where it is. Open to any suggestions.

![Hidden](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/28012494/dbb93dd5-a97e-4c7f-8920-f5e2b82db9ff)

### Testing
Steps:
1. Open the grid from a mobile device / browser mobile mode
2. Notice the limited view when the columns are pinned
3. Unpin the columns and enjoy additional grid real estate
4. ![giphy](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/28012494/ff3478ec-266b-4ab7-98ec-83aa01e17b4c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2037)
<!-- Reviewable:end -->
