### PR TITLE
Added checking for north pole configuration

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2106,7 +2106,7 @@
                 },
                 "hasNorthPole": {
                     "type": "boolean",
-                    "description": "Indicates if this tile schema shows the north pole."
+                    "description": "Indicates if this tile schema shows the north pole. Will be defaulted to false if the basemap is mercator and true to if it's any other type of basemap."
                 },
                 "recoveryBasemap": {
                     "type": "object",


### PR DESCRIPTION
### Related Item(s)
#2030 

### Changes
- Now the north pole will be configured based on the boolean `hasNorthPole` from the config if it exists
- If `hasNorthPole` is true or if it's not defined and the basemap is not mercator, then there is tracking set up for the pole
- If `hasNorthPole` is false or if it's not defined and the basemap is mercator, then there is no tracking set up for the pole

### Testing
Steps:
1. Open RAMP and pick a sample.
2. If the basemap is Web Mercator, then the pole will not be tracked as you move the map around.
3. If the basemap is not Web Mercator, then the pole will be tracked as you move the map around.

There are no samples where the config has `hasNorthPole: false` but you can make the change to any sample and see that the pole won't be tracked (regardless of if it's Web Mercator or not). 
There are also no samples where the config for a Web Mercator basemap has `hasNorthPole: true` but you can make the change in the config to see that the pole still won't be tracked, I'm not sure for the logic behind this but I think that is the expected behaviour for the basemap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2064)
<!-- Reviewable:end -->
