### PR TITLE
Colour contrast and wizard imagery layer fix

### DIFF
--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="map-caption absolute bottom-0 flex justify-end pointer-events-auto cursor-default select-none text-gray-400 bg-black-75 left-0 right-0 py-2 sm:py-6"
+        class="map-caption absolute bottom-0 flex justify-end pointer-events-auto cursor-default select-none text-gray-200 bg-black-75 left-0 right-0 py-2 sm:py-6"
     >
         <about-ramp-dropdown
             class="sm:block display-none ml-8 mr-4"
@@ -109,7 +109,7 @@
             >
                 <template #header>
                     <span
-                        class="text-gray-400 hover:text-white text-sm sm:text-base pb-5"
+                        class="text-gray-200 hover:text-white text-sm sm:text-base pb-5"
                     >
                         {{ t('map.language.short') }}
                     </span>

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -22,7 +22,7 @@ wizard.fileType.shapefile,zipped Shapefile,1,Shapefile zippé,1
 wizard.fileType.geojson,GeoJSON,1,GeoJSON,1
 wizard.layerType.esriFeature,ESRI Feature Layer,1,Couche d'éléments d'ESRI,1
 wizard.layerType.esriMapImage,ESRI Map Image Layer,1,Couche d'image de la carte ESRI,1
-wizard.layerType.esriImagery,ESRI Image Layer,1,Couche d'images d'ESRI,1
+wizard.layerType.esriImagery,ESRI Imagery Layer,1,Couche d’imagerie ESRI,0
 wizard.layerType.esriTile,ESRI Tile Layer,1,Couche de tuiles d'ESRI,1
 wizard.layerType.ogcWms,OGC Web Map Service,1,Couche WMS de l'OGC,1
 wizard.layerType.ogcWfs,OGC Web Feature Service,1,Service d'entités Web OGC,1


### PR DESCRIPTION
### Related Item(s)
#2116, #2120

### Changes
For #2116:
- Changed the `ESRI Image Layer` to `ESRI Imagery Layer` in the second step (list of service or file formats) in the Wizard

For #2120:
- Changed the text colour of the status bar to a lighter colour (gray-200) for higher contrast

### Notes
For #2120, colour contrast checker had these results:
- With a lighter basemap (aka lighter background of the status bar):
![lighter_background](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/335c42d0-4524-4205-b88b-d504f9e0f939)
- With a darker basemap (aka darker background of the status bar):
![darker_background](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/a17e4e6a-a8bf-448c-a849-f60c702010a7)

### Testing
For #2116:
1. Open the Wizard on any sample.
2. Upload a service (ex. `https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer`).
3. Ensure that formats include `ESRI Imagery Layer` and not `ESRI Image Layer`.

For #2120:
1. Use [this tool](https://accessibleweb.com/color-contrast-checker/) to check if the status bar passes the colour contrast check for accessibility. Select a pixel from the status bar background and another from the text to determine the contrast.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2121)
<!-- Reviewable:end -->
