### PR TITLE
Hilighter Improvements

### DIFF
--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -230,11 +230,13 @@ export class DetailsAPI extends FixtureInstance {
                 // our request on this thread is still the most recent one. begin to add graphics to highlighter
                 await hilightFix.addHilight(graphics);
 
-                // NOTE if addHighlight is also slow, will need additional check here. this one is trickier, since
-                //      our stale graphics have been added but need to get-gone. However, calling remove will
-                //      remove everything; if a new fast request came in after it and alredy completed, then
-                //      remove will erase that as well. May need to add timestamp to the origin key for
-                //      targeted removal.
+                // while unlikely, given everything is async its possible that a delete request completes before
+                // the graphics could be added to the hilight layer.
+                // so check one again. If we're now stale, remove the hilight.
+                if (this.detailsStore.lastHilight !== thisHighlight) {
+                    // hilight removal will gracefully exit if something else already deleted any of these graphics.
+                    hilightFix.removeHilight(graphics);
+                }
             }
         }
     }

--- a/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
@@ -4,6 +4,10 @@ import { useConfigStore } from '@/stores/config';
 import { FOG_HILIGHT_LAYER_NAME } from '../hilight-defs';
 import { LiftHilightMode } from './lift-hilight-mode';
 
+/**
+ * Hilight mode that places a translucent tile beneath a graphics to make them
+ * stand out from the rest of the map.
+ */
 export class FogHilightMode extends LiftHilightMode {
     handlers: Array<string> = [];
     // TODO: make these configurable later
@@ -92,10 +96,7 @@ export class FogHilightMode extends LiftHilightMode {
         }
     }
 
