### PR TITLE
Export CSV from the grid

### DIFF
--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -7,6 +7,7 @@ grid.splash.building,Building table...,1,Création du tableau...,1
 grid.splash.cancel,Cancel,1,Annuler,1
 grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,1
 grid.pinColumns,Pin columns,1,Épingler les colonnes,0
+grid.export,Export,1,Exporter,1
 grid.layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
 grid.label.columns,Hide columns,1,Masquer les colonnes,1
 grid.label.copied,Copied,1,Copié,0

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -342,6 +342,25 @@
                                 </g>
                             </svg>
                         </a>
+                        <a
+                            href="javascript:;"
+                            class="flex leading-snug items-center w-256"
+                            :class="{ hover: 'text-black' }"
+                            @click="exportData()"
+                        >
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 24 24"
+                                class="fill-current inline w-20 h-20 mr-2 text-gray-500"
+                            >
+                                <g>
+                                    <path
+                                        d="M6 2c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6H6zm7 7V3.5L18.5 9H13z"
+                                    ></path>
+                                </g>
+                            </svg>
+                            {{ t('grid.export') }}
+                        </a>
                     </dropdown-menu>
                 </div>
             </div>
@@ -502,6 +521,7 @@ export interface SpecialColumnDefinition {
     cellStyle: Function;
     cellRenderer?: Function;
     cellRendererParams?: any;
+    preventExport: boolean;
 }
 
 // these should match up with the `type` value returned by the attribute promise.
@@ -760,6 +780,34 @@ const togglePinned = () => {
     );
 };
 
+const exportData = () => {
+    // Filter out the 'special columns'
+    const columnsToExport = columnApi.value
+        .getAllDisplayedColumns()
+        .filter(column => !(column.getColDef() as any).preventExport);
+
+    agGridApi.value.exportDataAsCsv({
+        columnKeys: columnsToExport,
+        suppressQuotes: true,
+        processCellCallback: cell => {
+            let cellType = cell.column.getColDef().cellRendererParams;
+            if (!cell.value || (cellType && cellType.type === 'number'))
+                return cell.value;
+            else if (cellType && cellType.type === 'date')
+                return `"${new Date(cell.value).toLocaleDateString('en-CA', {
+                    timeZone: 'UTC',
+                    year: 'numeric',
+                    month: '2-digit',
+                    day: '2-digit',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                    second: '2-digit'
+                })}"`;
+            else return `"${cell.value.toString().replace(/"/g, '""')}"`;
+        }
+    });
+};
+
 const setUpDateFilter = (
     colDef: ColumnDefinition,
     state: TableStateManager
@@ -901,7 +949,8 @@ const setUpSpecialColumns = (
                 clearFilters: clearFilters,
                 suppressFilterButton: true
             },
-            filter: true
+            filter: true,
+            preventExport: true
         };
 
         colDef.push(indexDef);
@@ -929,7 +978,8 @@ const setUpSpecialColumns = (
                 t: t,
                 layerCols: layerCols.value,
                 isTeleport: props.panel.teleport !== undefined
-            }
+            },
+            preventExport: true
         };
 
         // Only add this button if it is defined in the grid controls.
@@ -956,7 +1006,8 @@ const setUpSpecialColumns = (
                     $iApi: iApi,
                     layerCols: layerCols.value,
                     isTeleport: props.panel.teleport !== undefined
-                }
+                },
+                preventExport: true
             };
 
             // Only add this button if it is defined in the grid controls.
@@ -989,7 +1040,8 @@ const setUpSpecialColumns = (
                         t: t,
                         layerCols: layerCols.value,
                         config: buttonConfig
-                    }
+                    },
+                    preventExport: true
                 };
 
                 colDef.push(buttonDef);
@@ -1027,7 +1079,8 @@ const setUpSpecialColumns = (
             cellRendererParams: {
                 $iApi: iApi,
                 oidField: oidField.value
-            }
+            },
+            preventExport: true
         };
 
         colDef.push(iconDef);


### PR DESCRIPTION
### Related Item(s)
#1964

### Changes
The user will now be able to export the contents of the data grid into a csv. This works with merged grids and columns containing commas.

### Notes
- Special columns have been removed. 
- ~~HTML tags have been stripped~~ After discussing with James, we're not going to strip HTML. The data will be dumped as it appears in the data source. 

### Testing
Steps:
1. Open a grid
2. Select 'More'
3. Select Export
4. Verify the data is correct. Test with merge grids / any other funky grid you can think of.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2082)
<!-- Reviewable:end -->
