### PR TITLE
Add ts-docs and vite-docs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ dist/
 /.vs
 
 **/.vitepress/cache
+
+# Generated docs folders
+vite-docs
+ts-docs


### PR DESCRIPTION
### Related Item(s)
Issue #2131 

### Changes
- [FEATURE] Add ts-docs and vite-docs folders to .gitignore, preventing them from being added to any stages/commits.

### Notes
This is ignorance manifest:
<img width="292" alt="image" src="https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/3b0594d8-7f9e-4c6b-bd79-f0baefb57258">


### Testing
Steps:
1. Generate docs using `npm run ts-docs:generate` and `npm run vite-docs:generate`.
2. 🎉 All docs files ignored by git! 🎉

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2212)
<!-- Reviewable:end -->
