### PR TITLE
Fix infinite loading when adding layers after error

### DIFF
--- a/docs/api-guides/layers.md
+++ b/docs/api-guides/layers.md
@@ -174,7 +174,7 @@ The creation of the layer just generates the controlling Layer object. To genera
 
 The `initiationState` property on the Layer will indicate the current state of the Layer in this matter.
 
-If an uninitated Layer is passed to `map.addLayer()`, it will be initialized automatically.
+If an uninitiated Layer is passed to `map.addLayer()`, it will be initialized automatically.
 
 ### Waiting For Layer Load
 

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -142,6 +142,19 @@ export class MapImageLayer extends MapLayer {
 
         this.layerTree.name = this.name;
 
+        // throw error for FeatureServer added as MIL, has no export map function
+        if (!this.esriLayer.capabilities.exportMap) {
+            this.$iApi.notify.show(
+                NotificationType.WARNING,
+                this.$iApi.$i18n.t('layer.noexportmap', {
+                    name: this.name || this.id
+                })
+            );
+
+            throw new Error(
+                'Service does not support Map Image Layer, Map Export is not enabled'
+            );
+        }
         this.isDynamic =
             this.esriLayer.capabilities.exportMap.supportsDynamicLayers;
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -51,3 +51,4 @@ layer.longdraw,{id} is taking longer than expected to draw,1,{id} prend plus de 
 layer.mismatch,{name} cannot be displayed in the current projection,1,{name} ne peut pas être affiché dans la projection actuelle,0
 layer.filtersdisabled,Filters have been disabled for {name},1,Les filtres ont été désactivés par {name},0
 layer.filterwarning,You are attempting to use a grid that contains unmodifiable layers. Filtering will be partially disabled,1,Vous tentez d'utiliser une grille contenant des calques non modifiables. Le filtrage sera partiellement désactivé,0
+layer.noexportmap,{name} was attempted to be added as a Map Image Layer but Map Export is not enabled for the service,1,{name} a été tenté d'être ajouté en tant que couche d'images cartographiques mais l'exportation de cartes n'est pas activée pour le service,0


### PR DESCRIPTION
### Related Item(s)
#2103 

### Changes
- adds error handling for layers that run into issues during `onLoad()` process (these layers will be put into error state instead of waiting for timeout)
- added a comment for future analysis into the root of the issue which may be timing related (error'd layers should have no impact on future `esriLayer` objects not triggering its watchers)

### Testing
Steps:
1. Add any layer that will error - either through API or one that sneaks by wizard with incorrect typing (this [layer](https://services.arcgis.com/lGOekm0RsNxYnT3j/arcgis/rest/services/Wildlife_Habitat_Availability_on_Farmland_2015/FeatureServer) from issue as MIL through wizard)
2. Add a functional layer with the correct type , it should load normally instead of being in infinite loading state

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2125)
<!-- Reviewable:end -->
