### PR TITLE
Fix Max WebGL Context Issue

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -348,6 +348,10 @@
                     >RAMP inside the WET template with teleport enabled</a
                 >
             </li>
+            <li>
+                <a href="index-multi-wet.html"
+                    >Multiple RAMP instances inside the WET template</a>
+            </li>
         </ul>
     </body>
 </html>

--- a/demos/index-multi-wet.html
+++ b/demos/index-multi-wet.html
@@ -1,0 +1,515 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="no-js lt-ie9" lang="en" dir="ltr"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" dir="ltr" lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW) wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+        <title>Wet Template</title>
+        <meta content="width=device-width,initial-scale=1" name="viewport" />
+        <!-- Meta data -->
+        <meta
+            content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities"
+            name="description"
+        />
+        <!-- Meta data-->
+
+        <!-- the host page must load Vue since RAMP doesn't bundle it -->
+        <script src="https://unpkg.com/vue@3.1.5/dist/vue.global.prod.js"></script>
+
+        <!-- Load closure template scripts -->
+        <script
+            id="CDTSsoyutils"
+            src="https://ssl-templates.services.gc.ca/app/cls/WET/gcweb/v4_0_32/cdts/compiled/soyutils.js"
+            type="text/javascript"
+        ></script>
+        <script
+            id="CDTSwet"
+            src="https://ssl-templates.services.gc.ca/app/cls/WET/gcweb/v4_0_32/cdts/compiled/wet-en.js"
+            type="text/javascript"
+        ></script>
+        <script
+            src="https://code.jquery.com/jquery-2.0.3.min.js"
+            integrity="sha384-5BJxsRUsHmz1Kk/hmquvrNXoqth2fWO8TW4G5MbuwrD7g7eyanb4SJ9KV+VGChAT"
+            crossorigin="anonymous"
+        ></script>
+
+        <noscript>
+            <!-- Write closure fall-back static file -->
+            <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/refTop.html -->
+            <!--[if gte IE 9 | !IE]><!-->
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/favicon.ico"
+                rel="icon"
+                type="image/x-icon"
+            />
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/css/theme.min.css"
+                rel="stylesheet"
+            />
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/cdts/cdtsfixes.css"
+                rel="stylesheet"
+            />
+            <!--<![endif]-->
+            <!--[if lt IE 9]>
+                <link
+                    href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/favicon.ico"
+                    rel="shortcut icon"
+                />
+                <link
+                    rel="stylesheet"
+                    href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/css/ie8-theme.min.css"
+                />
+            <![endif]-->
+            <!--[if lte IE 9]> <![endif]-->
+            <link
+                href="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/css/noscript.min.css"
+                rel="stylesheet"
+            />
+        </noscript>
+
+        <!-- Write closure template -->
+        <script id="CDTSRefTopScript" type="text/javascript">
+            document.write(
+                wet.builder.refTop({
+                    cdnEnv: 'prod'
+                })
+            );
+        </script>
+    </head>
+    <body typeof="WebPage" vocab="http://schema.org/">
+        <div id="def-top">
+            <!-- Write closure fall-back static file -->
+            <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/top-en.html -->
+            <ul id="wb-tphp">
+                <li class="wb-slc">
+                    <a class="wb-sl" href="#wb-cont">Skip to main content</a>
+                </li>
+                <li class="wb-slc visible-sm visible-md visible-lg">
+                    <a class="wb-sl" href="#wb-info"
+                        >Skip to "About this site"</a
+                    >
+                </li>
+            </ul>
+            <header role="banner">
+                <div class="container" id="wb-bnr">
+                    <section
+                        class="visible-md visible-lg text-right"
+                        id="wb-lng"
+                    >
+                        <h2 class="wb-inv">Language selection</h2>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <ul class="list-inline margin-bottom-none">
+                                    <li>
+                                        <a href="javascript:;" lang="fr"
+                                            >Français</a
+                                        >
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </section>
+                    <div class="row">
+                        <div class="brand col-xs-8 col-sm-9 col-md-6">
+                            <a href="https://www.canada.ca/en.html">
+                                <img
+                                    data="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/sig-blk-en.svg"
+                                    tabindex="-1"
+                                    type="image/svg+xml"
+                                />
+                                <span class="wb-inv">
+                                    Government of Canada</span
+                                >
+                            </a>
+                        </div>
+                        <section
+                            class="wb-mb-links col-xs-4 col-sm-3 visible-sm visible-xs"
+                            id="wb-glb-mn"
+                        >
+                            <h2>Search and menus</h2>
+                            <ul class="list-inline text-right chvrn">
+                                <li>
+                                    <a
+                                        aria-controls="mb-pnl"
+                                        class="overlay-lnk"
+                                        href="#mb-pnl"
+                                        role="button"
+                                        title="Search and menus"
+                                        ><span
+                                            class="glyphicon glyphicon-search"
+                                            ><span
+                                                class="glyphicon glyphicon-th-list"
+                                                ><span class="wb-inv"
+                                                    >Search and menus</span
+                                                ></span
+                                            ></span
+                                        ></a
+                                    >
+                                </li>
+                            </ul>
+                            <div id="mb-pnl"></div>
+                        </section>
+                        <section
+                            class="col-xs-6 text-right visible-md visible-lg"
+                            id="wb-srch"
+                        >
+                            <h2>Search</h2>
+                            <form
+                                action="https://www.canada.ca/en/sr.html#wb-land"
+                                class="form-inline"
+                                method="get"
+                                name="cse-search-box"
+                                role="search"
+                            >
+                                <div class="form-group">
+                                    <label class="wb-inv" for="wb-srch-q"
+                                        >Search website</label
+                                    >
+                                    <input
+                                        name="cdn"
+                                        type="hidden"
+                                        value="canada"
+                                    />
+                                    <input name="st" type="hidden" value="s" />
+                                    <input
+                                        name="num"
+                                        type="hidden"
+                                        value="10"
+                                    />
+                                    <input
+                                        name="langs"
+                                        type="hidden"
+                                        value="en"
+                                    />
+                                    <input
+                                        name="st1rt"
+                                        type="hidden"
+                                        value="1"
+                                    />
+                                    <input
+                                        name="s5bm3ts21rch"
+                                        type="hidden"
+                                        value="x"
+                                    />
+                                    <input
+                                        class="wb-srch-q form-control"
+                                        id="wb-srch-q"
+                                        list="wb-srch-q-ac"
+                                        maxlength="150"
+                                        name="q"
+                                        placeholder="Search Canada.ca"
+                                        size="27"
+                                        type="search"
+                                        value=""
+                                    />
+                                    <input
+                                        name="_charset_"
+                                        type="hidden"
+                                        value="UTF-8"
+                                    />
+                                    <datalist id="wb-srch-q-ac">
+                                        <!--[if lte IE 9]><select><![endif]-->
+                                        <!--[if lte IE 9]></select><![endif]-->
+                                    </datalist>
+                                </div>
+                                <div class="form-group submit">
+                                    <button
+                                        class="btn btn-primary btn-small"
+                                        id="wb-srch-sub"
+                                        name="wb-srch-sub"
+                                        type="submit"
+                                    >
+                                        <span
+                                            class="glyphicon-search glyphicon"
+                                        ></span
+                                        ><span class="wb-inv">Search</span>
+                                    </button>
+                                </div>
+                            </form>
+                        </section>
+                    </div>
+                </div>
+                <nav
+                    class="wb-menu visible-md visible-lg"
+                    id="wb-sm"
+                    role="navigation"
+                    typeof="SiteNavigationElement"
+                >
+                    <div class="container nvbar">
+                        <h2>Topics menu</h2>
+                        <div class="row">
+                            <ul class="list-inline menu">
+                                <li>
+                                    <a
+                                        href="https://www.esdc.gc.ca/en/jobs/index.page"
+                                        >Jobs</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.cic.gc.ca/english/index.asp"
+                                        >Immigration</a
+                                    >
+                                </li>
+                                <li>
+                                    <a href="https://travel.gc.ca/">Travel</a>
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services/business.html"
+                                        >Business</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services/benefits.html"
+                                        >Benefits</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://healthycanadians.gc.ca/index-eng.php"
+                                        >Health</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services/taxes.html"
+                                        >Taxes</a
+                                    >
+                                </li>
+                                <li>
+                                    <a
+                                        href="https://www.canada.ca/en/services.html"
+                                        >More services</a
+                                    >
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </nav>
+                <nav id="wb-bc" property="breadcrumb" role="navigation">
+                    <h2>You are here:</h2>
+                    <div class="container">
+                        <div class="row">
+                            <ol class="breadcrumb">
+                                <li>
+                                    <a href="https://www.canada.ca/en.html"
+                                        >Home</a
+                                    >
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                </nav>
+            </header>
+        </div>
+        <!-- Write closure template -->
+        <script id="CDTSTopScript" type="text/javascript">
+            var defTop = document.getElementById('def-top');
+            defTop.outerHTML = wet.builder.top({
+                cdnEnv: 'prod',
+                lngLinks: [
+                    {
+                        lang: 'fr',
+                        href: '#',
+                        text: 'Français'
+                    }
+                ],
+                search: true
+            });
+        </script>
+        <main class="container" property="mainContentOfPage" role="main">
+            <div id="IE"></div>
+            <div id="app" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app2" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app3" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app4" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app5" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app6" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app7" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app8" style="height: 70vh; margin-bottom: 300px;"></div>
+            <div id="app9" style="height: 70vh"></div>
+            <span id="ramp-version"></span>
+
+            <div id="def-preFooter">
+                <!-- Write closure fall-back static file -->
+                <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/preFooter-en.html -->
+                <div class="row pagedetails">
+                    <div class="col-sm-6 col-lg-4 mrgn-tp-sm">
+                        <a
+                            class="btn btn-default btn-block"
+                            href="https://www.canada.ca/en/report-problem.html"
+                            >Report a problem or mistake on this page</a
+                        >
+                    </div>
+                    <div class="datemod col-xs-12 mrgn-tp-lg">
+                        <dl id="wb-dtmd"></dl>
+                    </div>
+                </div>
+            </div>
+            <script>
+                $(function () {
+                    var iframeBody = $('#if-content').contents().find('body');
+                    var styleTag = iframeBody.append($('#app'));
+                });
+            </script>
+            <!-- Write closure template -->
+            <script id="CDTSPreFooterScript" type="text/javascript">
+                var defPreFooter = document.getElementById('def-preFooter');
+                defPreFooter.outerHTML = wet.builder.preFooter({
+                    cdnEnv: 'prod'
+                });
+            </script>
+
+            <script type="module" src="./starter-scripts/multi-instances.js"></script>
+        </main>
+
+        <div id="def-footer">
+            <!-- Write closure fall-back static file -->
+            <!-- /ROOT/etc/designs/canada/cdts/gcweb/latest/cdts/static/footer-en.html -->
+            <aside class="gc-nttvs container">
+                <h2>Government of Canada activities and initiatives</h2>
+                <div class="wb-eqht row" id="gcwb_prts">
+                    <p class="mrgn-lft-md">
+                        <a href="https://www.canada.ca/activities.html"
+                            >Access Government of Canada activities and
+                            initiatives</a
+                        >
+                    </p>
+                </div>
+            </aside>
+            <footer id="wb-info" role="contentinfo">
+                <nav class="container wb-navcurr" role="navigation">
+                    <h2 class="wb-inv">About government</h2>
+                    <ul class="list-unstyled colcount-sm-2 colcount-md-3">
+                        <li>
+                            <a href="https://www.canada.ca/en/contact.html"
+                                >Contact us</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/dept.html"
+                                >Departments and agencies</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/publicservice.html"
+                                >Public service and military</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://www.servicecanada.gc.ca/gcnews"
+                                >News</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/system/laws.html"
+                                >Treaties, laws and regulations</a
+                            >
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/transparency/reporting.html"
+                                >Government-wide reporting</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://pm.gc.ca/eng">Prime Minister</a>
+                        </li>
+                        <li>
+                            <a
+                                href="https://www.canada.ca/en/government/system.html"
+                                >How government works</a
+                            >
+                        </li>
+                        <li>
+                            <a href="https://open.canada.ca/en/"
+                                >Open government</a
+                            >
+                        </li>
+                    </ul>
+                </nav>
+                <div class="brand">
+                    <div class="container">
+                        <div class="row">
+                            <nav class="col-md-10 ftr-urlt-lnk">
+                                <h2 class="wb-inv">About this site</h2>
+                                <ul>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/social.html"
+                                            >Social media</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/mobile.html"
+                                            >Mobile applications</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www1.canada.ca/en/newsite.html"
+                                            >About Canada.ca</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/transparency/terms.html"
+                                            >Terms and conditions</a
+                                        >
+                                    </li>
+                                    <li>
+                                        <a
+                                            href="https://www.canada.ca/en/transparency/privacy.html"
+                                            >Privacy</a
+                                        >
+                                    </li>
+                                </ul>
+                            </nav>
+                            <div class="col-xs-6 visible-sm visible-xs tofpg">
+                                <a href="#wb-cont"
+                                    >Top of Page
+                                    <span
+                                        class="glyphicon glyphicon-chevron-up"
+                                    ></span
+                                ></a>
+                            </div>
+                            <div class="col-xs-6 col-md-2 text-right">
+                                <img
+                                    aria-label="Symbol of the Government of Canada"
+                                    data="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_32/assets/wmms-blk.svg"
+                                    role="img"
+                                    tabindex="-1"
+                                    type="image/svg+xml"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </footer>
+        </div>
+
+        <!-- Write closure template -->
+        <script id="CDTSDefFooterScript" type="text/javascript">
+            var defFooter = document.getElementById('def-footer');
+            defFooter.outerHTML = wet.builder.footer({
+                cdnEnv: 'prod'
+            });
+        </script>
+        <!-- Write closure template -->
+        <script id="CDTSRefFooterScript" type="text/javascript">
+            document.write(
+                wet.builder.refFooter({
+                    cdnEnv: 'prod'
+                })
+            );
+        </script>
+    </body>
+</html>

