### PR TITLE
Maptips and Draw Order (Respect Achieved)

### DIFF
--- a/demos/starter-scripts/cam.js
+++ b/demos/starter-scripts/cam.js
@@ -317,7 +317,12 @@ let config = {
                     },
                     mouseTolerance: 5,
                     identifyMode: 'hybrid',
-                    drawOrder: [{ field: 'Program_name', ascending: true }],
+                    drawOrder: [
+                        {
+                            arcade: "Decode(Left($feature.Icon,1),'M',1,'C',2,'P',3,'A',4,'O',5,6)",
+                            ascending: true
+                        }
+                    ],
                     state: {
                         opacity: 1,
                         visibility: true

--- a/docs/using-ramp4/layer-config.md
+++ b/docs/using-ramp4/layer-config.md
@@ -314,12 +314,13 @@ The object structure matches the ArcGIS Server [Renderer](https://developers.arc
 
 *array of objects*, only applies to layers that [have vector client data](#layer-abilities)
 
-Specifies the z-order of how graphics should be drawn on the map. While the array structure supports multiple fields, the current version of the ESRI API (`v4.24`) will only support one field. If missing, the default draw order will be used (usually Object ID, or an alternate primary index defined on the server).
+Specifies the z-order of how graphics should be drawn on the map. While the array structure supports multiple fields, the current version of the ESRI API (`v4.29`) will only support one field. If missing, the draw order will be the order that features are returned from the source.
 
-It is highly recommended to use a field with unique values to avoid current limitations in the ESRI clients ability to determine a top-most feature (will impact maptip accuracy)
+- `field`: string. The field name that contains the values to order by. Case sensitive. The field must have a numeric or date data type.
+- `arcade`: string. An [Arcade](https://developers.arcgis.com/javascript/latest/arcade/) expression that evaluates to a number or date. Draw order will be based on the expression result.
+- `ascending`: boolean. If `true`, smaller values will appear "on top" of larger values. `false` will produce the opposite order. Defaults to `true`.
 
-- `field`: string. The field name that contains the data to order by. Case sensitive.
-- `ascending`: boolean. If `true`, smaller values will appear "on top" of larger values. `false` will produce the opposite order.
+One of `field` or `arcade` must be specified, but not both.
 
 ```js
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
     "name": "ramp-pcar",
-    "version": "4.5.0",
+    "version": "4.6.0-beta",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-pcar",
-            "version": "4.5.0",
+            "version": "4.6.0-beta",
             "dependencies": {
-                "@arcgis/core": "4.26.5",
+                "@arcgis/core": "4.29.10",
                 "@popperjs/core": "^2.11.6",
                 "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect",
                 "@tailwindcss/line-clamp": "^0.4.4",
@@ -266,18 +266,24 @@
             }
         },
         "node_modules/@arcgis/core": {
-            "version": "4.26.5",
-            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.26.5.tgz",
-            "integrity": "sha512-Z8KoJrTD1ZQwVVZAIpkdjAQVT/MjAaWAr5u0krifKd6Y1m0TrEb8/iK86KvyWX8yNNWEroEP9SiE19vH/JKquQ==",
+            "version": "4.29.10",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.10.tgz",
+            "integrity": "sha512-EMJOJkeXG7sYeKLrjEWvF3cKWCFB4CFEjcsfRi0j9UlULv9NV9IarVryG1oLCg17CtEzcKjl7EZXiPnZsX5M2Q==",
             "dependencies": {
                 "@esri/arcgis-html-sanitizer": "~3.0.1",
                 "@esri/calcite-colors": "~6.1.0",
-                "@esri/calcite-components": "~1.0.7",
-                "@popperjs/core": "~2.11.6",
-                "focus-trap": "~7.2.0",
-                "luxon": "~3.2.1",
-                "sortablejs": "~1.15.0"
+                "@esri/calcite-components": "^2.4.0",
+                "@popperjs/core": "~2.11.8",
+                "@vaadin/grid": "~24.3.6",
+                "@zip.js/zip.js": "~2.7.34",
+                "luxon": "~3.4.4",
+                "sortablejs": "~1.15.2"
             }
+        },
+        "node_modules/@arcgis/core/node_modules/sortablejs": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
+            "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
         },
         "node_modules/@babel/code-frame": {
             "version": "7.18.6",
@@ -585,32 +591,43 @@
             "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
         },
         "node_modules/@esri/calcite-components": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.8.tgz",
-            "integrity": "sha512-aeBSZQdtv7CRGbcGZh49RT4Z481muFspnY+98X6RRnf8QHdjpwTk+JbyS1pLAvenyLqTV+Gwa/Q5BPhbsfLiRw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.6.0.tgz",
+            "integrity": "sha512-GbpascF/mI3TvC5EQejzMi8zDG/wv0pzGU5HzUsrzHqIkIwRruuIe7qdg/srjaEQkXwwpJKxfd8r5QaBXjlQWw==",
             "dependencies": {
-                "@floating-ui/dom": "1.2.1",
-                "@stencil/core": "2.20.0",
-                "@types/color": "3.0.3",
+                "@floating-ui/dom": "1.6.3",
+                "@stencil/core": "4.9.0",
+                "@types/color": "3.0.6",
                 "color": "4.2.3",
-                "focus-trap": "7.2.0",
-                "form-request-submit-polyfill": "2.0.0",
+                "composed-offset-position": "0.0.4",
+                "dayjs": "1.11.10",
+                "focus-trap": "7.5.4",
                 "lodash-es": "4.17.21",
-                "sortablejs": "1.15.0"
+                "sortablejs": "1.15.1",
+                "timezone-groups": "0.8.0"
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
-            "integrity": "sha512-qrcbyfnRVziRlB6IYwjCopYhO7Vud750JlJyuljruIXcPxr22y8zdckcJGsuOdnQ639uVD1tTXddrcH3t3QYIQ=="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+            "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.1"
+            }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
-            "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+            "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
             "dependencies": {
-                "@floating-ui/core": "^1.2.1"
+                "@floating-ui/core": "^1.0.0",
+                "@floating-ui/utils": "^0.2.0"
             }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+            "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
         },
         "node_modules/@hapi/hoek": {
             "version": "9.2.1",
@@ -735,6 +752,19 @@
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
             "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+        },
+        "node_modules/@lit-labs/ssr-dom-shim": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+            "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+        },
+        "node_modules/@lit/reactive-element": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+            "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0"
+            }
         },
         "node_modules/@mapbox/node-pre-gyp": {
             "version": "1.0.10",
@@ -991,10 +1021,23 @@
                 "@octokit/openapi-types": "^16.0.0"
             }
         },
+        "node_modules/@open-wc/dedupe-mixin": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+            "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+        },
+        "node_modules/@polymer/polymer": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
+            "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
+            "dependencies": {
+                "@webcomponents/shadycss": "^1.9.1"
+            }
+        },
         "node_modules/@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -1036,15 +1079,15 @@
             "dev": true
         },
         "node_modules/@stencil/core": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
-            "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.0.tgz",
+            "integrity": "sha512-aWSkhBmk3yPwRAkUwBbzRwmdhb8hKiQ/JMr9m5jthpBZLjtppYbzz6PN2MhSMDfRp6K93eQw5WogSEH4HHuB6w==",
             "bin": {
                 "stencil": "bin/stencil"
             },
             "engines": {
-                "node": ">=12.10.0",
-                "npm": ">=6.0.0"
+                "node": ">=16.0.0",
+                "npm": ">=7.10.0"
             }
         },
         "node_modules/@tailwindcss/forms": {
@@ -1089,25 +1132,25 @@
             "dev": true
         },
         "node_modules/@types/color": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
-            "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.6.tgz",
+            "integrity": "sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==",
             "dependencies": {
                 "@types/color-convert": "*"
             }
         },
         "node_modules/@types/color-convert": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
-            "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
+            "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
             "dependencies": {
                 "@types/color-name": "*"
             }
         },
         "node_modules/@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-87W6MJCKZYDhLAx/J1ikW8niMvmGRyY+rpUxWpL1cO7F8Uu5CHuQoFv+R0/L5pgNdW4jTyda42kv60uwVIPjLw=="
         },
         "node_modules/@types/debounce": {
             "version": "1.2.1",
@@ -1237,6 +1280,11 @@
             "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-2.1.0.tgz",
             "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
             "dev": true
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "node_modules/@types/web-bluetooth": {
             "version": "0.0.17",
@@ -1451,6 +1499,172 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@vaadin/a11y-base": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.8.tgz",
+            "integrity": "sha512-BCbPcsFmXWf47JFpkeoLBK+eRSR8CwVLoWdre/z/yNTpW0sKChBi8fUbW5HU2mN021rDobAShyu+ZZ6Hwd0cLw==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/checkbox": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.8.tgz",
+            "integrity": "sha512-13ViRjxf7pho6DbC2cReDwG4XuDlhr5WY6N8diB5lj3b/aXr/hzVltxEFd98HVGkX5st4Qo/ERkyq6FUUrmRKA==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/field-base": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/component-base": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.8.tgz",
+            "integrity": "sha512-uHXZ/6CwdWzsu0V+SqZC6oKvHVhHaY7hAgjjOzgp+x4BQ/kkN+1Uj/09KYqmM51EXODpYYY/EN16Ut9kd/BGtQ==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+                "@vaadin/vaadin-usage-statistics": "^2.1.0",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/field-base": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.8.tgz",
+            "integrity": "sha512-bRK0C4v2c+LTmFP2d9gh5VkKnYaAP3FRy2ze4Dw58Hi2twagw2eanUX1AeVpU6pamA7zeDcbJwdgGO1/VdiRLA==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/grid": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.8.tgz",
+            "integrity": "sha512-rhux0J47TH98dgB9r1hIhVtq1418g17yByND1Ua0ss2KnIdAmRjlM98B2ALlfeV4Jse4iYpxe7aglO+48pPY3A==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/checkbox": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/lit-renderer": "~24.3.8",
+                "@vaadin/text-field": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8"
+            }
+        },
+        "node_modules/@vaadin/icon": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.8.tgz",
+            "integrity": "sha512-KDz0qxS/nNiT8UpR7WRXEy21lPhn4fNyk7BpLuwLK0oZG1ULHqmuoYVYpOVhKlEcxpOlaNxK6bfcJ+pupDvWVA==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/input-container": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.8.tgz",
+            "integrity": "sha512-tidh+7ITtPvnGrpdJj5eUmlRqRwXFSW8JfQs2gT9FRTb+FMGAUBHm4v8qAthL0D1ctnanK8QNSAZJlZWNXU5+w==",
+            "dependencies": {
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/lit-renderer": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.8.tgz",
+            "integrity": "sha512-qERkHUidtciNNOpHTIaKvakXPd3KLpWH0iyn/JKo9VRxn7Cm2fqjSgtlgENykRyVoNzKCRj/NH9BrO8xmfCqtw==",
+            "dependencies": {
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/text-field": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.8.tgz",
+            "integrity": "sha512-8/4UWFziL5frN9jsposZDq0pbHK/RwYmGdOTrUyBzE/oS/JSsLNAbI9/+aEVDTKbPvQ1rc/5r7fIA5LXV+acJQ==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/field-base": "~24.3.8",
+                "@vaadin/input-container": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/vaadin-development-mode-detector": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.6.tgz",
+            "integrity": "sha512-N6a5nLT/ytEUlpPo+nvdCKIGoyNjPsj3rzPGvGYK8x9Ceg76OTe1xI/GtN71mRW9e2HUScR0kCNOkl1Z63YDjw=="
+        },
+        "node_modules/@vaadin/vaadin-lumo-styles": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.8.tgz",
+            "integrity": "sha512-AuaGJ/Pjxy4F0s+t66O3YsvaqwPHeYRP+ajp7UD7EIQ9m6zn1zON/aAXfI6y4krKdieAnWdaIhhimMWzQlKsUg==",
+            "dependencies": {
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/icon": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8"
+            }
+        },
+        "node_modules/@vaadin/vaadin-material-styles": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.8.tgz",
+            "integrity": "sha512-Ise2B2Xe/wCmIYrgTfPUvufDETMGbNOrgtxqoehqDm9hgQKQ/JfULPM+G1JFDNQnCSCANmtQ5lmKzcwSHEzD0g==",
+            "dependencies": {
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8"
+            }
+        },
+        "node_modules/@vaadin/vaadin-themable-mixin": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.8.tgz",
+            "integrity": "sha512-q1jh0SqT7uNMiRnpJi8HrTEggx0DhoMZfuA8TcVCuiy3yh0xPD2GC+Uc6DViq4X2R/q+8YJLNnLvMntSPJPcmQ==",
+            "dependencies": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "lit": "^3.0.0"
+            }
+        },
+        "node_modules/@vaadin/vaadin-usage-statistics": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
+            "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
         "node_modules/@vitejs/plugin-vue": {
@@ -1894,6 +2108,21 @@
                 "@vue/composition-api": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@webcomponents/shadycss": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
+            "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
+        },
+        "node_modules/@zip.js/zip.js": {
+            "version": "2.7.40",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.40.tgz",
+            "integrity": "sha512-kSYwO0Wth6G66QM4CejZqG0nRhBsVVTaR18M/Ta8EcqcvaV0dYrnDDyKAstfy0V5+ejK4b9w5xc1W0ECATJTvA==",
+            "engines": {
+                "bun": ">=0.7.0",
+                "deno": ">=1.0.0",
+                "node": ">=16.5.0"
             }
         },
         "node_modules/abab": {
@@ -2851,6 +3080,11 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/composed-offset-position": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+            "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
+        },
         "node_modules/computeds": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
@@ -3169,10 +3403,9 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
-            "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==",
-            "dev": true
+            "version": "1.11.10",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+            "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
         },
         "node_modules/de-indent": {
             "version": "1.0.2",
@@ -4203,11 +4436,11 @@
             "dev": true
         },
         "node_modules/focus-trap": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
-            "integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+            "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
             "dependencies": {
-                "tabbable": "^6.0.1"
+                "tabbable": "^6.2.0"
             }
         },
         "node_modules/follow-redirects": {
@@ -4252,11 +4485,6 @@
             "engines": {
                 "node": ">= 0.12"
             }
-        },
-        "node_modules/form-request-submit-polyfill": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
-            "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
         },
         "node_modules/fraction.js": {
             "version": "4.2.0",
@@ -5284,6 +5512,34 @@
                 }
             }
         },
+        "node_modules/lit": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
+            "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+            "dependencies": {
+                "@lit/reactive-element": "^2.0.4",
+                "lit-element": "^4.0.4",
+                "lit-html": "^3.1.2"
+            }
+        },
+        "node_modules/lit-element": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
+            "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+            "dependencies": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0",
+                "@lit/reactive-element": "^2.0.4",
+                "lit-html": "^3.1.2"
+            }
+        },
+        "node_modules/lit-html": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
+            "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+            "dependencies": {
+                "@types/trusted-types": "^2.0.2"
+            }
+        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5406,9 +5662,9 @@
             "dev": true
         },
         "node_modules/luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+            "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
             "engines": {
                 "node": ">=12"
             }
@@ -7153,9 +7409,9 @@
             }
         },
         "node_modules/sortablejs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
+            "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -7536,9 +7792,9 @@
             "optional": true
         },
         "node_modules/tabbable": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
-            "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ=="
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
         },
         "node_modules/tailwindcss": {
             "version": "3.0.23",
@@ -7657,6 +7913,14 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true
+        },
+        "node_modules/timezone-groups": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
+            "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA==",
+            "bin": {
+                "timezone-groups": "dist/cli.cjs"
+            }
         },
         "node_modules/tiny-emitter": {
             "version": "2.1.0",
@@ -8067,15 +8331,6 @@
             },
             "bin": {
                 "vitepress": "bin/vitepress.js"
-            }
-        },
-        "node_modules/vitepress/node_modules/focus-trap": {
-            "version": "7.4.3",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-            "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
-            "dev": true,
-            "dependencies": {
-                "tabbable": "^6.1.2"
             }
         },
         "node_modules/vscode-oniguruma": {
@@ -8652,17 +8907,25 @@
             }
         },
         "@arcgis/core": {
-            "version": "4.26.5",
-            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.26.5.tgz",
-            "integrity": "sha512-Z8KoJrTD1ZQwVVZAIpkdjAQVT/MjAaWAr5u0krifKd6Y1m0TrEb8/iK86KvyWX8yNNWEroEP9SiE19vH/JKquQ==",
+            "version": "4.29.10",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.29.10.tgz",
+            "integrity": "sha512-EMJOJkeXG7sYeKLrjEWvF3cKWCFB4CFEjcsfRi0j9UlULv9NV9IarVryG1oLCg17CtEzcKjl7EZXiPnZsX5M2Q==",
             "requires": {
                 "@esri/arcgis-html-sanitizer": "~3.0.1",
                 "@esri/calcite-colors": "~6.1.0",
-                "@esri/calcite-components": "~1.0.7",
-                "@popperjs/core": "~2.11.6",
-                "focus-trap": "~7.2.0",
-                "luxon": "~3.2.1",
-                "sortablejs": "~1.15.0"
+                "@esri/calcite-components": "^2.4.0",
+                "@popperjs/core": "~2.11.8",
+                "@vaadin/grid": "~24.3.6",
+                "@zip.js/zip.js": "~2.7.34",
+                "luxon": "~3.4.4",
+                "sortablejs": "~1.15.2"
+            },
+            "dependencies": {
+                "sortablejs": {
+                    "version": "1.15.2",
+                    "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
+                    "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
+                }
             }
         },
         "@babel/code-frame": {
@@ -8889,32 +9152,43 @@
             "integrity": "sha512-wHQYWFtDa6c328EraXEVZvgOiaQyYr0yuaaZ0G3cB4C3lSkWefW34L/e5TLAhtuG3zJ/wR6pl5X1YYNfBc0/4Q=="
         },
         "@esri/calcite-components": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-1.0.8.tgz",
-            "integrity": "sha512-aeBSZQdtv7CRGbcGZh49RT4Z481muFspnY+98X6RRnf8QHdjpwTk+JbyS1pLAvenyLqTV+Gwa/Q5BPhbsfLiRw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/@esri/calcite-components/-/calcite-components-2.6.0.tgz",
+            "integrity": "sha512-GbpascF/mI3TvC5EQejzMi8zDG/wv0pzGU5HzUsrzHqIkIwRruuIe7qdg/srjaEQkXwwpJKxfd8r5QaBXjlQWw==",
             "requires": {
-                "@floating-ui/dom": "1.2.1",
-                "@stencil/core": "2.20.0",
-                "@types/color": "3.0.3",
+                "@floating-ui/dom": "1.6.3",
+                "@stencil/core": "4.9.0",
+                "@types/color": "3.0.6",
                 "color": "4.2.3",
-                "focus-trap": "7.2.0",
-                "form-request-submit-polyfill": "2.0.0",
+                "composed-offset-position": "0.0.4",
+                "dayjs": "1.11.10",
+                "focus-trap": "7.5.4",
                 "lodash-es": "4.17.21",
-                "sortablejs": "1.15.0"
+                "sortablejs": "1.15.1",
+                "timezone-groups": "0.8.0"
             }
         },
         "@floating-ui/core": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
-            "integrity": "sha512-qrcbyfnRVziRlB6IYwjCopYhO7Vud750JlJyuljruIXcPxr22y8zdckcJGsuOdnQ639uVD1tTXddrcH3t3QYIQ=="
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
+            "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+            "requires": {
+                "@floating-ui/utils": "^0.2.1"
+            }
         },
         "@floating-ui/dom": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
-            "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
+            "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
             "requires": {
-                "@floating-ui/core": "^1.2.1"
+                "@floating-ui/core": "^1.0.0",
+                "@floating-ui/utils": "^0.2.0"
             }
+        },
+        "@floating-ui/utils": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
+            "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
         },
         "@hapi/hoek": {
             "version": "9.2.1",
@@ -9011,6 +9285,19 @@
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
             "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+        },
+        "@lit-labs/ssr-dom-shim": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.0.tgz",
+            "integrity": "sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g=="
+        },
+        "@lit/reactive-element": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+            "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+            "requires": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0"
+            }
         },
         "@mapbox/node-pre-gyp": {
             "version": "1.0.10",
@@ -9208,10 +9495,23 @@
                 "@octokit/openapi-types": "^16.0.0"
             }
         },
+        "@open-wc/dedupe-mixin": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+            "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+        },
+        "@polymer/polymer": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.5.1.tgz",
+            "integrity": "sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==",
+            "requires": {
+                "@webcomponents/shadycss": "^1.9.1"
+            }
+        },
         "@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw=="
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
         },
         "@ramp4-pcar4/vue3-treeselect": {
             "version": "git+ssh://git@github.com/ramp4-pcar4/vue3-treeselect.git#3dccc9e78dca3681289e7cff1cb94464c52443fa",
@@ -9246,9 +9546,9 @@
             "dev": true
         },
         "@stencil/core": {
-            "version": "2.20.0",
-            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.20.0.tgz",
-            "integrity": "sha512-ka+eOW+dNteXIfLCRipNbbAlBEQjqJ2fkx3fxzlKgnNHEQMdZiuIjlWt63KzvOJStNeuADdQXo89BB1dC2VRUw=="
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.0.tgz",
+            "integrity": "sha512-aWSkhBmk3yPwRAkUwBbzRwmdhb8hKiQ/JMr9m5jthpBZLjtppYbzz6PN2MhSMDfRp6K93eQw5WogSEH4HHuB6w=="
         },
         "@tailwindcss/forms": {
             "version": "0.5.3",
@@ -9284,25 +9584,25 @@
             "dev": true
         },
         "@types/color": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.3.tgz",
-            "integrity": "sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@types/color/-/color-3.0.6.tgz",
+            "integrity": "sha512-NMiNcZFRUAiUUCCf7zkAelY8eV3aKqfbzyFQlXpPIEeoNDbsEHGpb854V3gzTsGKYj830I5zPuOwU/TP5/cW6A==",
             "requires": {
                 "@types/color-convert": "*"
             }
         },
         "@types/color-convert": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.0.tgz",
-            "integrity": "sha512-m7GG7IKKGuJUXvkZ1qqG3ChccdIM/qBBo913z+Xft0nKCX4hAU/IxKwZBU4cpRZ7GS5kV4vOblUkILtSShCPXQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/color-convert/-/color-convert-2.0.3.tgz",
+            "integrity": "sha512-2Q6wzrNiuEvYxVQqhh7sXM2mhIhvZR/Paq4FdsQkOMgWsCIkKvSGj8Le1/XalulrmgOzPMqNa0ix+ePY4hTrfg==",
             "requires": {
                 "@types/color-name": "*"
             }
         },
         "@types/color-name": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-            "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-87W6MJCKZYDhLAx/J1ikW8niMvmGRyY+rpUxWpL1cO7F8Uu5CHuQoFv+R0/L5pgNdW4jTyda42kv60uwVIPjLw=="
         },
         "@types/debounce": {
             "version": "1.2.1",
@@ -9433,6 +9733,11 @@
             "integrity": "sha512-5eQEtSCoESnh2FsiLTxE121IiE60hnMqcb435fShf4bpLRjEu1Eoekht23y6zXS9Ts3l+Szu3TARnTsA0GkOkQ==",
             "dev": true
         },
+        "@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+        },
         "@types/web-bluetooth": {
             "version": "0.0.17",
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.17.tgz",
@@ -9557,6 +9862,168 @@
             "requires": {
                 "@typescript-eslint/types": "5.18.0",
                 "eslint-visitor-keys": "^3.0.0"
+            }
+        },
+        "@vaadin/a11y-base": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-24.3.8.tgz",
+            "integrity": "sha512-BCbPcsFmXWf47JFpkeoLBK+eRSR8CwVLoWdre/z/yNTpW0sKChBi8fUbW5HU2mN021rDobAShyu+ZZ6Hwd0cLw==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/checkbox": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-24.3.8.tgz",
+            "integrity": "sha512-13ViRjxf7pho6DbC2cReDwG4XuDlhr5WY6N8diB5lj3b/aXr/hzVltxEFd98HVGkX5st4Qo/ERkyq6FUUrmRKA==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/field-base": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/component-base": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-24.3.8.tgz",
+            "integrity": "sha512-uHXZ/6CwdWzsu0V+SqZC6oKvHVhHaY7hAgjjOzgp+x4BQ/kkN+1Uj/09KYqmM51EXODpYYY/EN16Ut9kd/BGtQ==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+                "@vaadin/vaadin-usage-statistics": "^2.1.0",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/field-base": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-24.3.8.tgz",
+            "integrity": "sha512-bRK0C4v2c+LTmFP2d9gh5VkKnYaAP3FRy2ze4Dw58Hi2twagw2eanUX1AeVpU6pamA7zeDcbJwdgGO1/VdiRLA==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/grid": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-24.3.8.tgz",
+            "integrity": "sha512-rhux0J47TH98dgB9r1hIhVtq1418g17yByND1Ua0ss2KnIdAmRjlM98B2ALlfeV4Jse4iYpxe7aglO+48pPY3A==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/checkbox": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/lit-renderer": "~24.3.8",
+                "@vaadin/text-field": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8"
+            }
+        },
+        "@vaadin/icon": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/icon/-/icon-24.3.8.tgz",
+            "integrity": "sha512-KDz0qxS/nNiT8UpR7WRXEy21lPhn4fNyk7BpLuwLK0oZG1ULHqmuoYVYpOVhKlEcxpOlaNxK6bfcJ+pupDvWVA==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/input-container": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-24.3.8.tgz",
+            "integrity": "sha512-tidh+7ITtPvnGrpdJj5eUmlRqRwXFSW8JfQs2gT9FRTb+FMGAUBHm4v8qAthL0D1ctnanK8QNSAZJlZWNXU5+w==",
+            "requires": {
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/lit-renderer": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-24.3.8.tgz",
+            "integrity": "sha512-qERkHUidtciNNOpHTIaKvakXPd3KLpWH0iyn/JKo9VRxn7Cm2fqjSgtlgENykRyVoNzKCRj/NH9BrO8xmfCqtw==",
+            "requires": {
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/text-field": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-24.3.8.tgz",
+            "integrity": "sha512-8/4UWFziL5frN9jsposZDq0pbHK/RwYmGdOTrUyBzE/oS/JSsLNAbI9/+aEVDTKbPvQ1rc/5r7fIA5LXV+acJQ==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/a11y-base": "~24.3.8",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/field-base": "~24.3.8",
+                "@vaadin/input-container": "~24.3.8",
+                "@vaadin/vaadin-lumo-styles": "~24.3.8",
+                "@vaadin/vaadin-material-styles": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/vaadin-development-mode-detector": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.6.tgz",
+            "integrity": "sha512-N6a5nLT/ytEUlpPo+nvdCKIGoyNjPsj3rzPGvGYK8x9Ceg76OTe1xI/GtN71mRW9e2HUScR0kCNOkl1Z63YDjw=="
+        },
+        "@vaadin/vaadin-lumo-styles": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-24.3.8.tgz",
+            "integrity": "sha512-AuaGJ/Pjxy4F0s+t66O3YsvaqwPHeYRP+ajp7UD7EIQ9m6zn1zON/aAXfI6y4krKdieAnWdaIhhimMWzQlKsUg==",
+            "requires": {
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/icon": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8"
+            }
+        },
+        "@vaadin/vaadin-material-styles": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-24.3.8.tgz",
+            "integrity": "sha512-Ise2B2Xe/wCmIYrgTfPUvufDETMGbNOrgtxqoehqDm9hgQKQ/JfULPM+G1JFDNQnCSCANmtQ5lmKzcwSHEzD0g==",
+            "requires": {
+                "@polymer/polymer": "^3.0.0",
+                "@vaadin/component-base": "~24.3.8",
+                "@vaadin/vaadin-themable-mixin": "~24.3.8"
+            }
+        },
+        "@vaadin/vaadin-themable-mixin": {
+            "version": "24.3.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-24.3.8.tgz",
+            "integrity": "sha512-q1jh0SqT7uNMiRnpJi8HrTEggx0DhoMZfuA8TcVCuiy3yh0xPD2GC+Uc6DViq4X2R/q+8YJLNnLvMntSPJPcmQ==",
+            "requires": {
+                "@open-wc/dedupe-mixin": "^1.3.0",
+                "lit": "^3.0.0"
+            }
+        },
+        "@vaadin/vaadin-usage-statistics": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
+            "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+            "requires": {
+                "@vaadin/vaadin-development-mode-detector": "^2.0.0"
             }
         },
         "@vitejs/plugin-vue": {
@@ -9839,6 +10306,16 @@
                     "requires": {}
                 }
             }
+        },
+        "@webcomponents/shadycss": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
+            "integrity": "sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw=="
+        },
+        "@zip.js/zip.js": {
+            "version": "2.7.40",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.40.tgz",
+            "integrity": "sha512-kSYwO0Wth6G66QM4CejZqG0nRhBsVVTaR18M/Ta8EcqcvaV0dYrnDDyKAstfy0V5+ejK4b9w5xc1W0ECATJTvA=="
         },
         "abab": {
             "version": "2.0.6",
@@ -10531,6 +11008,11 @@
             "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
             "dev": true
         },
+        "composed-offset-position": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+            "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
+        },
         "computeds": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
@@ -10796,10 +11278,9 @@
             }
         },
         "dayjs": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
-            "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug==",
-            "dev": true
+            "version": "1.11.10",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+            "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
         },
         "de-indent": {
             "version": "1.0.2",
@@ -11572,11 +12053,11 @@
             "dev": true
         },
         "focus-trap": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.2.0.tgz",
-            "integrity": "sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+            "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
             "requires": {
-                "tabbable": "^6.0.1"
+                "tabbable": "^6.2.0"
             }
         },
         "follow-redirects": {
@@ -11601,11 +12082,6 @@
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
-        },
-        "form-request-submit-polyfill": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/form-request-submit-polyfill/-/form-request-submit-polyfill-2.0.0.tgz",
-            "integrity": "sha512-p0+M92y2gFnP0AuuL8VJ0GYVzAT0bYp3GsSkmPFhvUopdnfDLP/9xplQTBBc4w8qOjKRzdK7GaFcdL9IhlXdTQ=="
         },
         "fraction.js": {
             "version": "4.2.0",
@@ -12404,6 +12880,34 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
+        "lit": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.2.tgz",
+            "integrity": "sha512-VZx5iAyMtX7CV4K8iTLdCkMaYZ7ipjJZ0JcSdJ0zIdGxxyurjIn7yuuSxNBD7QmjvcNJwr0JS4cAdAtsy7gZ6w==",
+            "requires": {
+                "@lit/reactive-element": "^2.0.4",
+                "lit-element": "^4.0.4",
+                "lit-html": "^3.1.2"
+            }
+        },
+        "lit-element": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.4.tgz",
+            "integrity": "sha512-98CvgulX6eCPs6TyAIQoJZBCQPo80rgXR+dVBs61cstJXqtI+USQZAbA4gFHh6L/mxBx9MrgPLHLsUgDUHAcCQ==",
+            "requires": {
+                "@lit-labs/ssr-dom-shim": "^1.2.0",
+                "@lit/reactive-element": "^2.0.4",
+                "lit-html": "^3.1.2"
+            }
+        },
+        "lit-html": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.2.tgz",
+            "integrity": "sha512-3OBZSUrPnAHoKJ9AMjRL/m01YJxQMf+TMHanNtTHG68ubjnZxK0RFl102DPzsw4mWnHibfZIBJm3LWCZ/LmMvg==",
+            "requires": {
+                "@types/trusted-types": "^2.0.2"
+            }
+        },
         "locate-path": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -12501,9 +13005,9 @@
             "dev": true
         },
         "luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+            "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
         },
         "magic-string": {
             "version": "0.30.0",
@@ -13730,9 +14234,9 @@
             }
         },
         "sortablejs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.1.tgz",
+            "integrity": "sha512-P5Cjvb0UG1ZVNiDPj/n4V+DinttXG6K8n7vM/HQf0C25K3YKQTQY6fsr/sEGsJGpQ9exmPxluHxKBc0mLKU1lQ=="
         },
         "source-map": {
             "version": "0.6.1",
@@ -14024,9 +14528,9 @@
             "optional": true
         },
         "tabbable": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.2.tgz",
-            "integrity": "sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ=="
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
         },
         "tailwindcss": {
             "version": "3.0.23",
@@ -14122,6 +14626,11 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true
+        },
+        "timezone-groups": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/timezone-groups/-/timezone-groups-0.8.0.tgz",
+            "integrity": "sha512-t7E/9sPfCU0m0ZbS7Cqw52D6CB/UyeaiIBmyJCokI1SyOyOgA/ESiQ/fbreeFaUG9QSenGlZSSk/7rEbkipbOA=="
         },
         "tiny-emitter": {
             "version": "2.1.0",
@@ -14409,17 +14918,6 @@
                 "shiki": "^0.14.2",
                 "vite": "^4.3.9",
                 "vue": "^3.3.4"
-            },
-            "dependencies": {
-                "focus-trap": {
-                    "version": "7.4.3",
-                    "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
-                    "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
-                    "dev": true,
-                    "requires": {
-                        "tabbable": "^6.1.2"
-                    }
-                }
             }
         },
         "vscode-oniguruma": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ramp-pcar",
-    "version": "4.5.0",
+    "version": "4.6.0-beta",
     "description": "RAMP4 - The Reusable Accessible Mapping Platform, is a Javascript based web mapping platform that provides a reusable, responsive and WCAG 2.1 AA compliant common viewer for the Government of Canada. ",
     "type": "module",
     "module": "./dist/lib/ramp.bundle.es.js",
@@ -35,7 +35,7 @@
         "vite-docs:generate": "npx vitepress build docs"
     },
     "dependencies": {
-        "@arcgis/core": "4.26.5",
+        "@arcgis/core": "4.29.10",
         "@popperjs/core": "^2.11.6",
         "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect",
         "@tailwindcss/line-clamp": "^0.4.4",

--- a/schema.json
+++ b/schema.json
@@ -742,22 +742,26 @@
         },
         "drawOrder": {
             "type": "array",
-            "description": "Attribute fields used to control drawing order on the map for vector features. Note ESRI currently only supports one field.",
+            "description": "Specification of the map drawing order for vector features. A value for the field or arcade property must be provided. Note ESRI currently only supports one definition.",
             "items": {
                 "type": "object",
                 "description": "Draw order for one attribute field.",
                 "properties": {
                     "field": {
                         "type": "string",
-                        "description": "Layer field name contianing the value to order by."
+                        "description": "Layer field name contianing the value to order by. Must be numeric or date field."
+                    },
+                    "arcade": {
+                        "type": "string",
+                        "description": "An Arcade function to derive an ordering value. Must return a numeric or date value."
                     },
                     "ascending": {
                         "type": "boolean",
-                        "description": "Direction to order in. True means smaller values are on top of larger values. False is the opposite."
+                        "description": "Direction to order in. True means smaller values are on top of larger values. False is the opposite.",
+                        "default": true
                     }
                 },
-                "additionalProperties": false,
-                "required": ["field", "ascending"]
+                "additionalProperties": false
             }
         },
         "basicLayer": {

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -287,7 +287,8 @@ export const enum DrawState {
 }
 
 export interface DrawOrder {
-    field: string;
+    field?: string;
+    arcade?: string;
     ascending: boolean; // true means smaller values are drawn ON TOP of larger values. false is the opposite
 }
 

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -177,21 +177,8 @@ export class FileLayer extends AttribLayer {
 
         delete esriConfig.url;
 
-        if (
-            Array.isArray(rampLayerConfig.drawOrder) &&
-            rampLayerConfig.drawOrder.length > 0
-        ) {
-            // Note esri currently only supports one field, but coding to support multiple when they
-            //      enhance the api to handle that.
-            esriConfig.orderBy = rampLayerConfig.drawOrder.map(dr => ({
-                field: dr.field,
-                order: dr.ascending ? 'ascending' : 'descending'
-            }));
-            this._drawOrder = rampLayerConfig.drawOrder.slice();
-        } else {
-            esriConfig.orderBy = [{ field: oidField, order: 'descending' }];
-            this._drawOrder = [{ field: oidField, ascending: false }];
-        }
+        // process any order-by configuration
+        this.configDrawOrder(rampLayerConfig, esriConfig);
 
         return esriConfig;
     }

--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -440,7 +440,7 @@ export class MapLayer extends CommonLayer {
     }
 
     /**
-     * Returns an array describing the draw order of features. Raster layers will have empty arrays
+     * Returns an array describing the draw order of features, if applicable.
      */
     get drawOrder(): Array<DrawOrder> {
         return this._drawOrder;


### PR DESCRIPTION
### Related Item(s)

#2151 , #2152

### Changes
- Updates ESRI API to `v4.29`
- Maptips will now accurately show top-most feature if draw order is non-deterministic
- Removes all the hackery introduced in #1264 
- Adds support for Arcade expressions for use in configuring layer draw order
  - I couldn't find a nice way to encode the "one of these fields is required" rule in the schema without duplicating the definition via a `oneOf`. Comment if you have clever solution.


### Testing

General maptip stuff: Easiest way is to zoom in close so you can see the name of distinct features. Then zoom out until they overlap and validate the name matches what is drawn on top.

![zoomers](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/7585245/4efe98fd-9860-4680-8d34-964815f6d946)

Reminders:

- ESRI's edge detection on symbols is not pixel perfect. When mousing from one overlapped feature to another, sometimes you need to get two or three pixels into the next one for it to recognize the exit.
- Raster layers can obscure vector features and the maptip will still fire through. https://github.com/ramp4-pcar4/ramp4-pcar4/issues/800

Arcade Fun:
Sample 23 (CAM).
🚨  DON'T DO IDENTIFY CLICKS IN THE HEAVILY POPULATED AREAS (#2156) 🚨 

The draw order on this sample should now be by symbol colour. From top to bottom we should see
1. Green (Globes 🌍 )
2. Black (Bus 🚍 )
3. Yellow (Lightbulbs 💡 )
4. Blue (Train Tunnel? 🛤️ )
5. Purple (Talkin Bubble 💬 )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2157)
<!-- Reviewable:end -->
