### PR TITLE
Document and change types for panel move() direction

### DIFF
--- a/docs/api-guides/panels.md
+++ b/docs/api-guides/panels.md
@@ -62,7 +62,7 @@ Additionally, the `PanelInstance` Object has the following methods:
 * `open(value?: string | { screen: string; props?: object })` - opens the panel. If a screen is specified, that is the one that will be shown.
 * `close()` - closes the panel. This means that the panel is no longer in the stack, but its `PanelInstance` object is still accessible for future use.
 * `minimize()` - minimizes the panel.
-* `move(direction: string)` - moves the panel by one position in the specified direction (left or right), if possible.
+* `move(direction: 'left' | 'right')` - moves the panel by one position in the specified direction (left or right), if possible.
 * `remove()` - removes the panel from the stack as well as from the entire app. Unlike the `close()` method, the `PanelInstance` object no longer accessible.
 * `toggle(value?: boolean | { screen: string; props?: object; toggle?: boolean })` - toggle open/close panel if no value provided, force toggle panel if value specified (open if `toggle` is true, `close` if toggle is false), or toggle panel on specified screen if provided.
 * `toggleMinimize(value?: boolean | { screen: string; props?: object; toggle?: boolean })` - toggle panel's minimize state if no value provided, force toggle panel's minimize state if value specified, or toggle panel's minimize state on specified screen if provided.
@@ -362,7 +362,7 @@ The API provides the following methods:
 * `visible(): PanelInstance[]` - returns an array of all the panels that are currently visible.
 * `close(value: string | PanelInstance): PanelInstance` - closes the specified panel.
 * `minimize(value: string | PanelInstance): PanelInstance` - minimizes the specified panel. Note that the difference between this and closing is that minimizing will result in the temporary appbar buttons staying instead of going away.
-* `move(value: string | PanelInstance, direction: string): PanelInstance` - moves the specified panel one position in the specified direction, if possible. The `direction` parameter can take values of either "left" or "right".
+* `move(value: string | PanelInstance, direction: 'left' | 'right'): PanelInstance` - moves the specified panel one position in the specified direction, if possible. The `direction` parameter can take values of either "left" or "right".
 * `toggle(value: string | PanelInstance | PanelInstancePath, toggle?: boolean): PanelInstance` - toggles the panel open/closed. The optional `toggle` boolean can be used to force the panel to open/close (`true` for open, `false` for close).
 * `toggleMinimize(value: string | PanelInstance | PanelInstancePath, toggle?: boolean): PanelInstance` - same as `toggle`, but toggles between open and minimize instead of open and close.
 * `pin(value: string | PanelInstance, pin?: boolean): PanelInstance` -  pins/unpins/toggles (if no `pin` value provided) the pin status of the provided panel. When pinning, automatically unpins any previous pinned panel if exists.

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -15,6 +15,7 @@ import type {
     PanelConfigRoute,
     PanelConfigScreens,
     PanelConfigStyle,
+    PanelDirection,
     AsyncComponentFactoryEh,
     AsyncComponentEh
 } from '@/stores/panel';
@@ -298,10 +299,11 @@ export class PanelInstance extends APIScope {
      * Move this panel left or right in the stack.
      * This is a proxy to `InstanceAPI.panel.move(...)`.
      *
+     * @param {PanelDirection} direction the direction of movement, either "left" or "right".
      * @returns {this}
      * @memberof PanelInstance
      */
-    move(direction: string): this {
+    move(direction: PanelDirection): this {
         this.$iApi.panel.move(this, direction);
 
         return this;

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -1,5 +1,9 @@
 import { APIScope, GlobalEvents, PanelInstance } from './internal';
-import { usePanelStore, type PanelConfigStyle } from '@/stores/panel';
+import {
+    usePanelStore,
+    type PanelConfigStyle,
+    type PanelDirection
+} from '@/stores/panel';
 import type { PanelConfig, PanelConfigRoute } from '@/stores/panel';
 
 import type { I18nComponentOptions } from '@/lang';
@@ -298,12 +302,13 @@ export class PanelAPI extends APIScope {
      * Moves the specifed visible panel to the left or right.
      *
      * @param {(string | PanelInstance)} value
+     * @param {PanelDirection} direction the direction of movement, either "left" or "right".
      * @returns {PanelInstance | undefined} the panel instance if the panel is currently registered, undefined otherwise.
      * @memberof PanelAPI
      */
     move(
         value: string | PanelInstance,
-        direction: string
+        direction: PanelDirection
     ): PanelInstance | undefined {
         const panel = this.get(value);
 

--- a/src/stores/panel/panel-state.ts
+++ b/src/stores/panel/panel-state.ts
@@ -121,6 +121,11 @@ export type PanelConfigStyle = { [key: string]: string };
 export type PanelConfigControls = { expand?: boolean };
 export type PanelAppbarButton = { icon: string; tooltip: string };
 
+/**
+ * All directions a panel may be moved.
+ */
+export type PanelDirection = 'left' | 'right';
+
 export interface PanelConfig {
     /**
      * A collection of panel screens to be displayed inside the panel.

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import type { PanelInstance } from '@/api';
 import { DefPromise } from '@/geo/api';
+import type { PanelDirection } from './panel-state';
 
 export const usePanelStore = defineStore('panel', () => {
     const pinned = ref<PanelInstance | undefined>(undefined);
@@ -65,7 +66,7 @@ export const usePanelStore = defineStore('panel', () => {
         updateVisible();
     }
 
-    function movePanel(panel: PanelInstance, direction: string): void {
+    function movePanel(panel: PanelInstance, direction: PanelDirection): void {
         move(panel, direction);
         updateVisible();
     }
@@ -219,7 +220,7 @@ export const usePanelStore = defineStore('panel', () => {
         }
     }
 
-    function move(panel: PanelInstance, direction: string): void {
+    function move(panel: PanelInstance, direction: PanelDirection): void {
         //@ts-ignore
         const index = orderedItems.value.indexOf(panel);
         const delta = direction === 'right' ? 1 : -1;


### PR DESCRIPTION
### Related Item(s)
Issue #1664 

### Changes
- [DOCS] Change JSDoc for PanelAPI/PanelInstance `move()` functions to describe acceptable options for direction (`"left"`/`"right"`).
- [REFACTOR] Change type of `direction` parameter from `string` to `"left" | "right"`, to be clearer.
- [DOCS] Modify panels.md to indicate the above change in parameter type.

### Testing
Steps:
1. In the "samples" demo site, go to `02. Lots of panels`. 
2. Try all of the following: Move the leftmost panel all the way to the right; swap the rightmost two panels repeatedly, then the leftmost two; move the rightmost panel all the way to the left; close the leftmost panel, then reopen it.
4. All previously-working panel movement interactions should still work, as seen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2207)
<!-- Reviewable:end -->
