### PR TITLE
Layer Order Refactor

### DIFF
--- a/demos/starter-scripts/grid.js
+++ b/demos/starter-scripts/grid.js
@@ -121,7 +121,13 @@ const rInstance = createInstance(
 );
 
 rInstance.fixture
-    .addDefaultFixtures(['legend', 'appbar', 'grid', 'details'])
+    .addDefaultFixtures([
+        'legend',
+        'appbar',
+        'grid',
+        'layer-reorder',
+        'details'
+    ])
     .then(() => {
         rInstance.panel.open('legend');
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp",
-    "version": "4.4.0",
+    "version": "4.5.0-beta",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp",
-            "version": "4.4.0",
+            "version": "4.5.0-beta",
             "dependencies": {
                 "@arcgis/core": "4.26.5",
                 "@popperjs/core": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ramp",
-    "version": "4.4.0",
+    "version": "4.5.0-beta",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -5,7 +5,6 @@ import { APIScope, GlobalEvents, InstanceAPI, LayerInstance } from './internal';
 import { useConfigStore } from '@/stores/config';
 import type { FixtureBase } from '@/stores/fixture';
 import { useFixtureStore } from '@/stores/fixture';
-import type { RampConfig } from '@/types';
 import { usePanelStore } from '@/stores/panel';
 
 const fixtureModules = import.meta.glob<{ default: typeof FixtureInstance }>(
@@ -397,7 +396,6 @@ export class FixtureInstance extends APIScope implements FixtureBase {
      */
     getLayerFixtureConfigs(): { [layerId: string]: any } {
         const fixtureConfigs: { [layerId: string]: any } = {};
-        const layerStore = (this as any).$iApi.useStore('layer');
 
         const layerCrawler = (layer: any, parent: any = undefined) => {
             if (layer.fixtures && layer.fixtures[this.id] !== undefined) {
@@ -418,9 +416,9 @@ export class FixtureInstance extends APIScope implements FixtureBase {
         };
 
         // Crawl through the layer store and check for layers that may have a custom config.
-        layerStore.layers?.forEach((layer: LayerInstance) =>
-            layerCrawler(layer.config)
-        );
+        this.$iApi.geo.layer
+            .allLayers()
+            .forEach((layer: LayerInstance) => layerCrawler(layer.config));
 
         return fixtureConfigs;
     }

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -216,52 +216,21 @@ export class InstanceAPI {
                     //@ts-ignore
                     maptipStore.setMaptipInstance(mapViewElement._tippy);
 
-                    // add layers
                     if (langConfig.layers && langConfig.layers.length > 0) {
-                        // console.log('Adding layers:', langConfig.layers);
-                        const addedLayerProms = langConfig.layers
-                            .map(layerConfig => {
-                                const layer =
-                                    this.geo.layer.createLayer(layerConfig);
-                                this.geo.map.addLayer(layer);
-                                return layer;
-                            })
-                            .filter(Boolean); // strip out any lurking undefined values
-
-                        // do re-order magic on the map layers
-                        addedLayerProms
-                            .filter(l => l.mapLayer) // strip out data layers. they do not occupy the map stack
-                            .forEach((layer: LayerInstance, index: number) => {
-                                // TODO: This code is fishy. Error'd layers in the map stack are not reordered.
-                                // Also, cosmetic layers are not always at the top and can appear in the middle, depending on the order that stuff loads.
-                                // How much does this matter?
-                                // From the testing I've done, this was already not 100% respectful before the introduction of data layers.
-                                layer
-                                    .loadPromise()
-                                    .then(() => {
-                                        if (layer.isLoaded) {
-                                            this.geo.map.reorder(layer, index);
-                                        }
-                                    })
-                                    .catch(() =>
-                                        console.error(
-                                            `Failed to add/reorder layer: ${layer.id}.`
-                                        )
-                                    );
-                            });
-
-                        // check for any nastyness on data layers
-                        addedLayerProms
-                            .filter(l => !l.mapLayer)
-                            .forEach((layer: LayerInstance) => {
-                                layer
-                                    .loadPromise()
-                                    .catch(() =>
-                                        console.error(
-                                            `Failed to add/reorder layer: ${layer.id}.`
-                                        )
-                                    );
-                            });
+                        // Add all the config layers to the instance, in order.
+                        // Config layers always get "added first", so we provide order positions here for the map layers.
+                        // Enhanced positioning logic is now handled by map.addLayer()
+                        let mapOrderPos = 0;
+                        langConfig.layers.forEach(layerConfig => {
+                            const layer =
+                                this.geo.layer.createLayer(layerConfig);
+                            this.geo.map.addLayer(layer, mapOrderPos);
+                            if (layer.mapLayer) {
+                                // we only increment for map layers. Data layers get added but do not live in the map stack.
+                                // so no ++. We pass the param to map.addLayer above out of lazyness. It gets ignored for data layers.
+                                mapOrderPos++;
+                            }
+                        });
                     }
                 }
             }, 100);

--- a/src/fixtures/export-legend/index.ts
+++ b/src/fixtures/export-legend/index.ts
@@ -1,5 +1,4 @@
 import { FixtureInstance, LayerInstance } from '@/api/internal';
-import { useLayerStore } from '@/stores/layer';
 import type { ExportAPI, ExportSubFixture } from '@/fixtures/export/api/export';
 import { fabric } from 'fabric';
 import type { LegendSymbology } from '@/geo/api';
@@ -56,9 +55,9 @@ class ExportLegendFixture extends FixtureInstance implements ExportSubFixture {
 
     async make(options: any): Promise<fabric.Group> {
         // filter out loading/errored, invisible, and cosmetic layers
-        const layers = useLayerStore(this.$vApp.$pinia).layers.filter(
-            layer => !layer.isCosmetic
-        );
+        const layers = this.$iApi.geo.layer
+            .allLayersOnMap()
+            .filter(layer => !layer.isCosmetic);
 
         if (layers.length === 0) {
             // return an empty group

--- a/src/fixtures/help/section.vue
+++ b/src/fixtures/help/section.vue
@@ -49,7 +49,6 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();

--- a/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
@@ -20,7 +20,16 @@ export class FogHilightMode extends LiftHilightMode {
             config.options?.offOpacity > 0.02
                 ? config.options.offOpacity
                 : 0.02;
-        this.hilightSetup();
+
+        if (this.$iApi.geo.map.created) {
+            this.hilightSetup();
+        } else {
+            this.handlers.push(
+                this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
+                    this.hilightSetup();
+                })
+            );
+        }
 
         this.handlers.push(
             this.$iApi.event.on(GlobalEvents.MAP_BASEMAPCHANGE, () => {
@@ -72,12 +81,14 @@ export class FogHilightMode extends LiftHilightMode {
             return;
         }
 
-        const layers = this.$iApi.geo.layer.allLayers();
-        const fogIdx: number = layers.indexOf(fogLayer);
-        const hilightIdx: number = layers.indexOf(hilightLayer);
+        const layerOrder = this.$iApi.geo.layer.layerOrderIds();
+        const fogIdx = layerOrder.indexOf(fogLayer.id);
+        const hilightIdx = layerOrder.indexOf(hilightLayer.id);
 
-        if (hilightIdx < fogIdx) {
-            this.$iApi.geo.map.reorder(hilightLayer, fogIdx + 1, false);
+        if (hilightIdx < fogIdx && hilightIdx > -1 && fogIdx > -1) {
+            // No +1. Since highlight is below, fog will get pushed down
+            // as things shift.
+            this.$iApi.geo.map.reorder(hilightLayer, fogIdx, false);
         }
     }
 

--- a/src/fixtures/layer-reorder/definitions.ts
+++ b/src/fixtures/layer-reorder/definitions.ts
@@ -3,7 +3,15 @@ export interface LayerModel {
     id: string;
     uid: string;
     name: string;
+
+    /**
+     * Order position in the map (i.e. the layer store)
+     */
     orderIdx: number;
+
+    /**
+     * Order position in the fixture UI
+     */
     componentIdx: number;
     isExpanded: boolean;
     isLoaded: boolean;

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -43,9 +43,6 @@ export class LegendAPI extends FixtureInstance {
         this.$iApi.geo.layer.allLayers().forEach(l => {
             this.updateLegend(l);
         });
-        this.$iApi.geo.layer.allErrorLayers().forEach(l => {
-            this.updateLegend(l);
-        });
     }
 
     // Create

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -227,7 +227,7 @@ export class CommonLayer extends LayerInstance {
     // when esri layer load errors
     onError(): void {
         // if promise was previously not in pending status, make a new one
-        // otherwise we're trying to resolve a resolved/rejected promise
+        // otherwise we're trying to reject a resolved promise
         if (this.loadPromFulfilled) {
             this.loadDefProm = new DefPromise();
         }

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -48,11 +48,13 @@ export class FeatureLayer extends AttribLayer {
     }
 
     protected async onInitiate(): Promise<void> {
+        // this is OG code, don't clear out
         markRaw(
             (this.esriLayer = new EsriFeatureLayer(
                 this.makeEsriLayerConfig(this.origRampConfig)
             ))
         );
+
         await super.onInitiate();
     }
 

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -26,7 +26,6 @@ import {
 } from '@/geo/api';
 
 import type {
-    FieldDefinition,
     GeoJsonOptions,
     GetGraphicParams,
     Graphic,

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -20,15 +20,15 @@ import {
     WfsLayer,
     WmsLayer
 } from '@/api/internal';
+import type { ArcGisServerMetadata, RampLayerConfig } from '@/geo/api';
 import {
-    type ArcGisServerMetadata,
     DataFormat,
     Extent,
     GeometryType,
+    InitiationState,
     LayerControl,
     LayerState,
-    LayerType,
-    type RampLayerConfig
+    LayerType
 } from '@/geo/api';
 import { EsriField, EsriRendererFromJson, EsriRequest } from '@/geo/esri';
 import { useLayerStore } from '@/stores/layer';
@@ -115,11 +115,14 @@ export class LayerAPI extends APIScope {
         // this function acts as a nice / obvious endpoint and saves caller
         // from figuring out how to use the store.
 
+        // TODO: make result non-reactive via toRaw ?
+        //       is anything requiring layer reactivity?
+
         let layer: LayerInstance | undefined;
 
         // test if param is layer id
         const layerStore = useLayerStore(this.$vApp.$pinia);
-        layer = layerStore.getLayerById(layerId);
+        layer = layerStore.getLayerByAny(layerId);
         if (!layer) {
             // test if layer is a string uid
             layer = layerStore.getLayerByUid(layerId);
@@ -129,16 +132,48 @@ export class LayerAPI extends APIScope {
     }
 
     /**
+     * Get the current map stack position of a given map layer
+     *
+     * @param {string} layerId layer id or uid of the layer
+     * @returns {number | undefined} The layer position in the map stack. Undefined if a data layer or layer not found
+     */
+    getLayerPosition(layerId: string): number | undefined {
+        // layer search required since order array only tracks layerid, not uid
+        const layer = this.getLayer(layerId);
+        if (layer && layer.mapLayer) {
+            const searchId = layer.isSublayer
+                ? layer.parentLayer!.id
+                : layer.id;
+
+            const idx = this.layerOrderIds().findIndex(
+                orderId => orderId === searchId
+            );
+            return idx === -1 ? undefined : idx;
+        } else {
+            return undefined;
+        }
+    }
+
+    /**
+     * Return the Layer IDs of all registered map layers in the order they occupy,
+     * or will occupy, the map stack.
+     * @returns {Array<string>} layer ids, from bottom to top
+     */
+    layerOrderIds(): Array<string> {
+        // using slice to prevent caller from messing with array.
+        return useLayerStore(this.$vApp.$pinia).mapOrder.slice(0) || [];
+    }
+
+    /**
      * Return all registered layers.
      * @returns {Array<LayerInstance>} all registered layers
      */
     allLayers(): Array<LayerInstance> {
-        // we don't include allDataLayers in the concat here, since
-        // those layers will also appear in the active and error lists
-
-        return this.allActiveLayers().concat(
-            this.allErrorLayers(),
-            this.allInitiatingLayers()
+        // TODO: make result non-reactive via toRaw ?
+        //       is anything requiring layer reactivity?
+        return (
+            (useLayerStore(this.$vApp.$pinia)
+                .layers as unknown as Array<LayerInstance>) || []
         );
     }
 
@@ -147,21 +182,37 @@ export class LayerAPI extends APIScope {
      * @returns {Array<LayerInstance>} all layers that have initiated and not errored
      */
     allActiveLayers(): Array<LayerInstance> {
-        return this.allLayersOnMap()
-            .concat(this.allDataLayers())
-            .filter(l => l.layerState !== LayerState.ERROR);
+        return this.allLayers().filter(
+            l =>
+                l.layerState !== LayerState.ERROR &&
+                l.initiationState === InitiationState.INITIATED
+        );
     }
 
     /**
-     * Returns all layers currently on the map.
      * Returns all map-based layers currently on the map.
+     * Result can be ordered in map stack order. Unordered is more performant.
+     *
+     * @param {boolean} [inMapOrder=true] if result array should be sorted by map order.
      * @returns {Array<LayerInstance>} all layers on the map
      */
-    allLayersOnMap(): Array<LayerInstance> {
-        return (
-            (useLayerStore(this.$vApp.$pinia)
-                .layers as unknown as Array<LayerInstance>) || []
+    allLayersOnMap(inMapOrder: boolean = true): Array<LayerInstance> {
+        let mapLayers = this.allLayers().filter(
+            l => l.mapLayer && l.initiationState === InitiationState.INITIATED
         );
+
+        if (inMapOrder) {
+            const lOrder = this.layerOrderIds();
+            const cash = new Map<string, number>(
+                lOrder.map((layerId, i) => [layerId, i])
+            );
+            mapLayers.sort((lay1, lay2) => {
+                // index of layer 1 - index of layer 2
+                return cash.get(lay1.id)! - cash.get(lay2.id)!;
+            });
+        }
+
+        return mapLayers;
     }
 
     /**
@@ -169,9 +220,8 @@ export class LayerAPI extends APIScope {
      * @returns {Array<LayerInstance>} all loaded data layers
      */
     allDataLayers(): Array<LayerInstance> {
-        return (
-            (useLayerStore(this.$vApp.$pinia)
-                .dataLayers as unknown as Array<LayerInstance>) || []
+        return this.allLayers().filter(
+            l => !l.mapLayer && l.initiationState === InitiationState.INITIATED
         );
     }
 
@@ -180,19 +230,7 @@ export class LayerAPI extends APIScope {
      * @returns {Array<LayerInstance>} all errored layers
      */
     allErrorLayers(): Array<LayerInstance> {
-        return (
-            (
-                useLayerStore(this.$vApp.$pinia)
-                    .penaltyBox as unknown as Array<LayerInstance>
-            ).concat(
-                this.allLayersOnMap().filter(
-                    l => l.layerState === LayerState.ERROR
-                ),
-                this.allDataLayers().filter(
-                    l => l.layerState === LayerState.ERROR
-                )
-            ) || []
-        );
+        return this.allLayers().filter(l => l.layerState === LayerState.ERROR);
     }
 
     /**
@@ -200,9 +238,8 @@ export class LayerAPI extends APIScope {
      * @returns {Array<LayerInstance>} all initiating layers
      */
     allInitiatingLayers(): Array<LayerInstance> {
-        return (
-            (useLayerStore(this.$vApp.$pinia)
-                .initiatingLayers as unknown as Array<LayerInstance>) || []
+        return this.allLayers().filter(
+            l => l.initiationState === InitiationState.INITIATING
         );
     }
 
@@ -446,7 +483,7 @@ export class LayerAPI extends APIScope {
         const restParam: __esri.RequestOptions = {
             query: {
                 f: 'json',
-                where: permanentFilter || '1=1',
+                where: permanentFilter || '1=1', // apparently the 1=1 is required to make the count call work on entire dataset
                 returnCountOnly: true,
                 returnGeometry: false
             }

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -61,6 +61,7 @@ export class MapImageLayer extends MapLayer {
         this.esriLayer = markRaw(
             new EsriMapImageLayer(this.makeEsriLayerConfig(this.origRampConfig))
         );
+
         await super.onInitiate();
     }
 

--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -172,19 +172,14 @@ export class MapLayer extends CommonLayer {
             return;
         }
 
-        // TODO verify best default if we can't find actual old position.
-        // top of the stack seems correct? top of data layer stack (to avoid covering north arrow)?
-        let mapStackPosition = 0;
-
         if (this.initiationState === InitiationState.INITIATED) {
             if (this.esriLayer) {
-                // attempt to find esri layer in esri map
+                // attempt to find esri layer in esri map. remove if found
                 const tempPosition =
                     this.$iApi.geo.map.esriMap.layers.findIndex(
                         l => l.id === this.id
                     );
                 if (tempPosition > -1) {
-                    mapStackPosition = tempPosition;
                     this.$iApi.geo.map.esriMap.layers.remove(this.esriLayer);
                 }
             }
@@ -206,7 +201,10 @@ export class MapLayer extends CommonLayer {
             return;
         }
 
-        this.$iApi.geo.map.esriMap.layers.add(this.esriLayer, mapStackPosition);
+        // put back in the ESRI map.
+        // we use this method, since global position of this layer may have changed
+        // during the async terminates and awaits in this method.
+        this.$iApi.geo.map.insertToEsriMap(this);
 
         this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_END, this);
         this.sublayers.forEach(sublayer =>

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -96,7 +96,7 @@ export class MapAPI extends CommonMapAPI {
 
         // remove all layers (need to use uid so we don't mutate layers collection when looping)
         this.$iApi.geo.layer
-            .allLayersOnMap()
+            .allLayersOnMap(false)
             .map(l => l.uid)
             .forEach(l => this.removeLayer(l));
 
@@ -537,8 +537,8 @@ export class MapAPI extends CommonMapAPI {
     }
 
     /**
-     * Adds a layer to the map
-     * Optionally can specify the layer order index
+     * Adds a layer to the map. The layer is considered "registered" with RAMP until it is removed.
+     * Optionally can specify the layer order index for map layers.
      *
      * @param {LayerInstance} layer the Ramp layer to add
      * @param {number | undefined} index optional order index to add the layer to
@@ -561,9 +561,51 @@ export class MapAPI extends CommonMapAPI {
                 // could also await for this but its technically not necessary thanks to the watcher.
                 layer.initiate();
             }
+
+            // figure out insertion position if not provided. We do this before inserting in the store;
+            // afterwards any re-orders and such that happen before the layerWatcher awakes is handled by
+            // the store, and we avoid a race.
+            if (layer.mapLayer && index === undefined) {
+                const currentMapOrder = this.$iApi.geo.layer.layerOrderIds();
+                if (layer.isCosmetic) {
+                    // to the top
+                    index = currentMapOrder.length;
+                } else {
+                    // insert beneath the top-most swath of cosmetic layers
+                    const layerParty = this.$iApi.geo.layer.allLayers();
+                    let searching = true;
+
+                    for (
+                        let i = currentMapOrder.length - 1;
+                        i >= 0 && searching;
+                        i--
+                    ) {
+                        // go backwards down the layer order. Find each layer, test the type
+                        const lTest = layerParty.find(
+                            l => l.id === currentMapOrder[i]
+                        );
+                        if (lTest && !lTest.isCosmetic) {
+                            // found topmost non-cosmetic. insert our incoming layer 1 above
+                            index = i + 1;
+                            searching = false;
+                        }
+                    }
+
+                    if (searching) {
+                        // no friends were found in the for loop.
+                        // can conclude this layer is first non-cosmetic layer. To the bottom with you!
+                        index = 0;
+                    }
+                }
+            }
+
+            // register with the store.
             const layerStore = useLayerStore(this.$vApp.$pinia);
-            layerStore.addInitiatingLayer(layer);
+            layerStore.addLayer(layer, index);
+
             let timeElapsed = 0;
+            // This interval waits for layer initiation, and has a kickout for layers that initiate forever.
+            // After it initiates the callback will start the next step in the loading pipeline.
             // Alternative to this: use event API and watch for layer initiated and layer error events??
             const layerWatcher = setInterval(() => {
                 timeElapsed += 250;
@@ -574,9 +616,8 @@ export class MapAPI extends CommonMapAPI {
                     // Layer took too long to initiate. Move to error to avoid infinite load animation.
                     // Issue #1491 Ponders making the 20 second timeout configurable.
                     clearInterval(layerWatcher);
-                    layerStore.removeInitiatingLayer(layer);
-                    layerStore.addErrorLayer(layer);
                     layer.onError(); // need this thanks to an edge case where the legend sometimes doesnt update
+                    console.error(`Failed to add layer: ${layer.id}.`);
                     reject();
                 } else if (
                     layer.initiationState === InitiationState.INITIATED &&
@@ -586,20 +627,10 @@ export class MapAPI extends CommonMapAPI {
                     // carry on with resolution steps.
                     clearInterval(layerWatcher);
                     if (layer.mapLayer) {
-                        this.esriMap?.add(layer.esriLayer!);
-                        layerStore.removeInitiatingLayer(layer);
-                        layerStore.addLayer(layer);
-                        // if index is provided, reorder the layer to the given index
-                        // use the reorder method so that the esri map-stack and the layer store can stay in sync
-                        if (index !== undefined) {
-                            this.reorder(layer, index);
-                        }
+                        // ramp layer is map ready, add it at the correct position
+                        this.insertToEsriMap(layer);
                     } else {
                         // data layer
-                        // push to the appropriate store
-                        layerStore.removeInitiatingLayer(layer);
-                        layerStore.addDataLayer(layer);
-
                         // there is no esri layer "load" first, so we trigger
                         // the data layer load now.
                         layer.onLoad();
@@ -614,63 +645,211 @@ export class MapAPI extends CommonMapAPI {
     }
 
     /**
-     * Reorders a layer on the map
+     * Utility method to insert a Map Layer into the ESRI map. The position in ESRI map
+     * is derived from global order and what layers are currently in the map.
      *
-     * @param {LayerInstance} layer the RAMP layer to be moved
-     * @param {number} index the RAMP layer index for placing the layer
-     * @param {boolean} ignoreCosmetic indicates if cosmetic layers should be ignored during reordering
+     * @param {LayerInstance} layer the RAMP layer to insert. Must be a Map layer
+     */
+    insertToEsriMap(layer: LayerInstance): void {
+        // need to re-grab global position from store. This utility is usually called after some
+        // Promise sleeps, so order may have changed in that time.
+
+        let esriNewIndex = 0;
+
+        const globalInsertIndex =
+            this.$iApi.geo.layer.getLayerPosition(layer.id) ?? -1;
+
+        // if global is 0, it will be at bottom of esri map. no need to run the position hunter.
+        if (globalInsertIndex > 0) {
+            // find appropriate position in esri map stack to insert at. Some layers in global order
+            // may not be in the map yet.
+            // we do this by walking backwards down the global order, from layer's index-1 to 0
+            // then attempt to find each "lower" layer in the esri stack. The first one we find
+            // should be directly below where we insert the layer in esri-map-land
+
+            // global positions may have changed since this layer started loading. Get up-to-date
+            const globalPositions = this.$iApi.geo.layer.layerOrderIds();
+
+            // load the layers array to do searches on, instead of using getLayer() on each id.
+            // getLayer() will do BFS into children, and thus slower (children have same "order" as parent)
+            const allLayers = this.$iApi.geo.layer.allLayers();
+
+            for (let i = globalInsertIndex - 1; i > -1; i--) {
+                const testLayerId = globalPositions[i];
+                const matchLayer = allLayers.find(fl => fl.id === testLayerId);
+                if (matchLayer && matchLayer.esriLayer) {
+                    // this layer exists in esri form.
+                    const testEsriIndex = this.esriMap!.layers.indexOf(
+                        matchLayer.esriLayer
+                    );
+                    if (testEsriIndex > -1) {
+                        // it also exists in the map stack. can conclude it is the layer in the
+                        // esri map stack that is immediately below where we want to insert our
+                        // added layer. Our result is + 1, donethanks.
+
+                        esriNewIndex = testEsriIndex + 1;
+                        break; // stop the hunt
+                    }
+                } else if (!matchLayer) {
+                    // this should never happen. report and skip this layer test.
+                    console.error(
+                        'ESRI Layer insert encountered bad state. Layer likely inserted at bottom of map.'
+                    );
+                }
+            }
+        }
+
+        // this check is incase the layer no longer existed in the store after it finished loading.
+        // maybe possible if someone did a fast delete and a promise was still running.
+        if (globalInsertIndex > -1) {
+            this.esriMap?.add(layer.esriLayer!, esriNewIndex);
+        }
+    }
+
+    /**
+     * Reorders a layer on the map. The position is based on the instance layer order state
+     * maintained by the LayerAPI.
+     * If ignoreCosmetic is set, the index changes to a different basis. Essentially the
+     * as if cosmetic layers did not exists in the layer order state.
+     *
+     * @param {LayerInstance} layer the RAMP layer to be moved. If a sublayer is passed, the parent will be reordered.
+     * @param {number} index the RAMP layer index where the layer will be moved to
+     * @param {boolean} ignoreCosmetic indicates if the index should ignore cosmetic layers
      */
     reorder(
         layer: LayerInstance,
         index: number,
         ignoreCosmetic: boolean = false
     ): void {
+        if (index < 0) {
+            // alternative: can set to 0 and continue
+            console.error('Negative index passed to map reorder');
+            return;
+        }
         if (!this.esriMap) {
             this.noMapErr();
             return;
         }
-        if (layer.esriLayer) {
-            if (ignoreCosmetic && layer.isCosmetic) {
+
+        if (layer.isSublayer) {
+            layer = layer.parentLayer!;
+        }
+
+        if (!layer.mapLayer) {
+            console.error('Attempted to reorder a data layer');
+            return;
+        }
+
+        // load the layers array to do searches on, instead of using getLayer() on each id.
+        // getLayer() will do BFS into children, and thus slower (can't reorder children)
+        const allLayers = this.$iApi.geo.layer.allLayers();
+        let globalPositions = this.$iApi.geo.layer.layerOrderIds();
+
+        if (ignoreCosmetic) {
+            if (layer.isCosmetic) {
                 // trying to reorder a cosmetic layer when ignore cosmetic is true
                 return;
+            } else if (index > 0) {
+                // if 0, bottom is bottom. only grind if non-zero;
+                // derive actual layer position in map stack. i.e. reverse collapsed index
+
+                const squashedLayers = globalPositions.filter(testId => {
+                    const matchLayer = allLayers.find(fl => fl.id === testId);
+                    if (matchLayer) {
+                        return !matchLayer.isCosmetic;
+                    } else {
+                        // this should never happen.
+                        console.error('Layer reorder had critical error');
+                        return false;
+                    }
+                });
+
+                // find the non-cosmetic layer at our "ignoreCosmetic" index
+                if (index >= squashedLayers.length) {
+                    // report problem but just set to "top".
+                    console.error('non-cosmetic reorder index was too high');
+                    index = squashedLayers.length - 1;
+                }
+
+                // map to where that layer is in the actual order index.
+                // squashedLayers[index] is the layerid of the non-cosmetic layer currently sitting at
+                // our fake "non-cosmetic" index.  Then find that id's index in the real order.
+                index = globalPositions.indexOf(squashedLayers[index]);
+
+                // at this point, index is no longer in "non-cosmetic" units.
+            }
+        } else if (index >= globalPositions.length) {
+            // report problem but just set to "top".
+            console.error('reorder index was too high');
+            index = globalPositions.length - 1;
+        }
+
+        // need to derive if the layer is going up or down the stack. Find old position before changing the store.
+        const oldIndex = globalPositions.indexOf(layer.id);
+
+        if (oldIndex === index) {
+            // position didn't change
+            return;
+        }
+
+        const layerStore = useLayerStore(this.$vApp.$pinia);
+        // sync layer store order with map order
+        layerStore.reorderLayer(layer, index);
+
+        if (
+            layer.esriLayer &&
+            this.esriMap.layers.indexOf(layer.esriLayer) > -1
+        ) {
+            // the global order is up to date. But the layer is also in the esri map.
+            // need to reorder that as well, taking into account that layers "lower"
+            // on the map may not have loaded yet.
+
+            let esriNewIndex = 0;
+
+            if (index > 0) {
+                // find appropriate position in esri map stack to move to. some layers in global order
+                // may not be in the map yet.
+                // we do this by walking backwards down the global order, from index-1 to 0
+                // then attempt to find each "lower" layer in the esri stack. The first one we find
+                // should be directly below our reordered layer after we reorder the esri map
+
+                // our store has been re-ordered, get again
+                globalPositions = this.$iApi.geo.layer.layerOrderIds();
+
+                for (let i = index - 1; i > -1; i--) {
+                    const testId = globalPositions[i];
+                    const matchLayer = allLayers.find(fl => fl.id === testId);
+                    if (matchLayer && matchLayer.esriLayer) {
+                        // this layer exists in esri form.
+                        const testEsriIndex = this.esriMap.layers.indexOf(
+                            matchLayer.esriLayer
+                        );
+                        if (testEsriIndex > -1) {
+                            // it also exists in the map stack. can conclude it is the layer in the
+                            // esri map stack that is immediately below our reordered layer.
+                            //
+                            // the esri insertion index in relation to the test layer depends
+                            // if we were moving down or up the stack
+                            const upDownOffset = index < oldIndex ? 1 : 0;
+                            esriNewIndex = testEsriIndex + upDownOffset;
+                            break; // stop the hunt
+                        }
+                    } else if (!matchLayer) {
+                        // this should never happen. report and skip this layer test.
+                        console.error('Layer reorder had critical error');
+                    }
+                }
             }
 
-            const layerStore = useLayerStore(this.$vApp.$pinia);
-            const layers = layerStore.layers as unknown as LayerInstance[];
-
-            // number of layers in store but not on map, probably errored (up to target index)
-            const notLoaded: number = layers
-                .slice(0, index + 1)
-                .filter(
-                    layer => !this.esriMap!.layers.find(l => l.id === layer.id)
-                ).length;
-
-            // calculate corresponding map layer index
-            const esriLayerIndex: number = this.esriMap.layers.indexOf(
-                this.esriMap.layers
-                    .filter(esrilayer => {
-                        const l: LayerInstance | undefined = layers.find(
-                            l => l.id === esrilayer.id
-                        );
-                        return !!l && !(ignoreCosmetic && l!.isCosmetic);
-                    })
-                    .slice(0, index + 1 - notLoaded) // adjust for layers not on map
-                    .pop()
-            );
-            // set map order
-            this.esriMap.reorder(layer.esriLayer, esriLayerIndex);
-
-            // sync layer store order with map order
-            layerStore.reorderLayer(layer, index);
-            this.$iApi.event.emit(GlobalEvents.MAP_REORDER, {
-                layer,
-                newIndex: index
-            });
-        } else {
-            console.error(
-                'Attempted reorder without an esri layer. Likely layer.initiate() was not called or had not finished.'
-            );
+            // move our target esri layer to the desired position in the esri map stack
+            this.esriMap.reorder(layer.esriLayer, esriNewIndex);
         }
+
+        // spread the good word
+        this.$iApi.event.emit(GlobalEvents.MAP_REORDER, {
+            layer,
+            newIndex: index
+        });
     }
 
     /**
@@ -716,7 +895,8 @@ export class MapAPI extends CommonMapAPI {
     }
 
     /**
-     * Removes a layer from the map and fires the LAYER_REMOVE event
+     * Removes a layer from the map and fires the layer remove event.
+     * This will also unregister the layer from the Ramp instance.
      *
      * @param {LayerInstance | string} layer the Ramp layer or layer id/uid to remove
      * @returns {Promise<void>} a promise that resolves when the layer has been removed from the map
@@ -1046,9 +1226,9 @@ export class MapAPI extends CommonMapAPI {
      */
 
     runIdentify(targetPoint: MapClick | Point): MapIdentifyResult {
-        const layers: LayerInstance[] | undefined = useLayerStore(
-            this.$vApp.$pinia
-        ).layers as unknown as LayerInstance[];
+        const layers = this.$iApi.geo.layer
+            .allLayersOnMap(false)
+            .filter(l => l.canIdentify());
 
         let mapClick: MapClick;
         if (targetPoint instanceof Point) {
@@ -1077,9 +1257,8 @@ export class MapAPI extends CommonMapAPI {
         if (
             layers.some(l => {
                 return (
-                    l.canIdentify() &&
-                    (l.identifyMode === LayerIdentifyMode.HYBRID ||
-                        l.identifyMode === LayerIdentifyMode.SYMBOLIC)
+                    l.identifyMode === LayerIdentifyMode.HYBRID ||
+                    l.identifyMode === LayerIdentifyMode.SYMBOLIC
                 );
             })
         ) {
@@ -1147,10 +1326,7 @@ export class MapAPI extends CommonMapAPI {
         }
 
         // Get a copy of all layers from the layer store (this will be in reverse order)
-        const layers: LayerInstance[] | undefined = (
-            useLayerStore(this.$vApp.$pinia)
-                .layers as unknown as LayerInstance[]
-        )?.slice(0);
+        const layers = this.$iApi.geo.layer.allLayersOnMap(true);
 
         // Don't perform a hittest request if the layers array hasn't been established yet.
         if (layers === undefined) {

--- a/src/geo/utils/renderer.ts
+++ b/src/geo/utils/renderer.ts
@@ -176,7 +176,7 @@ export class SimpleRenderer extends BaseRenderer {
         const su = new BaseSymbolUnit(this);
         su.label = esriRenderer.label || '';
         su.symbol = esriRenderer.symbol;
-        su.definitionClause = '1=1';
+        su.definitionClause = '';
 
         this.symbolUnits.push(su);
     }


### PR DESCRIPTION
## Related Item(s)

#2006, #2094

## Changes

- Race conditions fixed :racehorse::dash:.
- Layer state greatly simplified. No longer juggles layers between four internal arrays.
- Layer insertion logic is no longer scattered across modules. `RampMap` is new boss.
- Layers can now be reordered if they are currently not on the ESRI map.
  - Can be done via API.
  - Am not changing the Reordering fixture UI. It still only shows loaded non-cosmetic layers. However using the fixture while other layers are pending will no longer corrupt layer order.
- Can now provide a sublayer to the reorder method (will derive the parent)
- Map no longer raises "reorder" events when the layer loads
  - While this was "true", it never really made any sense. The reorder was a technical hack done to avoid deriving the correct insertion index.
  - This fix now just inserts in the correct location.
  - In theory this is a breaking change, and will be documented in the release notes. The "layer registered" event can be used to detect when the layer first enters the ESRI stack.
- Comment enhancements, since it was confusing figuring out most of this.
- Fixes separate race condition in the Fog Highlighter

I hope you all enjoy reviewing every single line of this PR.

## Timing

This changes a lot of internals. While my code is :cherries: and my testing is :goat: , the large scope means something could be missed. Ideally this gets pulled then endures a good amount of time being used in regular development testing and project testing.

Am strongly recommending to delay pulling until after a testing party and release of `v4.4.0`. This should also not go into any project that is releasing imminently.

But it would be ideal if this is in the codebase early in the dev cycle for the CESI and CCCS initiatives releasing end-of-fiscal.

## Blockers

Some things are temporarily changed to allow testing. They will be un-did prior to pulling.

- Sleeper logic in `feature-layer.ts`
- Race setup changes in `simple-feature.js`
- Reload setup changes in `grid.js`

Part of this edit forces every Feature layer to take about 10 seconds to initialize. Can allow you to brew up your own races, reorder things before they are loaded, cancel loads, etc.

## Testing

Some scripts are in the bottom section that can help with any API testing.  As well, I suggest pasting this block of code into the console when doing tests. It will give you easy readouts of the relevant app state when certain events happen (layers load, reorders happen), and you can request a readout at any point by just typing `stat()` in the console. You need to yell "STAT" like an emergency room doctor, it will perform better.

```js
const stat = () => {
  const gOrder = debugInstance.geo.layer.layerOrderIds();

  const statStr = gOrder.map(layId => {
      const mapL = debugInstance.geo.layer.getLayer(layId);
      if (mapL) {
        return mapL.layerState;
      } else {
        return '???';
      }
    }).join(', ');
  console.log('Global Status: ' + statStr);

  console.log('Global Order: ' + gOrder.join(', '));

  const esriOrder = debugInstance.geo.map.esriMap?.layers
      .map(eLayer => eLayer.id)
      .join(', ') ?? 'no layers';
  console.log('ESRI Order:   ' + esriOrder);
};

debugInstance.event.on(
  'map/reorder',
  evt => {
    console.group(`reorder ${evt.layer.id} to index ${evt.newIndex}`);
    stat();
    console.groupEnd();
  }
);

debugInstance.event.on(
  'layer/registered',
  evt => {
    console.group(`layer initialized ${evt.id}`);
    stat();
    console.groupEnd();
  }
);

debugInstance.event.on(
  'layer/layerstatechange',
  evt => {
    if (evt.state === 'loaded') {
      console.group(`layer loaded ${evt.layer.id}`);
      stat();
      console.groupEnd();    
    }    
  }
);

stat();
```

### From Config

Ensuring things load from config correctly and in proper order.

- Normal load. Try your favourite samples.
- Forced race condition load.
  - Sample 15
  - Will load in order `2 4 3 1`
  - Should end up `1 2 3 4` in on map, reorder fixture, and console report.
  - Try with Reorder fixture open to be amazed :sparkles:
- Data Layers (they have no order)
  - Sample 42
  - Validate nothing explodes
  - Validate data layer (`ce_table`) does not appear in order stores.

### From API

- `addLayer` with explicit index position
- `addLayer` with no index provided
  - Normal and cosmetic
- Add delayed layer, then issue a reorder prior to it loading

### System Cosmetics

Checking system cosmetics are on top. (hilight, north arrow)

- Spotcheck `Ramp-Hilight` gets created and is above normie layers.
- North pole marker.
  - Zoom in so the North is far out of view.
  - Switch to Lambert basemap.
  - Check console report, should be no pole marker layer yet.
  - Zoom to HOME, revealing north pole flag.
  - `RampPoleMarker` should be topmost layer in console report.

### General API

- new methods
  - `geo.layer.layerOrderIds()`
  - `geo.layer.getLayerPosition(layerId)`  
- classic methods (behavior is same, but innards use different plumbing)
  - `geo.map.reorder(layer, newIdx)` 
  - `geo.layer.allLayers()`
  - `geo.layer.allActiveLayers()`
  - `geo.layer.allLayersOnMap(bool)` 
  - `geo.layer.allDataLayers()`
  - `geo.layer.allErrorLayers()`
  - `geo.layer.allInitiatingLayers()`

The `allLayersOnMap` has a new optional boolean param to sort result by map order. Defaults to true to keep backwards compatibility. If false, result should not change between reorders.

- Sample 41 has Data Layers.
- Sample 18 has Error Layers.
- Anything with a feature layer gives you 10 seconds to catch Initiating Layers.

### Reorder Fixture

- Buttons
  - Ensure store and map look correct
- Drag layers in list
  - Try moving both a distance of one layer and greater than one
  - Ensure store and map look correct
- Ensure view updates when new layer is added 
  - Try targeted position add via API to ensure it appears in correct list location
- Ensure view updates when layer is removed
- Ensure view updates when layer is reordered via API

### Legend

- Reload sucessful layer (use Reload from `...` menu).
- Reload error'd layer.
  - Sample 11.
  - Clean Air layer fails first load. Console stats should show it lurking in the middle position but in errored status.
  - Click reload. Layer should load, and be in middle position everywhere (the ESRI layer is recreate so there is a re-insert).
- Removal of loaded, ok layer (test for bugs).
- For "Cancel" tests, can use any delayed feature layer. Have a 10 second window it hit the X.
  - Cancel then reload.
  - Cancel then remove (trashcan).

Be aware of issue #2088 which may cause some reloads to fail.

### Highlighter

- Test highlights after reorders
  - Normal highlighter fun.
  - Try reordering while a point pile is identified and highlighted.
- Test fog hilighter
  - Sample 26

### Error Fun

- Try various order stuff when Errored layers exist.
- Sample 18 is your friend for content.
- Try to reorder an errored layer via the API (Sample below).

```js
// SAMPLE 18 

// ONE: test error in esri stack funtimes

const errLayer = debugInstance.geo.layer.getLayer('WaterQuantity');
debugInstance.geo.map.reorder(errLayer, 3);

// layer should now be above WFSLayer in both store and esri map.
// map visually should not change.

const tomLayer = debugInstance.geo.layer.getLayer('WFSLayer');
tomLayer.visibility = true;
debugInstance.geo.map.reorder(tomLayer, 4);

// layer should now be above Caribous in both store and esri map.
// red dots should be above green polygons on map.


// TWO: test error not in esri stack funtimes

const errFile = debugInstance.geo.layer.getLayer('FileLayer');
debugInstance.geo.map.reorder(errFile, 3);

// layer should now be below Caribous in the store.
// esri map stack should not change.
// map visually should not change.

const oilLayer = debugInstance.geo.layer.getLayer('OilFacility');
oilLayer.visibility = true;
debugInstance.geo.map.reorder(oilLayer, 3);

// layer should now be below FileLayer in the store.
// should be below Caribous in the esri map stack.
// bigger red dots (Alberta) should be below green polygons on map.
```

### Bonus Console Scripts

API add and reorder.

Adjust stuff as you see fit. Interesting things are cosmetic flag, insertion index (can omit this as well), reorder target index. Also, running the reorder while layer is initializing or after it loads are both smart tests.

The points in this layer are white circles, can be hard to see in lighter basemaps. Satellite works best.

```js
var funConfig = {
 id: "fun",
 name: "Big Fun",
 cosmetic: true,
 url: "https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/BasicCity/MapServer/0",
 layerType: "esri-feature"
};

var funLayer = debugInstance.geo.layer.createLayer(funConfig);
debugInstance.geo.map.addLayer(funLayer, 2);

debugInstance.geo.map.reorder(funLayer, 3); 
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2095)
<!-- Reviewable:end -->
