### PR TITLE
fix confusing TreeSelect behaviour

### DIFF
--- a/scripts/vue-slider-component.d.ts
+++ b/scripts/vue-slider-component.d.ts
@@ -1,0 +1,4 @@
+// Fix taken from here https://github.com/NightCatSama/vue-slider-component/issues/649#issuecomment-1281910702.
+// When vue-slider-component fixes the type errors we can remove this file.
+
+export { DefineComponent } from 'vue';

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -854,12 +854,22 @@ const populateFlatWMS = (
 const sublayerOptions = (layers: any[]) => {
     // set sublayer option properties based on whether its a map image or WMS layer
     return layers.map((layerIdx: any) => {
-        return typeSelection.value === LayerType.MAPIMAGE
-            ? {
-                  index: layerIdx,
-                  state: { opacity: 1, visibility: true }
-              }
-            : { id: layerIdx };
+        switch (typeSelection.value) {
+            case LayerType.MAPIMAGE:
+                return {
+                    index: layerIdx,
+                    state: { opacity: 1, visibility: true }
+                };
+            case LayerType.WMS: {
+                // Remove the unique tag added to the end of the ID.
+                const removeHash = layerIdx.lastIndexOf('#');
+                return { id: layerIdx.substring(0, removeHash) };
+            }
+            default:
+                return {
+                    id: layerIdx
+                };
+        }
     });
 };
 

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -21,6 +21,7 @@ export interface SublayerInfo {
 
 export class LayerSource extends APIScope {
     layerCount = 0;
+    sublayerCount = 0;
 
     constructor($iApi: InstanceAPI) {
         super($iApi);
@@ -218,7 +219,7 @@ export class LayerSource extends APIScope {
             if (sublayers === undefined) {
                 return false;
             }
-            let i, parent;
+            let parent;
             if (sublayers.find(sl => sl.id === id)) {
                 return sublayers.find(sl => sl.id === id);
             } else {
@@ -364,7 +365,7 @@ export class LayerSource extends APIScope {
         if (nested) {
             return modLayers.flatMap((layer: any) => {
                 return {
-                    id: layer.name,
+                    id: `${layer.name}#${++this.sublayerCount}`,
                     label: layer.title,
                     children:
                         layer.layers.length > 0
@@ -377,7 +378,7 @@ export class LayerSource extends APIScope {
                 layer.layers && layer.layers.length > 0
                     ? this.mapWmsLayerList(layer.layers, nested)
                     : {
-                          id: layer.name,
+                          id: `${layer.name}#${++this.sublayerCount}`,
                           label: layer.title
                       }
             );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "compilerOptions": {
         "baseUrl": ".",
         "paths": {
-            "@/*": ["./src/*"]
+            "@/*": ["./src/*"],
+            "vue-slider-component": ["./scripts/vue-slider-component.d.ts"]
         },
         "lib": ["DOM", "DOM.Iterable", "ES2020"],
         "pretty": true


### PR DESCRIPTION
### Related Item(s)
#2075 

### Changes
- Multiple checkboxes will no longer be selected when choosing which sublayers to add through the wizard.

### Testing
Steps:
1. Open the wizard by clicking on the `+` button in the legend.
2. Add [this URL](https://geo.weather.gc.ca/geomet-climate?service=WMS&version=1.3.0&request=GetCapabilities) and click `Continue`.
3. Press `Continue` again, the dropdown should already be set to `OGC Web Map Service`.
4. Choose some sublayers to add to the map. When clicking on a sublayer, notice that other entries are not automatically selected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2090)
<!-- Reviewable:end -->
