### PR TITLE
add system variable to bypass number localization

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -681,7 +681,8 @@ let config = {
                 }
             },
             system: {
-                animate: true
+                animate: true,
+                suppressNumberLocalization: true
             }
         }
     }

--- a/schema.json
+++ b/schema.json
@@ -2798,6 +2798,11 @@
                     "type": "boolean",
                     "description": "Determines whether the browser will scroll to the RAMP instance when a button within the app is pressed.",
                     "default": false
+                },
+                "suppressNumberLocalization": {
+                    "type": "boolean",
+                    "description": "If set to true, the app will display numbers in plain decimal format instead of formatting them based on the app language.",
+                    "default": false
                 }
             },
             "required": [],

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -86,7 +86,9 @@ export class InstanceAPI {
         maptip: MaptipAPI;
         exposeOids: boolean;
         getZoomIcon: () => string;
+        formatNumber: (num: number) => string;
         scrollToInstance: boolean;
+        suppressNumberLocalization: boolean;
     };
     startRequired: boolean = false;
 
@@ -123,7 +125,9 @@ export class InstanceAPI {
             maptip: this.geo.map.maptip,
             exposeOids: false,
             getZoomIcon: () => '',
-            scrollToInstance: false
+            formatNumber: () => '',
+            scrollToInstance: false,
+            suppressNumberLocalization: false
         };
         this.notify = new NotificationAPI(this);
 
@@ -310,6 +314,10 @@ export class InstanceAPI {
             if (langConfig.system?.scrollToInstance) {
                 this.ui.scrollToInstance = langConfig.system?.scrollToInstance;
             }
+            if (langConfig.system?.suppressNumberLocalization) {
+                this.ui.suppressNumberLocalization =
+                    langConfig.system?.suppressNumberLocalization;
+            }
 
             // set up key to SVG bindings for zoom icons
             const zoomSvgs: { [key: string]: string } = {
@@ -323,6 +331,12 @@ export class InstanceAPI {
 
             this.ui.getZoomIcon = () => {
                 return zoomIcon;
+            };
+
+            this.ui.formatNumber = (num: number) => {
+                return this.ui.suppressNumberLocalization
+                    ? num.toString()
+                    : this.$i18n.n(num, 'number');
             };
         }
 

--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -71,7 +71,7 @@ const itemData = () => {
         helper[key] = {
             value:
                 typeof helper[key] === 'number'
-                    ? iApi?.$i18n.n(helper[key], 'number')
+                    ? iApi?.ui.formatNumber(helper[key])
                     : helper[key],
             alias: aliases[key].name || key, // use the key name if alias is undefined
             type: aliases[key].type

--- a/src/fixtures/grid/templates/cell-renderer.vue
+++ b/src/fixtures/grid/templates/cell-renderer.vue
@@ -65,9 +65,8 @@ const copy = () => {
 
 const formatValue = computed<string>(() => {
     if (props.params.type === 'number') {
-        return props.params.value == null
-            ? ''
-            : iApi.$i18n.n(props.params.value, 'number');
+        if (props.params.value == null) return '';
+        return iApi.ui.formatNumber(props.params.value);
     } else if (props.params.type === 'date') {
         // get YYYY-MM-DD from date
         return props.params.value == null

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -23,6 +23,7 @@ export interface RampConfig {
         exposeOid?: boolean;
         zoomIcon?: string;
         scrollToInstance?: boolean;
+        suppressNumberLocalization?: boolean;
     };
 }
 


### PR DESCRIPTION
### Related Item(s)
#2122 

### Changes
- Adds a system flag `overrideNumberFormat`. When set to true, the details and grid will not use the i18n number localizer and will instead display the numbers exactly as they were received from the service.

### Testing
1. Open the main sample page, which has the new flag set to `false` (default)
2. Set the app language to French.
3. Add a [French CESI layer](https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/ICDE/MapServer/24).
4. Inspect a data point in the grid and in the details panel. Notice how latitude/longitude is formatted with a comma instead of a decimal `(51,44814 vs 51.44814)`.
5. Switch to sample 24 (CESI sample), which has the new flag set to `true`.
6. Set the app language to French.
7. Add the same [French CESI layer](https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/ICDE/MapServer/24).
8. Now inspect the data in the details and grid fixtures. The latitude and longitude should be appearing with a decimal point and not a comma.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2126)
<!-- Reviewable:end -->
