### PR TITLE
Make MapCaptionConfig props optional, set defaults in createCaption

### DIFF
--- a/demos/starter-scripts/basemaps.js
+++ b/demos/starter-scripts/basemaps.js
@@ -34,9 +34,6 @@ let config = {
                     }
                 ],
                 caption: {
-                    mapCoords: {
-                        formatter: 'WEB_MERCATOR'
-                    },
                     scaleBar: {
                         imperialScale: true
                     }

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -718,9 +718,9 @@ export interface RampLodConfig {
 
 // Contains properties for compoents on the map caption bar
 export interface MapCaptionConfig {
-    mapCoords: { disabled?: boolean; formatter?: string };
-    scaleBar: { disabled?: boolean; imperialScale?: boolean };
-    langToggle: LangToggle;
+    mapCoords?: { disabled?: boolean; formatter?: string };
+    scaleBar?: { disabled?: boolean; imperialScale?: boolean };
+    langToggle?: LangToggle;
 }
 
 // actual ramp config is kinda wonky, split over lots of classes

--- a/src/geo/map/caption.ts
+++ b/src/geo/map/caption.ts
@@ -45,33 +45,40 @@ export class MapCaptionAPI extends APIScope {
         }
 
         const mapCaptionStore = useMapCaptionStore(this.$vApp.$pinia);
+        mapCaptionStore.coords.disabled = false; // default
+        mapCaptionStore.scale.disabled = false; // default
+        mapCaptionStore.scale.imperialScale = false; // default
 
-        // check if map coords has been disabled
-        if (captionConfig.mapCoords.disabled) {
-            mapCaptionStore.coords = { disabled: true };
-        } else {
-            // get formatter specified in the config
-            const defaultFormatter: string | undefined =
-                captionConfig.mapCoords.formatter;
-            if (defaultFormatter !== undefined) {
-                this.setPointFormatter(defaultFormatter);
+        // check if map coords exists, and has been disabled
+        if (captionConfig.mapCoords) {
+            if (captionConfig.mapCoords.disabled) {
+                mapCaptionStore.coords.disabled = true;
+            } else {
+                // get formatter specified in the config
+                const defaultFormatter: string | undefined =
+                    captionConfig.mapCoords.formatter;
+                if (defaultFormatter !== undefined) {
+                    this.setPointFormatter(defaultFormatter);
+                }
             }
         }
 
-        // check if the scalebar has been disabled
-        if (captionConfig.scaleBar.disabled) {
-            mapCaptionStore.scale = { disabled: true };
-        } else {
-            // get the scalebar unit specified in the config
-            const useImperialUnits: boolean | undefined =
-                captionConfig.scaleBar.imperialScale;
-            if (useImperialUnits !== undefined) {
-                // update the value in the store
-                mapCaptionStore.toggleScale(useImperialUnits);
-                // wait for the map to load since updateScale needs map view resolution
-                this.$iApi.geo.map.viewPromise.then(() => {
-                    this.updateScale();
-                });
+        // check if the scalebar exists, and has not been disabled
+        if (captionConfig.scaleBar) {
+            if (captionConfig.scaleBar.disabled) {
+                mapCaptionStore.scale.disabled = true;
+            } else {
+                // get the scalebar unit specified in the config
+                const useImperialUnits: boolean | undefined =
+                    captionConfig.scaleBar.imperialScale;
+                if (useImperialUnits !== undefined) {
+                    // update the value in the store
+                    mapCaptionStore.toggleScale(useImperialUnits);
+                    // wait for the map to load since updateScale needs map view resolution
+                    this.$iApi.geo.map.viewPromise.then(() => {
+                        this.updateScale();
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
### Related Item(s)
Issue #2158

### Changes
- Made the properties of the MapCaptionConfig interface optional. 
- Set default values for the caption store initialized in createCaption(). 
- Made checks in createCaption() to ensure that mapCoords and scaleBar existed before their respective processing blocks are entered. 

### Testing
1. Open sample 36
2. Observe that when mapCoords is removed from the caption (within demos/basemap/starter-scripts/basemaps.js) there is no error in the console (using F12)
3. Prior to the changes, there would be the following error in the console:
![Screenshot 2024-05-29 125103](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/90575655/fdeee169-5749-4789-8ee4-f069493155c6)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2202)
<!-- Reviewable:end -->
