### PR TITLE
Filter columns based on if flag is set, set flag in config

### DIFF
--- a/demos/starter-scripts/grid-config.js
+++ b/demos/starter-scripts/grid-config.js
@@ -57,6 +57,9 @@ let config = {
                     url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#FF5555',
+                    columnMetadata: {
+                        exclusiveColumns: true
+                    },
                     state: {
                         visibility: true
                     },

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -396,7 +396,8 @@ import {
     onBeforeMount,
     onBeforeUnmount,
     ref,
-    watch
+    watch,
+    toRaw
 } from 'vue';
 
 import {
@@ -591,6 +592,7 @@ const gridLayers = computed(() => {
             .filter(layer => layer !== undefined);
     } else return [];
 });
+
 const systemCols = ref<Set<string>>(new Set<string>());
 
 // manages fast incoming filter change events. Forces them to finish
@@ -1469,6 +1471,24 @@ const setUpColumns = () => {
     const fancyLayers: LayerInstance[] = gridLayers.value.filter(
         layer => layer && layer.supportsFeatures && layer.isLoaded
     ) as LayerInstance[];
+
+    const selectedColumns = toRaw(
+        gridStore.grids[props.gridId].state.state.columns
+    );
+
+    if (selectedColumns) {
+        let selectedColumnNames = [];
+        for (let i = 0; i < selectedColumns.length; i++) {
+            selectedColumnNames.push(selectedColumns[i]['field']);
+        }
+
+        // use selectedColumnNames to filter out unwanted columns, but only if the appropriate flag is set
+        if (fancyLayers[0]?.config?.columnMetadata?.exclusiveColumns) {
+            fancyLayers[0].fields = fancyLayers[0].fields.filter(field =>
+                selectedColumnNames.includes(field.name)
+            );
+        }
+    }
 
     if (fancyLayers.length === 0) {
         // in the event of error'd layers, otherwise a blank datagrid will appear


### PR DESCRIPTION
### Related Item(s)
Issue #1932

### Changes
- Added filtering to columns of data grid before having them display

### Notes
Should I add the 'exclusiveColumns' flag to all configs, or just for the one mentioned in the issue?

### Testing
Steps:
1. Open sample 29
2. Click on 'WFSLayer'
3. Observe that the only visible columns are 'Object ID' and 'Station ID'. Initially, all 14 columns would display
