### PR TITLE
fix tooltips being added to wrong instance on multi-instance samples

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -36,8 +36,7 @@ export default defineComponent({
                 trigger: 'mouseenter manual focus',
                 touch: ['hold', 200],
                 delay: [300, 0],
-                // needed to have tooltips in fullscreen, by default it appends to document.body
-                appendTo: instance?.proxy?.$el
+                appendTo: () => document.fullscreenElement || document.body
             });
         });
     }


### PR DESCRIPTION
### Related Item(s)
#2166 

### Changes
- Modified the tippy `appendTo` target. The tooltip will now attach to the document body or a full-screened element instead of the last-instantiated RAMP instance. 

### Notes
I first attempted Spencer's recommendation to set the append target at the Vue-Tippy level, but it didn't seem to have any effect. The target was still being set to the last instantiated RAMP element. I looked at the [source code for the package](https://github.com/KABBOUCHI/vue-tippy/blob/main/src/plugin/index.ts#L10) and it seems like the props are getting set at the tippy level either way.

Based on the existing comment in the code, I'm assuming we added the `appendTo` prop because the tooltips weren't working in full-screen mode. I've added the `document.fullscreenElement` target so this shouldn't happen anymore. If there was another reason why we needed it, please let me know!

I've tested this change on the RAMP sample, the multi-instance RAMP sample, and on Storylines and it seems to work everywhere.

### Testing
Steps:
1. Open the main RAMP sample and the multi-instance sample.
2. In both samples, ensure that tooltips are working as expected in both regular view and in full-screen mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2179)
<!-- Reviewable:end -->
