### PR TITLE
Centered icon for zooming button

### DIFF
--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -46,7 +46,7 @@
                     "
                     ref="zoomButton"
                     @click="(e: MouseEvent) => { e.stopPropagation(); zoomToFeature() }"
-                    class="text-gray-600 w-24 h-24 p-2"
+                    class="text-gray-600 w-24 h-24 p-2 zoomButtonCenter"
                     v-if="isMapLayer"
                 >
                     <div
@@ -419,4 +419,10 @@ onBeforeUnmount(() => {
 });
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.zoomButtonCenter {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+</style>


### PR DESCRIPTION
### Related items
Issue: #2142 

### Changes
- [FIX] Converted zooming button to flex container, then centered its contents with respect to both axes. 

### Notes

![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/90575655/e432718f-1551-45e9-9ae2-d620496efe2f)

### Testing
Steps:
1. Click a feature or open details view from the a grid row.
2. Click the zoomies 🌍 , this will put the focus on the button.
3. Icon should be centered.

