### PR TITLE
add markdown support to metadata fixture

### DIFF
--- a/demos/starter-scripts/layer-metadata.js
+++ b/demos/starter-scripts/layer-metadata.js
@@ -80,8 +80,7 @@ let config = {
                     layerType: 'esri-feature',
                     url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/6',
                     metadata: {
-                        url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/6?f=pjson',
-                        name: 'JSON'
+                        url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/public/help/en.md'
                     }
                 }
             ],

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -236,8 +236,11 @@ const toggleMetadata = () => {
         if (metaConfig.url) {
             // Check the file extension to see if this is an XML file. Defaults to HTML.
             const parseUrl = metaConfig.url.split('.');
+            const metadataExtension = parseUrl[parseUrl.length - 1];
             const metadataType =
-                parseUrl[parseUrl.length - 1] === 'xml' ? 'xml' : 'html';
+                metadataExtension === 'xml' || metadataExtension === 'md'
+                    ? metadataExtension
+                    : 'html';
 
             // TODO: toggle metadata panel through API/store call
             iApi.event.emit(GlobalEvents.METADATA_TOGGLE, {

--- a/src/fixtures/metadata/screen.vue
+++ b/src/fixtures/metadata/screen.vue
@@ -27,10 +27,12 @@
                     <!-- Found Screen, HTML -->
                     <div
                         v-else-if="
-                            payload.type === 'html' && status == 'success'
+                            (payload.type === 'html' ||
+                                payload.type === 'md') &&
+                            status == 'success'
                         "
                         v-html="response"
-                        class="flex flex-col justify-center max-w-full"
+                        class="flex flex-col justify-center max-w-full metadata-view"
                     ></div>
 
                     <!-- Error Screen -->
@@ -72,6 +74,7 @@ import {
 } from '@/api';
 import type { MetadataCache, MetadataPayload, MetadataResult } from './store';
 import { useMetadataStore } from './store';
+import { marked } from 'marked';
 
 import XSLT_en from './files/xstyle_default_en.xsl?raw';
 import XSLT_fr from './files/xstyle_default_fr.xsl?raw';
@@ -196,6 +199,12 @@ const loadMetadata = () => {
             //@ts-ignore
             metadataStore.response = r.response;
         });
+    } else if (props.payload.type === 'md') {
+        requestContent(props.payload.url).then(r => {
+            metadataStore.status = r.status;
+            //@ts-ignore
+            metadataStore.response = marked(r.response);
+        });
     }
 };
 
@@ -298,7 +307,33 @@ function stringToFragment(string: string) {
 .xml-content {
     font-size: 14px;
 }
-.metadata-view a {
-    color: blue;
+
+// Tailwind removes basic heading styling, so add some here
+// to make the markdown presentable.
+.metadata-view {
+    a {
+        color: blue;
+    }
+
+    h1 {
+        font-size: 1.5em;
+        margin: 0.1em 0px;
+        font-weight: bold;
+    }
+    h2 {
+        font-size: 1.2em;
+        margin: 0.1em 0px;
+        font-weight: bold;
+    }
+
+    h3 {
+        font-size: 1em;
+        margin: 0.1em 0px;
+        font-weight: bold;
+    }
+
+    p {
+        margin: 0.2em 0px;
+    }
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
#2045 

### Changes
- Adds support for markdown files in the metadata fixture.

### Notes
Correct me if I'm wrong, but I couldn't find any layers that actually used a JSON file for metadata so I didn't bother implementing it. If we wanted to support this we would probably need a template to specify how the JSON should be displayed as well.

### Testing
Steps:
1. Open the `Layer with metadata` sample ([sample 20](https://ramp4-pcar4.github.io/ramp4-pcar4/fix-2045/demos/index-samples.html?sample=20))
2. Click on the `...` in the legend beside the `Nature` layer and open the metadata.
3. The metadata fixture should open and the markdown should be formatted correctly (images are using a local path so they won't be displayed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2079)
<!-- Reviewable:end -->
