### PR TITLE
Enforce order for grid columns

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -294,6 +294,17 @@ let config = {
                         details: {
                             template: 'WFSLayer-Custom'
                         }
+                    },
+                    fieldMetadata: {
+                        fieldInfo: [
+                            { name: 'station_name__nom_station' },
+                            { name: 'station_id__id_station' },
+                            { name: 'province__province' },
+                            { name: 'identifier__identifiant' },
+                            { name: 'year_range__annees' }
+                        ],
+                        exclusiveFields: false,
+                        enforceOrder: true
                     }
                 },
                 {

--- a/docs/using-ramp4/layer-config.md
+++ b/docs/using-ramp4/layer-config.md
@@ -340,6 +340,7 @@ Specifies additional attribute field information that will override the default 
 
 - `fieldInfo`: An array that contians objects having valid field names and a custom field alias. If using the `exclusiveFields` option, the alias can be left blank to use the field as-is. Field names are case sensitive.
 - `exclusiveFields`: A boolean, if true, only fields in the `fieldInfo` array will be used in the layer.
+- `enforceOrder`: A boolean, if true, the order of the fields in the `fieldInfo` array will be enforced when the grid is displayed. If not all fields are specified in the `fieldInfo` array and the `exclusiveFields` option is not used or is false, then only the specified columns will be displayed in order, followed by the rest of the columns in the order as it appears in the source.
 
 Note that if the system requires additional fields that are missing in the `exclusiveFields` mode, they will be included in the map layer (e.g. an order-by field).
 
@@ -356,7 +357,8 @@ Note that if the system requires additional fields that are missing in the `excl
                 alias: "Address"
             }
         ],
-        exclusiveFields: true
+        exclusiveFields: true,
+        enforceOrder: true
     }
 }
 ```

--- a/schema.json
+++ b/schema.json
@@ -1821,6 +1821,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "If true, only fields in fieldInfo are recognized and downloaded. Otherwise, all fields are used."
+                },
+                "enforceOrder": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, the layer's field array will be ordered the same as fieldInfo. Otherwise, the array will be ordered as it appears in the source."
                 }
             }
         },

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -1409,7 +1409,8 @@ function fieldsSausageGrinder(r2layer: any, r4layer: any): void {
 
     const struct = {
         fieldInfo: [] as any[],
-        exclusiveFields: false
+        exclusiveFields: false,
+        enforceOrder: false
     };
 
     if (r2layer.fieldMetadata) {

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -588,6 +588,7 @@ export interface RampLayerFieldInfoConfig {
 export interface RampLayerFieldMetadataConfig {
     fieldInfo?: Array<RampLayerFieldInfoConfig>;
     exclusiveFields?: boolean; // default to false. if true, means we only recognize and download field in fieldInfo. if false, we download all fields, and fieldInfo provides additional data as needed
+    enforceOrder?: boolean; //default to false. if true, then order the fields in the same order as fieldInfo. if false, randomize ordering of field array
 }
 
 // i.e. a dynamic layer child

--- a/src/geo/layer/file-utils.ts
+++ b/src/geo/layer/file-utils.ts
@@ -11,7 +11,8 @@ import {
     type CsvOptions,
     FieldType,
     type GeoJsonOptions,
-    LayerType
+    LayerType,
+    type FieldDefinition
 } from '@/geo/api';
 
 /**
@@ -458,7 +459,7 @@ export class FileUtils extends APIScope {
             defRender.renderer
         );
 
-        // .fields currently has our objectid field. the concat adds the rest
+        // add all the fields to config.Package
         configPackage.fields = (configPackage.fields || []).concat(
             options.fieldMetadata?.exclusiveFields
                 ? (this.extractGeoJsonFields(geoJson) as Array<Object>).filter(
@@ -469,6 +470,19 @@ export class FileUtils extends APIScope {
                   )
                 : (this.extractGeoJsonFields(geoJson) as Array<Object>)
         );
+
+        // fix the order in configPackage.fields if specified in the config
+        if (
+            options.fieldMetadata?.enforceOrder &&
+            options.fieldMetadata?.fieldInfo &&
+            options.fieldMetadata?.fieldInfo.length > 0
+        ) {
+            // demand respect for order
+            configPackage.fields = this.$iApi.geo.attributes.orderFields(
+                configPackage.fields as Array<FieldDefinition>,
+                options.fieldMetadata?.fieldInfo
+            ) as __esri.FieldProperties[];
+        }
 
         // clean the fields. in particular, CSV files can be loaded with spaces in
         // the field names

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -7,6 +7,7 @@ import type {
     Extent,
     FieldDefinition,
     GetGraphicServiceDetails,
+    RampLayerFieldInfoConfig,
     RampLayerFieldMetadataConfig,
     TabularAttributeSet
 } from '@/geo/api';
@@ -366,6 +367,55 @@ export class AttributeAPI extends APIScope {
     }
 
     /**
+     * Will order the fields of a layer based on its fieldInfo.
+     *
+     * @param currentFields the current order of the fields
+     * @param orderInfo the fieldInfo config that contains the order the fields should be displayed in
+     */
+    orderFields(
+        currentFields: Array<FieldDefinition>,
+        orderInfo: Array<RampLayerFieldInfoConfig>
+    ): Array<FieldDefinition> {
+        const magicFinder = (sauce: Array<any>, targetName: string): number => {
+            // finds index of matching name, -1 if not in array.
+            return sauce.findIndex(
+                (protoField: any) => protoField.name === targetName
+            );
+        };
+
+        const magicSorter = (
+            field1: FieldDefinition,
+            field2: FieldDefinition
+        ) => {
+            // return value:
+            // negative if f1 is less than f2; positive if f1 is greater than f2; zero if they are equal (should be impossible)
+
+            // find in order, if exists
+            const ordF1 = magicFinder(orderInfo, field1.name);
+            const ordF2 = magicFinder(orderInfo, field2.name);
+
+            if (ordF1 === -1 && ordF2 === -1) {
+                // neither have order. fallback to source order,
+                return (
+                    magicFinder(currentFields, field1.name) -
+                    magicFinder(currentFields, field2.name)
+                );
+            } else if (ordF1 === -1) {
+                // field 1 is unordered, so field 2 must come before
+                return 1;
+            } else if (ordF2 === -1) {
+                // field 2 is unordered, so field 1 must come before
+                return -1;
+            } else {
+                return ordF1 - ordF2;
+            }
+        };
+
+        // copy array so magicFinder doesn't start reading half-sorted values
+        return currentFields.slice().sort(magicSorter);
+    }
+
+    /**
      * Will apply any field config metadata to a layer.
      * Should be used after loading process has populated .fields property of the layer
      *
@@ -382,6 +432,22 @@ export class AttributeAPI extends APIScope {
         if (!fieldMetadata || !fieldMetadata.fieldInfo) {
             layer.fieldList = '*';
             return;
+        }
+
+        // if order enforced, order the fields first before doing exclusive fields check
+        if (
+            fieldMetadata?.enforceOrder &&
+            fieldMetadata?.fieldInfo &&
+            fieldMetadata?.fieldInfo.length > 0
+        ) {
+            // demand respect for order
+            layer.fields = this.orderFields(
+                layer.fields,
+                fieldMetadata.fieldInfo
+            );
+            layer.fieldList = fieldMetadata.fieldInfo
+                .map(f => f.name)
+                .join(',');
         }
 
         // if exlusive fields, only respect fields in the field info array


### PR DESCRIPTION
### Related Item(s)
#2076 

### Changes
- Added a new boolean to the `fieldMetaData` configuration structure that allows the order in `fieldInfo` to be enforced when displaying columns in the grid

### Notes
- If `enforceOrder` is true, the columns in `fieldInfo` will be displayed in order. If there are other columns returned by the service that are not in `fieldInfo`, those will be displayed in a random order after those in `fieldInfo`.
![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/47f53e7c-8332-47b2-8c83-8375ac9f4721)
- If `enforceOrder` is true and `exclusiveFields` is true then only those columns in `fieldInfo` will be displayed (in order).

### Testing
I've added `fieldMetaData` to the WFS layer in the Default sample configuration for testing purposes, I can remove it later on if needed.
Steps:
1. Open the WFS layer grid in the Default sample.
2. The first four columns in the grid should be: `station_name__nom_station`, `station_id__id_station`, `province__province`, `identifier__identifiant`, followed by the rest of the columns in a random order. This is order they are in according to the `fieldInfo` array.
3. Refresh to ensure the order of the first four columns never changes, while the rest of the columns' order does.

Additionally, in lines 513 and 523 of `src/geo/layer/file-utils.ts`, I had to add the `!` because an error was popping up stating that `configPackage.fields` could be empty, however I don't think that case will ever happen. I hope I haven't missed anything there. 

If there are any suggestions for making the code more concise, that would be much appreciated!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2089)
<!-- Reviewable:end -->
