### PR TITLE
Fix accessible label for scalebar

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -5,7 +5,7 @@
             class="text-gray-500 hover:text-black dropdown-button"
             @click="open = !open"
             :content="tooltip"
-            :aria-label="String(tooltip)"
+            :aria-label="ariaLabel ? String(ariaLabel) : String(tooltip)"
             v-tippy="{
                 placement: tooltipPlacement,
                 theme: tooltipTheme,
@@ -63,7 +63,8 @@ const props = defineProps({
     tooltipPlacement: { type: String, default: 'bottom' },
     tooltipTheme: { type: String, default: 'ramp4' },
     tooltipAnimation: { type: String, default: 'scale' },
-    centered: { type: Boolean, default: true }
+    centered: { type: Boolean, default: true },
+    ariaLabel: { type: String }
 });
 
 watchers.push(

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -67,7 +67,11 @@
                 class="flex-shrink-0 mx-2 sm:mx-10 px-4 pointer-events-auto cursor-pointer border-none"
                 @click="onScaleClick"
                 :aria-pressed="scale?.isImperialScale"
-                :aria-label="changeScaleMessage(scale?.isImperialScale)"
+                :aria-label="`
+                    ${scale?.label} - ${changeScaleMessage(
+                    scale?.isImperialScale
+                )}
+                `"
                 v-tippy="{
                     delay: [300, 0],
                     placement: 'top',
@@ -99,6 +103,9 @@
                     touch: ['hold', 200]
                 }"
                 :content="t('map.changeLanguage')"
+                :ariaLabel="`${t('map.language.short')} - ${t(
+                    'map.changeLanguage'
+                )}`"
             >
                 <template #header>
                     <span


### PR DESCRIPTION
### Related Item(s)
#2109 

### Changes
Modified the accessibility label for scalebar to include the visible text label. I was unable to reproduce this using lighthouse devtool though so hopefully this addresses the [rule](https://www.w3.org/TR/WCAG21/#label-in-name) for the first point in the issue. 

For the second violation, Spencer [commented](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2109#issuecomment-1908663665) that we should be passing the reported [WCAG rule](https://www.w3.org/TR/WCAG20/#ensure-compat-rsv) since an `aria-labelledby` property is added upon hover/tooltip, so nothing was needed to be done.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2110)
<!-- Reviewable:end -->
