### PR TITLE
disable maptip on layer that doesn't support features

### DIFF
--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -1177,8 +1177,8 @@ export class MapAPI extends CommonMapAPI {
                 return result.graphic.layer.id === layer.id;
             });
             if (matchedResult) {
-                if (layer.isCosmetic) {
-                    // means topmost thing was in a cosmetic layer.
+                if (layer.isCosmetic || !layer.supportsFeatures) {
+                    // means topmost thing was in a cosmetic layer, or the layer doesn't support features.
                     // we currently can't do a hovertip on these.
                     // Acually it's graphic layers that are the problem, but
                     // cosmetics shouldnt be interactive anyways. if someone decides


### PR DESCRIPTION
### Related Item(s)
Closes #2099 

### Changes
- Fixes an issue where the console would be spammed with errors when hovering over an image service layer.

### Testing
Steps
1. Open the [CESI sample page](https://ramp4-pcar4.github.io/ramp4-pcar4/fix-2099/demos/index-samples.html?sample=24)
2. Ensure the "Agriculture and Agri-Food Canada" layer is visible.
3. Open the console and move your mouse around the map. Ensure that there is no hit test errors or warnings appearing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2100)
<!-- Reviewable:end -->
