### PR TITLE
Support links in name fields

### DIFF
--- a/src/fixtures/details/item-screen.vue
+++ b/src/fixtures/details/item-screen.vue
@@ -108,8 +108,10 @@
                                     class="animate-spin spinner h-20 w-20"
                                 ></div>
                             </div>
-                            <span class="flex-grow my-auto text-lg px-8">
-                                {{ itemName }}
+                            <span
+                                class="flex-grow my-auto text-lg px-8"
+                                v-html="makeHtmlLink(itemName)"
+                            >
                             </span>
                             <button
                                 type="button"
@@ -237,6 +239,7 @@ import type { LayerInstance, PanelInstance } from '@/api/internal';
 
 import ESRIDefault from './templates/esri-default.vue';
 import HTMLDefault from './templates/html-default.vue';
+import linkifyHtml from 'linkify-html';
 import Toggle from '../../components/controls/toggle-switch-control.vue';
 import { useI18n } from 'vue-i18n';
 
@@ -360,6 +363,32 @@ const detailsTemplate = computed(() => {
         return ESRIDefault;
     }
 });
+
+// make links look like links and work like links
+const makeHtmlLink = (html: any): any => {
+    if (typeof html === 'string') {
+        const classes = 'underline text-blue-600 break-all';
+        const div = document.createElement('div');
+        div.innerHTML = html.trim();
+
+        // check if the html string is just an <a> tag
+        if (div.firstElementChild?.tagName == 'A') {
+            div.firstElementChild.className = classes;
+            return div.innerHTML;
+        } else {
+            // otherwise, look for any valid links
+            const options = {
+                className: classes,
+                target: '_blank',
+                validate: {
+                    url: (value: string) => /^https?:\/\//.test(value) // only links that begin with a protocol will be hyperlinked
+                }
+            };
+            return linkifyHtml(html, options);
+        }
+    }
+    return html;
+};
 
 const icon = ref<string>('');
 const zoomStatus = ref<'zooming' | 'zoomed' | 'error' | 'none'>('none');


### PR DESCRIPTION
### Related Item(s)
#1937, #2073

### Changes
- Added `v-html` directive to support links in name fields 

### Notes
Before, if a name was hyperlinked (courtesy of James):
![raw html text](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/929c3606-8b21-4383-b7a3-092ea3bbbf96)

Now, the title "I am a link" is clickable and opens the linked site:
![link support](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/daa01df6-48ae-4e86-aeb6-9bd8e24b72c7)

Not sure if we want this change for other name fields as well.

### Testing
Steps:
1. Save this JSON into a file:
```
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "name": "<a href=\"https://www.google.ca\" target=\"_blank\">I am a link</a>"
      },
      "geometry": {
        "coordinates": [-52.814656036021375, 48.12660352100187],
        "type": "Point"
      }
    }
  ]
}
```

2. Open RAMP, and upload the saved JSON file as a layer through the Wizard. In the third step of the Wizard, select "name" as the Primary Field.
3. Search for the point (hint: find it at the island named after an iconic bird, or use the zoomies button).
4. See the details the panel, the Item Title should be "I am a link" and it should be clickable and redirect you to the Google website.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2074)
<!-- Reviewable:end -->
