### PR TITLE
Change font of data grid icons to Roboto

### DIFF
--- a/src/geo/layer/data-layer.ts
+++ b/src/geo/layer/data-layer.ts
@@ -308,12 +308,18 @@ export class DataLayer extends CommonLayer {
         //      or a custom icon that looks like "data"
         //      or possibly allow layer config to override with custom svg
 
-        // return this.$iApi.geo.symbology.generatePlaceholderSymbology('D', '#2e8b57').svg;
+        // return this.$iApi.geo.symbology.generatePlaceholderSymbology('D', '#2e8b57').svgcode;
 
         // this is the result of the above call. Use until symbol is finalized
         // if we do use one of the .generateX methods, prob better to hardcode the result.
         // No reason to run the same logic for every data row.
-        return '<svg id="SvgjsSvg1012" width="32" height="32" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" viewBox="0 0 32 32"><defs id="SvgjsDefs1013"></defs><rect id="SvgjsRect1014" width="28" height="28" x="2" y="2" fill="#2e8b57"></rect><text id="SvgjsText1015" font-family="Roboto" font-size="23" fill="#ffffff" font-weight="bold" x="7.6875" y="-6.40000057220459" svgjs:data="{&quot;leading&quot;:&quot;1.3&quot;}"><tspan id="SvgjsTspan1016" dy="29.900000000000002" x="7.6875" svgjs:data="{&quot;newLined&quot;:true}">D</tspan></text></svg>';
+        return '<svg id="SvgjsSvg1012" width="32" height="32" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svgjs="http://svgjs.com/svgjs" viewBox="0 0 32 32">\
+                      <defs id="SvgjsDefs1013"></defs>\
+                      <rect id="SvgjsRect1014" width="28"  height="28" x="2" y="2" fill="#2e8b57"></rect>\
+                      <text id="SvgjsText1015" font-family="Roboto" font-size="23" fill="#ffffff" font-weight="bold" x="7.6875" y="-6.40000057220459" svgjs:data="{&quot;leading&quot;:&quot;1.3&quot;}">\
+                          <tspan id="SvgjsTspan1016" class="grid-icons" dy="29.900000000000002" x="7.6875" svgjs:data="{&quot;newLined&quot;:true}">D</tspan>\
+                      </text>\
+                </svg>';
     }
 
     async getFilterOIDs(

--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -282,7 +282,8 @@ export class SymbologyAPI extends APIScope {
             .center(this.CONTAINER_CENTER, this.CONTAINER_CENTER)
             .fill(colour);
 
-        draw.text(name[0].toUpperCase()) // take the first letter
+        const textElement = draw
+            .text(name[0].toUpperCase()) // take the first letter
             .size(23)
             .fill('#fff')
             .attr({
@@ -290,6 +291,11 @@ export class SymbologyAPI extends APIScope {
                 'font-family': 'Roboto'
             })
             .center(this.CONTAINER_CENTER, this.CONTAINER_CENTER);
+
+        textElement.tspan(name[0].toUpperCase()).addClass('grid-icons').attr({
+            dy: '29.900000000000002',
+            x: '7.6875'
+        });
 
         return {
             name,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -58,6 +58,10 @@
         Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }
 
+.grid-icons {
+    font-family: 'Roboto' !important;
+}
+
 /* styling for rectangle when Shift+Left-click+Drag zooming */
 .ramp-styles .esri-zoom-box__container {
     position: absolute;


### PR DESCRIPTION
### Related Item(s)
Issue #1920

### Changes
- Set the font of data grid icons (which come from getIcon()) to Roboto, in order to match corresponding icons in Legend

### Testing
Steps:
1. Open sample 38 or 43
2. Click on a Legend option whose icon is 'D'
3. Observe that data grid icons with an icon of 'D' have the same font as their corresponding Legend option icon

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2219)
<!-- Reviewable:end -->
