### PR TITLE
add check for registered graphic before disabling fog

### DIFF
--- a/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
@@ -132,9 +132,14 @@ export class FogHilightMode extends LiftHilightMode {
         // to be requested. If we see that one was, we will not turn off and
         // simply wait for next add to finish.
         const lastRemove = Date.now();
+        const hilightLayer = await this.getHilightLayer();
+        if (!hilightLayer) {
+            return;
+        }
         setTimeout(() => {
-            if (this.lastAdd < lastRemove) {
-                // nothing was added during the timeout, so we turn off the fog
+            if (this.lastAdd < lastRemove && !hilightLayer.getGraphicCount()) {
+                // nothing was added during the timeout AND there is nothing
+                // currently hilighted, so we turn off the fog
                 fogLayer.opacity = this.offOpacity;
             }
         }, 300);


### PR DESCRIPTION
### Related Item(s)
Issue: #2183

### Changes
- [FIX] Added a check to determine if there are any hilight layers active before disabling fog


### Notes
Script used to test:
``` 
const hilite = debugInstance.fixture.get('hilight');

const yellow = new debugInstance.geo.geom.PointStyle({colour: '#ffff00'});
const magent = new debugInstance.geo.geom.PointStyle({colour: '#ff00ff'});

const westP = new debugInstance.geo.geom.Point('w', [-91, 58]);
const eastP = new debugInstance.geo.geom.Point('e', [-80, 57]);

const west = new debugInstance.geo.geom.Graphic(westP);
west.style = yellow;

const east = new debugInstance.geo.geom.Graphic(eastP);
east.style = magent;

hilite.addHilight([east, west]);

hilite.removeHilight(east);

hilite.removeHilight(west);
```

Two graphics are added to the highlighter:
![Screenshot 2024-05-27 112303](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/90575655/a6ec0fcf-ed8d-41a7-9bb7-279758d1ed6e)
One graphic is removed from the highlighter, and the fog remains enabled:
![Screenshot 2024-05-27 112322](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/90575655/a41eaae0-84b3-4df3-9a85-c9d319db03c5)
The second graphic is removed from the highlighter, and the fog is now disabled, because no graphics are highlighted:
![Screenshot 2024-05-27 112343](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/90575655/aa4616a7-6907-4225-b1d9-082d5366ad2c)


### Testing
Steps:
1. Run a site with a fog highlighter (26)
2. Make an API call that adds two graphics to the highlighter
3. Should see fog + the two graphics
4. Remove one graphic from the highlighter
5. Fog should remain enabled
6. Remove the second graphic from the highlighter
7. Fog should now be disabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2197)
<!-- Reviewable:end -->
