### PR TITLE
Extent Guard

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -20,6 +20,7 @@ let config = {
         'overviewmap',
         'scrollguard',
         'panguard',
+        'extentguard',
         'settings',
         'wizard',
         'export'
@@ -35,6 +36,15 @@ let config = {
                             xmin: -3681457,
                             ymax: 4482193,
                             ymin: -983440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        },
+                        maximum: {
+                            xmax: 3754208,
+                            xmin: -2556116,
+                            ymax: 4821223,
+                            ymin: -1131913,
                             spatialReference: {
                                 wkid: 3978
                             }
@@ -262,7 +272,7 @@ let config = {
                     id: 'AirEmissions_GHG',
                     name: 'Greenhouse gas emissions from large facilities',
                     layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Ammonia%20emissions%20by%20facility.xml'
                     },
@@ -313,7 +323,7 @@ let config = {
                     nameField: 'GridColumn1',
                     name: 'Sulphur oxide emissions by facility',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/18',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/18',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Sulphur%20oxide%20emissions%20by%20facility.xml'
                     },
@@ -348,7 +358,7 @@ let config = {
                     nameField: 'StationName',
                     name: 'Average fine particulate matter concentrations at monitoring stations',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/26',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/26',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Average%20ambient%20fine%20particulate%20matter%20concentrations%20at%20monitoring%20stations.xml'
                     },
@@ -379,7 +389,7 @@ let config = {
                     nameField: 'StationName',
                     name: 'Average sulphur dioxide concentrations at monitoring stations',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/28',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/28',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Average%20ambient%20sulphur%20dioxide%20concentrations%20at%20monitoring%20stations.xml'
                     },
@@ -410,7 +420,7 @@ let config = {
                     nameField: 'GridColumn1',
                     name: 'Cadmium emissions to air by facility',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/13',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/13',
                     state: {
                         visibility: false
                     },
@@ -440,7 +450,7 @@ let config = {
                     nameField: 'FacilityName',
                     name: 'Releases of lead to water by facility',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/38',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/38',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Releases%20of%20lead%20to%20water%20by%20facility.xml'
                     },
@@ -474,7 +484,7 @@ let config = {
                     id: 'Conserved_Areas',
                     name: 'Conserved areas',
                     layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Protected%20Areas.xml'
                     },
@@ -518,7 +528,7 @@ let config = {
                     nameField: 'Name',
                     name: 'Water quality at monitoring sites',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/5',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/5',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Water%20quality%20at%20monitoring%20sites.xml'
                     },
@@ -533,7 +543,7 @@ let config = {
                     nameField: 'StationName',
                     name: 'Water quantity at monitoring stations',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer/1',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/1',
                     metadata: {
                         url: 'https://indicators-map.ec.gc.ca/metadata/en/Water%20quantity%20at%20monitoring%20stations.xml'
                     },
@@ -567,7 +577,7 @@ let config = {
                     id: 'EZ',
                     name: 'Ecozones',
                     layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer',
                     state: {
                         query: false,
                         visibility: true,
@@ -679,7 +689,8 @@ let config = {
                     title: {
                         value: 'Canadian Environmental Sustainability Indicators (CESI)'
                     }
-                }
+                },
+                extentguard: { extentSetIds: ['EXT_NRCAN_Lambert_3978'] }
             },
             system: {
                 animate: true,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -51,7 +51,7 @@ export default {
               items: [
                 { text: "Default Setup", link: "/using-ramp4/default-setup" },
                 { text: "Language Configuration", link: "/using-ramp4/config-language" },
-                { text: "Layers", 
+                { text: "Layers",
                   collapsed: false,
                   items : [
                         { text: "Overview", link: "/using-ramp4/layer-overview" },
@@ -75,11 +75,12 @@ export default {
                         collapsed: true,
                         items: [
                             { text: "Appbar", link: "/using-ramp4/fixtures/appbar" },
-                            { text: "Legend", link: "/using-ramp4/fixtures/legend" },
-                            { text: "Details Custom Templating", link: "/using-ramp4/fixtures/details" },
-                            { text: "Geosearch", link: "/using-ramp4/fixtures/geosearch" },
                             { text: "Data Grid", link: "/using-ramp4/fixtures/grid" },
+                            { text: "Details Custom Templating", link: "/using-ramp4/fixtures/details" },
+                            { text: "Extent Guard", link: "/using-ramp4/fixtures/extentguard" },
+                            { text: "Geosearch", link: "/using-ramp4/fixtures/geosearch" },
                             { text: "Layer Settings", link: "/using-ramp4/fixtures/layer-settings" },
+                            { text: "Legend", link: "/using-ramp4/fixtures/legend" },
                         ]
                     },
                     { text: "Custom Fixtures", link: "/using-ramp4/fixtures/custom-fixtures" },

--- a/docs/api-guides/instance.md
+++ b/docs/api-guides/instance.md
@@ -35,7 +35,7 @@ Note that all the properties above are read only.
 * `toggleFullscreen()` - Toggles fullscreen for the app.
 * `updateAlert(alert: string)` - Updates the screen reader alert. Use this to inform screen reader users of visual changes in the app (pieces of ui appearing/leaving).
 * `start()` - Starts the app i.e. loads the map and layers. Used when `startRequired` is set to true in the [instance options](../introduction/instantiation.md#instance-options).
-* `useStore(id: string)` - Returns the store with the specified id, if it exists, else returns undefined. The following out-of-the-box store ID's are currently supported: appbar, areas-of-interest, config, details, export, fixture, geosearch, grid, help, instance, layer, legend, map-caption, mapnav, maptip, metadata, northarrow, notification, overviewmap, panel, scrollgurard, and wizard. Note that for ids that correspond to fixture ids, the fixture must be added before the store can be retrieved.
+* `useStore(id: string)` - Returns the store with the specified id, if it exists, else returns undefined. The following out-of-the-box store ID's are currently supported: `appbar`, `areas-of-interest`, `config`, `details`, `export`, `extentguard`, `fixture`, `geosearch`, `grid`, `help`, `instance`, `layer`, `legend`, `map-caption`, `mapnav`, `maptip`, `metadata`, `northarrow`, `notification`, `overviewmap`, `panel`, `scrollgurard`, and `wizard`. Note that for ids that correspond to fixture ids, the fixture must be added before the store can be retrieved.
 
 
 

--- a/docs/using-ramp4/fixture-overview.md
+++ b/docs/using-ramp4/fixture-overview.md
@@ -4,48 +4,69 @@ The following fixtures are included in the default setup. Any special interfaces
 
 ### Appbar
 
-The `appbar` provides a means to open and track panels, or run custom commands.
-
-### Mapnav
-
-The `mapnav` provides a means pan and zoom the map. TODO create and hyperlink to `mapnav.md`, or provide any other relevant info here.
-
-### Legend
-
-The `legend` provides an interactive listing of the layers and other data on the map. TODO create and hyperlink to `legend.md`
-
-### Grid
-
-The `grid` provides a tabular view of attributes for a feature class.
-
-### Details
-
-The `details` provides an interface to view information about a feature / voxel, and to see a collection of identify results.
+The `appbar` provides a means to open and track panels, or run custom commands. See the [Appbar docs](./fixtures/appbar) for more information.
 
 ### Basemap
 
-The `basemap` provides a means to change the basemap layers of the map. TODO create and hyperlink to `basemap.md`, or provide any other relevant info here.
-
-### Geosearch
-
-The `geosearch` is a utility that allows one to search for geographic names and zoom to the results.
-
-### Help
-
-The `help` provides a means to display user help for the application. TODO create and hyperlink to `help.md`, or provide any other relevant info here.
-
-### Settings
-
-The `settings` allow you to make live modifications to a layer on the map.
-
-### Northarrow
-
-The `northarrow` provides an arrow at the top of the map pointing to the geographic north pole. TODO create and hyperlink to `northarrow.md`
-
-### Overviewmap
-
-The `overviewmap` provides a smaller map displaying the current map extent within the context of a larger area. TODO create and hyperlink to `overviewmap.md`
+The `basemap` provides an interface to change the basemap layers of the map.
 
 ### Crosshairs
 
-The `crosshairs` displays crosshairs at the centre of the map when keyboard navigation is active. TODO create and hyperlink to `crosshairs.md`
+The `crosshairs` displays crosshairs at the centre of the map when keyboard navigation is active.
+
+### Details
+
+The `details` provides an interface to view information about a feature / voxel, and to see a collection of identify results. See the [Details docs](./fixtures/details) for more information.
+
+### Geosearch
+
+The `geosearch` is a utility that allows one to search for geographic names and zoom to the results. See the [Geosearch docs](./fixtures/geosearch) for more information.
+
+### Grid
+
+The `grid` provides a tabular view of attributes for a feature class. See the [Grid docs](./fixtures/grid) for more information.
+
+### Help
+
+The `help` provides a means to display user help for the application.
+
+### Hilight
+
+The `hilight` enables specific features on the map to become visually prominent.
+
+### Layer Reorder
+
+The `layer-reorder` provides an interface to reorder the stack of layers on the map.
+
+### Legend
+
+The `legend` provides an interactive listing of the layers and other data on the map.  See the [Legend docs](./fixtures/legend) for more information.
+
+### Mapnav
+
+The `mapnav` provides controls to help navigate the map.
+
+### Northarrow
+
+The `northarrow` provides an arrow pointing to or a symbol marking the geographic north pole.
+
+### Panguard
+
+The `panguard` can prevent the map from panning on a single touch-swipe, requiring a double-touch.
+
+### Overviewmap
+
+The `overviewmap` provides a smaller map displaying the current map extent within the context of a larger area.
+
+### Scrollguard
+
+The `scrollguard` can prevent the map from zooming when a user scroll-wheels on the map. Useful for maps embedded in pages that a user would scroll through.
+
+### Settings
+
+The `settings` allow you to make live modifications to a layer on the map. See the [Layer Settings docs](./fixtures/layer-settings) for more information.
+
+### Wizard
+
+The `wizard` provides an interface to allow users to add layers to the map.
+

--- a/docs/using-ramp4/fixtures/custom-fixtures.md
+++ b/docs/using-ramp4/fixtures/custom-fixtures.md
@@ -10,6 +10,19 @@ The fixture interface has three methods, all optional. They take no parameters a
 - `initialized()` is run when the fixture is `added` and the instance Map has finished initializing
 - `removed()` is run after fixture is removed from the RAMP instance
 
+## Pre-Made Fixtures
+
+RAMP includes some pre-made fixtures that are not considered "default", meaning they must be added. Given the implementation exists in the library, only the fixture name needs to be provided to the instance.
+
+This can be accomplished via the `startingFixtures` array in the instance configuration, or via an API call (`instance.fixture.add('fixturename')`).
+
+The current list of available fixture names are
+
+- `areas-of-interest`
+- `export`
+- `extentguard`
+- `metadata`
+
 ## Creation
 
 ### Internal

--- a/docs/using-ramp4/fixtures/details.md
+++ b/docs/using-ramp4/fixtures/details.md
@@ -1,16 +1,13 @@
 # Details Fixture
 
-TODO this page needs updating to reflect the new two-panel approach
-
 The details fixture adds a panel to RAMP that displays in-depth information about any specific data point on the map. It can be opened by performing an identify query either on the map or through the RAMP API.
 
 ## Panels
-The details fixture consists of three screens:
+The details fixture consists of three sections:
 
-1. The __Layer List__ is the first screen that opens when you issue an identify request. It contains a list of visible map layers and displays how many results were found for each layer. Clicking on one of these layers will bring you to the next screen, the __feature list__.
-2. The __Feature List__ contains a list of all results found for the selected layer. Clicking on an item in this list will bring you to the __feature info__ screen.
-3. The __Feature Info__ screen displays information about one single data point. This screen will look different depending on the format of the information returned by the identify query. This is also the screen that can be customized using custom templates (see below).
-
+1. The __Layer List__ is the vertical column of icons along the left side of the panel. It contains a list of map layers participating in the identify and displays how many results were found for each layer. Clicking on one of these icons will display results for that layer.
+2. The __Feature Info__ view displays information about a single result item. This screen will look different depending on the format of the information returned by the identify query. This is also the screen that can be customized using custom templates (see below). Scroll controls can move the view to other results in the layer. The "See List" button will switch to __List View__.
+3. The __List View__ contains a list of all results found for the selected layer. Clicking on an item in this list will bring you to the __Feature Info__ screen.
 
 ## Creating a Custom Template
 

--- a/docs/using-ramp4/fixtures/extentguard.md
+++ b/docs/using-ramp4/fixtures/extentguard.md
@@ -1,0 +1,44 @@
+# Extent Guard
+
+## Overview
+
+The extent guard fixture allows a map view to be restricted to a geographical extent. If the center of the map view goes outside of the bounds, the map will pan back within the bounds.
+
+The extent guard fixture is not a default fixture, meaning it [must be added to the instance](custom-fixtures#pre-made-fixtures).
+
+
+## Configuration
+
+Configuration should be placed in the `fixtures` object of the config file, keyed by the fixture name. Extent Guard supports two modes of operation.
+
+### Always On
+
+The fixture will be active regardless of the Extent Set being used by the map.
+
+```
+{
+  fixtures: {
+    extentguard: {
+        alwaysOn: true
+    }
+  }
+}
+```
+
+### Specific Extent Sets
+
+The fixture will only be active when the provided Extent Sets are being used. Typically this will align with specific basemap schemas. The Extent Set ids must match ids defined in the `map.extentSets` section of the config file.
+
+```
+{
+  fixtures: {
+    extentguard: {
+        extentSetIds: ["EXT_NRCAN_Lambert_3978"]
+    }
+  }
+}
+```
+
+## Bounding Area
+
+The Extent Guard uses the `maximum` extent defined in the active Extent Set as the boundary to enforce. If `maximum` is not defined, it will fallback to use the `full` extent, or the `default` extent if full is not provided either.

--- a/schema.json
+++ b/schema.json
@@ -96,6 +96,26 @@
                 }
             }
         },
+        "extentguard": {
+            "type": "object",
+            "description": "Provides the configuration to the extentguard fixture.",
+            "properties": {
+                "alwaysOn": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indicates if the extentguard should be active regardless of the extent set the map is using."
+                },
+                "extentSetIds": {
+                    "type": "array",
+                    "description": "Indicates a specific set of extent set ids. The extent guard will only be active if the map is using one of these extent sets. Ignored if alwaysOn is true.",
+                    "default": [],
+                    "items": {
+                        "type": "string",
+                        "description": "An extent set id"
+                    }
+                }
+            }
+        },
         "areas-of-interest": {
             "type": "object",
             "description": "Provides the configuration to the areas of interest fixture",
@@ -2412,13 +2432,6 @@
             "type": "object",
             "description": "Optional configuration for required map fixtures. TODO: fixtures may not exist so cannot enforce fixtures in config file",
             "properties": {
-                "legend": {
-                    "$ref": "#/$defs/legend",
-                    "default": {
-                        "root": {}
-                    },
-                    "description": "Provides configuration to legend. If not supplied, a blank legend is displayed."
-                },
                 "appbar": {
                     "$ref": "#/$defs/appbar",
                     "default": {
@@ -2426,52 +2439,18 @@
                     },
                     "description": "Provides configuration to the appbar. If not supplied, default appbar controls are displayed."
                 },
-                "mapnav": {
-                    "$ref": "#/$defs/mapnav",
-                    "default": {
-                        "zoom": "buttons",
-                        "items": [
-                            "fullscreen",
-                            "home",
-                            "geolocator",
-                            "help",
-                            "basemap"
-                        ]
-                    },
-                    "description": "Provides configuration to the appbar. If not supplied, default appbar controls are displayed."
+                "areas-of-interest": {
+                    "$ref": "#/$defs/areas-of-interest",
+                    "description": "Provides configuration to the areas of interest fixture"
                 },
-                "geosearch": {
-                    "$ref": "#/$defs/geosearch",
-                    "default": {
-                        "serviceUrls": {
-                            "geoNames": "https://geogratis.gc.ca/services/geoname/@{language}/geonames.json",
-                            "geoLocation": "https://geogratis.gc.ca/services/geolocation/@{language}/locate",
-                            "geoProvince": "https://geogratis.gc.ca/services/geoname/@{language}/codes/province.json",
-                            "geoTypes": "https://geogratis.gc.ca/services/geoname/@{language}/codes/concise.json"
-                        }
-                    },
-                    "description": "Provides configuration to geosearch. If not supplied, default geosearch services are used."
-                },
-                "grid": {
+                "basemap": {
+                    "description": "Provides configuration to the basemap fixture",
                     "type": "object",
-                    "description": "Provides configuration to the grid fixture.",
                     "properties": {
-                        "mergeGrids": {
-                            "type": "array",
-                            "description": "Provides specifications for merge grids. Can also be used to configure single-layer grids, but the 'gridOption' property within the layer configuration object is preferred.",
-                            "items": {
-                                "$ref": "#/$defs/mergeGrid"
-                            }
-                        },
                         "panelTeleport": {
                             "$ref": "#/$defs/panelTeleport"
-                        },
-                        "panelWidth": {
-                            "$ref": "#/$defs/panelWidth"
                         }
-                    },
-                    "required": ["mergeGrids"],
-                    "unevaluatedProperties": false
+                    }
                 },
                 "details": {
                     "description": "Provides default template configuration to the details fixture. If not supplied, RAMP default templates wil be used.",
@@ -2511,6 +2490,47 @@
                     },
                     "required": ["templates"]
                 },
+                "export": {
+                    "$ref": "#/$defs/export",
+                    "description": "Provides the configuration to the export fixture"
+                },
+                "extentguard": {
+                    "$ref": "#/$defs/extentguard",
+                    "description": "Provides configuration to the extentguard fixture"
+                },
+                "geosearch": {
+                    "$ref": "#/$defs/geosearch",
+                    "default": {
+                        "serviceUrls": {
+                            "geoNames": "https://geogratis.gc.ca/services/geoname/@{language}/geonames.json",
+                            "geoLocation": "https://geogratis.gc.ca/services/geolocation/@{language}/locate",
+                            "geoProvince": "https://geogratis.gc.ca/services/geoname/@{language}/codes/province.json",
+                            "geoTypes": "https://geogratis.gc.ca/services/geoname/@{language}/codes/concise.json"
+                        }
+                    },
+                    "description": "Provides configuration to geosearch. If not supplied, default geosearch services are used."
+                },
+                "grid": {
+                    "type": "object",
+                    "description": "Provides configuration to the grid fixture.",
+                    "properties": {
+                        "mergeGrids": {
+                            "type": "array",
+                            "description": "Provides specifications for merge grids. Can also be used to configure single-layer grids, but the 'gridOption' property within the layer configuration object is preferred.",
+                            "items": {
+                                "$ref": "#/$defs/mergeGrid"
+                            }
+                        },
+                        "panelTeleport": {
+                            "$ref": "#/$defs/panelTeleport"
+                        },
+                        "panelWidth": {
+                            "$ref": "#/$defs/panelWidth"
+                        }
+                    },
+                    "required": ["mergeGrids"],
+                    "unevaluatedProperties": false
+                },
                 "help": {
                     "$ref": "#/$defs/help",
                     "default": {
@@ -2523,22 +2543,6 @@
                         }
                     },
                     "description": "Specifies details for the Help section"
-                },
-                "northarrow": {
-                    "$ref": "#/$defs/northarrow",
-                    "default": {
-                        "arrowIcon": "",
-                        "poleIcon": ""
-                    },
-                    "description": "Provides configuration to the north arrow and pole marker"
-                },
-                "overviewmap": {
-                    "$ref": "#/$defs/overviewmap",
-                    "description": "Provides the configuration to the overviewmap fixture"
-                },
-                "scrollguard": {
-                    "$ref": "#/$defs/scrollguard",
-                    "description": "Provides the configuration to the scrollguard fixture"
                 },
                 "hilight": {
                     "description": "Provides configuration to the map's highlighter",
@@ -2568,23 +2572,6 @@
                         }
                     }
                 },
-                "areas-of-interest": {
-                    "$ref": "#/$defs/areas-of-interest",
-                    "description": "Provides configuration to the areas of interest fixture"
-                },
-                "basemap": {
-                    "description": "Provides configuration to the basemap fixture",
-                    "type": "object",
-                    "properties": {
-                        "panelTeleport": {
-                            "$ref": "#/$defs/panelTeleport"
-                        }
-                    }
-                },
-                "export": {
-                    "$ref": "#/$defs/export",
-                    "description": "Provides the configuration to the export fixture"
-                },
                 "layer-reorder": {
                     "description": "Provides configuration to the layer reorder fixture",
                     "type": "object",
@@ -2594,6 +2581,27 @@
                         }
                     }
                 },
+                "legend": {
+                    "$ref": "#/$defs/legend",
+                    "default": {
+                        "root": {}
+                    },
+                    "description": "Provides configuration to legend. If not supplied, a blank legend is displayed."
+                },
+                "mapnav": {
+                    "$ref": "#/$defs/mapnav",
+                    "default": {
+                        "zoom": "buttons",
+                        "items": [
+                            "fullscreen",
+                            "home",
+                            "geolocator",
+                            "help",
+                            "basemap"
+                        ]
+                    },
+                    "description": "Provides configuration to the appbar. If not supplied, default appbar controls are displayed."
+                },
                 "metadata": {
                     "description": "Provides configuration to the metadata fixture",
                     "type": "object",
@@ -2602,6 +2610,22 @@
                             "$ref": "#/$defs/panelTeleport"
                         }
                     }
+                },
+                "northarrow": {
+                    "$ref": "#/$defs/northarrow",
+                    "default": {
+                        "arrowIcon": "",
+                        "poleIcon": ""
+                    },
+                    "description": "Provides configuration to the north arrow and pole marker"
+                },
+                "overviewmap": {
+                    "$ref": "#/$defs/overviewmap",
+                    "description": "Provides the configuration to the overviewmap fixture"
+                },
+                "scrollguard": {
+                    "$ref": "#/$defs/scrollguard",
+                    "description": "Provides the configuration to the scrollguard fixture"
                 },
                 "settings": {
                     "description": "Provides configuration to the settings fixture",

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -201,8 +201,8 @@ export class FixtureAPI extends APIScope {
                 'mapnav',
                 'northarrow',
                 'overviewmap',
-                'scrollguard',
                 'panguard',
+                'scrollguard',
                 'settings',
                 'wizard'
             ];

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -52,6 +52,7 @@ import { useAreasOfInterestStore } from '@/fixtures/areas-of-interest/store';
 import { useConfigStore } from '@/stores/config';
 import { useDetailsStore } from '@/fixtures/details/store';
 import { useExportStore } from '@/fixtures/export/store';
+import { useExtentguardStore } from '@/fixtures/extentguard/store';
 import { useFixtureStore } from '@/stores/fixture';
 import { useGeosearchStore } from '@/fixtures/geosearch/store';
 import { useGridStore } from '@/fixtures/grid/store';
@@ -489,6 +490,7 @@ export class InstanceAPI {
             'areas-of-interest',
             'details',
             'export',
+            'extentguard',
             'geosearch',
             'grid',
             'help',
@@ -502,10 +504,12 @@ export class InstanceAPI {
         ];
 
         if (fixtureIds.includes(id) && !this.fixture.get(id)) {
+            // protects against a call wanting a store for a fixture that's been removed
             return undefined;
         }
 
         switch (id) {
+            // Fixture stores
             case 'appbar':
                 return <Readonly<T>>useAppbarStore(this.$vApp.$pinia);
             case 'areas-of-interest':
@@ -514,6 +518,8 @@ export class InstanceAPI {
                 return <Readonly<T>>useDetailsStore(this.$vApp.$pinia);
             case 'export':
                 return <Readonly<T>>useExportStore(this.$vApp.$pinia);
+            case 'extentguard':
+                return <Readonly<T>>useExtentguardStore(this.$vApp.$pinia);
             case 'geosearch':
                 return <Readonly<T>>useGeosearchStore(this.$vApp.$pinia);
             case 'grid':
@@ -534,6 +540,8 @@ export class InstanceAPI {
                 return <Readonly<T>>useScrollguardStore(this.$vApp.$pinia);
             case 'wizard':
                 return <Readonly<T>>useWizardStore(this.$vApp.$pinia);
+
+            // core stores
             case 'config':
                 return <Readonly<T>>useConfigStore(this.$vApp.$pinia);
             case 'fixture':

--- a/src/fixtures/extentguard/api/extentguard.ts
+++ b/src/fixtures/extentguard/api/extentguard.ts
@@ -1,0 +1,37 @@
+import { FixtureInstance } from '@/api';
+import { useExtentguardStore } from '../store';
+import type { ExtentguardConfig } from '../store';
+
+/**
+ * Will force map extent to remain within the defined maximum extent
+ */
+export class ExtentguardAPI extends FixtureInstance {
+    /**
+     * Parses the extentguard config JSON snippet from the config file and save to the fixture store.
+     *
+     * @param {extentguardConfig} [ExtentguardConfig]
+     * @memberof ExtentguardAPI
+     */
+    _parseConfig(extentguardConfig?: ExtentguardConfig) {
+        // NOTE: do not set store.active in this method.
+        //       it needs to remain inactive so the handler managing code
+        //       can know if it needs to wire up new handlers
+
+        if (extentguardConfig) {
+            const store = useExtentguardStore(this.$vApp.$pinia);
+
+            if (extentguardConfig.alwaysOn) {
+                store.setAlwaysOn(true);
+            }
+
+            const esi = extentguardConfig.extentSetIds;
+            if (esi && Array.isArray(esi) && esi.length > 0) {
+                store.setExtentSetIds(esi);
+            }
+        }
+    }
+
+    get config(): ExtentguardConfig | undefined {
+        return super.config;
+    }
+}

--- a/src/fixtures/extentguard/index.ts
+++ b/src/fixtures/extentguard/index.ts
@@ -1,0 +1,239 @@
+import { Extent } from '@/geo/api';
+import { ExtentguardAPI } from './api/extentguard';
+import { type ExtentguardConfig, useExtentguardStore } from './store';
+import { GlobalEvents } from '@/api';
+
+interface ClipResult {
+    min: number;
+    max: number;
+    changed: boolean;
+}
+
+/**
+ * Compares a range of co-ordinates to a bounding range of co-ordinates. If center of the range falls outside
+ * the bounding range, function will return a range that is back inside the bounding range
+ *
+ * @function clipCoords
+ * @param {Number} testMax maximum value of the range to test
+ * @param {Number} testMin minimum value of the range to test
+ * @param {Number} boundingMax maximum value of the bounding range
+ * @param {Number} boundingMin minimum value of the bounding range
+ * @return {ClipResult} bundle of information. resulting range and flag if it was adjusted
+ */
+function clipCoords(
+    testMax: number,
+    testMin: number,
+    boundingMax: number,
+    boundingMin: number
+): ClipResult {
+    // center co-ord of the  range to test
+    const testLength = testMax - testMin;
+    const middle = testMin + testLength / 2;
+
+    // smallest of the two input ranges.
+    // this is required to avoid a "washing machine" effect when the test range
+    // is much larger than the bounding range. Re-adjusting by the test range size can
+    // overshoot the bound and then another bound violation triggers. Which sends it
+    // back too far. Over and over and over.
+    const safeLength = Math.min(testLength, boundingMax - boundingMin);
+
+    if (middle > boundingMax) {
+        // our midpoint is too high
+        return {
+            min: boundingMax - safeLength,
+            max: boundingMax,
+            changed: true
+        };
+    } else if (middle < boundingMin) {
+        // our midpoint is too low
+        return {
+            min: boundingMin,
+            max: boundingMin + safeLength,
+            changed: true
+        };
+    } else {
+        // range was all good
+        return {
+            min: testMin,
+            max: testMax,
+            changed: false
+        };
+    }
+}
+
+class ExtentguardFixture extends ExtentguardAPI {
+    /**
+     * Schema change event handler name
+     */
+    private schemaEH = '';
+
+    /**
+     * Extent change event handler name
+     */
+    private extentEH = '';
+
+    added(): void {
+        // take in any configuration
+
+        this._parseConfig(this.config);
+
+        // watch for configuration changes
+        const unwatch = this.$vApp.$watch(
+            () => this.config,
+            (value: ExtentguardConfig | undefined) => this._parseConfig(value)
+        );
+
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            // cleanup
+
+            unwatch();
+
+            const store = useExtentguardStore(this.$vApp.$pinia);
+            store.$reset();
+            this.evtOff('schemaEH');
+            this.evtOff('extentEH');
+        };
+
+        // watch for basemap schema changes
+        this.schemaEH = this.$iApi.event.on(
+            GlobalEvents.MAP_BASEMAPCHANGE,
+            (payload: { basemapId: string; schemaChanged: boolean }) => {
+                if (payload.schemaChanged) {
+                    // make sure new schema wants the fixture active
+                    this.checkActive();
+                }
+            }
+        );
+
+        // do a status check when map creates, or if map already created
+        if (this.$iApi.geo.map.created) {
+            this.checkActive();
+        } else {
+            this.$iApi.event.once(GlobalEvents.MAP_CREATED, () => {
+                this.checkActive();
+            });
+        }
+    }
+
+    /**
+     * Examines current state of the instance and activates or deactivates appropriately
+     */
+    private checkActive(): void {
+        const store = useExtentguardStore(this.$vApp.$pinia);
+        if (
+            store.alwaysOn ||
+            store.extentSetIds.includes(this.$iApi.geo.map.getExtentSet().id)
+        ) {
+            if (!store.active) {
+                // turn on, start listening to extent changes
+                store.setActive(true);
+
+                this.extentEH = this.$iApi.event.on(
+                    GlobalEvents.MAP_EXTENTCHANGE,
+                    (extent: Extent) => {
+                        if (!store.enforcing) {
+                            this.enforceBoundary(extent, false);
+                        }
+                    }
+                );
+            }
+        } else if (store.active) {
+            // turn off
+            store.setActive(false);
+            this.evtOff('extentEH');
+        }
+    }
+
+    /**
+     * Wraps the act of checking if an event handler exists, and if so, removing it.
+     * Just a reapeated code saver
+     * @param eventPropName property name of this class that can hold an event handler name
+     * @private
+     */
+    private evtOff(eventPropName: 'extentEH' | 'schemaEH'): void {
+        if (this[eventPropName]) {
+            this.$iApi.event.off(this[eventPropName]);
+            this[eventPropName] = '';
+        }
+    }
+
+    /**
+     * Checks if the center of the given extent is outside of the maps maximum extent. If it is,
+     * will pan the map back to something appropriate
+     *
+     * @function enforceBoundary
+     * @param {Extent} extent an extent to adjudicate
+     * @param {boolean} safetyCheck indicates if this enforcement is a check against an original enforcement
+     */
+    private enforceBoundary(extent: Extent, safetyCheck: boolean): void {
+        const maxExtent = this.$iApi.geo.map.getExtentSet().maximumExtent;
+
+        const xTest = clipCoords(
+            extent.xmax,
+            extent.xmin,
+            maxExtent.xmax,
+            maxExtent.xmin
+        );
+
+        const yTest = clipCoords(
+            extent.ymax,
+            extent.ymin,
+            maxExtent.ymax,
+            maxExtent.ymin
+        );
+
+        if (yTest.changed || xTest.changed) {
+            // something was adjusted.
+
+            if (safetyCheck) {
+                // stranded in a stuck zone.
+                // attempting to zoomTo back to a good location will not work. esri map will
+                // just derivate the equivalent co-ord in the stuck zone and stay there.
+                // this hard-resets our view back to a safe zone, then the following zoomTo
+                // will place the map where we wanted it.
+
+                this.$iApi.geo.map.esriView!.extent = maxExtent.toESRI();
+            }
+
+            const respectfulExtent = Extent.fromParams(
+                'extguard',
+                xTest.min,
+                yTest.min,
+                xTest.max,
+                yTest.max,
+                extent.sr
+            );
+
+            const store = useExtentguardStore(this.$vApp.$pinia);
+            store.setEnforcing(true);
+            // timeout due to how spammy extent change events are when mouse-panning.
+            // lets the user pan finish before triggering the snapback.
+            // adjusted animation as the default is pretty aggressive and mildly shocking.
+            // 300ms on linear is also ok. ease-in-out feels a bit more natural to me.
+            setTimeout(() => {
+                this.$iApi.geo.map
+                    .zoomMapTo(
+                        respectfulExtent,
+                        undefined,
+                        true,
+                        400,
+                        'ease-in-out'
+                    )
+                    .then(() => {
+                        store.setEnforcing(false);
+                        // need to check again. a very wild pan on a wrappable co-ord system
+                        // can strand us in a zone where you get stuck.
+                        // the saftey param gets turned on, will perform rescue moves if
+                        // we're stuck.
+                        this.enforceBoundary(
+                            this.$iApi.geo.map.getExtent(),
+                            true
+                        );
+                    });
+            }, 150);
+        }
+    }
+}
+
+export default ExtentguardFixture;

--- a/src/fixtures/extentguard/store/extentguard-state.ts
+++ b/src/fixtures/extentguard/store/extentguard-state.ts
@@ -1,0 +1,11 @@
+export interface ExtentguardConfig {
+    alwaysOn: boolean;
+    extentSetIds: Array<string>;
+}
+
+export interface ExtentguardState {
+    active: boolean;
+    enforcing: boolean;
+    alwaysOn: boolean;
+    extentSetIds: Array<string>;
+}

--- a/src/fixtures/extentguard/store/extentguard-store.ts
+++ b/src/fixtures/extentguard/store/extentguard-store.ts
@@ -1,0 +1,39 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useExtentguardStore = defineStore('extentguard', () => {
+    const active = ref(false);
+
+    function setActive(value: boolean) {
+        active.value = value;
+    }
+
+    const enforcing = ref(false);
+
+    function setEnforcing(value: boolean) {
+        enforcing.value = value;
+    }
+
+    const alwaysOn = ref(false);
+
+    function setAlwaysOn(value: boolean) {
+        alwaysOn.value = value;
+    }
+
+    const extentSetIds = ref<Array<string>>([]);
+
+    function setExtentSetIds(value: Array<string>) {
+        extentSetIds.value = value;
+    }
+
+    return {
+        active,
+        setActive,
+        enforcing,
+        setEnforcing,
+        alwaysOn,
+        setAlwaysOn,
+        extentSetIds,
+        setExtentSetIds
+    };
+});

--- a/src/fixtures/extentguard/store/index.ts
+++ b/src/fixtures/extentguard/store/index.ts
@@ -1,0 +1,2 @@
+export * from './extentguard-state';
+export * from './extentguard-store';

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -327,6 +327,14 @@ export interface MapMove {
     moveTime: number;
 }
 
+// needs to align to esri values for GoToOptions2D.easing
+export type ZoomEasing =
+    | 'linear'
+    | 'ease'
+    | 'ease-in'
+    | 'ease-out'
+    | 'ease-in-out';
+
 export interface ScreenPoint {
     screenX: number;
     screenY: number;

--- a/src/geo/api/graphic/geometry/extent.ts
+++ b/src/geo/api/graphic/geometry/extent.ts
@@ -91,6 +91,29 @@ export class Extent extends BaseGeometry {
     }
 
     /**
+     * Reports if a point is within the boundary of the extent.
+     * For performance reasons, the point must be in the same spatial reference as the extent.
+     *
+     * @param {Point} testPoint
+     * @returns {boolean} if point was within the extent or not
+     */
+    contains(testPoint: Point): boolean {
+        if (this.sr.isEqual(testPoint.sr)) {
+            return (
+                this.xmin <= testPoint.x &&
+                this.xmax >= testPoint.x &&
+                this.ymin <= testPoint.y &&
+                this.ymax >= testPoint.y
+            );
+        } else {
+            console.error(
+                'Extent.contains(point) must have point in same spatial reference as the extent.'
+            );
+            return false;
+        }
+    }
+
+    /**
      * Returns an array of point arrays (e.g. [[x1, y1], [x2, y2]] )
      */
     toArray(): Array<Array<number>> {

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -20,8 +20,7 @@ import {
     GeometryType,
     SpatialReference
 } from '@/geo/api';
-
-import type { RampMapConfig } from '@/geo/api';
+import type { RampMapConfig, ZoomEasing } from '@/geo/api';
 
 // Would ideally call this BaseMap, but that would get confused with Basemap.
 // Do not add any event emits or listeners that would be tied to a specific map
@@ -370,13 +369,17 @@ export class CommonMapAPI extends APIScope {
      *
      * @param {BaseGeometry} geom A RAMP API geometry to zoom the map to
      * @param {number} [scale] An optional scale value of the map. Is ignored for non-Point geometries
-     * @param {boolean} [animate] An optional animation setting. On by default
+     * @param {boolean} [animate] Option to turn off the zoom animation. On by default
+     * @param {number} [duration] Option to change animation duration (in milliseconds). Default of 200. Ignored if animate is off.
+     * @param {ZoomEasing} [easing] Option to change animation easing function. Default of 'ease'. Ignored if animate is off.
      * @returns {Promise<void>} A promise that resolves when the map has finished zooming
      */
     async zoomMapTo(
         geom: BaseGeometry,
         scale?: number,
-        animate = true
+        animate = true,
+        duration = 200,
+        easing: ZoomEasing = 'ease'
     ): Promise<void> {
         if (this.esriView) {
             if (geom.invalid()) {
@@ -392,7 +395,7 @@ export class CommonMapAPI extends APIScope {
             if (g.type === GeometryType.POINT) {
                 zoomP.scale = scale || this.pointZoomScale;
             }
-            const opts: any = { animate: animate };
+            const opts: __esri.GoToOptions2D = { animate, duration, easing };
 
             return this.viewPromise.then(() => {
                 return this.esriView!.goTo(zoomP, opts);


### PR DESCRIPTION
## Related Item(s)

#2176

## Changes

- Made `extentguard` fixture
- Doc & Schema updates
  - Stuff for extent guard
  - Added some other missing things, removed some todos
  - Enforced some respect for the alphabet
- Added more optional params to the map zoomies API to tweak how it animates

## Notes

The fixture file structure is essentially copied from `scrollguard`. Feel free to suggest other things.

The enforced extents are just testing values. This PR is not to create a bounding box that is optimal for user experience.

### Testing

#### Selective Enforcement

1. Open Sample 24 (CESI).
2. Turn off visibility of all layers so Danbos server isn't pummelled with all the pan-induced requests that would happen.
3. The guard is set to enforce on the square that is visible around Canada on the basemaps. Pan the map so the center of the map view goes outside of this square.
4. Map should pan back to something reasonable.
5. Try more, try different boundaries, different zoom levels, have a good time.
6. Change the basemap to a Mercator basemap.
7. Verify you can pan anywhere, nothing gets re-adjusted.

#### Full Enforcement

1. Open Sample 15 (Simple Features).
2. Turn off visibility of all layers.
3. The guard is set to enforce on the initial extent (smaller than your screen, actual viewed extent is a best fit). There is no visible indicator for it. Pan the map so the center of the map view goes outside general Canada area.
4. Map should eventually pan back to something reasonable inside of Canada.
5. Change the basemap to a Lambert basemap.
6. This basemap is also using the initial extent (not the box on the basemap). Verify that panning away from Canada eventually returns you.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2178)
<!-- Reviewable:end -->
