### PR TITLE
File Layer Load Perf

### DIFF
--- a/docs/using-ramp4/layer-config.md
+++ b/docs/using-ramp4/layer-config.md
@@ -269,7 +269,13 @@ Defines the desired state of the layer at load time.
 
 *boolean*, only applies to file based layers that have the [rawData](#rawdata) property set
 
-Specifies if a layers raw data should be preserved after the layer is created. This type of layer does not have a server-based source to ask for the data again, so enabling caching will allow for reloads to occur. It will however double the memory footprint of the layer. If missing, defaults to `false`.
+Specifies if a layers raw data should be preserved on the config object after the layer is created. Using this will double the memory footprint of the layer. 
+
+If missing, defaults to `false`.
+
+A scenario where this can be useful is a host page containing a collection of layer configuration objects and controls to allow users to add and remove these layer at whim. Without caching, the `rawData` will get erased after a first add and thus fail if removed and added again.
+
+Enabling caching will allow for layer reloads to occur. In most scenarios there is no reason to reload this type of layer (the data is static, and any load errors will typically recur on reload).
 
 ### colour
 
@@ -517,6 +523,8 @@ To align a legend symbol stack with a particular permanent filter, see the `symb
 *string | object | ArrayBuffer*, only applies to file based layers (including Data layers in file formats)
 
 Specifies the file contents on the config. If provided, the `url` property will be ignored.
+
+For memory considerations, this property will be deleted from the configuration object after the layer loads. If it needs to be preserved, enable the [caching](#caching) configuration.
 
 - `file-geojson`: The value can be a GeoJSON object, or a string containing the stringified GeoJSON object.
 - `file-csv`: The value is the file content contained in a string, encoded in UTF-8.

--- a/schema.json
+++ b/schema.json
@@ -1451,6 +1451,11 @@
                     "type": "object",
                     "description": "Optional content to use as the layer source (instead of loading via the url property). Date Json accepts json object or stringified object. Table will ignore.",
                     "additionalProperties": true
+                },
+                "caching": {
+                    "type": "boolean",
+                    "description": "Indicates whether to preserve the layer's raw data after initiation.",
+                    "default": "false"
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -1570,11 +1575,6 @@
                 "drawOrder": {
                     "$ref": "#/$defs/drawOrder",
                     "default": []
-                },
-                "caching": {
-                    "type": "boolean",
-                    "description": "Indicates whether to preserve the layer's raw data after initiation. If set to true, reloading will not refresh data from the server.",
-                    "default": "false"
                 },
                 "identifyMode": {
                     "type": "string",

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -220,6 +220,11 @@ export const enum GeoJsonGeomType {
     MULTIPOLYGON = 'MultiPolygon'
 }
 
+export interface GeoJsonField {
+    name: string;
+    type: string;
+}
+
 // pending https://github.com/ramp4-pcar4/ramp4-pcar4/issues/130
 // commenting out to avoid any undecided constants being exposed
 

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -55,7 +55,7 @@ export class FileLayer extends AttribLayer {
 
     // temporarily stores GeoJSON. acts as a nice way for subclasses to parse their random sources to GeoJSON, drop it here,
     // and have the generic initiation code in this file just grab it.
-    protected sourceGeoJson: string | object | undefined;
+    protected sourceGeoJson: object | undefined;
 
     tooltipField: string; // if we end up having more things that are shared with FeatureLayer, consider making a FeatureBaseLayer class for both to inherit from
 
@@ -91,15 +91,14 @@ export class FileLayer extends AttribLayer {
         // NOTE subclasses of FileLayer should do all their file data processing first,
         //      drop it in this.sourceGeoJson,
         //      then call super.onInitiate() as final step.
+        //      If the configuration uses rawData and caching, the subclass is responsible
+        //      for ensuring sourceGeoJson does not point to same object as rawData.
+        //      sourceGeoJson will get modified by this method, and rawData must remain
+        //      untouched when caching is on.
 
         if (!this.sourceGeoJson) {
-            throw new Error('File Layer is missing raw data.');
+            throw new Error('File Layer is missing source data.');
         }
-
-        const realJson: any =
-            typeof this.sourceGeoJson === 'string'
-                ? JSON.parse(this.sourceGeoJson)
-                : JSON.parse(JSON.stringify(this.sourceGeoJson)); // need a deep copy so that all the manipulation of realJson below does not affect sourceGeoJson
 
         // NOTE: we are not setting the source projection option. It will assume LatLong, or use projection
         //       contained in the geojson file. The option flag is only there in case other blocks of code
@@ -118,7 +117,7 @@ export class FileLayer extends AttribLayer {
         };
 
         this.esriJson = await this.$iApi.geo.layer.files.geoJsonToEsriJson(
-            realJson,
+            this.sourceGeoJson,
             opts
         );
 
@@ -127,7 +126,7 @@ export class FileLayer extends AttribLayer {
         );
 
         this.esriJson = undefined;
-        if (this.origRampConfig.caching !== true) {
+        if (!this.origRampConfig.caching) {
             delete this.origRampConfig.rawData;
         }
         delete this.sourceGeoJson;

--- a/src/geo/layer/geojson-layer.ts
+++ b/src/geo/layer/geojson-layer.ts
@@ -14,13 +14,12 @@ export class GeoJsonLayer extends FileLayer {
     protected async onInitiate(): Promise<void> {
         // get geojson from appropriate source and set to special property.
         // then initiate the FileLayer
-        if (
-            this.origRampConfig.rawData &&
-            (typeof this.origRampConfig.rawData === 'string' ||
-                this.origRampConfig.rawData instanceof Object)
-        ) {
-            // geojson has been passed in as static string or GeoJSON object
-            this.sourceGeoJson = this.origRampConfig.rawData;
+
+        if (this.origRampConfig.rawData) {
+            this.sourceGeoJson = this.$iApi.geo.layer.files.rawDataJsonParser(
+                this.origRampConfig.rawData,
+                this.origRampConfig.caching
+            );
         } else if (this.origRampConfig.url) {
             this.sourceGeoJson = await this.$iApi.geo.layer.files.fetchFileData(
                 this.origRampConfig.url,

--- a/src/geo/layer/json-data-layer.ts
+++ b/src/geo/layer/json-data-layer.ts
@@ -11,15 +11,15 @@ export class JsonDataLayer extends DataLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        // get geojson from appropriate source and set to special property.
+        // get json from appropriate source and set to special property.
         // then initiate the DataLayer to complete setup
-        if (
-            this.origRampConfig.rawData &&
-            (typeof this.origRampConfig.rawData === 'string' ||
-                this.origRampConfig.rawData instanceof Object)
-        ) {
-            // geojson has been passed in as static string or GeoJSON object
-            this.sourceJson = this.origRampConfig.rawData;
+        if (this.origRampConfig.rawData) {
+            // json has been passed in as static string or JSON object
+
+            this.sourceJson = this.$iApi.geo.layer.files.rawDataJsonParser(
+                this.origRampConfig.rawData,
+                this.origRampConfig.caching
+            );
         } else if (this.origRampConfig.url) {
             this.sourceJson = await this.$iApi.geo.layer.files.fetchFileData(
                 this.origRampConfig.url,

--- a/src/geo/layer/shapefile-layer.ts
+++ b/src/geo/layer/shapefile-layer.ts
@@ -15,13 +15,16 @@ export class ShapefileLayer extends FileLayer {
 
         if (
             this.origRampConfig.rawData &&
-            typeof this.origRampConfig.rawData === 'string'
+            this.origRampConfig.rawData instanceof ArrayBuffer
         ) {
             // shapefile data has been passed in as static data.
             // since shapefile is binary, you cannot drop this in a layer config file.
-            // I think what can happen is a wizard could read the file (via file picker)
-            // or some random api code could do pre-processing, and then drop it on the rawData
-            // parameter which allows this routine to consume it.
+            // The wizard does not use this route. It converts the zip to GeoJson ahead of time and
+            // writes the layer config as `file-geojson`.
+            // Only way this would be used is some other code (custom fixture or outside the instance)
+            // has the zipped shape as an array buffer and tacks it onto the layer config it creates
+            // during runtime.
+
             shapefileData = this.origRampConfig.rawData;
         } else if (this.origRampConfig.url) {
             shapefileData = await this.$iApi.geo.layer.files.fetchFileData(
@@ -30,7 +33,7 @@ export class ShapefileLayer extends FileLayer {
             );
         } else {
             throw new Error(
-                'shapefile file config contains no raw data or url'
+                'shapefile config contains no url or no/invalid raw data'
             );
         }
 

--- a/src/geo/layer/wfs-layer.ts
+++ b/src/geo/layer/wfs-layer.ts
@@ -18,17 +18,14 @@ export class WfsLayer extends FileLayer {
         // get start index and limit set on the url
         const { offset, limit } = wrapper.queryMap;
 
-        // fetch data from server only if it has not been cached
-        if (!this.sourceGeoJson) {
-            this.sourceGeoJson = await this.$iApi.geo.layer.ogc.loadWfsData(
-                this.config.url,
-                -1,
-                parseInt(offset) || 0,
-                parseInt(limit) || 1000,
-                undefined,
-                this.config.xyInAttribs
-            );
-        }
+        this.sourceGeoJson = await this.$iApi.geo.layer.ogc.loadWfsData(
+            this.config.url,
+            -1,
+            parseInt(offset) || 0,
+            parseInt(limit) || 1000,
+            undefined,
+            this.config.xyInAttribs
+        );
 
         // TODO error handling? set layer state to error if above call fails?
         await super.onInitiate();


### PR DESCRIPTION
### Related Item(s)

#2173

### Changes
- Removes redundant `JSON.parse(JSON.stringify())` from file loader
- Converts some `forEach()` loops to classic `for(;;)` loops
- Removes fancy geometry checker for faster plain geometry checker
- Adds info to the docsite for what `caching` is actually useful for, and impacts for both settings
- Fixes bug in Shapefile layer where loading via `rawData` was impossible
- Removes redundant caching checks on WFS layers
- Fixes broken caching on CustomJSON Data layers
- Adds some missing schema items

### Testing

In general, see if anything breaks when loading file layers.

Performance:

Can try the giant shapefile here https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2164#issuecomment-2025428403
May need to compare against this PR and `main` to see any differences. 
Note this PR doesn't have the grid symbol patch so opening the grid will still be very slow.

Caching:

Can do this test to see if `caching` is doing what it's supposed to do. This layer will add a single point near North Bay.

Caching off:

In console of any sample:

```
const funConf = {
    id: 'GeoJson',
    name: 'GeoJson',
    layerType: 'file-geojson',
    rawData: '{"type": "FeatureCollection","features": [{"type": "Feature","properties": {},"geometry": {"coordinates": [-79.361760,46.290297],"type": "Point"}}]}'
};
const funLay = debugInstance.geo.layer.createLayer(funConf);
debugInstance.geo.map.addLayer(funLay);
```

This will not add anything to the legend, but wait until point appears on map. Then type `funConf` in the console, and confirm the config object no longer has the `rawData` property.

Caching on:

Reload if you just ran the previous caching test.

In console of any sample:

```
const funConf = {
    id: 'GeoJson',
    name: 'GeoJson',
    layerType: 'file-geojson',
    rawData: '{"type": "FeatureCollection","features": [{"type": "Feature","properties": {},"geometry": {"coordinates": [-79.361760,46.290297],"type": "Point"}}]}',
    caching: true
};
const funLay = debugInstance.geo.layer.createLayer(funConf);
debugInstance.geo.map.addLayer(funLay);
```

Again, wait until point appears on map. Then type `funConf` in the console, and confirm the config object still has the `rawData` property.

Then type `funLay.reload()` and confirm nothing explodes / can still identify the point on the map. Will likely be too fast to see the flicker of the layer actually reloading.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2174)
<!-- Reviewable:end -->
