### PR TITLE
Disable reload menu item for un-reloadable layers

### DIFF
--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -148,7 +148,23 @@
                 href="javascript:;"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem!.layerControlAvailable(LayerControl.Reload)
+                    disabled: !reloadableLayer
+                }"
+                :content="
+                    !reloadableLayer
+                        ? t('legend.layer.controls.reloadDisabled')
+                        : ''
+                "
+                @mouseover.stop="hover($event.currentTarget!)"
+                @mouseout.self="
+                    //@ts-ignore
+                    mobileMode ? null : $event.currentTarget?._tippy?.hide(),
+                        (hovered = false)
+                "
+                v-tippy="{
+                    placement: 'top-start',
+                    trigger: 'manual focus',
+                    aria: 'describedby'
                 }"
                 @click="reloadLayer"
             >
@@ -169,13 +185,17 @@
 <script setup lang="ts">
 import { GlobalEvents, InstanceAPI } from '@/api';
 import { LayerControl } from '@/geo/api';
-import { inject, ref, toRaw } from 'vue';
+import { computed, inject, ref, toRaw } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { LayerItem } from '../store/layer-item';
+import { usePanelStore } from '@/stores/panel';
 
 const { t } = useI18n();
 const iApi = inject('iApi') as InstanceAPI;
 const dropdown = ref();
+const hovered = ref(false);
+const panelStore = usePanelStore();
+const mobileMode = ref(panelStore.mobileView);
 
 const props = defineProps({
     legendItem: LayerItem
@@ -278,10 +298,29 @@ const removeLayer = () => {
  * Reloads a layer on the map.
  */
 const reloadLayer = () => {
-    if (props.legendItem!.layerControlAvailable(LayerControl.Reload)) {
+    if (reloadableLayer) {
         toRaw(props.legendItem!.layer!).reload();
         dropdown.value.open = false;
     }
+};
+
+/**
+ * Determine if the layer can be reloaded
+ */
+const reloadableLayer = computed((): boolean => {
+    return (
+        props.legendItem!.layerControlAvailable(LayerControl.Reload) &&
+        props.legendItem instanceof LayerItem &&
+        toRaw(props.legendItem!.layer)?.canReload
+    );
+});
+
+const hover = (t: EventTarget) => {
+    hovered.value = true;
+    setTimeout(() => {
+        //@ts-ignore
+        if (hovered.value) mobileMode.value ? null : t._tippy?.show();
+    }, 300);
 };
 
 /**

--- a/src/fixtures/legend/lang/lang.csv
+++ b/src/fixtures/legend/lang/lang.csv
@@ -32,6 +32,7 @@ legend.layer.controls.boundaryzoom,Zoom to Layer Boundary,1,Zoomer à la limite,
 legend.layer.controls.cancel,Cancel,1,Annuler,1
 legend.layer.controls.remove,Remove,1,Retirer,1
 legend.layer.controls.reload,Reload,1,Recharger,1
+legend.layer.controls.reloadDisabled,Layer cannot be reloaded,1,Le calque ne peut pas être rechargé,0
 legend.alert.symbologyExpanded,Layer legend expanded,1,Légende de la couche développée,1
 legend.alert.symbologyCollapsed,Layer legend collapsed,1,Légende de la couche réduite,1
 legend.alert.groupExpanded,Legend group expanded,1,Groupe de légende développé,1

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -89,7 +89,8 @@ export class CommonLayer extends LayerInstance {
         this.initiationState = InitiationState.NEW;
         this.drawState = DrawState.NOT_LOADED;
         this.loadDefProm = new DefPromise();
-
+        this.url = this.origRampConfig.url;
+        this.canReload = !!(this.url || this.origRampConfig.caching);
         this.loadPromFulfilled = false;
 
         this.layerTree = new TreeNode(0, this.uid, this.name, true); // is a layer with layer index 0 by default. subclasses will change this when they load

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -229,6 +229,16 @@ export class LayerInstance extends APIScope {
      */
     canModifyLayer: boolean;
 
+    /**
+     * Indicates if the layer can be reloaded.
+     */
+    canReload: boolean;
+
+    /**
+     * url of the service
+     */
+    url: string;
+
     protected _parentLayer: LayerInstance | undefined;
     protected _sublayers: Array<LayerInstance>;
 
@@ -277,6 +287,8 @@ export class LayerInstance extends APIScope {
         this.expectedTime = { draw: 0, load: 0 };
         this.maxLoadTime = 0;
         this.canModifyLayer = true;
+        this.canReload = true;
+        this.url = '';
     }
 
     /**

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -32,6 +32,8 @@ export class MapImageSublayer extends AttribLayer {
         this.dataFormat = DataFormat.ESRI_FEATURE; // this will get flipped to raster during the server metadata checks if needed
         this.tooltipField = '';
         this.hovertips = false;
+        this.url = this.parentLayer?.url;
+        this.canReload = !!(this.url || this.origRampConfig.caching);
 
         if (!parent.esriLayer) {
             throw new Error(


### PR DESCRIPTION
### Related Item(s)
#2170

### Changes
- [FIX] Disables the Reload menu item for un-reloadable layers. These are layers that have no url or do not have caching enabled.

### Notes
Need to remove sample 45 before merging. 

Feel free to suggest alternate tooltip text

### Testing
Steps:
1. Open sample 45
2. Confirm that the Vector, CESI and Caching Test layers can all be reloaded.
3. Verify that the Disabled Test layer cannot be reloaded and a tooltip appears

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2180)
<!-- Reviewable:end -->
