### PR TITLE
Prevent undesirable refreshes of export image

### DIFF
--- a/src/fixtures/export/settings-button.vue
+++ b/src/fixtures/export/settings-button.vue
@@ -73,7 +73,6 @@ import { useExportStore } from './store';
 const { t } = useI18n();
 const panelStore = usePanelStore();
 const exportStore = useExportStore();
-const emit = defineEmits(['onComponentToggle']);
 
 defineProps({
     componentSelectedState: {
@@ -94,9 +93,6 @@ const toggleComponent = (component: any): void => {
     exportStore.toggleSelected({
         name: component.name
     });
-
-    // notify the parent that a component was toggled
-    emit('onComponentToggle');
 };
 </script>
 


### PR DESCRIPTION
### Related Item(s)
Issue #1901 

### Changes
- [FIX] Remove the `onComponentToggle` emitter/listener for the export settings, and replace it with a watcher for `selectedComponents`, which contains all the settings values. 

### Notes
This prevents unwanted refreshes of the export image after the following actions:
- Pinning any panel, including the export panel.
- Moving any panel.
- Closing any panel.
- Opening any panel other than the export panel.

### Testing
Steps:
1. Open the default sample.
2. Open the export panel.
3. Try the following actions:
  a. Pinning the export panel, or any other panel.
  b. Moving any panel.
  c. Opening any panel.
  d. Closing any other panel.
4. The export image should not refresh.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2215)
<!-- Reviewable:end -->
