### PR TITLE
Allow quotes in lang text

### DIFF
--- a/scripts/vite-plugin-i18n.ts
+++ b/scripts/vite-plugin-i18n.ts
@@ -24,6 +24,7 @@ export default function vueI18nPlugin(): Plugin {
                     .replace('export default "', '')
                     .replace(/"$/, '')
                     .replace(/\\n/g, '\n')
+                    .replace(/\\"/g, '"')
             );
             // pick columns that have the value suffixes (they contain actual text);
             const locales = res.columns


### PR DESCRIPTION
### Related Item(s)
Issues #2048 #2046

### Changes
Replaced all instances of `\"`  with `"`, so that quotes are capable of surrounding text in lang.csv files. 


### Testing
I made an extra commit to include commas in various different texts. I will remove that commit once the PR is ready to be merged. 

Steps:
1. Open sample 1
2. Hover over the 'Vector Layers' Legend option, and observe that the text displayed is "Collapse, group"
3. Hover over the Zoom In button in the Mapnav, and observe that the text displayed is "Zoom, in"
4. Switch to French
5. Click on the Notifications button, clear any notifications, and observe that the text displayed is 'Aucune nouvelle, notification'
6. Hover over the Zoom out button in the Mapnav, and observe that the text displayed is "Zoom, arrière"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2220)
<!-- Reviewable:end -->
