### PR TITLE
Move right button will now be disabled on column hide

### DIFF
--- a/src/fixtures/grid/column-dropdown.vue
+++ b/src/fixtures/grid/column-dropdown.vue
@@ -37,6 +37,7 @@
             v-on:click="
                 columnApi?.setColumnVisible(col.field, col.hide);
                 col.hide = !col.hide;
+                $emit('refreshHeaders');
             "
             href="javascript:;"
             class="flex leading-snug items-center w-256"

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -133,6 +133,7 @@
                         :columnApi="columnApi"
                         :columnDefs="columnDefs"
                         :oidCols="oidCols"
+                        @refreshHeaders="agGridApi.refreshHeader()"
                     ></column-dropdown>
 
                     <!-- clear all filters -->


### PR DESCRIPTION
### Related Item(s)
#2011

### Changes
- Refreshes the column headers so that the button disabling logic is applied to the new right most column.

### Testing
Steps:
1. Hide the right most column
2. Witness the disabled Move Right button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2087)
<!-- Reviewable:end -->
