### PR TITLE
Ensure basemap-change event emits after map view is regenerated

### DIFF
--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -476,6 +476,12 @@ export class MapAPI extends CommonMapAPI {
             this.viewPromise.then(() => {
                 this.$iApi.event.emit(GlobalEvents.MAP_REFRESH_END);
 
+                // fire the basemap change event
+                this.$iApi.event.emit(GlobalEvents.MAP_BASEMAPCHANGE, {
+                    basemapId: basemapId,
+                    schemaChanged: schemaChanged
+                });
+
                 const newScale = this.findClosestScale(scale);
 
                 // go to equivalent extent in new projection
@@ -488,17 +494,19 @@ export class MapAPI extends CommonMapAPI {
         } else {
             // change the basemap
             this.applyBasemap(bm);
+
+            // When schema changes, the recreation of the view will also set the background colour.
             this.esriView.set(
                 'background.color',
                 new Colour(bm.backgroundColour).toESRI()
             );
-        }
 
-        // fire the basemap change event
-        this.$iApi.event.emit(GlobalEvents.MAP_BASEMAPCHANGE, {
-            basemapId: basemapId,
-            schemaChanged: schemaChanged
-        });
+            // fire the basemap change event
+            this.$iApi.event.emit(GlobalEvents.MAP_BASEMAPCHANGE, {
+                basemapId: basemapId,
+                schemaChanged: schemaChanged
+            });
+        }
 
         return schemaChanged;
     }


### PR DESCRIPTION
### Related Item(s)
Issue #2211

### Changes
Emitting the 'basemap change' event separately within each code block of setBasemap(). 
- In the projection code block, the 'basemap change'  is emitted after the promise has resolved
- In the non-projection code block, the 'basemap change' is emitted right after the call to applyBasemap()

### Notes
When switching from another basemap to the 'World Imagery" basemap, the caption text switches from 'Powered by ESRI' to 'Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community', at varying speeds. 

However, this issue gets resolved by #2204. 

### Testing
Steps:
1. Open sample 1 
2. Switch to the Transportation (CBMT) basemap, and observe that the caption text is '© His Majesty the King in Right of Canada, as represented by the Minister of Natural Resources Canada'
3. Switch to the World Physical Map basemap, and observe that the caption text switches to 'Source: US National Park Service'
4. Switch to the Simple basemap, and observe that the caption text switches to 'Powered by ESRI'

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2214)
<!-- Reviewable:end -->
