### PR TITLE
Moved layer name to body of settings panel

### DIFF
--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -1,15 +1,14 @@
 <template>
     <panel-screen :panel="panel">
         <template #header>
-            {{
-                layerExists
-                    ? `${t('settings.title')}: ${layerName}`
-                    : t('settings.title')
-            }}
+            {{ t('settings.title') }}
         </template>
 
         <template #content>
             <div v-if="layerExists">
+                <div class="p-8 font-bold break-words mb-8 bg-gray-100">
+                    {{ layerName }}
+                </div>
                 <div class="flex flex-col justify-center">
                     <span class="rv-subheader">{{
                         t('settings.label.display')


### PR DESCRIPTION
### Related Item(s)
#1975, #2071 

### Changes
- Moved layer name in the settings panel to the body from the header, to match the Details panel

### Notes
Before:
![layer name in header](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/5bb3475e-5ea3-4ad1-8c67-60dd78984c36)

Now:
![layer name in body](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/eae6205d-c18f-4db1-bae1-3b353d9015b0)

### Testing
Open the settings panel of any layer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2072)
<!-- Reviewable:end -->
