### PR TITLE
load details config when opening point via grid

### DIFF
--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -36,25 +36,7 @@ export class DetailsAPI extends FixtureInstance {
                 .useStore('layer')
                 .getLayerByUid(p.uid);
 
-            if (layer) {
-                // Check to see if we've already saved this layer's details config.
-                const detailsItem = this.detailsStore.properties[layer.id];
-
-                // If we haven't and the layer has a details config set, add it to the details store.
-                if (detailsItem === undefined) {
-                    const layerDetailsConfigs: any =
-                        this.getLayerFixtureConfigs();
-
-                    if (layerDetailsConfigs[layer.id] !== undefined) {
-                        this.detailsStore.addConfigProperty({
-                            id: layer.id,
-                            name: layerDetailsConfigs[layer.id].name,
-                            template: layerDetailsConfigs[layer.id].template,
-                            fields: layerDetailsConfigs[layer.id].fields
-                        });
-                    }
-                }
-            }
+            this._loadDetailsConfig(layer);
         });
 
         // Open the details panel.
@@ -117,6 +99,9 @@ export class DetailsAPI extends FixtureInstance {
         this.detailsStore.currentFeatureId = featureData.data
             ? currFeatureId
             : undefined;
+
+        // Check to see if the layer has a fixture config in the store.
+        this._loadDetailsConfig(layer);
 
         // toggle rules based on last opened details panel
         if (open === false) {
@@ -182,6 +167,28 @@ export class DetailsAPI extends FixtureInstance {
         );
 
         this._validateItems();
+    }
+
+    _loadDetailsConfig(layer: LayerInstance | undefined) {
+        // Check to see if the layer has a fixture config in the store.
+        if (layer) {
+            // Check to see if we've already saved this layer's details config.
+            const detailsItem = this.detailsStore.properties[layer.id];
+
+            // If we haven't and the layer has a details config set, add it to the details store.
+            if (detailsItem === undefined) {
+                const layerDetailsConfigs: any = this.getLayerFixtureConfigs();
+
+                if (layerDetailsConfigs[layer.id] !== undefined) {
+                    this.detailsStore.addConfigProperty({
+                        id: layer.id,
+                        name: layerDetailsConfigs[layer.id].name,
+                        template: layerDetailsConfigs[layer.id].template,
+                        fields: layerDetailsConfigs[layer.id].fields
+                    });
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2068

### Changes
- Fixes issue where the details config was not being loaded correctly when opening a point through the grid.

### Testing
1. Open the [CESI sample page](https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=24)
2. Open the grid for the `Greenhouse gas emissions from large facilities` layer
3. Click on the icon to open the details for a specific point
4. The `Symbol` field should no longer appear

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2069)
<!-- Reviewable:end -->
