### PR TITLE
Info notification symbol and wizard step 2 text

### DIFF
--- a/src/components/notification-center/notification-item.vue
+++ b/src/components/notification-center/notification-item.vue
@@ -84,7 +84,7 @@ const props = defineProps({
 const open = ref(false);
 const icons = reactive({
     [NotificationType.WARNING]: '⚠',
-    [NotificationType.INFO]: '☑',
+    [NotificationType.INFO]: 'ℹ️',
     [NotificationType.ERROR]: '❌'
 });
 

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -47,7 +47,7 @@
                 <!-- Select format wizard step -->
                 <stepper-item
                     :title="t('wizard.format.title')"
-                    :summary="typeSelection"
+                    :summary="displayFormat"
                 >
                     <form name="format" @submit="onSelectContinue">
                         <!-- List of file/service types based on layer -->
@@ -122,6 +122,7 @@
                                     url ? (goNext = true) : (goNext = false);
                                     validation = false;
                                     wizardStore.goToStep(0);
+                                    displayFormat = '';
                                 }
                             "
                             :animation="true"
@@ -361,6 +362,8 @@ const layerReady = ref<Boolean>(false);
 const layerUploaded = ref<Boolean>(true);
 const layerName = ref<String>('');
 
+const displayFormat = ref<string>('');
+
 const selectedValues = ref<Array<string | number>>([]);
 
 // service layer formats
@@ -552,6 +555,14 @@ const onSelectContinue = async (event: any) => {
     failureError.value = false;
     validation.value = true;
 
+    displayFormat.value = isFileLayer()
+        ? (fileTypeOptions.find(
+              element => element.value === typeSelection.value
+          )?.label as string)
+        : (serviceTypeOptions.find(
+              element => element.value === typeSelection.value
+          )?.label as string);
+
     try {
         layerInfo.value = isFileLayer()
             ? ((await layerSource.value!.fetchFileInfo(
@@ -615,6 +626,7 @@ const onConfigureContinue = async (data: any) => {
     );
 
     selectedValues.value = [];
+    displayFormat.value = '';
 
     // config.url =
     //     'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign';


### PR DESCRIPTION
### Related Item(s)
#1663, #2105 

### Changes
- #1663: Display the blue square info icon (ℹ️) for the `info` notifications instead of the checkbox
- #2105: Display the user-friendly format of the layer type instead of the raw layer type

### Notes
#1663:
![info icon](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/00dfa4d7-9a9c-4042-bd28-292f74c74679)
#2105:
![wizard step 2](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/83516523/e95ef06f-5a7c-4aaa-8c3a-7faed9f59c80)

### Testing
#1663 Steps:
1. Open the Console in any sample.
2. Run this command 
```[1, 2, 3, 4].forEach(i => { debugInstance.notify.show('info', `Test message ${i}`) })```
3. Open the Notification Center and see the notifications of type `info`

#2105 Steps:
1. Open the Wizard in any sample.
2. Upload any layer in step 1 and select the respective layer format in step 2.
3. The layer format chosen in step 2 should be displayed in the collapsed view of step 2 once you've moved on to step 3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2139)
<!-- Reviewable:end -->
