### PR TITLE
Fixed parsing error for help search no results French

### DIFF
--- a/src/fixtures/help/lang/lang.csv
+++ b/src/fixtures/help/lang/lang.csv
@@ -3,4 +3,4 @@ help.title,Help,1,Aide,1
 help.search,Search Help,1,Rechercher aide,0
 help.section.expand,Expand section,1,Développer une section,1
 help.section.collapse,Collapse section,1,Réduire une section,1
-help.noResults,Nothing is found. Please try a different search.,1,Rien n'est trouvé. S'il vous plaît, essayez une recherche différente.,0
+help.noResults,Nothing is found. Please try a different search.,1,Rien n'est trouvé. Essayez une autre recherche s'il vous plaît.,0


### PR DESCRIPTION
### Related Item(s)
#2046 

### Changes
- The parsing error was due to the comma in the middle of the sentence as it was being interpreted as the end of the content.
- Changed the message to "Rien n'est trouvé. Essayez une autre recherche s'il vous plaît." instead of "S'il vous plaît, essayez une recherche différente"

### Notes
With the change:
![full message displayed](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/1d41d9fe-2f4c-4eb9-a4ef-b1c852dde9ad)

Without the change:
![not full message](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/5ee85df5-c544-4e0f-aa16-6ea68f81962f)

### Testing
Steps:
1. Switch to RAMP to French
2. Open Help and type a search term that will yield no results (ex. "something").
3. See the complete message displayed for no results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2047)
<!-- Reviewable:end -->
