### PR TITLE
added check for setCustomParameter object

### DIFF
--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -285,6 +285,9 @@ export class WmsLayer extends MapLayer {
         if (!this.esriLayer) {
             this.noLayerErr();
         } else {
+            if (!this.esriLayer.customLayerParameters) {
+                this.esriLayer.customLayerParameters = {};
+            }
             this.esriLayer.customLayerParameters[key] = value;
             if (forceRefresh) {
                 this.esriLayer.refresh();


### PR DESCRIPTION
### Related Item(s)
Issue #2160

### Changes
- [FIX] Added a check for the customLayersParameter object to ensure that it exists before it's accessed. 

### Notes
Script used to test:
```
const layer = debugInstance.geo.layer.getLayer('DCS_tmax_ANN_rcp45_2081_en');
layer.setCustomParameter('letsgo', 'kaboom');
 ```

### Testing
Steps:
1. Run a site with a WMS layer (25)
2. Attempt to call setCustomParameter on a WMS layer (using above script)
3. Rather than an error, 'undefined' should appear in the console.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2198)
<!-- Reviewable:end -->
