### PR TITLE
File Layer Icon & Attribute Performance

### DIFF
--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -415,6 +415,7 @@ export interface DiscreteGraphicResult {
 export interface QueryFeaturesParams {
     filterGeometry?: BaseGeometry; // filter by geometry
     filterSql?: string; // filter by sql query
+    filterOIDs?: Array<number>; // filtering against object ids
     includeGeometry?: boolean; // if geometry should be included in the result
     sourceSR?: SpatialReference; // the spatial reference of the web service. providing helps avoid some reprojection issues
 }

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -19,16 +19,17 @@ import {
     DefPromise,
     Extent,
     GeometryType,
+    Graphic,
     IdentifyResultFormat,
     LayerFormat,
     LayerIdentifyMode,
+    NoGeometry,
     Point
 } from '@/geo/api';
 
 import type {
     GeoJsonOptions,
     GetGraphicParams,
-    Graphic,
     IdentifyItem,
     IdentifyParameters,
     IdentifyResult,
@@ -42,6 +43,7 @@ import {
     EsriField,
     EsriRendererFromJson
 } from '@/geo/esri';
+
 import { markRaw, reactive, toRaw } from 'vue';
 
 /**
@@ -442,26 +444,44 @@ export class FileLayer extends AttribLayer {
         objectId: number,
         opts: GetGraphicParams
     ): Promise<Graphic> {
-        const gjOpt: QueryFeaturesParams = {
-            filterSql: `${this.oidField}=${objectId}`,
-            includeGeometry: !!opts.getGeom
-        };
+        let resGraphic: Graphic;
 
-        // TODO not sure how much we care about this. since local, result will always have attribs and geom,
-        //      regardless of what requester asked for.
-        //      if thats a problem, add some logic to pare off properties of the result (might need to clone
-        //      to avoid breaking original source in the layer)
+        if (!opts.getGeom && this.attribs.attLoader.isLoaded()) {
+            // we don't need geometry, and the attribute cache exists.
+            // much faster to use it for lookup (as it it keyed on OID)
 
-        const resultArr = await this.queryFeatures(gjOpt);
-        if (resultArr.length === 0) {
-            throw new Error(`Could not find object id ${objectId}`);
-        } else if (resultArr.length !== 1) {
-            console.warn(
-                'did not get a single result on a query for a specific object id'
+            const atSet = await this.attribs.attLoader.getAttribs();
+
+            resGraphic = new Graphic(
+                new NoGeometry(),
+                '',
+                atSet.features[atSet.oidIndex[objectId]]
             );
-        }
+        } else {
+            // use query against layer innards.
+            // performance is significantly worse.
 
-        const resGraphic = resultArr[0];
+            const gjOpt: QueryFeaturesParams = {
+                filterOIDs: [objectId],
+                includeGeometry: !!opts.getGeom
+            };
+
+            // TODO not sure how much we care about this. since local, result will always have attribs and geom,
+            //      regardless of what requester asked for.
+            //      if thats a problem, add some logic to pare off properties of the result (might need to clone
+            //      to avoid breaking original source in the layer)
+
+            const resultArr = await this.queryFeatures(gjOpt);
+            if (resultArr.length === 0) {
+                throw new Error(`Could not find object id ${objectId}`);
+            } else if (resultArr.length !== 1) {
+                console.warn(
+                    'did not get a single result on a query for a specific object id'
+                );
+            }
+
+            resGraphic = resultArr[0];
+        }
 
         if (opts.getStyle) {
             const esriSymb = toRaw(
@@ -477,6 +497,7 @@ export class FileLayer extends AttribLayer {
      * Requests a set of features for this layer that match the criteria of the options
      * - filterGeometry : a RAMP API geometry to restrict results to
      * - filterSql : a where clause to apply against feature attributes
+     * - filterOIDs : an array of Object IDs to filter against (more performant than SQL)
      * - includeGeometry : a boolean to indicate if result features should include the geometry
      * - outFields : a string of comma separated field names. will restrict fields included in the output
      * - sourceSR : a spatial reference indicating what the source layer is encoded in. providing can assist in result geometry being of a proper resolution

--- a/src/geo/utils/query.ts
+++ b/src/geo/utils/query.ts
@@ -83,6 +83,10 @@ export class QueryAPI extends APIScope {
             query.where = options.filterSql;
         }
 
+        if (options.filterOIDs) {
+            query.objectIds = options.filterOIDs;
+        }
+
         await options.layer.loadPromise();
 
         if (!options.layer.esriLayer) {


### PR DESCRIPTION
### Related Item(s)

#2164


### Changes

Utilizes attribute cache in File Layers when requesting individual attributes or symbol icons.
Utilizes more performant ESRI query parameter when attribute cache doesn't exist or geometry is required.

### Testing

Steps:
1. Open a sample
2. Download test file found here: https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2164#issuecomment-2025428403
3. Open wizard and add that test file (Zipped Shapefile)
4. Wait a few seconds as it has to grind out a mountain of points. Should see USA covered in dots.
5. Click in the USA, verify symbols appear in identify results (check both detail view and the result list for the layer). Doing this before opening the grid tests the updated fallback logic performance boost (won't notice speed but proves it still works).
6. Open data grid on new layer once it loads.
7. Symbols should render in the grid in reasonable time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2165)
<!-- Reviewable:end -->
