### PR TITLE
Legend padding and appbar scrolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "lodash.clonedeep": "^4.5.0",
                 "marked": "^4.0.10",
                 "pinia": "^2.0.30",
+                "popper-max-size-modifier": "^0.2.0",
                 "proj4": "^2.8.1",
                 "redaxios": "^0.5.1",
                 "screenfull": "~5.0.2",
@@ -6195,6 +6196,15 @@
             "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
             "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
             "dev": true
+        },
+        "node_modules/popper-max-size-modifier": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
+            "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
+            "deprecated": "We recommend switching to Floating UI which supports this modifier out of the box: https://floating-ui.com/docs/size",
+            "peerDependencies": {
+                "@popperjs/core": "^2.2.0"
+            }
         },
         "node_modules/postcss": {
             "version": "8.4.24",
@@ -12962,6 +12972,12 @@
             "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.3.tgz",
             "integrity": "sha512-VJK1SRmXBpjwsB4YOHYSturx48rLKMzHgCqDH2ZDa6ZbMS/N5huoNqyQdK5Fj/xayu3fqbXckn5SeCS1EbMDZg==",
             "dev": true
+        },
+        "popper-max-size-modifier": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
+            "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
+            "requires": {}
         },
         "postcss": {
             "version": "8.4.24",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "lodash.clonedeep": "^4.5.0",
         "marked": "^4.0.10",
         "pinia": "^2.0.30",
+        "popper-max-size-modifier": "^0.2.0",
         "proj4": "^2.8.1",
         "redaxios": "^0.5.1",
         "screenfull": "~5.0.2",

--- a/src/fixtures/appbar/more-button.vue
+++ b/src/fixtures/appbar/more-button.vue
@@ -3,10 +3,11 @@
         <button
             type="button"
             class="text-gray-400 w-full h-48 focus:outline-none hover:text-white"
-            @click="open = !open"
+            @click="popperSetUp()"
             v-focus-item
             :content="t('appbar.more')"
-            v-tippy="{ placement: 'right' }"
+            v-tippy="{ placement: 'right-end' }"
+            ref="dropdownTrigger"
         >
             <svg
                 class="fill-current w-24 h-24 m-auto"
@@ -21,10 +22,9 @@
         </button>
         <div
             v-show="open"
-            @blur="open = false"
-            :position="position"
             id="dropdown"
             class="dropdown shadow-md border border-gray:200 absolute w-64 flex flex-col bg-white rounded"
+            ref="dropdown"
         >
             <slot></slot>
         </div>
@@ -32,20 +32,86 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import type { InstanceAPI } from '@/api/internal';
+
+import type { Placement, Modifier, State } from '@popperjs/core';
+import { createPopper } from '@popperjs/core';
+import maxSize from 'popper-max-size-modifier';
 
 const { t } = useI18n();
+const iApi = inject('iApi') as InstanceAPI;
 
-defineProps({
+const props = defineProps({
     position: {
         type: String,
-        default: 'bottom-right'
+        default: 'right-end'
+    },
+    popperOptions: {
+        type: Object,
+        default() {
+            return {};
+        }
     }
 });
 
 const open = ref(false);
+
 const el = ref<Element>();
+const dropdownTrigger = ref<Element>();
+const dropdown = ref<HTMLElement>();
+
+const popperSetUp = () => {
+    open.value = !open.value;
+
+    const applyMaxSize = {
+        name: 'applyMaxSize',
+        enabled: true,
+        phase: 'beforeWrite',
+        requires: ['maxSize'],
+        fn({ state }: { state: State }) {
+            // The `maxSize` modifier provides this data
+            const { width, height } = state.modifiersData.maxSize;
+
+            state.styles.popper = {
+                ...state.styles.popper,
+                maxWidth: `${width}px`,
+                maxHeight: `${Math.max(80, height) - 38}px`
+            };
+
+            state.styles.popper.overflowY = 'auto';
+            state.styles.popper.overflowX = 'hidden';
+        }
+    };
+
+    const innerShell = iApi.$vApp.$el.querySelector('.inner-shell');
+    if (dropdownTrigger.value && dropdown.value) {
+        createPopper(
+            dropdownTrigger.value as Element,
+            dropdown.value as HTMLElement,
+            {
+                placement: (props.position || 'right-end') as Placement,
+                modifiers: [
+                    {
+                        ...maxSize,
+                        options: {
+                            boundary: innerShell
+                        }
+                    },
+                    applyMaxSize as Modifier<'applyMaxsize', {}>,
+                    {
+                        name: 'offset',
+                        options: {
+                            offset: [0, 5]
+                        }
+                    }
+                ],
+                ...props.popperOptions
+            }
+        );
+    }
+};
 
 onMounted(() => {
     window.addEventListener(

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -325,7 +325,7 @@
 
                 <!-- offscale icon -->
                 <div
-                    class="relative mx-5 cursor-default"
+                    class="relative p-4 cursor-default"
                     :content="t('legend.layer.offscale')"
                     v-tippy="{
                         placement: 'top-start'
@@ -351,7 +351,7 @@
 
                 <!-- data only icon -->
                 <div
-                    class="relative mx-5 cursor-default"
+                    class="relative p-4 cursor-default"
                     :content="t('legend.layer.data.only')"
                     v-tippy="{
                         placement: 'top-end'


### PR DESCRIPTION
### Related Item(s)
#1866, #2020

### Changes
- For #1866: Made changes to the dropdown that appears when the `more` button is clicked when the appbar has too many icons, so that there is no clipping 
- For #2020: Changed the margin and padding for focus on legend bonus icons

### Notes
For #1866, this was the behaviour of the appbar before changes:
![before appbar](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/d0d1fcfd-5315-457b-a650-374414ee5c02)

And after:
![after appbar](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/b99feb1a-1b70-4cc8-be30-e041d0aeb020)

For #2020, this was the focus on the legend bonus icons before changes:
![before padding](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/c40bad1e-dad7-4dcc-8e8a-2c0322251cf6)

And after:
![fixed padding](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/29d25a5f-6e3b-4f52-8780-02b4ed1143d0)

### Testing
For #1866:
1. Open a bunch of panels to populate the appbar with icons.
2. Decrease the height of the screen to get the `more` or `...` button to appear.
3. Click on the `...` to get the rest of the icons. Change the height of the screen to see how the dropdown reacts.

It does glitch when the more button is clicked for the first time, but I was not able to figure out why. After anything else is done on the screen (scrolling, etc.), it fixes itself. Once the map is less than 200px, the clipping does mess up and the bottom part of the section gets covered by the map caption bar.

For #2020:
1. Open Sample 32 or 41 and tab through the icons in the legend to check the focus around each item.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2083)
<!-- Reviewable:end -->
