### PR TITLE
Disabled reload button will no longer trigger

### DIFF
--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -298,7 +298,7 @@ const removeLayer = () => {
  * Reloads a layer on the map.
  */
 const reloadLayer = () => {
-    if (reloadableLayer) {
+    if (reloadableLayer.value) {
         toRaw(props.legendItem!.layer!).reload();
         dropdown.value.open = false;
     }


### PR DESCRIPTION
### Related Item(s)
#2170, #2188

### Changes
- [FIX] Restores respect to the disabled reload button. It will no longer try to reload when you click it.

### Testing
Steps:
1. Open sample 41
2. Attempt to reload 'Tasty Eats'
3. Witness respectful denial of reload functionality
4. Throw tomatoes at me

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2189)
<!-- Reviewable:end -->
