### PR TITLE
pygeoapi update for WFS layers

### DIFF
--- a/demos/starter-scripts/custom-grid-buttons.js
+++ b/demos/starter-scripts/custom-grid-buttons.js
@@ -263,7 +263,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#55ffff',
                     fixtures: {
@@ -748,7 +748,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#55ffff',
                     fixtures: {

--- a/demos/starter-scripts/custom-renderer.js
+++ b/demos/starter-scripts/custom-renderer.js
@@ -363,7 +363,7 @@ let config = {
                 {
                     id: 'WFSSimple',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     customRenderer: {
                         type: 'simple',
@@ -389,7 +389,7 @@ let config = {
                 {
                     id: 'WFSUniqueValue',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     customRenderer: {
                         type: 'uniqueValue',
@@ -454,7 +454,7 @@ let config = {
                 {
                     id: 'WFSClassBreaks',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     customRenderer: {
                         type: 'classBreaks',

--- a/demos/starter-scripts/custom-symbology.js
+++ b/demos/starter-scripts/custom-symbology.js
@@ -274,7 +274,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FFA500'
                 }

--- a/demos/starter-scripts/delayed-start.js
+++ b/demos/starter-scripts/delayed-start.js
@@ -349,7 +349,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/error-layers.js
+++ b/demos/starter-scripts/error-layers.js
@@ -345,7 +345,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/form.js
+++ b/demos/starter-scripts/form.js
@@ -349,7 +349,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/grid-config.js
+++ b/demos/starter-scripts/grid-config.js
@@ -54,7 +54,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/grid-custom-template.js
+++ b/demos/starter-scripts/grid-custom-template.js
@@ -54,7 +54,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca/collections/hydrometric-stations/items?startindex=6000',
+                    url: 'https://api.weather.gc.ca/collections/hydrometric-stations/items?offset=6000',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     customRenderer: {},

--- a/demos/starter-scripts/legend.js
+++ b/demos/starter-scripts/legend.js
@@ -143,7 +143,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -285,7 +285,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#55ffff',
                     fixtures: {
@@ -739,7 +739,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#55ffff',
                     fixtures: {

--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -343,7 +343,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     state: {
                         visibility: true
@@ -778,7 +778,7 @@ let config2 = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     state: {
                         visibility: true
@@ -1219,7 +1219,7 @@ let config3 = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     state: {
                         visibility: true

--- a/demos/starter-scripts/old-main.js
+++ b/demos/starter-scripts/old-main.js
@@ -349,7 +349,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -304,7 +304,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/teleport-wet.js
+++ b/demos/starter-scripts/teleport-wet.js
@@ -332,7 +332,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     state: {
                         visibility: true

--- a/demos/starter-scripts/teleport.js
+++ b/demos/starter-scripts/teleport.js
@@ -349,7 +349,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -334,7 +334,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     state: {
                         visibility: true

--- a/public/starter-scripts/esm.js
+++ b/public/starter-scripts/esm.js
@@ -345,7 +345,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
                     state: {

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -266,7 +266,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#55ffff',
                     fixtures: {
@@ -724,7 +724,7 @@ let config = {
                 {
                     id: 'WFSLayer',
                     layerType: 'ogc-wfs',
-                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&startindex=0&limit=1000&province__province=on',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#55ffff',
                     fixtures: {

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -291,11 +291,11 @@ export class LayerSource extends APIScope {
     async getWfsInfo(url: string): Promise<LayerInfo> {
         // get wfs data here then load as geojson layer so we can get fields
         const wrapper = new UrlWrapper(url);
-        const { startindex, limit } = wrapper.queryMap;
+        const { offset, limit } = wrapper.queryMap;
         const wfsJson = await this.$iApi.geo.layer.ogc.loadWfsData(
             url,
             -1,
-            parseInt(startindex) || 0,
+            parseInt(offset) || 0,
             parseInt(limit) || 1000
         );
 

--- a/src/geo/layer/ogc-utils.ts
+++ b/src/geo/layer/ogc-utils.ts
@@ -20,7 +20,7 @@ export class OgcUtils extends APIScope {
      *
      * @param {string} url the current url to the wfs service. Should be a /collections/id/items/ endpoint with optional params after the question operator
      * @param {number} [totalCount=-1] the total number of features available on that service. If not provided, the service will be interrogated for the count.
-     * @param {number} [startindex=0] the feature index to start the querying from. default 0
+     * @param {number} [offset=0] the feature index to start the querying from. default 0
      * @param {number} [limit=1000] the limit of how many results we want returned per server request. default 1000
      * @param {WFSData} [wfsData={
      *                 type: 'FeatureCollection',
@@ -33,7 +33,7 @@ export class OgcUtils extends APIScope {
     async loadWfsData(
         url: string,
         totalCount = -1,
-        startindex = 0,
+        offset = 0,
         limit = 1000,
         wfsData: WFSData = {
             type: 'FeatureCollection',
@@ -42,7 +42,7 @@ export class OgcUtils extends APIScope {
         xyInAttribs = false
     ): Promise<any> {
         let newQueryMap: UrlQueryMap = {
-            startindex: startindex.toString(),
+            offset: offset.toString(),
             limit: limit.toString()
         };
 
@@ -85,7 +85,7 @@ export class OgcUtils extends APIScope {
             return this.loadWfsData(
                 url,
                 totalCount,
-                startindex,
+                offset,
                 limit,
                 wfsData,
                 xyInAttribs
@@ -97,16 +97,16 @@ export class OgcUtils extends APIScope {
         wfsData.features = wfsData.features.concat(data.features);
 
         // check if all the requested features are downloaded
-        if (data.features.length < totalCount - startindex) {
+        if (data.features.length < totalCount - offset) {
             // the next limit is either the provided limit or the number of remaining features
             const newLimit = Math.min(
                 limit,
-                totalCount - startindex - data.features.length
+                totalCount - offset - data.features.length
             );
             return this.loadWfsData(
                 requestUrl,
                 totalCount,
-                data.features.length + startindex,
+                data.features.length + offset,
                 newLimit,
                 wfsData,
                 xyInAttribs

--- a/src/geo/layer/wfs-layer.ts
+++ b/src/geo/layer/wfs-layer.ts
@@ -16,14 +16,14 @@ export class WfsLayer extends FileLayer {
         const wrapper = new UrlWrapper(this.config.url);
 
         // get start index and limit set on the url
-        const { startindex, limit } = wrapper.queryMap;
+        const { offset, limit } = wrapper.queryMap;
 
         // fetch data from server only if it has not been cached
         if (!this.sourceGeoJson) {
             this.sourceGeoJson = await this.$iApi.geo.layer.ogc.loadWfsData(
                 this.config.url,
                 -1,
-                parseInt(startindex) || 0,
+                parseInt(offset) || 0,
                 parseInt(limit) || 1000,
                 undefined,
                 this.config.xyInAttribs


### PR DESCRIPTION
### Related Item(s)
#2035 

### Changes
- Changed `startindex` to `offset` in sample config files and in the WFS loader

### Notes
Most of the samples appear the same, but here's an example of a significant change in Sample 40:
With `startindex` (aka without the change):
![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/f8001b78-e017-4f61-92bb-6177548e249e)

With `offset` (aka with the change):
![image (1)](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/0a8acf09-a3e1-41cf-a7a7-f5047ceacfba)

### Testing
Select any sample to view the loaded WFS layer on the map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2044)
<!-- Reviewable:end -->
