### PR TITLE
Add image service layer type option when creating layer

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -596,6 +596,14 @@ let config = {
                         }
                     ],
                     disabledControls: ['identify', 'data']
+                },
+                {
+                    id: 'AAFC',
+                    name: 'AAFC Land Use',
+                    layerType: 'esri-imagery',
+                    url: 'https://agriculture.canada.ca/atlas/rest/services/servicesimage/utilisation_des_terres_30m_2020/ImageServer',
+                    catalogueUrl:
+                        'https://open.canada.ca/data/en/dataset/fa84a70f-03ad-4946-b0f8-a3b481dd5248'
                 }
             ],
             fixtures: {
@@ -616,6 +624,10 @@ let config = {
                                         sublayerIndex: 34
                                     }
                                 ]
+                            },
+                            {
+                                name: 'Agriculture and Agri-Food Canada',
+                                layerId: 'AAFC'
                             },
                             {
                                 name: 'Water quantity at monitoring stations',

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -523,6 +523,7 @@
                         <checkbox
                             v-if="
                                 modifiableLayer &&
+                                legendItem.layer.supportsFeatures &&
                                 ((!item.imgUrl && symbologyStack.length > 1) ||
                                     (item.imgUrl && item.definitionClause))
                             "

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -7,6 +7,7 @@ import {
     FeatureLayer,
     GeoJsonLayer,
     GraphicLayer,
+    ImageryLayer,
     InstanceAPI,
     JsonDataLayer,
     LayerInstance,
@@ -86,6 +87,9 @@ export class LayerAPI extends APIScope {
                 break;
             case LayerType.DATAJSON:
                 closs = JsonDataLayer;
+                break;
+            case LayerType.IMAGERY:
+                closs = ImageryLayer;
                 break;
             case LayerType.SHAPEFILE:
                 closs = ShapefileLayer;


### PR DESCRIPTION
### Related Item(s)
#2085 

### Changes
Added option to support ESRI image service layers when constructing RAMP layer. 

### Testing
Steps:
1. Use [this](https://agriculture.canada.ca/atlas/rest/services/imageservices/landuse_30m_2020/ImageServer) as test service
2. Adding through wizard or config (via CESI [sample page](https://ramp4-pcar4.github.io/ramp4-pcar4/add-esri-imagery-option/demos/index-samples.html?sample=24)) should load the layer properly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2086)
<!-- Reviewable:end -->