--- a/demos/starter-scripts/multi-instances.js
+++ b/demos/starter-scripts/multi-instances.js
@@ -1,0 +1,478 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+// document.getElementById('ramp-version').innerText =
+//     'v.' +
+//     RAMP.version.major +
+//     '.' +
+//     RAMP.version.minor +
+//     '.' +
+//     RAMP.version.patch +
+//     ' [#' +
+//     RAMP.version.hash.slice(0, 6) +
+//     ']  -  built on ' +
+//     new Date(RAMP.version.timestamp).toLocaleDateString();
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WaterQuantity',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 1,
+                            name: 'Water quantity child',
+                            state: {
+                                opacity: 1,
+                                visibility: true
+                            },
+                            fixtures: {
+                                details: {
+                                    template: 'Water-Quantity-Template'
+                                },
+                                settings: {
+                                    controls: ['visibility', 'opacity']
+                                }
+                            }
+                        },
+                        {
+                            index: 9,
+                            name: 'Carbon monoxide emissions by facility',
+                            state: {
+                                opacity: 0.5,
+                                visibility: true
+                            },
+                            disabledControls: ['opacity']
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md',
+                        name: 'Read Me!'
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WaterQuality',
+                    layerType: 'esri-map-image',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    sublayers: [
+                        {
+                            index: 5,
+                            state: {}
+                        }
+                    ],
+                    state: {
+                        opacity: 1,
+                        visibility: true
+                    },
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'CleanAir',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/9',
+                    state: {
+                        opacity: 0.8,
+                        visibility: true,
+                        hovertips: false
+                    },
+                    mouseTolerance: 10,
+                    customRenderer: {} // just to chill things out. real ramp will have all properties defaulted and filled in
+                },
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    state: {
+                        visibility: true
+                    },
+                    customRenderer: {},
+                    metadata: {
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/README.md'
+                    },
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
+                    }
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                name: 'Visibility Set',
+                                exclusive: true,
+                                children: [
+                                    {
+                                        layerId: 'CleanAir',
+                                        name: 'Clean Air in Set',
+                                        disabledLayerControls: ['boundaryZoom']
+                                    },
+                                    {
+                                        name: 'Group in Set',
+                                        children: [
+                                            {
+                                                layerId: 'WaterQuantity',
+                                                name: 'Water Quantity in Nested Group',
+                                                sublayerIndex: 1,
+                                                layerControls: [
+                                                    'datatable',
+                                                    'metadata',
+                                                    'reload',
+                                                    'remove',
+                                                    'settings',
+                                                    'symbology'
+                                                ]
+                                            },
+                                            {
+                                                layerId: 'WaterQuantity',
+                                                name: 'CO2 in Nested Group',
+                                                sublayerIndex: 9
+                                            },
+                                            {
+                                                layerId: 'WaterQuality',
+                                                name: 'Water Quality in Nested Group',
+                                                sublayerIndex: 5
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                layerId: 'WFSLayer',
+                                name: 'WFSLayer',
+                                layerControls: [
+                                    'metadata',
+                                    'boundaryZoom',
+                                    'refresh',
+                                    'reload',
+                                    'remove',
+                                    'datatable',
+                                    'settings',
+                                    'symbology'
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: ['legend', 'geosearch']
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap'
+                    ]
+                },
+                export: {
+                    title: {
+                        value: 'All Your Base are Belong to Us',
+                        selectable: false
+                    },
+                    legend: {
+                        selected: false
+                    },
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                }
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+let rInstance;
+const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+        if (entry.isIntersecting) {
+            rInstance = createInstance(entry.target, config, options);
+            observer.unobserve(entry.target);
+        }
+    });
+});
+observer.observe(document.getElementById('app'));
+observer.observe(document.getElementById('app2'));
+observer.observe(document.getElementById('app3'));
+observer.observe(document.getElementById('app4'));
+observer.observe(document.getElementById('app5'));
+observer.observe(document.getElementById('app6'));
+observer.observe(document.getElementById('app7'));
+observer.observe(document.getElementById('app8'));
+observer.observe(document.getElementById('app9'));
+
+window.debugInstance = rInstance;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -67,7 +67,8 @@ export default defineConfig(({ command, mode }) => {
                         all: '/index-all.html',
                         form: '/index-form.html',
                         teleport: '/index-teleport.html',
-                        teleportWet: '/index-teleport-wet.html'
+                        teleportWet: '/index-teleport-wet.html',
+                        multiWet: '/index-multi-wet.html'
                     }
                 }
             });


