### PR TITLE
Centered boxes in legend and data grid

### DIFF
--- a/src/fixtures/grid/column-dropdown.vue
+++ b/src/fixtures/grid/column-dropdown.vue
@@ -14,9 +14,9 @@
                     height="24px"
                     width="24px"
                     preserveAspectRatio="xMidYMid meet"
-                    viewBox="0 0 24 24"
+                    viewBox="0 0 23 24"
                     focusable="false"
-                    class="inline mr-1 fill-current"
+                    class="inline fill-current"
                 >
                     <g id="format-list-checks_cache966">
                         <path

--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -65,7 +65,7 @@
                 :content="t(`grid.header.reorder.left`)"
                 v-tippy="{ placement: 'top' }"
                 @click="moveLeft()"
-                class="move-left opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
+                class="move-left opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default flex justify-center items-center"
                 tabindex="-1"
                 :disabled="!canMoveLeft"
             >
@@ -84,7 +84,7 @@
                 :content="t(`grid.header.reorder.right`)"
                 v-tippy="{ placement: 'top' }"
                 @click="moveRight()"
-                class="move-right opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
+                class="move-right opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default flex justify-center items-center"
                 tabindex="-1"
                 :disabled="!canMoveRight"
             >

--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -1,7 +1,7 @@
 <template>
     <button
         type="button"
-        class="flex items-center justify-center w-42 h-38"
+        class="flex items-center justify-center w-40 h-36"
         :content="t('grid.cells.details')"
         v-tippy="{ placement: 'top' }"
         @click="openDetails"

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -2,7 +2,7 @@
     <button
         v-if="isMapLayer"
         type="button"
-        class="flex items-center justify-center w-42 h-38"
+        class="flex items-center justify-center w-40 h-36"
         :content="
             t(`grid.cells.zoom${zoomStatus === 'none' ? '' : `.${zoomStatus}`}`)
         "

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -8,7 +8,7 @@
             ref="dropdown"
         >
             <template #header>
-                <div class="flex p-4">
+                <div class="flex p-4 justify-center items-center">
                     <svg
                         class="inline-block fill-current w-18 h-18 mx-4"
                         viewBox="0 0 23 21"

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -14,7 +14,7 @@
                 <div class="p-8">
                     <svg
                         class="fill-current w-18 h-18 flip"
-                        viewBox="0 0 23 21"
+                        viewBox="0 0 24 24"
                     >
                         <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"></path>
                     </svg>
@@ -26,7 +26,7 @@
             <button
                 type="button"
                 @click="toggleLayerReorder"
-                class="relative mr-auto text-gray-500 hover:text-black"
+                class="relative mr-auto text-gray-500 hover:text-black flex justify-center items-center"
                 v-show="
                     getLayerReorderExists() &&
                     isControlAvailable('layerReorder')
@@ -38,7 +38,7 @@
                 <div class="p-8">
                     <svg
                         class="fill-current w-18 h-18 flip"
-                        viewBox="0 0 23 21"
+                        viewBox="0 0 24 24"
                     >
                         <path d="M0 0h24v24H0z" fill="none" />
                         <path
@@ -59,7 +59,7 @@
         >
             <template #header>
                 <div class="p-8">
-                    <svg class="fill-current w-18 h-18" viewBox="0 0 23 21">
+                    <svg class="fill-current w-18 h-18" viewBox="0 0 24 24">
                         <path
                             d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
                         />
@@ -91,7 +91,7 @@
         >
             <template #header>
                 <div class="flex p-8">
-                    <svg class="fill-current w-18 h-18" viewBox="0 0 23 21">
+                    <svg class="fill-current w-18 h-18" viewBox="0 0 24 24">
                         <path
                             d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
                         />


### PR DESCRIPTION
### Changes
[FIX] Centered boxes in the legend and grid fixtures

- In the legend:
   - 'Reorder Layers' box
   - 'Add Layer' box
   - 'Toggle Visibility' box
   - 'Toggle Groups' box

- In the grid:
   - 'Details' box
   - 'Zoom' box
   - 'Hide columns' box
   - 'Move left/right' boxes

### Testing
Steps:
1. Open legend and observe the above listed boxes
2. Click on one of the layers in the legend, and observe the above listed boxes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2201)
<!-- Reviewable:end -->
