### PR TITLE
Added a toggle to create a flat layer hierarchy

### DIFF
--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -38,6 +38,7 @@ wizard.configure.sublayers.label,Layers,1,Couches,1
 wizard.configure.sublayers.results,No results,1,Pas de résultats,0
 wizard.configure.sublayers.search,Search layers,1,Rechercher des couches,1
 wizard.configure.sublayers.select,Select layer(s),1,Sélectionner le(s) couche(s),0
+wizard.configure.sublayers.nested,Nested,1,Imbriqué,0
 wizard.configure.colour.label,Colour,1,Couleur,1
 wizard.configure.colour.hue,Hue,1,Teinte,1
 wizard.configure.colour.copy,Copy colour,1,Copier la couleur,1

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -10,6 +10,7 @@ export interface LayerInfo {
     fields?: Array<FieldDefinition>; // the fields for the layer
     latLonFields?: { lat: Array<string>; lon: Array<string> }; // lat and lon are a list of field names that can be possible lat/lon fields
     layers?: Array<SublayerInfo>; // a nested list of info for the parent layer, sublayer groups, and sublayers. Only defined for MIL/WMS
+    layersRaw?: [];
 }
 
 export interface SublayerInfo {
@@ -144,13 +145,14 @@ export class LayerSource extends APIScope {
      */
     async fetchServiceInfo(
         url: string,
-        serviceType: string
+        serviceType: string,
+        nested: boolean
     ): Promise<LayerInfo | undefined> {
         switch (serviceType) {
             case LayerType.FEATURE:
                 return this.getFeatureInfo(url);
             case LayerType.MAPIMAGE:
-                return this.getMapImageInfo(url);
+                return this.getMapImageInfo(url, nested);
             case LayerType.TILE:
                 return this.getTileInfo(url);
             case LayerType.IMAGERY:
@@ -158,7 +160,7 @@ export class LayerSource extends APIScope {
             case LayerType.WFS:
                 return this.getWfsInfo(url);
             case LayerType.WMS:
-                return this.getWmsInfo(url);
+                return this.getWmsInfo(url, nested);
         }
     }
 
@@ -188,7 +190,7 @@ export class LayerSource extends APIScope {
      * @param {string} url
      * @returns {Promise<LayerInfo>} data configuration
      */
-    async getMapImageInfo(url: string): Promise<LayerInfo> {
+    async getMapImageInfo(url: string, nested: boolean): Promise<LayerInfo> {
         const response = await axios.get(url, { params: { f: 'json' } });
         const config = {
             id: `${LayerType.MAPIMAGE}#${++this.layerCount}`,
@@ -201,57 +203,72 @@ export class LayerSource extends APIScope {
 
         return {
             config,
-            layers: mapMapImageLayerList(response.data.layers),
-            configOptions: ['name', 'sublayers']
+            layers: this.createLayerHierarchy(response.data.layers, nested),
+            configOptions: ['name', 'sublayers'],
+            layersRaw: response.data.layers
+        };
+    }
+
+    createLayerHierarchy(layers: any[], nested: boolean) {
+        // avoid case of disordered layers from endpoint
+        layers.sort((l1: any, l2: any) => l1.id - l2.id);
+
+        // traverses the layer tree to insert child layers
+        const findParent = (id: number, sublayers: Array<any>): any => {
+            if (sublayers === undefined) {
+                return false;
+            }
+            let i, parent;
+            if (sublayers.find(sl => sl.id === id)) {
+                return sublayers.find(sl => sl.id === id);
+            } else {
+                for (const sublayer of sublayers) {
+                    parent = findParent(id, sublayer.children);
+                    if (parent !== false) {
+                        return parent;
+                    }
+                }
+                return false;
+            }
         };
 
-        function mapMapImageLayerList(layers: any[]) {
-            // avoid case of disordered layers from endpoint
-            layers.sort((l1: any, l2: any) => l1.id - l2.id);
+        const opts: Array<SublayerInfo> = [];
 
-            // traverses the layer tree to insert child layers
-            const findParent = (id: number, sublayers: Array<any>): any => {
-                if (sublayers === undefined) {
-                    return false;
-                }
-                let i, parent;
-                if (sublayers.find(sl => sl.id === id)) {
-                    return sublayers.find(sl => sl.id === id);
-                } else {
-                    for (i = 0; i < sublayers.length; i += 1) {
-                        parent = findParent(id, sublayers[i].children);
-                        if (parent !== false) {
-                            return parent;
-                        }
-                    }
-                    return false;
-                }
-            };
+        const parentIds = new Set(
+            layers
+                .filter(
+                    layer => layer.subLayerIds && layer.subLayerIds.length > 0
+                )
+                .map(layer => layer.id)
+        );
 
-            const opts: Array<SublayerInfo> = [];
-
-            for (const layer of layers) {
-                if (layer.parentLayerId === -1) {
-                    opts.push({
+        for (const layer of layers) {
+            if (nested && layer.parentLayerId === -1) {
+                opts.push({
+                    id: layer.id,
+                    label: layer.name,
+                    children: layer.subLayerIds ? [] : undefined
+                });
+            } else if (nested) {
+                const parentLayer = findParent(layer.parentLayerId, opts);
+                parentLayer.children = [
+                    ...parentLayer.children,
+                    {
                         id: layer.id,
                         label: layer.name,
                         children: layer.subLayerIds ? [] : undefined
-                    });
-                } else {
-                    const parentLayer = findParent(layer.parentLayerId, opts);
-                    parentLayer.children = [
-                        ...parentLayer.children,
-                        {
-                            id: layer.id,
-                            label: layer.name,
-                            children: layer.subLayerIds ? [] : undefined
-                        }
-                    ];
-                }
+                    }
+                ];
+            } else if (!parentIds.has(layer.id)) {
+                opts.push({
+                    id: layer.id,
+                    label: layer.name,
+                    children: undefined
+                });
             }
-
-            return opts;
         }
+
+        return opts;
     }
 
     async getTileInfo(url: string): Promise<LayerInfo> {
@@ -311,7 +328,7 @@ export class LayerSource extends APIScope {
      * @param {string} url
      * @returns {Promise<LayerInfo>} data configuration
      */
-    async getWmsInfo(url: string): Promise<LayerInfo> {
+    async getWmsInfo(url: string, nested: boolean): Promise<LayerInfo> {
         const capabilities = await this.$iApi.geo.layer.ogc.parseCapabilities(
             url
         );
@@ -327,32 +344,42 @@ export class LayerSource extends APIScope {
 
         return {
             config,
-            layers: mapWmsLayerList(capabilities.layers),
-            configOptions: ['name', 'sublayers']
+            layers: this.mapWmsLayerList(capabilities.layers, nested),
+            configOptions: ['name', 'sublayers'],
+            layersRaw: capabilities.layers
         };
+    }
 
-        function mapWmsLayerList(layers: any) {
-            // filter out items with nonexistant id
-            let modLayers: any = [];
-            layers.forEach((layer: any) => {
-                if (layer.name === null && layer.layers) {
-                    modLayers = [...modLayers, ...layer.layers];
-                } else {
-                    modLayers.push(layer);
-                }
+    mapWmsLayerList(layers: any, nested: boolean) {
+        // filter out items with non-existent id
+        let modLayers: any = [];
+        layers.forEach((layer: any) => {
+            if (layer.name === null && layer.layers) {
+                modLayers = [...modLayers, ...layer.layers];
+            } else {
+                modLayers.push(layer);
+            }
+        });
+
+        if (nested) {
+            return modLayers.flatMap((layer: any) => {
+                return {
+                    id: layer.name,
+                    label: layer.title,
+                    children:
+                        layer.layers.length > 0
+                            ? this.mapWmsLayerList(layer.layers, nested)
+                            : undefined
+                };
             });
-            return [].concat.apply(
-                [],
-                modLayers.map((layer: any) => {
-                    return {
-                        id: layer.name,
-                        label: layer.title,
-                        children:
-                            layer.layers.length > 0
-                                ? mapWmsLayerList(layer.layers)
-                                : undefined
-                    };
-                })
+        } else {
+            return modLayers.flatMap((layer: any) =>
+                layer.layers && layer.layers.length > 0
+                    ? this.mapWmsLayerList(layer.layers, nested)
+                    : {
+                          id: layer.name,
+                          label: layer.title
+                      }
             );
         }
     }

--- a/src/fixtures/wizard/store/wizard-store.ts
+++ b/src/fixtures/wizard/store/wizard-store.ts
@@ -13,6 +13,7 @@ export const useWizardStore = defineStore('wizard', () => {
     const layerSource = ref<LayerSource>();
     const url = ref('');
     const typeSelection = ref('');
+    const nested = ref(true);
     const fileData = ref<ArrayBuffer | null>(null);
     const layerInfo = ref({
         config: placeholderConfig,
@@ -51,6 +52,7 @@ export const useWizardStore = defineStore('wizard', () => {
                     url.value = '';
                     typeSelection.value = '';
                     fileData.value = null;
+                    nested.value = true;
                     layerInfo.value = {
                         config: placeholderConfig,
                         configOptions: []
@@ -62,6 +64,7 @@ export const useWizardStore = defineStore('wizard', () => {
                         config: placeholderConfig,
                         configOptions: []
                     };
+                    nested.value = true;
                     currStep.value = WizardStep.FORMAT;
                 }
                 break;
@@ -72,6 +75,7 @@ export const useWizardStore = defineStore('wizard', () => {
         layerSource,
         url,
         typeSelection,
+        nested,
         fileData,
         layerInfo,
         currStep,


### PR DESCRIPTION
### Related Item(s)
#1949 

### Changes
Added a toggle that includes / removes subgroups from the list of layers in the configure step. If the toggle is unchecked, should the subgroups still remain in the list of layers and simply not be added to the legend? 

Personally I think it makes the most sense to remove them, but it makes no difference to me.

### Testing
Steps:
1. Add a MIL [service](https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Nest/MapServer) 
2. Toggle the Nested checkbox
3. Subgroups/Parents should be removed from the list
4. If Nested is toggled, any selected parent will be added to the legened
5. If Nested is unchecked, only sub layers should be available to be added to the legend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2066)
<!-- Reviewable:end -->
