### PR TITLE
Invisible MIL Groups

### DIFF
--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -409,17 +409,23 @@ export class MapImageLayer extends MapLayer {
             loadPromises.push(pLMD);
         });
 
-        // any sublayers not in our tree, we need to turn off.
+        // any sublayers lurking in the ESRI layer that are not in our set of sublayers,
+        // we need to deal with.
         this.esriLayer.allSublayers.forEach(s => {
-            // find sublayers that are not groups, and dont exist in our initilazation array
             if (
                 !s.sublayers &&
-                !leafsToInit.find(
-                    (sublayer: MapImageSublayer) => sublayer.layerIdx === s.id
-                )
+                !leafsToInit.find(sublayer => sublayer.layerIdx === s.id)
             ) {
+                // this sublayer is not a group, and doesn't exist in our initialization array.
+                // make sure it doesn't appear on the map
+
                 s.visible = false;
                 s.opacity = 0; // might be overkill
+            } else if (s.sublayers) {
+                // this sublayer is a group. make sure it's visible or else it
+                // can auto-hide any valid sublayers inside it
+
+                s.visible = true;
             }
         });
 


### PR DESCRIPTION
### Related Item(s)

#2221

### Changes

Ensures any group layers that were default-invisible on the surface do not end up hiding child layers on the client.

### Testing

1. Go to any sample with a wizard
2. Open wizard via legend `+`
3. Use [this url](https://services.sac-isc.gc.ca/geomatics/rest/services/ATRIS_PRD/GEO_ATRIS_E/MapServer)
4. Pick `Map Image Layer` service format
5. Select `First Nations` from the sublayer tree
6. Complete the wizard, add the layer
7. Observe the layer draw on the map

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2222)
<!-- Reviewable:end -->
