### PR TITLE
Custom Renderer sample fix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 ### Related Item(s)
 *#Item 1*, *#Item 2*
 
+*Do not put any of the following words before the issue number*
+*close ; closes ; closed ; fix ; fixes ; fixed ; resolve ; resolves ; resolved*
+
 ### Changes
 - [FEATURE] *Describe feature...*
 - [FIX] *Describe fix...*

--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -221,7 +221,7 @@
             </li>
             <li>
                 39.
-                <a href="index-samples.html?sample=38">Old Default Sample</a>.
+                <a href="index-samples.html?sample=39">Old Default Sample</a>.
                 Contains an outdated main sample.
                 <span class="tag layer">Feature Layer</span
                 ><span class="tag layer">Map Image Layer</span
@@ -350,7 +350,8 @@
             </li>
             <li>
                 <a href="index-multi-wet.html"
-                    >Multiple RAMP instances inside the WET template</a>
+                    >Multiple RAMP instances inside the WET template</a
+                >
             </li>
         </ul>
     </body>

--- a/demos/starter-scripts/custom-renderer.js
+++ b/demos/starter-scripts/custom-renderer.js
@@ -249,6 +249,7 @@ let config = {
                     url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/9',
                     customRenderer: {
                         type: 'simple',
+                        label: 'Super Simple',
                         symbol: {
                             type: 'esriSMS',
                             style: 'esriSMSCross',
@@ -280,6 +281,7 @@ let config = {
                         uniqueValueInfos: [
                             {
                                 value: 'Clean Air',
+                                label: 'The Cleanest Airs',
                                 symbol: {
                                     type: 'esriSMS',
                                     style: 'esriSMSDiamond',
@@ -367,6 +369,7 @@ let config = {
                     xyInAttribs: true,
                     customRenderer: {
                         type: 'simple',
+                        label: 'Ultra Simple',
                         symbol: {
                             type: 'esriSMS',
                             style: 'esriSMSTriangle',
@@ -393,7 +396,7 @@ let config = {
                     xyInAttribs: true,
                     customRenderer: {
                         type: 'uniqueValue',
-                        field1: 'STATUS_EN',
+                        field1: 'joined__rejoint',
                         defaultSymbol: {
                             type: 'esriSMS',
                             style: 'esriSMSCircle',
@@ -411,7 +414,7 @@ let config = {
                         // all possible values must be covered or use defaultSymbol
                         uniqueValueInfos: [
                             {
-                                value: 'Discontinued',
+                                value: 0,
                                 symbol: {
                                     type: 'esriSMS',
                                     style: 'esriSMSDiamond',
@@ -425,10 +428,10 @@ let config = {
                                         width: 0.5
                                     }
                                 },
-                                label: 'Discontinued'
+                                label: 'Not Joined'
                             },
                             {
-                                value: 'Active',
+                                value: 1,
                                 symbol: {
                                     type: 'esriSMS',
                                     style: 'esriSMSDiamond',
@@ -442,7 +445,7 @@ let config = {
                                         width: 0.5
                                     }
                                 },
-                                label: 'Active'
+                                label: 'Joined'
                             }
                         ]
                     },
@@ -525,7 +528,7 @@ let config = {
                 {
                     id: 'MILSimple',
                     layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer',
                     sublayers: [
                         {
                             index: 18,
@@ -535,6 +538,7 @@ let config = {
                             },
                             customRenderer: {
                                 type: 'simple',
+                                label: 'Extra Simple',
                                 symbol: {
                                     type: 'esriSMS',
                                     style: 'esriSMSCircle',
@@ -555,6 +559,7 @@ let config = {
                             },
                             customRenderer: {
                                 type: 'simple',
+                                label: 'Very Simple',
                                 symbol: {
                                     type: 'esriSMS',
                                     style: 'esriSMSCircle',
@@ -572,7 +577,7 @@ let config = {
                 {
                     id: 'MILUniqueValue',
                     layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer',
                     sublayers: [
                         {
                             index: 18,
@@ -582,7 +587,7 @@ let config = {
                             },
                             customRenderer: {
                                 type: 'uniqueValue',
-                                field1: 'GridColumn3', // Province
+                                field1: 'GridColumn3', // aliased to Province
                                 defaultSymbol: {
                                     type: 'esriSMS',
                                     style: 'esriSMSTriangle',
@@ -634,7 +639,7 @@ let config = {
                 {
                     id: 'MILClassBreaks',
                     layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer',
                     sublayers: [
                         {
                             index: 18,
@@ -699,7 +704,8 @@ let config = {
                         children: [
                             {
                                 name: 'Feature Layer',
-                                exclusiveVisibility: [
+                                exclusive: true,
+                                children: [
                                     {
                                         layerId: 'FeatureSimple',
                                         name: 'Simple'
@@ -716,7 +722,8 @@ let config = {
                             },
                             {
                                 name: '(fake) File Layer',
-                                exclusiveVisibility: [
+                                exclusive: true,
+                                children: [
                                     {
                                         layerId: 'WFSSimple',
                                         name: 'Simple'
@@ -733,7 +740,8 @@ let config = {
                             },
                             {
                                 name: 'Map Image Layer',
-                                exclusiveVisibility: [
+                                exclusive: true,
+                                children: [
                                     {
                                         name: 'Simple',
                                         children: [

--- a/demos/starter-scripts/legend.js
+++ b/demos/starter-scripts/legend.js
@@ -170,7 +170,8 @@ let config = {
                             },
                             {
                                 name: 'Visibility Set',
-                                exclusiveVisibility: [
+                                exclusive: true,
+                                children: [
                                     {
                                         layerId: 'CleanAir',
                                         name: 'Clean Air in Set'

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -327,7 +327,8 @@ let config = {
                         children: [
                             {
                                 name: 'Visibility Set',
-                                exclusiveVisibility: [
+                                exclusive: true,
+                                children: [
                                     {
                                         layerId: 'CleanAir',
                                         name: 'Clean Air in Set'

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -510,7 +510,7 @@ export interface GeoJsonOptions {
 }
 
 export interface LoadLayerMetadataOptions {
-    customRenderer?: any; // valid JSON renderer. no handy typescript schema
+    customRenderer?: EsriRenderer; // renderer in ESRI API format
 }
 
 export interface CsvOptions {

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -143,10 +143,14 @@ export class AttribLayer extends MapLayer {
             });
 
             // add renderer and legend
+            // use custom renderer if defined. Otherwise use server.
+            // If server does not have a renderer defined, it's not drawing on the map. Can use ! to avoid extra checks, since
+            // layer is already roont.
             const esriRenderer =
                 options && options.customRenderer && options.customRenderer.type
                     ? options.customRenderer
-                    : sData.renderer;
+                    : sData.renderer!;
+
             this.renderer = this.$iApi.geo.symbology.makeRenderer(
                 esriRenderer,
                 this.fields

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -109,7 +109,7 @@ export class FeatureLayer extends AttribLayer {
             this.esriLayer && this.origRampConfig.customRenderer?.type;
         if (hasCustRed) {
             this.esriLayer!.renderer = EsriRendererFromJson(
-                this.config.customRenderer
+                this.origRampConfig.customRenderer
             );
         }
 

--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -304,10 +304,14 @@ export class SymbologyAPI extends APIScope {
     /**
      * Generate an SVG string for an ESRI symbol.
      * @private
-     * @param  {Object} symbol an ESRI symbol object in server format
+     * @param  {Object} symbol an ESRI symbol object in JS API format
      * @return {Promise} resolves to an SVG string representing the symbol
      */
     private async symbolToSvg(symbol: any): Promise<string> {
+        // the symbol param remains `any` due to us being cheeky with defaulting and constructing symbol defaults as we go.
+        // e.g. not every symbol has an outline; if we strong type we need to continually check if the symbol subclass
+        // supports outlines first.
+        //
         // TODO now that we are enlightened and using typescript and classes and such, consider taking this monster
         //      function with all it's nested functions and moving them to some type of SVG service / class.
         //      For now, we are using the typescript ignore flag to stop whining about our object-key mappings.


### PR DESCRIPTION
### Related Item(s)

#2107

### Changes

- Added a type to an interface to make things clearer.
- Updated sample with proper legend exclusive group syntax (updated the other samples with same mistake).
- Updated sample to align WFS renderer with field names.
- Pointed sample to Danbo CESI.
- Added extra renderer labels to make sample look less broken.
- Fixed wrong sample index in yellow pages.
- Updated PR template to help prevent issue auto-closes.

### Testing
Steps:
1. Run Sample 7
2. Inspect the various layers. Look at the symbols. Look at stuff in the grid, identify, highlighter. Ensure symbols are grand and no issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2108)
<!-- Reviewable:end -->
