### PR TITLE
Maintain height of legend option upon reload

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -448,7 +448,7 @@
                         legendItem.layerRedrawing &&
                         legendItem.visibility)
                 "
-                class="flex-1 h-3"
+                class="h-3 w-full absolute bottom-0"
             >
                 <div class="progress-line"></div>
             </div>


### PR DESCRIPTION
### Related Item(s)
Issue #1895

### Changes
- Fixed the height of the outer div (the one containing the legend option and progress bar) to 44px, which is the height it appears as within the browser
- Without this,  the outer div would grow vertically, pushing down the legend options below it. 

### Notes
I tried alternative ways to prevent the legend option from resizing when the progress bar appeared/disappeared, such as:
- Using flexbox on the outer div, and setting either flex-basis, flex-grow or flex-shrink on the inner divs
- Using relative positioning on the outer div and combinations of absolute/relative positioning divs on the inner divs

If there are any other alternative solutions that are less invasive than directly setting the height of the outer div, please let me know. 

### Testing
Steps:
1. Open any sample which has a legend
2. Ensure legend is open
3. Reload one of the legend options
4. Observe that the legend option(s) below do not get pushed down

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2216)
<!-- Reviewable:end -->
