### PR TITLE
Added class for grid clear all button

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -139,7 +139,7 @@
                     <!-- clear all filters -->
                     <button
                         type="button"
-                        class="p-4 h-40 text-gray-500 hover:text-black"
+                        class="grid-clearall p-4 h-40 text-gray-500 hover:text-black"
                         @click="clearSearchAndFilters()"
                         :content="t('grid.clearAll')"
                         :aria-label="t('grid.clearAll')"


### PR DESCRIPTION
### Related Item(s)
#1959 

### Changes
- Added the class `grid-clearall` to the clear-all button to simplify accessing it via CSS selectors
- The [issue](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1959) mentions using an id instead with the RAMP id appended to account for pages with multiple RAMP instances, however RAMP4 does not have an instance or RAMP id so a class was added instead. 

### Notes
The class appears in the DOM for the clear-all button:
![grid_clearall](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/940c061b-785d-4c8e-b758-1410bf81ef39)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2128)
<!-- Reviewable:end -->
