### PR TITLE
implement XML formatting for metadata panel

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -262,10 +262,11 @@ let config = {
                     name: 'Greenhouse gas emissions from large facilities',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Ammonia%20emissions%20by%20facility.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Ammonia%20emissions%20by%20facility.xml'
+                    },
                     catalogueUrl:
-                        'https://open.canada.ca/data/en/dataset/4221c508-00c9-4011-aca6-b0a017fc90dc',
+                        'http://open.canada.ca/data/en/dataset/4221c508-00c9-4011-aca6-b0a017fc90dc',
                     state: {
                         visibility: true,
                         opacity: 1
@@ -304,8 +305,9 @@ let config = {
                     name: 'Sulphur oxide emissions by facility',
                     layerType: 'esri-feature',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/18',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Sulphur%20oxide%20emissions%20by%20facility.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Sulphur%20oxide%20emissions%20by%20facility.xml'
+                    },
                     catalogueUrl:
                         'https://open.canada.ca/data/en/dataset/f4fb2aee-2d1b-4c75-aea1-2a7760cc4b58',
                     state: {
@@ -338,8 +340,9 @@ let config = {
                     name: 'Average fine particulate matter concentrations at monitoring stations',
                     layerType: 'esri-feature',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/26',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Average%20ambient%20fine%20particulate%20matter%20concentrations%20at%20monitoring%20stations.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Average%20ambient%20fine%20particulate%20matter%20concentrations%20at%20monitoring%20stations.xml'
+                    },
                     catalogueUrl:
                         'https://open.canada.ca/data/en/dataset/e6cc3ae2-92b1-4df6-87ff-698a1cd5a7bd',
                     state: {
@@ -368,8 +371,9 @@ let config = {
                     name: 'Average sulphur dioxide concentrations at monitoring stations',
                     layerType: 'esri-feature',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/28',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Average%20ambient%20sulphur%20dioxide%20concentrations%20at%20monitoring%20stations.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Average%20ambient%20sulphur%20dioxide%20concentrations%20at%20monitoring%20stations.xml'
+                    },
                     catalogueUrl:
                         'https://open.canada.ca/data/en/dataset/5f1b78ab-999a-41f0-82e9-351d236010ca',
                     state: {
@@ -428,8 +432,9 @@ let config = {
                     name: 'Releases of lead to water by facility',
                     layerType: 'esri-feature',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/38',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Releases%20of%20lead%20to%20water%20by%20facility.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Releases%20of%20lead%20to%20water%20by%20facility.xml'
+                    },
                     catalogueUrl:
                         'https://open.canada.ca/data/en/dataset/334f4740-c9bd-4193-ba69-04c21443d2b6',
                     state: {
@@ -461,8 +466,9 @@ let config = {
                     name: 'Conserved areas',
                     layerType: 'esri-map-image',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Protected%20Areas.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Protected%20Areas.xml'
+                    },
                     catalogueUrl:
                         'https://open.canada.ca/data/en/dataset/2888ff57-a21c-448c-a4fa-570c4cabd956',
                     state: {
@@ -504,8 +510,9 @@ let config = {
                     name: 'Water quality at monitoring sites',
                     layerType: 'esri-feature',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/5',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Water%20quality%20at%20monitoring%20sites.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Water%20quality%20at%20monitoring%20sites.xml'
+                    },
                     catalogueUrl:
                         'https://open.canada.ca/data/en/dataset/b6b6d5a6-bded-4b6e-9e8a-17f6e1b538dc',
                     state: {
@@ -518,8 +525,9 @@ let config = {
                     name: 'Water quantity at monitoring stations',
                     layerType: 'esri-feature',
                     url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/1',
-                    metadataUrl:
-                        'https://indicators-map.ec.gc.ca/metadata/en/Water%20quantity%20at%20monitoring%20stations.xml',
+                    metadata: {
+                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Water%20quantity%20at%20monitoring%20stations.xml'
+                    },
                     catalogueUrl:
                         'https://open.canada.ca/data/en/dataset/c7cd1178-c72b-4a5a-aa63-9ae59d5bc532',
                     state: {

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -227,13 +227,24 @@ const toggleMetadata = () => {
             props.legendItem?.layer?.parentLayer?.config?.metadata ||
             {};
         const name = metaConfig?.name || props.legendItem?.layer?.name || '';
+        const catalogueUrl =
+            props.legendItem?.layer?.config?.catalogueUrl ||
+            (props.legendItem?.layer?.layerType === 'sublayer' &&
+                props.legendItem?.layer?.parentLayer?.config?.catalogueUrl) ||
+            undefined;
 
         if (metaConfig.url) {
+            // Check the file extension to see if this is an XML file. Defaults to HTML.
+            const parseUrl = metaConfig.url.split('.');
+            const metadataType =
+                parseUrl[parseUrl.length - 1] === 'xml' ? 'xml' : 'html';
+
             // TODO: toggle metadata panel through API/store call
             iApi.event.emit(GlobalEvents.METADATA_TOGGLE, {
-                type: 'html',
+                type: metadataType,
                 layerName: name,
                 url: metaConfig.url,
+                catalogueUrl: catalogueUrl,
                 layer: props.legendItem!.layer
             });
         } else {

--- a/src/fixtures/metadata/screen.vue
+++ b/src/fixtures/metadata/screen.vue
@@ -20,7 +20,8 @@
                         v-else-if="
                             payload.type === 'xml' && status == 'success'
                         "
-                        class="flex flex-col justify-center"
+                        v-html="response"
+                        class="flex flex-col justify-center xml-content"
                     ></div>
 
                     <!-- Found Screen, HTML -->
@@ -145,7 +146,48 @@ const loadMetadata = () => {
 
             // Append the content to the panel.
             if (r !== null) {
-                el.value.childNodes[1].appendChild(r);
+                const textContainer = document.createElement('div');
+
+                textContainer.appendChild(
+                    stringToFragment(`${r.firstElementChild.outerHTML}`)
+                );
+
+                if (props.payload.catalogueUrl || props.payload.url) {
+                    textContainer.appendChild(
+                        stringToFragment(
+                            `<h5 class="text-xl font-bold mb-3">${t(
+                                'metadata.xslt.metadata'
+                            )}</h5>`
+                        )
+                    );
+                }
+
+                // Append catalogue URL link if it exists
+                if (props.payload.catalogueUrl) {
+                    textContainer.appendChild(
+                        stringToFragment(
+                            `<p><a style="color: blue;" href="${
+                                props.payload.catalogueUrl
+                            }" target="_blank">${t(
+                                'metadata.xslt.cataloguePage'
+                            )}</a></p>`
+                        )
+                    );
+                }
+
+                // Append raw XML link
+                textContainer.appendChild(
+                    stringToFragment(
+                        `<p><a style="color: blue;" href="${
+                            props.payload.url
+                        }" target="_blank">${t(
+                            'metadata.xslt.metadataPage'
+                        )}</a> (xml)</p>`
+                    )
+                );
+
+                //@ts-ignore
+                metadataStore.response = textContainer.outerHTML;
             }
         });
     } else if (props.payload.type === 'html') {
@@ -243,6 +285,20 @@ const requestContent = (url: string): Promise<MetadataResult> => {
         xobj.send();
     });
 };
+
+// Helper function to convert a HTML string to an HTMLElement.
+function stringToFragment(string: string) {
+    const temp = document.createElement('div');
+    temp.innerHTML = string;
+    return temp;
+}
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss">
+.xml-content {
+    font-size: 14px;
+}
+.metadata-view a {
+    color: blue;
+}
+</style>

--- a/src/fixtures/metadata/store/metadata-state.ts
+++ b/src/fixtures/metadata/store/metadata-state.ts
@@ -10,6 +10,7 @@ export interface MetadataPayload {
     type: string; // 'xml' or 'html'
     layerName: string;
     url: string;
+    catalogueUrl: string | undefined;
     layer: LayerInstance | undefined;
 }
 


### PR DESCRIPTION
### Related Item(s)
#2038 

### Changes
- Implements XML formatting for the metadata panel. 

### Notes
- While testing I've noticed that we have similar problems for both `json` and `md` metadata types. This PR is specifically fixing the `xml` format for CESI, but we should create a new issue to fix the remaining formats as well.

### Testing
The metadata URLs in the CESI config file are not accessible so testing may be hard to do at the moment. 

Here is a GIF of it working when I host the metadata locally:

![CESIxml](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/25874602/dcf83f33-c84c-4de2-b1bf-8b85fdd431af)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2040)
<!-- Reviewable:end -->
