### PR TITLE
Fix export from failing to load when receiving value from fixture config

### DIFF
--- a/src/fixtures/export-footnote/index.ts
+++ b/src/fixtures/export-footnote/index.ts
@@ -27,7 +27,7 @@ class ExportFootnoteFixture
             top: 0
         };
 
-        if (footnoteFixtureConfig) {
+        if (footnoteFixtureConfig?.value !== undefined) {
             fabricTextConfig.text = footnoteFixtureConfig.value;
         }
 

--- a/src/fixtures/export-timestamp/index.ts
+++ b/src/fixtures/export-timestamp/index.ts
@@ -29,7 +29,7 @@ class ExportTimestampFixture
             originX: 'left'
         };
 
-        if (timestampFixtureConfig) {
+        if (timestampFixtureConfig?.value !== undefined) {
             fabricTextConfig.text = timestampFixtureConfig.value;
         }
 

--- a/src/fixtures/export-title/index.ts
+++ b/src/fixtures/export-title/index.ts
@@ -27,7 +27,7 @@ class ExportTitleFixture extends FixtureInstance implements ExportSubFixture {
             originY: 'top'
         };
 
-        if (titleFixtureConfig) {
+        if (titleFixtureConfig?.value !== undefined) {
             fabricTextConfig.text = titleFixtureConfig.value;
         }
 


### PR DESCRIPTION
### Related Item(s)
#2171 

### Changes
- [FIX] Sub fixtures will no longer assign an undefined value when loading from the fixture config.

### Notes
Temporarily added a new sample. I'll remove it before this PR is merged.

### Testing
Steps:
1. Open sample 45 (needs VPN)
2. Open the export
3. Notice the custom title, timestamp and footnote
4. Flip the app into Francais mode
5. Notice the defined empty title & footnote, along with current timestamp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2172)
<!-- Reviewable:end -->
