### PR TITLE
feat: add ability to register a custom export renderer via the api

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -251,6 +251,11 @@
                 <a href="index-samples.html?sample=44">Failing Basemaps</a>.
                 Contains scenarios where basemaps fail.
             </li>
+            <li>
+                45.
+                <a href="index-samples.html?sample=45">Custom Export</a>.
+                Contains a custom layout for the export image.
+            </li>
         </ul>
 
         <h2>Simple Samples</h2>

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -107,6 +107,9 @@
                         43. Custom Grid Row Buttons
                     </option>
                     <option value="basemap-fail">44. Failing Basemap</option>
+                    <option value="export-custom-renderer">
+                        45. Custom Export
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/export-custom-renderer.js
+++ b/demos/starter-scripts/export-custom-renderer.js
@@ -1,0 +1,1052 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 50,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true,
+                        recoveryBasemap: {
+                            basemapId: 'baseProvinces_3978'
+                        }
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75'],
+                        recoveryBasemap: {
+                            basemapId: 'baseOpenStreetMap'
+                        }
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseProvinces_3978',
+                        name: 'Provincial and Territorial Boundaries',
+                        description:
+                            "A basic outline of Canada's provincial and territorial boundaries.",
+                        altText:
+                            'Canada Base Map - Provincial and Territorial outlines',
+                        hideThumbnail: true,
+                        layers: [
+                            {
+                                id: 'provinces_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#55ffff',
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
+                    },
+                    fieldMetadata: {
+                        fieldInfo: [
+                            { name: 'station_name__nom_station' },
+                            { name: 'station_id__id_station' },
+                            { name: 'province__province' },
+                            { name: 'identifier__identifiant' },
+                            { name: 'year_range__annees' }
+                        ],
+                        exclusiveFields: false,
+                        enforceOrder: true
+                    }
+                },
+                {
+                    id: 'TerritoriesPoly',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/SupportData/MapServer/3',
+                    permanentFilteredQuery: `Name = 'Nunavut' OR Name = 'Northwest Territories' OR Name = 'Yukon Territory'`
+                },
+                {
+                    id: 'BasinLine',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/2',
+                    permanentFilteredQuery: `OBJECTID > 80`
+                },
+                {
+                    id: 'CESI',
+                    layerType: 'esri-map-image',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/',
+                    sublayers: [{ index: 36 }, { index: 37 }, { index: 38 }]
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                infoType: 'title',
+                                name: 'Vector Layers',
+                                children: [
+                                    {
+                                        layerId: 'WFSLayer'
+                                    },
+                                    {
+                                        layerId: 'TerritoriesPoly',
+                                        name: 'TerritoriesPoly'
+                                    },
+                                    {
+                                        layerId: 'BasinLine',
+                                        name: 'BasinLine',
+                                        coverIcon:
+                                            'https://cdn-icons-png.flaticon.com/512/136/136893.png?w=826&t=st=1687287352~exp=1687287952~hmac=10dfcb5cc9522c65066d495e3f17973ecf30dc948bdbdfcb073c647b3b616365'
+                                    }
+                                ]
+                            },
+                            {
+                                layerId: 'CESI',
+                                name: 'Releases of cadmium',
+                                sublayerIndex: 36,
+                                children: [
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Releases of mercury',
+                                        sublayerIndex: 37
+                                    },
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Releases of lead',
+                                        sublayerIndex: 38
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'title',
+                                content: 'Open me for a surprise!',
+                                expanded: false,
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content: 'Keep opening!',
+                                        expanded: false,
+                                        children: [
+                                            {
+                                                name: 'Custom Info Section',
+                                                infoType: 'template',
+                                                content: `<div>
+                                                            <img src="https://i.imgur.com/0IcfK7s.gif" />
+                                                            </div>`
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder',
+                        'areas-of-interest'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                export: {
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                },
+                'areas-of-interest': {
+                    areas: [
+                        {
+                            title: 'Reservoir Manicougan, Quebec, Canada',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                            altText: 'Reservoir Manicougan, Quebec, Canada',
+                            description:
+                                'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
+                            extent: {
+                                xmax: 1840000,
+                                xmin: 1750000,
+                                ymax: 682193,
+                                ymin: 583440,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Gulf of St Lawrence',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                            extent: {
+                                xmin: 2050000,
+                                xmax: 2240000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Lake Grandmesnil and surrounding lakes',
+                            extent: {
+                                xmin: 1800000,
+                                xmax: 1840000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'CN Tower',
+                            thumbnail:
+                                'https://upload.wikimedia.org/wikipedia/commons/9/9c/Toronto_-_ON_-_CN_Tower_Turmkorb.jpg',
+                            description:
+                                'The CN Tower is a 553.3 m-high concrete communications and observation tower in downtown Toronto, Ontario, Canada.',
+                            extent: {
+                                xmin: -8838051.849695725,
+                                xmax: -8836512.572464375,
+                                ymin: 5409988.501845284,
+                                ymax: 5410763.023921062,
+                                spatialReference: {
+                                    wkid: 102100,
+                                    latestWkid: 3857
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        },
+        fr: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'WEB_MERCATOR'
+                    },
+                    scaleBar: {
+                        imperialScale: true
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        attribution: {
+                            text: {
+                                disabled: true
+                            },
+                            logo: {
+                                disabled: true
+                            }
+                        }
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseEsriWorld'
+            },
+            layers: [
+                {
+                    id: 'WFSLayer',
+                    layerType: 'ogc-wfs',
+                    url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
+                    xyInAttribs: true,
+                    colour: '#55ffff',
+                    fixtures: {
+                        details: {
+                            template: 'WFSLayer-Custom'
+                        }
+                    }
+                },
+                {
+                    id: 'TerritoriesPoly',
+                    layerType: 'esri-feature',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/SupportData/MapServer/3',
+                    permanentFilteredQuery: `Name = 'Nunavut' OR Name = 'Northwest Territories' OR Name = 'Yukon Territory'`
+                },
+                {
+                    id: 'BasinLine',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/ICDE/MapServer/2',
+                    permanentFilteredQuery: `OBJECTID > 80`
+                },
+                {
+                    id: 'CESI',
+                    layerType: 'esri-map-image',
+                    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/ICDE/MapServer/',
+                    sublayers: [{ index: 36 }, { index: 37 }, { index: 38 }]
+                }
+            ],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                infoType: 'title',
+                                name: 'Couches Vectorielles',
+                                children: [
+                                    {
+                                        layerId: 'WFSLayer'
+                                    },
+                                    {
+                                        layerId: 'TerritoriesPoly',
+                                        name: 'TerritoriesPoly'
+                                    },
+                                    {
+                                        layerId: 'BasinLine',
+                                        name: 'BasinLine',
+                                        coverIcon:
+                                            'https://cdn-icons-png.flaticon.com/512/136/136893.png?w=826&t=st=1687287352~exp=1687287952~hmac=10dfcb5cc9522c65066d495e3f17973ecf30dc948bdbdfcb073c647b3b616365'
+                                    }
+                                ]
+                            },
+                            {
+                                layerId: 'CESI',
+                                name: 'Rejets de cadmium',
+                                sublayerIndex: 36,
+                                children: [
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Rejets de mercure',
+                                        sublayerIndex: 37
+                                    },
+                                    {
+                                        layerId: 'CESI',
+                                        name: 'Rejets de plomb',
+                                        sublayerIndex: 38
+                                    }
+                                ]
+                            },
+                            {
+                                infoType: 'title',
+                                content: 'Ouvrez-moi pour une surprise!',
+                                expanded: false,
+                                children: [
+                                    {
+                                        infoType: 'text',
+                                        content: 'Continuer à ouvrir!',
+                                        expanded: false,
+                                        children: [
+                                            {
+                                                name: 'Custom Info Section',
+                                                infoType: 'template',
+                                                content: `<div>
+                                                            <img src="https://i.imgur.com/0IcfK7s.gif" />
+                                                            </div>`
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder',
+                        'areas-of-interest'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                export: {
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                },
+                'areas-of-interest': {
+                    areas: [
+                        {
+                            title: 'Reservoir Manicougan, Quebec, Canada',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                            altText: 'Reservoir Manicougan, Quebec, Canada',
+                            description:
+                                'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
+                            extent: {
+                                xmax: 1840000,
+                                xmin: 1750000,
+                                ymax: 682193,
+                                ymin: 583440,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Gulf of St Lawrence',
+                            thumbnail:
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                            extent: {
+                                xmin: 2050000,
+                                xmax: 2240000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'Lake Grandmesnil and surrounding lakes',
+                            extent: {
+                                xmin: 1800000,
+                                xmax: 1840000,
+                                ymin: 583440,
+                                ymax: 682193,
+                                spatialReference: {
+                                    wkid: 3978
+                                }
+                            }
+                        },
+                        {
+                            title: 'CN Tower',
+                            thumbnail:
+                                'https://upload.wikimedia.org/wikipedia/commons/9/9c/Toronto_-_ON_-_CN_Tower_Turmkorb.jpg',
+                            description:
+                                'The CN Tower is a 553.3 m-high concrete communications and observation tower in downtown Toronto, Ontario, Canada.',
+                            extent: {
+                                xmin: -8838051.849695725,
+                                xmax: -8836512.572464375,
+                                ymin: 5409988.501845284,
+                                ymax: 5410763.023921062,
+                                spatialReference: {
+                                    wkid: 102100,
+                                    latestWkid: 3857
+                                }
+                            }
+                        }
+                    ]
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+// rInstance.fixture.addDefaultFixtures().then(() => {
+//     rInstance.panel.open('legend');
+//     rInstance.panel.pin('legend');
+// });
+
+rInstance.$element.component('WFSLayer-Custom', {
+    props: ['identifyData'],
+    template: `
+        <div>
+            <span>This is an example template that contains an image.</span>
+            <img src="https://i.imgur.com/WtY0tdC.gif" />
+        </div>
+    `
+});
+
+// add export fixtures
+rInstance.fixture.add('export');
+
+// add areas of interest fixture
+rInstance.fixture.add('areas-of-interest');
+
+// load map if startRequired is true
+// rInstance.start();
+
+// function animateToggle() {
+//     if (rInstance.$vApp.$el.classList.contains('animation-enabled')) {
+//         rInstance.$vApp.$el.classList.remove('animation-enabled');
+//     } else {
+//         rInstance.$vApp.$el.classList.add('animation-enabled');
+//     }
+//     document.getElementById('animate-status').innerText =
+//         'Animate: ' + rInstance.animate;
+// }
+
+window.debugInstance = rInstance;
+
+rInstance.fixture.isLoaded('export').then(() => {
+    rInstance.fixture.get('export').customRenderer(customExportRenderer);
+});
+
+function customExportRenderer(canvas, { title, map }, { margin }) {
+    var runningHeight = margin.TOP;
+
+    const rvItext = new fabric.IText('[CUSTOM] ' + title.text, {
+        fontFamily:
+            'Montserrat, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif',
+        fill: '#000',
+        fontSize: 30,
+        top: margin.TOP,
+        angle: 5
+    });
+
+    if (rvItext.width > canvas.width) {
+        rvItext.scaleToWidth(canvas.width, false);
+    }
+
+    runningHeight += rvItext.getScaledHeight();
+
+    map.set({
+        top: runningHeight + margin.TOP,
+        left: margin.LEFT
+    });
+
+    map.scaleToWidth(canvas.width * 0.75, false);
+
+    const aRectangle = new fabric.Rect({
+        top: runningHeight + margin.TOP,
+        left: margin.LEFT + map.getScaledWidth() + margin.LEFT,
+        width: 50,
+        height: 50,
+        fill: '#f55'
+    });
+
+    const topHeight = runningHeight + margin.TOP;
+    const bottomHeight = topHeight + map.getScaledHeight() - 50;
+    function animate() {
+        aRectangle.animate(
+            'top',
+            aRectangle.get('top') === bottomHeight ? topHeight : bottomHeight,
+            {
+                duration: 1000,
+                onChange: canvas.renderAll.bind(canvas),
+                onComplete: animate
+            }
+        );
+    }
+
+    runningHeight += map.getScaledHeight() + margin.TOP;
+
+    canvas.add(rvItext);
+    canvas.add(map);
+    canvas.add(aRectangle);
+
+    rvItext.centerH();
+    animate();
+
+    canvas.setDimensions({
+        height: runningHeight + margin.BOTTOM
+    });
+}

--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -17,6 +17,17 @@ const GLOBAL_MARGIN = {
     LEFT: 40
 };
 
+type RenderCallback = (
+    canvas: fabric.StaticCanvas,
+    fabricObjects: Record<string, fabric.Object>,
+    options: {
+        panelWidth: number;
+        margin: typeof GLOBAL_MARGIN;
+        defaultWidth: number;
+        fabric: typeof fabric;
+    }
+) => Promise<void> | void;
+
 export class ExportAPI extends FixtureInstance {
     fcFabric: fabric.StaticCanvas | undefined;
     // download canvas will remain unscaled and only be used for download
@@ -26,6 +37,40 @@ export class ExportAPI extends FixtureInstance {
         runningHeight: 0,
         scale: 1
     };
+
+    // stores the custom render function if provided
+    customRendererFunc = undefined as RenderCallback | undefined;
+
+    /**
+     * Allows for a custom render callback function to be passed in to render the export canvas.
+     * The function should accept the blank ramp canvas as its first parameter and use that canvas to draw on.
+     * The width of the canvas is already set to the panel width, so the function only needs to set the height.
+     *
+     * Individual export elements like the map or the legend can be accessed from the `fabricObjects` object as the second parameter.
+     * You can pick and chose which elements to add to the canvas, or modify them as needed. You can also add custom elements to the canvas.
+     *
+     * Finally, the `options` object is passed in as the third parameter. This object contains useful information such as the panel width, the default margins, the default canvas width, and the fabric object itself.
+     *
+     * Some canvas operations are asynchronous like fetching an image or cloning objects. In these cases you should return a promise so ramp waits for your operations to complete, otherwise returning nothing (void) is fine.
+     *
+     * ramp uses Fabric.js instead of the native canvas API. Read more about Fabric.js here: [Fabric.js](http://fabricjs.com/)
+     *
+     * @param {RenderCallback} renderCallback
+     * @example myWatermarkingRenderer((canvas, fabricObjects, options) => {
+     *   const watermark = new fabric.Text('Watermark', { ... });
+     *   fabricObjects.map.addWithUpdate(watermark);
+     *   canvas.add(fabricObjects.map);
+     *   canvas.setHeight(1000);
+     * });
+     *
+     * rInstance.fixture.isLoaded('export').then(() => {
+     *   rInstance.fixture.get('export').customRenderer(myWatermarkingRenderer);
+     * });
+     * @memberof ExportAPI
+     */
+    customRenderer(renderCallback: RenderCallback): void {
+        this.customRendererFunc = renderCallback;
+    }
 
     /**
      * Returns `ExportConfig` section of the global config file.
@@ -86,6 +131,10 @@ export class ExportAPI extends FixtureInstance {
      */
     async make(canvas: HTMLCanvasElement, panelWidth: number): Promise<void> {
         const exportStore = useExportStore(this.$vApp.$pinia);
+
+        // stores the individual fabric objects for use with a custom render function
+        const selectedFabricObjects: Record<string, fabric.Object> = {};
+
         this.fcFabric = new fabric.StaticCanvas(canvas, {
             backgroundColor: '#fff'
         });
@@ -113,7 +162,6 @@ export class ExportAPI extends FixtureInstance {
         let fbLegend: fabric.Object | undefined;
         let fbFootnote: fabric.Object | undefined;
         let fbTimestamp: fabric.Object | undefined;
-        const selectedExportComponents: Array<fabric.Object> = [];
 
         if (selectedState.title && exportTitleFixture) {
             fbTitle = await exportTitleFixture.make({
@@ -125,7 +173,7 @@ export class ExportAPI extends FixtureInstance {
                 textAlign: 'center'
             });
             this.options.runningHeight += fbTitle.height! + 40;
-            selectedExportComponents.push(fbTitle);
+            selectedFabricObjects.title = fbTitle;
         }
 
         if (selectedState.map && exportMapFixture) {
@@ -140,7 +188,7 @@ export class ExportAPI extends FixtureInstance {
             }
 
             this.options.runningHeight += fbMap.height! + 40;
-            selectedExportComponents.push(fbMap);
+            selectedFabricObjects.map = fbMap;
         }
 
         // title should spread to length of canvas if map isn't rendered
@@ -160,7 +208,7 @@ export class ExportAPI extends FixtureInstance {
                 left: 0
             });
             this.options.runningHeight += fbScaleBar.height! + 40;
-            selectedExportComponents.push(fbScaleBar);
+            selectedFabricObjects.scaleBar = fbScaleBar;
 
             if (exportNorthArrowFixture) {
                 // keep it inline with the scale bar.
@@ -173,7 +221,7 @@ export class ExportAPI extends FixtureInstance {
                 fbNorthArrow.top! += fbNorthArrow.height! / 2 - 20;
                 fbNorthArrow.left! += -fbNorthArrow.width! * 2;
 
-                selectedExportComponents.push(fbNorthArrow);
+                selectedFabricObjects.northArrow = fbNorthArrow;
             }
         }
 
@@ -186,7 +234,7 @@ export class ExportAPI extends FixtureInstance {
             });
             fbLegend.top = this.options.runningHeight;
             this.options.runningHeight += fbLegend.height!;
-            selectedExportComponents.push(fbLegend);
+            selectedFabricObjects.legend = fbLegend;
         }
 
         if (selectedState.timestamp && exportTimestampFixture) {
@@ -195,7 +243,7 @@ export class ExportAPI extends FixtureInstance {
                 width: panelWidth
             });
             this.options.runningHeight += fbTimestamp.height!;
-            selectedExportComponents.push(fbTimestamp);
+            selectedFabricObjects.timestamp = fbTimestamp;
         }
 
         if (selectedState.footnote && exportFootnoteFixture) {
@@ -207,49 +255,78 @@ export class ExportAPI extends FixtureInstance {
             fbFootnote.left! += -fbFootnote.width! * 2;
 
             this.options.runningHeight += fbFootnote.height! + 20;
-            selectedExportComponents.push(fbFootnote);
+            selectedFabricObjects.footnote = fbFootnote;
         }
 
-        const fbGroup = new fabric.Group(selectedExportComponents, {
-            top: GLOBAL_MARGIN.TOP * this.options.scale,
-            left: GLOBAL_MARGIN.LEFT * this.options.scale
-        });
+        if (this.customRendererFunc) {
+            this.fcFabric.setWidth(panelWidth);
+            const options = {
+                panelWidth,
+                margin: GLOBAL_MARGIN,
+                defaultWidth: DEFAULT_WIDTH,
+                fabric: fabric
+            };
 
-        // clone items for download canvas
-        const fbGroupDownload: fabric.Group = await new Promise(resolve => {
-            fbGroup!.clone((g: fabric.Group) => {
-                resolve(g);
+            await this.customRendererFunc(
+                this.fcFabric,
+                selectedFabricObjects,
+                options
+            );
+
+            this.fcFabric.renderAll();
+
+            this.fcFabric.clone((clonedCanvas: fabric.StaticCanvas) => {
+                this.fcFabricDownload = clonedCanvas;
+                this.fcFabricDownload.setDimensions({
+                    width: this.fcFabric!?.getWidth()!,
+                    height: this.fcFabric!.getHeight()!
+                });
+                this.fcFabricDownload.renderAll();
             });
-        });
-        fbGroupDownload.top = GLOBAL_MARGIN.TOP;
-        fbGroupDownload.left = GLOBAL_MARGIN.LEFT;
-        this.fcFabricDownload.add(fbGroupDownload);
+        } else {
+            const fbGroup = new fabric.Group(
+                Object.values(selectedFabricObjects),
+                {
+                    top: GLOBAL_MARGIN.TOP * this.options.scale,
+                    left: GLOBAL_MARGIN.LEFT * this.options.scale
+                }
+            );
 
-        // scale down items for panel canvas
-        fbGroup.scale(this.options.scale);
-        this.fcFabric.add(fbGroup);
+            // clone items for download canvas
+            const fbGroupDownload: fabric.Group = await new Promise(resolve => {
+                fbGroup!.clone((g: fabric.Group) => {
+                    resolve(g);
+                });
+            });
+            fbGroupDownload.top = GLOBAL_MARGIN.TOP;
+            fbGroupDownload.left = GLOBAL_MARGIN.LEFT;
+            this.fcFabricDownload.add(fbGroupDownload);
+            // scale down items for panel canvas
+            fbGroup.scale(this.options.scale);
+            this.fcFabric.add(fbGroup);
 
-        this.fcFabric.setDimensions({
-            width: panelWidth,
-            height:
-                (this.options.runningHeight +
+            this.fcFabric.setDimensions({
+                width: panelWidth,
+                height:
+                    (this.options.runningHeight +
+                        GLOBAL_MARGIN.TOP +
+                        GLOBAL_MARGIN.BOTTOM) *
+                    this.options.scale
+            });
+            this.fcFabric.renderAll();
+
+            this.fcFabricDownload!.setDimensions({
+                width:
+                    (fbMap?.width! ?? DEFAULT_WIDTH) +
+                    GLOBAL_MARGIN.LEFT +
+                    GLOBAL_MARGIN.RIGHT,
+                height:
+                    this.options.runningHeight +
                     GLOBAL_MARGIN.TOP +
-                    GLOBAL_MARGIN.BOTTOM) *
-                this.options.scale
-        });
-        this.fcFabric.renderAll();
-
-        this.fcFabricDownload!.setDimensions({
-            width:
-                (fbMap?.width! ?? DEFAULT_WIDTH) +
-                GLOBAL_MARGIN.LEFT +
-                GLOBAL_MARGIN.RIGHT,
-            height:
-                this.options.runningHeight +
-                GLOBAL_MARGIN.TOP +
-                GLOBAL_MARGIN.BOTTOM
-        });
-        this.fcFabricDownload.renderAll();
+                    GLOBAL_MARGIN.BOTTOM
+            });
+            this.fcFabricDownload.renderAll();
+        }
     }
 
     export(): void {

--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -29,6 +29,7 @@
                 </button>
 
                 <export-settings
+                    v-if="!hasCustomRenderer"
                     :componentSelectedState="selectedComponents"
                     :onComponentToggle="make()"
                     class="ml-auto flex px-4 sm:px-8"
@@ -100,6 +101,10 @@ const selectedComponents = computed<any>(() => {
         );
     }
     return state;
+});
+
+const hasCustomRenderer = computed(() => {
+    return !!fixture.value?.customRendererFunc;
 });
 
 const make = debounce(300, () => {


### PR DESCRIPTION
### Changes
- [FEATURE] Adds the ability to register a custom export renderer callback function via the api.

### Notes
1. Current export functionality is unchanged
2. Fabric.js is being used to reduce complexity vs interfacing between fabric and the native canvas api

### Testing
Steps:
1. Open sample 45
2. Click the export button in the action bar
3. View the custom export

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2206)
<!-- Reviewable:end -->