### PR DESCRIPTION
### Related Item(s)
For #1908 

### Notes
- Most browsers have a webgl context limit of 16 (one instance of RAMP can use up to two instances - one for the overall map and another for the overview)
- Once the number of contexts on a page is higher than the limit, the oldest existing context will be lost. This previously resulted in all RAMP instances on the page breaking instead of only the instance that lost its context
- This solution does not require any changes to code for products that use RAMP (like Storylines)

### Changes
- Now when the oldest existing context is lost for an instance, all other RAMP instances will still be functional
- When a RAMP instance is visible on the screen, if its overview or map context is lost, it will be recovered

### Testing
There is a new demo in the catalogue labelled "Multiple RAMP instances inside the Wet template". It contains 9 RAMP instances that only render once visible on the screen. Was trying to stimulate something similar to viewing RAMP maps in Storylines and producing the notorious console warning `Too many active WebGL contexts. Oldest context will be lost`, so it can be removed once this issue is fully finished if we want to.

1. Open the demo and console. Slowly scroll down, rendering and keeping track of the number of webgl contexts used. Each instance rendered is two more webgl contexts
2. Once you reach the 8th instance, 16 contexts exist and we have reached the limit. Everything should be fine so far.
3. When the 9th instance renders, the warning should appear in the console. At this point we have 18 contexts, so two contexts should be lost. Following the order, the oldest two contexts should be the first instances map and overview. 
4. Scroll back to the first instance. Feel free to test the other instance on your way back to the top, they should still be functional. If you scroll back to the first instance you should briefly see that both the map and overview are empty (white background), and will reappear shortly once visible on the screen
5. The warning will appear as we are at 18 contexts again, and the oldest contexts will be lost, which will be the second instances map and overview. Once the second instance is visible, the contexts will be recovered and the cycle continues.

Note that if you render the instances in a different order, or are scrolling all over the place, there can be cases where an instance can have its overview context lost but still have its map context or vice versa. In these cases the respective missing context will reappear as well. No matter what happens when an instance is visible it should always have both its contexts.

Changes were also tested in Storylines with RAMP4, and similar behaviour was seen there. All maps were functional and once you viewed the instance with a lost context it was recovered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2041)
<!-- Reviewable:end -->
