### PR TITLE
add field override to details configuration

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -280,6 +280,14 @@ let config = {
                             },
                             nameField: 'Name',
                             fixtures: {
+                                details: {
+                                    fields: [
+                                        {
+                                            field: 'Symbol',
+                                            visible: false
+                                        }
+                                    ]
+                                },
                                 grid: {
                                     columns: [
                                         { name: 'CompanyName' },

--- a/schema.json
+++ b/schema.json
@@ -214,10 +214,37 @@
                 "template": {
                     "type": "string",
                     "description": "Custom Vue component to render as details template"
+                },
+                "fields": {
+                    "type": "array",
+                    "description": "An array to specify how the layer data fields are defined. Only applies to attribute layers that do not have an overriding template.",
+                    "items": {
+                        "$ref": "#/$defs/detailsField"
+                    }
                 }
             },
             "required": ["template"],
             "additionalProperties": false
+        },
+        "detailsField": {
+            "type": "object",
+            "description": "",
+            "properties": {
+                "field": {
+                    "type": "string",
+                    "description": "Unique identifier for the field. Aligns with the layer field name."
+                },
+                "alias": {
+                    "type": "string",
+                    "description": "Specifies the field title. If missing, attempts to use the service alias, then defaults to the field name."
+                },
+                "visible": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Specifies if the field is visible by default."
+                }
+            },
+            "required": ["field"]
         },
         "geosearch": {
             "type": "object",

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -49,7 +49,8 @@ export class DetailsAPI extends FixtureInstance {
                         this.detailsStore.addConfigProperty({
                             id: layer.id,
                             name: layerDetailsConfigs[layer.id].name,
-                            template: layerDetailsConfigs[layer.id].template
+                            template: layerDetailsConfigs[layer.id].template,
+                            fields: layerDetailsConfigs[layer.id].fields
                         });
                     }
                 }
@@ -162,7 +163,8 @@ export class DetailsAPI extends FixtureInstance {
             detailsConfigItems.push({
                 id: layerId,
                 name: layerDetailsConfigs[layerId].name,
-                template: layerDetailsConfigs[layerId].template
+                template: layerDetailsConfigs[layerId].template,
+                fields: layerDetailsConfigs[layerId].fields
             });
         });
 

--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -181,6 +181,7 @@
                             :is="detailsTemplate"
                             :identifyData="identifyItem"
                             :fields="fieldsList"
+                            :fixtureFields="fixtureFields"
                         ></component>
                     </div>
                     <!-- identified item is loading -->
@@ -222,7 +223,11 @@ import {
     ref
 } from 'vue';
 import type { PropType } from 'vue';
-import { DetailsItemInstance, useDetailsStore } from './store';
+import {
+    DetailsItemInstance,
+    useDetailsStore,
+    type DetailsFieldItem
+} from './store';
 import type { DetailsAPI } from './api/details';
 
 import { GlobalEvents, InstanceAPI } from '@/api';
@@ -287,6 +292,20 @@ const layerName = computed<string>(() => {
         return detailProperties.value[layer.id].name;
     }
     return layer?.name ?? '';
+});
+const fixtureFields = computed<DetailsFieldItem[] | undefined>(() => {
+    const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(
+        props.result.uid
+    );
+
+    if (
+        layer &&
+        detailProperties.value[layer.id] &&
+        detailProperties.value[layer.id].fields
+    ) {
+        return detailProperties.value[layer.id].fields;
+    }
+    return undefined;
 });
 const supportsFeatures = computed<Boolean>(() => {
     const layer: LayerInstance | undefined = iApi.geo.layer.getLayer(

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -17,6 +17,23 @@ export interface DetailsConfig {
     panelWidth: PanelWidthObject | number;
 }
 
+export interface DetailsFieldItem {
+    /**
+     * Unique identifier for the field. Aligns with the layer field name.
+     */
+    field: string;
+
+    /**
+     * Specifies the field title.
+     */
+    alias?: string;
+
+    /**
+     * Whether this field is displayed.
+     */
+    visible?: boolean;
+}
+
 export interface DetailsConfigItem {
     /**
      * The layer ID that we want to bind the custom template to.
@@ -41,6 +58,14 @@ export interface DetailsConfigItem {
      * @memberof DetailsConfigItem
      */
     template: string;
+
+    /**
+     * An array to specify how the layer data fields are defined.
+     *
+     * @type {array}
+     * @memberof DetailsConfigItem
+     */
+    fields?: DetailsFieldItem[];
 }
 
 export class DetailsItemInstance implements DetailsConfigItem {
@@ -50,6 +75,8 @@ export class DetailsItemInstance implements DetailsConfigItem {
 
     template: string;
 
+    fields?: DetailsFieldItem[];
+
     componentId?: string;
 
     constructor(value: string | DetailsConfigItem) {
@@ -58,6 +85,11 @@ export class DetailsItemInstance implements DetailsConfigItem {
                 ? { id: value, template: '', name: '' }
                 : value)
         };
-        ({ template: this.template, id: this.id, name: this.name } = params);
+        ({
+            template: this.template,
+            id: this.id,
+            name: this.name,
+            fields: this.fields
+        } = params);
     }
 }


### PR DESCRIPTION
### Related Item(s)
#2053, #2051 

### Changes
- Fixed the details template incorrectly removing the `Symbol` field
- Added a new property to the details configuration that allows field aliases and visibility to be overwritten.

### Notes
I've named the config option `fields` for now (based on us calling the option for the grid `columns`). If anyone has a better name for this let me know!

### Testing
Steps to test via config:
1. Open the CESI sample page.
2. Click on a point on the `Greenhouse gas emissions from large facilities` layer to open the details panel.
3. Notice that the `Symbol` field is not being displayed.

Steps to test via API call:
1. Open the CESI sample page.
2. Paste in the following code.
3. Click on a point on the newly added layer. Notice that the "City" field is not visible (and that the Symbol field is now visible), and that the Company field has been renamed to "Alias for Company".

```js
const NewLayer = {
  id: 'Testing_Layer',
  name: 'Test Layer',
  layerType: 'esri-feature',
  url: 'https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CESI/MapServer/10',
  fixtures: {
    details: {
      fields: [
         {
            field: 'City',
            visible: false
         },
         {
            field: 'CompanyName',
            alias: "Alias for company"
         }
      ]
    }
  }
};

var layerObj = debugInstance.geo.layer.createLayer(NewLayer);
debugInstance.geo.map.addLayer(layerObj);
debugInstance.fixture.get('legend').addLayerItem(layerObj);
```
