### PR TITLE
fix details/grid fixtures ignoring config of layers added via API

### DIFF
--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -1,7 +1,7 @@
 import { createApp, defineComponent, h, render } from 'vue';
 import type { Component, ComponentOptions } from 'vue';
 
-import { APIScope, GlobalEvents, InstanceAPI } from './internal';
+import { APIScope, GlobalEvents, InstanceAPI, LayerInstance } from './internal';
 import { useConfigStore } from '@/stores/config';
 import type { FixtureBase } from '@/stores/fixture';
 import { useFixtureStore } from '@/stores/fixture';
@@ -396,8 +396,8 @@ export class FixtureInstance extends APIScope implements FixtureBase {
      * @returns {{ [layerId: string]: any }} Dictionary where key is the layer id and the value is this fixture's config for that layer
      */
     getLayerFixtureConfigs(): { [layerId: string]: any } {
-        const mainConfig: RampConfig = this.$iApi.getConfig();
         const fixtureConfigs: { [layerId: string]: any } = {};
+        const layerStore = (this as any).$iApi.useStore('layer');
 
         const layerCrawler = (layer: any, parent: any = undefined) => {
             if (layer.fixtures && layer.fixtures[this.id] !== undefined) {
@@ -417,7 +417,10 @@ export class FixtureInstance extends APIScope implements FixtureBase {
             }
         };
 
-        mainConfig.layers?.forEach(layer => layerCrawler(layer));
+        // Crawl through the layer store and check for layers that may have a custom config.
+        layerStore.layers?.forEach((layer: LayerInstance) =>
+            layerCrawler(layer.config)
+        );
 
         return fixtureConfigs;
     }

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -30,6 +30,32 @@ export class DetailsAPI extends FixtureInstance {
         // Save the provided identify result in the store.
         this.detailsStore.payload = payload;
 
+        // Check to see if each layer has a fixture config in the store.
+        payload.forEach(p => {
+            const layer: LayerInstance | undefined = (this as any).$iApi
+                .useStore('layer')
+                .getLayerByUid(p.uid);
+
+            if (layer) {
+                // Check to see if we've already saved this layer's details config.
+                const detailsItem = this.detailsStore.properties[layer.id];
+
+                // If we haven't and the layer has a details config set, add it to the details store.
+                if (detailsItem === undefined) {
+                    const layerDetailsConfigs: any =
+                        this.getLayerFixtureConfigs();
+
+                    if (layerDetailsConfigs[layer.id] !== undefined) {
+                        this.detailsStore.addConfigProperty({
+                            id: layer.id,
+                            name: layerDetailsConfigs[layer.id].name,
+                            template: layerDetailsConfigs[layer.id].template
+                        });
+                    }
+                }
+            }
+        });
+
         // Open the details panel.
         const layersPanel = this.$iApi.panel.get('details-layers');
         if (!layersPanel.isOpen) {

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -54,6 +54,10 @@ export const useDetailsStore = defineStore('details', () => {
         }
     }
 
+    function addConfigProperty(item: DetailsItemInstance) {
+        properties.value = { ...properties.value, [item.id]: item };
+    }
+
     return {
         payload,
         properties,
@@ -63,6 +67,7 @@ export const useDetailsStore = defineStore('details', () => {
         activeGreedy,
         lastHilight,
         hilightToggle,
-        removeLayer
+        removeLayer,
+        addConfigProperty
     };
 });

--- a/src/fixtures/grid/api/grid.ts
+++ b/src/fixtures/grid/api/grid.ts
@@ -17,10 +17,12 @@ export class GridAPI extends FixtureInstance {
 
         // if no GridConfig exists for the given id, create it.
         if (!gridId) {
+            const layerGridConfigs: any = this.getLayerFixtureConfigs();
+
             this.gridStore.addGrid({
                 id: id,
                 layerIds: [id],
-                state: new TableStateManager(),
+                state: new TableStateManager(layerGridConfigs[id]),
                 fieldMap: {}
             });
         }


### PR DESCRIPTION
### Related Item(s)
#2052 

### Changes
- This PR modifies the `getLayerFixtureConfigs` function to check the layer store for additional layers that may have fixture configs set. This function previously only checked the main config and would not check layers added via API.

### Testing

From James in the original issue:

1. Open RAMP
2. Paste and run the snippet below in the console.
3. Do an identify on one of the water drop points
4. Layer title should no longer remain as "Clean Water".

```
var testConfig = {
  id: 'test',
  layerType: 'esri-feature',
  url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/8',
  fixtures: {
    details: {
      name: 'Water Water Everywhere'
    }
  }
};

var testLayer = debugInstance.geo.layer.createLayer(testConfig);
debugInstance.geo.map.addLayer(testLayer);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2058)
<!-- Reviewable:end -->
