### PR TITLE
Add fixture.exists() function

### DIFF
--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -32,6 +32,10 @@ export class FixtureAPI extends APIScope {
         super(iApi);
     }
 
+    exists(id: string) : boolean {
+        return id in useFixtureStore(this.$vApp.$pinia).items;
+    }
+
     /**
      * Loads a (built-in) fixture or adds supplied fixture into the R4MP Vue instance.
      *

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -365,7 +365,7 @@ export class InstanceAPI {
         // remove each fixture
         addedFixtures.forEach((id: string) => {
             // check if the fixture exists first otherwise it will error
-            if (this.fixture.get(id) !== undefined) {
+            if (this.fixture.exists(id) !== undefined) {
                 this.fixture.remove(id);
             }
         });
@@ -503,7 +503,7 @@ export class InstanceAPI {
             'wizard'
         ];
 
-        if (fixtureIds.includes(id) && !this.fixture.get(id)) {
+        if (fixtureIds.includes(id) && !this.fixture.exists(id)) {
             // protects against a call wanting a store for a fixture that's been removed
             return undefined;
         }

--- a/src/fixtures/appbar/api/appbar.ts
+++ b/src/fixtures/appbar/api/appbar.ts
@@ -86,7 +86,7 @@ export class AppbarAPI extends FixtureInstance {
             }
             // check for components with the id
             [id].some(v => {
-                if (this.$iApi.fixture.get(v) && !appbarStore.items[id]) {
+                if (this.$iApi.fixture.exists(v) && !appbarStore.items[id]) {
                     // if an item is registered globally, save the name of the registered component
                     (
                         appbarStore.items[id] as AppbarItemInstance

--- a/src/fixtures/areas-of-interest/index.ts
+++ b/src/fixtures/areas-of-interest/index.ts
@@ -42,7 +42,7 @@ class AreasOfInterestFixture extends AreasOfInterestAPI {
             // console.log(`[fixture] ${this.id} removed`);
             unwatch();
 
-            if (this.$iApi.fixture.get('appbar')) {
+            if (this.$iApi.fixture.exists('appbar')) {
                 const appbarStore = useAppbarStore(this.$vApp.$pinia);
                 appbarStore.removeButton('areas-of-interest');
             }

--- a/src/fixtures/basemap/index.ts
+++ b/src/fixtures/basemap/index.ts
@@ -33,11 +33,11 @@ class BasemapFixture extends FixtureInstance {
     removed() {
         // console.log(`[fixture] ${this.id} removed`);
 
-        if (this.$iApi.fixture.get('appbar')) {
+        if (this.$iApi.fixture.exists('appbar')) {
             const appbarStore = useAppbarStore(this.$vApp.$pinia);
             appbarStore.removeButton('basemap');
         }
-        if (this.$iApi.fixture.get('mapnav')) {
+        if (this.$iApi.fixture.exists('mapnav')) {
             const mapnavStore = useMapnavStore(this.$vApp.$pinia);
             mapnavStore.removeItem('basemap');
         }

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -43,7 +43,7 @@ class DetailsFixture extends DetailsAPI {
 
             this.$iApi.panel.remove('details-panel');
 
-            if (this.$iApi.fixture.get('appbar')) {
+            if (this.$iApi.fixture.exists('appbar')) {
                 const appbarStore = useAppbarStore(this.$vApp.$pinia);
                 appbarStore.removeButton('details-panel');
             }

--- a/src/fixtures/export/index.ts
+++ b/src/fixtures/export/index.ts
@@ -82,7 +82,7 @@ class ExportFixture extends ExportAPI {
                 .get<ExportFootnoteFixture>('export-footnote')
                 ?.remove();
 
-            if (this.$iApi.fixture.get('appbar')) {
+            if (this.$iApi.fixture.exists('appbar')) {
                 const appbarStore = useAppbarStore(this.$vApp.$pinia);
                 appbarStore.removeButton('export');
             }

--- a/src/fixtures/geosearch/index.ts
+++ b/src/fixtures/geosearch/index.ts
@@ -40,12 +40,12 @@ class GeosearchFixture extends GeosearchAPI {
     removed() {
         // console.log(`[fixture] ${this.id} removed`);
 
-        if (this.$iApi.fixture.get('appbar')) {
+        if (this.$iApi.fixture.exists('appbar')) {
             const appbarStore = useAppbarStore(this.$vApp.$pinia);
             appbarStore.removeButton('geosearch');
         }
 
-        if (this.$iApi.fixture.get('mapnav')) {
+        if (this.$iApi.fixture.exists('mapnav')) {
             const mapnavStore = useMapnavStore(this.$vApp.$pinia);
             mapnavStore.removeItem('geosearch');
         }

--- a/src/fixtures/grid/index.ts
+++ b/src/fixtures/grid/index.ts
@@ -38,7 +38,7 @@ class GridFixture extends GridAPI {
     }
 
     removed() {
-        if (this.$iApi.fixture.get('appbar')) {
+        if (this.$iApi.fixture.exists('appbar')) {
             const appbarStore = useAppbarStore(this.$vApp.$pinia);
             appbarStore.removeButton('grid');
         }

--- a/src/fixtures/help/index.ts
+++ b/src/fixtures/help/index.ts
@@ -42,7 +42,7 @@ class HelpFixture extends HelpAPI {
             // console.log(`[fixture] ${this.id} removed`);
             unwatch();
 
-            if (this.$iApi.fixture.get('mapnav')) {
+            if (this.$iApi.fixture.exists('mapnav')) {
                 const mapnavStore = useMapnavStore(this.$vApp.$pinia);
                 mapnavStore.removeItem('help');
             }

--- a/src/fixtures/layer-reorder/index.ts
+++ b/src/fixtures/layer-reorder/index.ts
@@ -35,7 +35,7 @@ class LayerReorderFixture extends LayerReorderAPI {
 
     removed() {
         // console.log(`[fixture] ${this.id} removed`);
-        if (this.$iApi.fixture.get('appbar')) {
+        if (this.$iApi.fixture.exists('appbar')) {
             const appbarStore = useAppbarStore(this.$vApp.$pinia);
             appbarStore.removeButton('layer-reorder');
         }

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -729,7 +729,7 @@ const getLegendGraphic = (item: any): string | undefined => {
  */
 const getDatagridExists = (): boolean => {
     try {
-        return !!iApi.fixture.get('grid');
+        return iApi.fixture.exists('grid');
     } catch (e) {
         return false;
     }

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -328,7 +328,7 @@ const hover = (t: EventTarget) => {
  */
 const getFixtureExists = (fixtureName: string): boolean => {
     try {
-        return !!iApi.fixture.get(fixtureName);
+        return iApi.fixture.exists(fixtureName);
     } catch (e) {
         return false;
     }

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -135,7 +135,7 @@ const toggleWizard = () => {
 
 const getWizardExists = (): boolean => {
     try {
-        return !!iApi.fixture.get('wizard');
+        return iApi.fixture.exists('wizard');
     } catch (e) {
         return false;
     }
@@ -147,7 +147,7 @@ const toggleLayerReorder = () => {
 
 const getLayerReorderExists = (): boolean => {
     try {
-        return !!iApi.fixture.get('layer-reorder');
+        return iApi.fixture.exists('layer-reorder');
     } catch (e) {
         return false;
     }

--- a/src/fixtures/legend/index.ts
+++ b/src/fixtures/legend/index.ts
@@ -59,12 +59,12 @@ class LegendFixture extends LegendAPI {
             // console.log(`[fixture] ${this.id} removed`);
             unwatch();
 
-            if (this.$iApi.fixture.get('appbar')) {
+            if (this.$iApi.fixture.exists('appbar')) {
                 const appbarStore = useAppbarStore(this.$vApp.$pinia);
                 appbarStore.removeButton('legend');
             }
 
-            if (this.$iApi.fixture.get('mapnav')) {
+            if (this.$iApi.fixture.exists('mapnav')) {
                 const mapnavStore = useMapnavStore(this.$vApp.$pinia);
                 mapnavStore.removeItem('legend');
             }

--- a/src/fixtures/mapnav/api/mapnav.ts
+++ b/src/fixtures/mapnav/api/mapnav.ts
@@ -71,7 +71,7 @@ export class MapnavAPI extends FixtureInstance {
             // so we make the assumption that it will always have the `-nav-button` prefix
 
             // check if fixture exists, or if control is a system control
-            if (this.$iApi.fixture.get(id) || systemControls.includes(id)) {
+            if (this.$iApi.fixture.exists(id) || systemControls.includes(id)) {
                 this.mapnavStore.items[id].componentId = `${id}-nav-button`;
             }
         });

--- a/src/fixtures/metadata/index.ts
+++ b/src/fixtures/metadata/index.ts
@@ -32,7 +32,7 @@ class MetadataFixture extends MetadataAPI {
 
         this.removed = () => {
             // console.log(`[fixture] ${this.id} removed`);
-            if (this.$iApi.fixture.get('appbar')) {
+            if (this.$iApi.fixture.exists('appbar')) {
                 const appbarStore = useAppbarStore(this.$vApp.$pinia);
                 appbarStore.removeButton('metadata');
             }

--- a/src/fixtures/settings/index.ts
+++ b/src/fixtures/settings/index.ts
@@ -33,7 +33,7 @@ class SettingsFixture extends SettingsAPI {
 
     removed() {
         // console.log(`[fixture] ${this.id} removed`);
-        if (this.$iApi.fixture.get('appbar')) {
+        if (this.$iApi.fixture.exists('appbar')) {
             const appbarStore = useAppbarStore(this.$vApp.$pinia);
             appbarStore.removeButton('settings');
         }


### PR DESCRIPTION
### Related Item(s)
Issue #2102 

### Changes
- [FEATURE] Add `fixture.exists(id: string) : boolean` function to simplify checks for fixture existence.
- [REFACTOR] Change all instances of `...fixture.get()` in `true`/`false` context to `...fixture.exists()`.

### Notes
Modified fixtures/files:
- Instance
- Appbar
- Areasofinterest
- basemapfixture
- Details
- export
- Geosearch
- Grid
- Help
- LayerReorder
- LegendGraphic
- Legend
- Header Wizard
- Mapnav
- Metadata
- Settings

### Testing
Steps:
(This PR mainly refactors existing code, so testing is to ensure stuff did not break)
1. On the 'Samples' demo map, go to `39. Old Default Sample`.
2. Rearrange the WFSLayer layer to the top; it should correctly move to be the top layer.
3. On `02. Lots of Panels`, shift some panels around, open/close panels, shift again, etc. It should work properly.
4. Try using any other of the modified fixtures; they should all still work properly.
