### PR TITLE
Allow delimiter to be changed for parsing csv files

### DIFF
--- a/scripts/vite-plugin-i18n.ts
+++ b/scripts/vite-plugin-i18n.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { Plugin } from 'vite';
 // @ts-ignore
-import { csvParse } from 'd3-dsv';
+import { dsvFormat } from 'd3-dsv';
 
 export default function vueI18nPlugin(): Plugin {
     type CsvRow = { key: string; [name: string]: string };
@@ -19,7 +19,7 @@ export default function vueI18nPlugin(): Plugin {
             if (!/lang\.csv/.test(id)) return;
 
             const valueField = 'Value';
-            const res: CsvRows = csvParse(
+            const res: CsvRows = dsvFormat(',').parse(
                 src
                     .replace('export default "', '')
                     .replace(/"$/, '')


### PR DESCRIPTION
### Related Item(s)
#2048, #2046

### Changes
- To specify the delimiter for parsing csv files, changed the function from `csvParse` to `dsvFormat` from the [d3 library](https://d3js.org/d3-dsv#dsvFormat)
- I've kept the delimiter as the comma for now since all the lang.csv files are formatted to use that currently

### Testing
Steps:
1. Open RAMP and see if the written content that is pulled from any lang.csv file is displayed correctly. For example, in help search the English message for no results is: "Nothing is found. Please try a different search.", and the French message is: "Rien n'est trouvé. Essayez une autre recherche s'il vous plaît."

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2050)
<!-- Reviewable:end -->
