### PR TITLE
Fix wrong layer grid state being applied per-language

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -367,6 +367,7 @@ export class InstanceAPI {
         const configStore = useConfigStore(this.$vApp.$pinia);
         const fixtureStore = useFixtureStore(this.$vApp.$pinia);
         const layerStore = useLayerStore(this.$vApp.$pinia);
+        const gridStore = useGridStore(this.$vApp.$pinia);
 
         // remove all fixtures
         // get list of all fixture ids currently added
@@ -377,6 +378,14 @@ export class InstanceAPI {
             if (this.fixture.get(id) !== undefined) {
                 this.fixture.remove(id);
             }
+        });
+
+        // remove all grids
+        // get list of all grid ids currently added
+        const addedGrids: Array<string> = Object.keys(gridStore.grids);
+        //remove each grid
+        addedGrids.forEach((id: string) => {
+            gridStore.removeGrid(id);
         });
 
         // reset start flag


### PR DESCRIPTION
### Related Item(s)
#1965 

### Changes
- Grid state for a layer in the English config will no longer be applied when switching to French

### Notes
- Looks like this was happening because the grid state was never being reset when reloading

### Testing
Steps:
1. Open sample 43 and the grid for the "Releases of mercury" layer. Notice the custom grid icons
2. Switch the language to French and reopen the same grid. Custom icons should be gone as they were only set in the English config

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2059)
<!-- Reviewable:end -->
