### PR TITLE
Added a flag to hide/show the Shape_Length and Shape_Area system fields

### DIFF
--- a/demos/starter-scripts/custom-grid-buttons.js
+++ b/demos/starter-scripts/custom-grid-buttons.js
@@ -941,7 +941,7 @@ let config = {
             panels: {
                 open: [{ id: 'legend', pin: true }]
             },
-            system: { animate: true }
+            system: { animate: true, exposeMeasurements: false }
         }
     }
 };

--- a/docs/api-guides/instance.md
+++ b/docs/api-guides/instance.md
@@ -19,6 +19,7 @@ The Instance API provides an interface to manage all aspects of a RAMP instance.
 * `screenSize` - a string representing the screen size for the app. Returns the largest tailwind screen class on the element. Possible values are 'lg', 'md', 'sm' or 'xs'.
 * `animate` - a boolean representing whether the app has animations enabled.
 * `exposeOid` - a boolean representing whether the app includes Object ID fields of a feature alongside attribute data.
+* `exposeMeasurements` - a boolean representing whether the app includes Shape_Length and Shape_Area of a feature alongside attribute data.
 * `isFullScreen` - a boolean representing whether the app is currently fullscreen.
 * `started` - a boolean representing whether the app has been started.
 

--- a/schema.json
+++ b/schema.json
@@ -2789,6 +2789,11 @@
                     "description": "Determines whether or not to include a feature's object ID field when viewing data on the site (e.g. within the details panel when identifying a feature).",
                     "default": false
                 },
+                "exposeMeasurements": {
+                    "type": "boolean",
+                    "description": "Determines whether or not to include a feature's Shape_Length and Shape_Area (e.g. within the details panel when identifying a feature).",
+                    "default": true
+                },
                 "zoomIcon": {
                     "type": "string",
                     "description": "Determines which icon to display for the zoom button in the grid and details panels. Can be 'globe', 'magnify', or a custom icon.",

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -94,7 +94,7 @@ function individualConfigUpgrader(r2c: any): any {
         layers: [],
         map: {},
         panels: { open: [] },
-        system: { animate: true, exposeOid: false },
+        system: { animate: true, exposeOid: false, exposeMeasurements: true },
         fixturesEnabled: [] // this will be removed in the final step of configUpgrade2to4
     };
 

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -85,6 +85,7 @@ export class InstanceAPI {
     readonly ui: {
         maptip: MaptipAPI;
         exposeOids: boolean;
+        exposeMeasurements: boolean;
         getZoomIcon: () => string;
         scrollToInstance: boolean;
     };
@@ -122,6 +123,7 @@ export class InstanceAPI {
         this.ui = {
             maptip: this.geo.map.maptip,
             exposeOids: false,
+            exposeMeasurements: true,
             getZoomIcon: () => '',
             scrollToInstance: false
         };
@@ -306,6 +308,10 @@ export class InstanceAPI {
             }
             if (langConfig.system?.exposeOid) {
                 this.ui.exposeOids = langConfig.system.exposeOid;
+            }
+            if (langConfig.system?.exposeMeasurements != undefined) {
+                this.ui.exposeMeasurements =
+                    langConfig.system.exposeMeasurements;
             }
             if (langConfig.system?.scrollToInstance) {
                 this.ui.scrollToInstance = langConfig.system?.scrollToInstance;

--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -43,14 +43,37 @@ const props = defineProps({
     }
 });
 
+const findAndDelete = (
+    fields: FieldDefinition[],
+    propertyType: 'type' | 'name',
+    property: string,
+    helper: any
+) => {
+    const field = fields.find(
+        f => f[propertyType].toLowerCase() === property.toLowerCase()
+    );
+
+    // If the field is found, delete it from the helper object
+    if (field) delete helper[field.name];
+};
+
 // clone identifyData and remove unwanted data
 const itemData = () => {
     const helper: any = {};
     Object.assign(helper, props.identifyData.data);
 
+    // Remove any fields of type geometry
+    findAndDelete(props.fields, 'type', 'geometry', helper);
+
     if (!iApi?.ui.exposeOids) {
         // check global oid flag
-        delete helper[props.fields.find(f => f.type === 'oid')!.name];
+        findAndDelete(props.fields, 'type', 'oid', helper);
+    }
+
+    if (!iApi?.ui.exposeMeasurements) {
+        // check global measurements flag
+        findAndDelete(props.fields, 'name', 'shape_length', helper);
+        findAndDelete(props.fields, 'name', 'shape_area', helper);
     }
 
     let aliases: any = {};

--- a/src/fixtures/grid/column-dropdown.vue
+++ b/src/fixtures/grid/column-dropdown.vue
@@ -31,7 +31,12 @@
                 c =>
                     c.headerName &&
                     c.headerName.length > 0 &&
-                    !(!iApi.ui.exposeOids && oidCols?.has(c.headerName))
+                    !(!iApi.ui.exposeOids && systemCols?.has(c.headerName)) &&
+                    !(
+                        !iApi.ui.exposeMeasurements &&
+                        (systemCols?.has(c.headerName) ||
+                            systemCols?.has(c.field))
+                    )
             )"
             :key="col.headerName"
             v-on:click="
@@ -73,6 +78,6 @@ const { t } = useI18n();
 defineProps({
     columnDefs: { type: Object as PropType<Array<any>>, required: true },
     columnApi: { type: Object },
-    oidCols: { type: Object as PropType<Set<string>> }
+    systemCols: { type: Object as PropType<Set<string>> }
 });
 </script>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -21,6 +21,7 @@ export interface RampConfig {
         proxyUrl?: string;
         animate?: boolean;
         exposeOid?: boolean;
+        exposeMeasurements?: boolean;
         zoomIcon?: string;
         scrollToInstance?: boolean;
     };


### PR DESCRIPTION
### Related Item(s)
#1945 

### Changes
Added a flag that can be used to hide the Shape_Length and Shape_Area system fields. 

### Testing
Steps:
1. Open the default sample and click into Nunavut
2. Confirm that Shape_Area and Shape_Length still show up in the details panel
3. Open the TerritoriesPoly grid and make sure the fields show up in the grid
4. Open Sample 43 and flip it into Francais mode
5. Click into Nunavut and witness no Shape_Length or Shape_Area
6. Open the TerritoriesPoly grid and witness no Shape_Length or Shape_Area
7. Open Sample 29 and make sure I didn't break anything with the Object ID

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2124)
<!-- Reviewable:end -->
