### PR TITLE
Add tooltips to focus lists and nav bars

### DIFF
--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -95,14 +95,7 @@
                 class="flex-shrink-0 pointer-events-auto focus:outline-none px-4 mr-4 relative top-2"
                 position="top-end"
                 v-if="!langtoggle?.disabled"
-                v-tippy="{
-                    delay: [300, 0],
-                    placement: 'top-end',
-                    theme: 'ramp4',
-                    animation: 'scale',
-                    touch: ['hold', 200]
-                }"
-                :content="t('map.changeLanguage')"
+                :tooltip="t('map.changeLanguage')"
                 :ariaLabel="`${t('map.language.short')} - ${t(
                     'map.changeLanguage'
                 )}`"

--- a/src/components/notification-center/notification-list.vue
+++ b/src/components/notification-center/notification-list.vue
@@ -1,7 +1,13 @@
 <template>
     <!-- Yes Notifications -->
     <div>
-        <ul v-if="notificationStack.length > 0" v-focus-list>
+        <ul
+            v-if="notificationStack.length > 0"
+            v-focus-list
+            :content="t('panels.controls.items')"
+            v-tippy="{ trigger: 'manual', placement: 'top-start' }"
+            ref="el"
+        >
             <template
                 v-for="(notification, index) in notificationStack"
                 :key="notification.message + index"
@@ -34,13 +40,37 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useNotificationStore } from '@/stores/notification';
 import NotificationItem from './notification-item.vue';
 
 const notificationStore = useNotificationStore();
 const { t } = useI18n();
+const el = ref<Element>();
+
+const blurEvent = () => {
+    (el.value as any)._tippy.hide();
+};
+
+const keyupEvent = (e: Event) => {
+    const evt = e as KeyboardEvent;
+    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+        (el.value as any)._tippy.show();
+    }
+};
+
+onMounted(() => {
+    el.value?.addEventListener('blur', blurEvent);
+
+    el.value?.addEventListener('keyup', keyupEvent);
+});
+
+onBeforeUnmount(() => {
+    el.value?.removeEventListener('blur', blurEvent);
+
+    el.value?.removeEventListener('keyup', keyupEvent);
+});
 
 const notificationStack = computed(() => notificationStore.notificationStack);
 </script>

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -6,7 +6,16 @@
 
         <template #content>
             <legend-header />
-            <div v-focus-list>
+            <div
+                v-focus-list
+                :content="t('panels.controls.items')"
+                v-tippy="{
+                    trigger: 'manual',
+                    placement: 'top-end',
+                    maxWidth: 190
+                }"
+                ref="el"
+            >
                 <legend-item
                     v-for="item in children"
                     :legendItem="item"
@@ -18,7 +27,14 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, inject } from 'vue';
+import {
+    computed,
+    defineAsyncComponent,
+    inject,
+    onBeforeUnmount,
+    onMounted,
+    ref
+} from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import type { InstanceAPI, PanelInstance } from '@/api';
@@ -31,6 +47,30 @@ const legendItem = defineAsyncComponent(() => import('./components/item.vue'));
 
 const { t } = useI18n();
 const iApi = inject('iApi') as InstanceAPI;
+const el = ref<Element>();
+
+const blurEvent = () => {
+    (el.value as any)._tippy.hide();
+};
+
+const keyupEvent = (e: Event) => {
+    const evt = e as KeyboardEvent;
+    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+        (el.value as any)._tippy.show();
+    }
+};
+
+onMounted(() => {
+    el.value?.addEventListener('blur', blurEvent);
+
+    el.value?.addEventListener('keyup', keyupEvent);
+});
+
+onBeforeUnmount(() => {
+    el.value?.removeEventListener('blur', blurEvent);
+
+    el.value?.removeEventListener('keyup', keyupEvent);
+});
 
 defineProps({
     panel: {

--- a/src/fixtures/mapnav/mapnav.vue
+++ b/src/fixtures/mapnav/mapnav.vue
@@ -1,6 +1,16 @@
 <template>
     <div class="mapnav absolute right-0 bottom-0 pb-36 sm:pb-48 pr-12">
-        <div class="flex flex-col" v-focus-list>
+        <div
+            class="flex flex-col"
+            v-focus-list
+            :content="t('panels.controls.items')"
+            v-tippy="{
+                trigger: 'manual',
+                placement: 'top-end',
+                maxWidth: 190
+            }"
+            ref="el"
+        >
             <zoom-nav-section
                 class="mapnav-section bg-white-75 hover:bg-white"
             ></zoom-nav-section>
@@ -22,12 +32,38 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useMapnavStore } from './store';
+import { useI18n } from 'vue-i18n';
 import ZoomNavSection from './buttons/zoom-nav.vue';
 import DividerNav from './buttons/divider-nav.vue';
 
 const mapnavStore = useMapnavStore();
+const { t } = useI18n();
+const el = ref<Element>();
+
+const blurEvent = () => {
+    (el.value as any)._tippy.hide();
+};
+
+const keyupEvent = (e: Event) => {
+    const evt = e as KeyboardEvent;
+    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+        (el.value as any)._tippy.show();
+    }
+};
+
+onMounted(() => {
+    el.value?.addEventListener('blur', blurEvent);
+
+    el.value?.addEventListener('keyup', keyupEvent);
+});
+
+onBeforeUnmount(() => {
+    el.value?.removeEventListener('blur', blurEvent);
+
+    el.value?.removeEventListener('keyup', keyupEvent);
+});
 
 /**
  * Return a list of mapnav items with registered components (ones that can be rendered right now).

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -42,6 +42,7 @@ panels.controls.expand,Expand,1,Développer,1
 panels.controls.collapse,Collapse,1,Réduire,1
 panels.controls.moveRight,Move Right,1,Aller à droite,1
 panels.controls.moveLeft,Move Left,1,Aller à gauche,1
+panels.controls.items,Use the arrow keys to navigate the items,1,Utilisez les touches fléchées pour naviguer entre les éléments,0
 panels.alert.open,{name} panel opened,1,Fenêtre {name} ouverte,1
 panels.alert.close,{name} panel closed,1,Fenêtre {name} fermée,1
 panels.alert.minimize,{name} panel minimized,1,Fenêtre {name} réduite,1


### PR DESCRIPTION
### Related Item(s)
Issue #1898 

### Changes

Added tooltips for the following
- Layer list (within Legend)
- Notification list
- Appbar
- Language selector
- Mapnav

The tooltips added are set to trigger manually, meaning that only keyboard (and mobile) users should be able to see them. 

### Testing
Steps:
1. Open any sample (ideally 1 or 30)
2. Use tab to navigate the items of the page
3. When focused on the Appbar, observe the tooltip 'Use the arrow keys to navigate the items' above it
4. When focused on the Layer list within the Legend, observe the tooltip 'Use the arrow keys to navigate the items' above it
5. When focused on the Notification button, click enter, and then click tab until focused on the list of notifications. Then observe the tooltip 'Use the arrow keys to navigate the items'  above it (note that this tooltip will only appear if there is at least one notification in the list)
6. When focused on the language selection button, observe the tooltip 'Change language' above it
7. When focused on the Mapnav, observe the tooltip 'Use the arrow keys to navigate the items' above it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2217)
<!-- Reviewable:end -->