-    /**
-     * Adds the given graphics to the hilight layer.
-     */
-    async add(graphics: Array<Graphic>) {
+    async add(graphics: Array<Graphic> | Graphic) {
         this.lastAdd = Date.now();
 
         // turn the fog "on"
@@ -109,10 +110,7 @@ export class FogHilightMode extends LiftHilightMode {
         await super.add(graphics);
     }
 
-    /**
-     * Removes the given graphics from the hilight layer.
-     */
-    async remove(graphics?: Array<Graphic>) {
+    async remove(graphics?: Array<Graphic> | Graphic | undefined) {
         // remove the given graphics from the layer
         await super.remove(graphics);
 
@@ -142,13 +140,13 @@ export class FogHilightMode extends LiftHilightMode {
         }, 300);
     }
 
-    async reloadHilight(graphics: Array<Graphic>) {
+    async reloadHilight(graphics: Array<Graphic> | Graphic) {
         await this.updateFogLayer();
         await super.reloadHilight(graphics);
     }
 
     /**
-     * Returns the Hilight layer.
+     * Returns the "fog" tile layer.
      */
     private getFogLayer(): TileLayer | undefined {
         const hilightLayer = this.$iApi.geo.layer.getLayer(

--- a/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
@@ -3,7 +3,10 @@ import type { Graphic } from '@/geo/api';
 import { HILIGHT_LAYER_NAME } from '../hilight-defs';
 import { LiftHilightMode } from './lift-hilight-mode';
 
-// This hilight mode uses the ESRI highlight to outline the given graphics, creating a "glow"
+/**
+ * Hilight mode that lifts graphics and applies a glow outline to make them
+ * stand out from the rest of the map.
+ */
 export class GlowHilightMode extends LiftHilightMode {
     handlers: Array<string> = [];
 
@@ -25,10 +28,7 @@ export class GlowHilightMode extends LiftHilightMode {
         });
     }
 
-    /**
-     * Adds the given graphics to the hilight layer.
-     */
-    async add(graphics: Array<Graphic>) {
+    async add(graphics: Array<Graphic> | Graphic) {
         // add the given graphics to the layer
         await super.add(graphics);
 
@@ -40,24 +40,18 @@ export class GlowHilightMode extends LiftHilightMode {
             hilightLayer.isLoaded &&
             hilightLayer instanceof GraphicLayer
         ) {
-            const gs: Array<Graphic> =
-                graphics instanceof Array ? graphics : [graphics];
+            const gs = graphics instanceof Array ? graphics : [graphics];
             this.$iApi.geo.map.esriView
                 ?.whenLayerView(hilightLayer.esriLayer)
                 ?.then(function (layerView) {
                     layerView.highlight(
-                        gs.map(
-                            (g: Graphic) => hilightLayer.getEsriGraphic(g.id)!
-                        )
+                        gs.map(g => hilightLayer.getEsriGraphic(g.id)!)
                     );
                 });
         }
     }
 
-    /**
-     * Removes the given graphics from the hilight layer.
-     */
-    async remove(graphics?: Array<Graphic>) {
+    async remove(graphics?: Array<Graphic> | Graphic | undefined) {
         await super.remove(graphics);
         // removing the graphic will also remove the esri highlight
         // so there's nothing else to do here

--- a/src/fixtures/hilight/api/hilight-mode/lift-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/lift-hilight-mode.ts
@@ -1,12 +1,12 @@
 import type { Graphic } from '@/geo/api';
 import { BaseHilightMode } from './base-hilight-mode';
 
-// This hilight mode populates the hilight layer with the given graphics, essentially "lifting" them
+/**
+ * Hilight mode that places graphics in a top-most layer, essentially "lifting" them
+ * above other map elements.
+ */
 export class LiftHilightMode extends BaseHilightMode {
-    /**
-     * Adds the given graphics to the hilight layer.
-     */
-    async add(graphics: Array<Graphic>) {
+    async add(graphics: Array<Graphic> | Graphic) {
         const hilightLayer = await this.getHilightLayer();
         if (!hilightLayer) {
             return;
@@ -14,10 +14,7 @@ export class LiftHilightMode extends BaseHilightMode {
         await hilightLayer.addGraphic(graphics);
     }
 
-    /**
-     * Removes the given graphics from the hilight layer.
-     */
-    async remove(graphics: Array<Graphic> | undefined) {
+    async remove(graphics: Array<Graphic> | Graphic | undefined) {
         const hilightLayer = await this.getHilightLayer();
         if (!hilightLayer) {
             return;
@@ -25,10 +22,7 @@ export class LiftHilightMode extends BaseHilightMode {
         hilightLayer.removeGraphic(graphics);
     }
 
-    /**
-     * Reload the hilighter's map elements.
-     */
-    async reloadHilight(graphics: Array<Graphic>) {
+    async reloadHilight(graphics: Array<Graphic> | Graphic) {
         await this.remove(graphics);
         await this.add(graphics);
     }

--- a/src/fixtures/hilight/api/hilight.ts
+++ b/src/fixtures/hilight/api/hilight.ts
@@ -11,6 +11,9 @@ import { FogHilightMode } from './hilight-mode/fog-hilight-mode';
 import { GlowHilightMode } from './hilight-mode/glow-hilight-mode';
 import { LiftHilightMode } from './hilight-mode/lift-hilight-mode';
 
+/**
+ * Exposes methods to manage the hilighting of features on the map
+ */
 export class HilightAPI extends FixtureInstance {
     hilightMode: BaseHilightMode = new BaseHilightMode({}, this.$iApi);
 
@@ -61,9 +64,11 @@ export class HilightAPI extends FixtureInstance {
     }
 
     /**
-     * Create the Hilight layer.
+     * Initialize the Hilight layer.
+     *
+     * @returns {Promise} resolves when layer is initialized
      */
-    async initHilightLayer() {
+    async initHilightLayer(): Promise<void> {
         const hilightLayer = this.$iApi.geo.layer.createLayer({
             id: HILIGHT_LAYER_NAME,
             layerType: LayerType.GRAPHIC,
@@ -77,20 +82,23 @@ export class HilightAPI extends FixtureInstance {
     /**
      * Add the given Graphics to the Hilighter
      *
-     * @param graphics Graphics to add
+     * @param {Graphic | Array<Graphic>} graphics Graphics to add
+     * @returns {Promise} resolves when graphics have been added
      */
-    async addHilight(graphics: Array<Graphic> | Graphic) {
+    async addHilight(graphics: Array<Graphic> | Graphic): Promise<void> {
         const gs = graphics instanceof Array ? graphics : [graphics];
         await this.hilightMode.add(gs);
     }
 
     /**
-     * Remove the given Graphics from the Hilighter
+     * Remove the given Graphics from the Hilighter. If no graphics are provided,
+     * all highlighted items will be removed.
      *
-     * @param graphics Graphics to remove
+     * @param {Graphic | Array<Graphic> | undefined} graphics Graphics to remove
+     * @returns {Promise} resolves when graphics have been removed
      */
-    async removeHilight(graphics?: Array<Graphic> | Graphic) {
-        const gs: Array<Graphic> | undefined = graphics
+    async removeHilight(graphics?: Array<Graphic> | Graphic): Promise<void> {
+        const gs = graphics
             ? graphics instanceof Array
                 ? graphics
                 : [graphics]
@@ -98,6 +106,11 @@ export class HilightAPI extends FixtureInstance {
         await this.hilightMode.remove(gs);
     }
 
+    /**
+     * Reload the provided graphics that are currently highlighted.
+     *
+     * @param {Array<Graphic> | Graphic} graphics
+     */
     async reloadHilight(graphics: Array<Graphic> | Graphic) {
         const gs = graphics instanceof Array ? graphics : [graphics];
         await this.hilightMode.reloadHilight(gs);

--- a/src/geo/layer/common-graphic-layer.ts
+++ b/src/geo/layer/common-graphic-layer.ts
@@ -60,6 +60,13 @@ export class CommonGraphicLayer extends MapLayer {
         return this._graphics.find(g => g.id === graphicId);
     }
 
+    /**
+     * Gets the ESRI graphic from the layer, if it exists, that is rendering the Graphic with the
+     * provided id.
+     *
+     * @param {string} graphicId id of the graphic to find
+     * @returns {ESRIGraphic} the graphic, undefined if no matching id is found.
+     */
     getEsriGraphic(graphicId: string): EsriGraphic | undefined {
         return this.esriLayer?.graphics.find((g: any) => g.id === graphicId);
     }
@@ -130,9 +137,9 @@ export class CommonGraphicLayer extends MapLayer {
     }
 
     /**
-     * If geometry specified, removes those items. Else removes all geometry.
+     * If Graphics are specified, removes those graphics from the layer. Passing no parameter removes all Graphics.
      *
-     * @param geometry any strings should reference a particular geometry instance with that ID. If undefined, all geometry is removed.
+     * @param {Graphic | string | Array<Graphic | string>} graphics Valid formats: A Graphic object, a graphic ID in string form, or an array of Graphic objects and/or graphic ID strings
      */
     removeGraphic(graphics?: Array<string | Graphic> | string | Graphic): void {
         if (!this.esriLayer) {
@@ -163,25 +170,23 @@ export class CommonGraphicLayer extends MapLayer {
             }
         });
 
-        const targets: Array<__esri.Graphic> = [];
         ids.forEach(id => {
             // need to tag the param as `any` because .id is something we manually added
-            const target = this.esriLayer?.graphics.find(
+
+            const esriIdx = this.esriLayer!.graphics.findIndex(
                 (g: any) => g.id === id
             );
-            if (target) {
-                targets.push(target);
-                const rampIdx = this._graphics.findIndex(g => g.id === id);
-                if (rampIdx != -1) {
-                    this._graphics.splice(rampIdx, 1);
-                }
+            if (esriIdx > -1) {
+                this.esriLayer!.graphics.removeAt(esriIdx);
+            }
+
+            const rampIdx = this._graphics.findIndex(g => g.id === id);
+            if (rampIdx > -1) {
+                this._graphics.splice(rampIdx, 1);
             }
         });
 
         // TODO remove hover stuff once supported
-        this.esriLayer.removeMany(targets);
-        this._graphics = this._graphics.filter(g => ids.includes(g.id));
-
         // TODO raise event?
     }
 }


### PR DESCRIPTION
### Related Item(s)

#2129 , #2149

### Changes
- Hilighter methods now only delay if they need to. Was previously doing a 125ms wait on most async calls, which in the majority of cases was not needed.
- Adds a cleanup check for stale hilights when spamming the details view scroller. The scenario should be rarer in general due to the above delay fix.
- Lots of doc cleanup
- Corrected small bug where highlighter could drop the visible Esri graphic but retain the source Ramp graphic. Difficult to detect since only the Esri part can be seen.

### Testing
Steps:
1. Open Sample 15
2. Do an identify click somewhere with larger stacks of points.
3. In the details panel, open the largest pile.
4. Zoom in a bit so you can get separation on the map graphics and see the highlight hop around
5. Ensure the highlight still changes when using the scroller arrows in the Details panel.
6. Go ham spamming the scrollers. Attempt to get a scenario where an old highlight and new highlight co-exist on the map.

Don't open the grid. Will make the details & highlight generation process faster (slow times === more room for timing problems)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2182)
<!-- Reviewable:end -->
