### PR TITLE
Add aria label to buttons, fix color contrast

### DIFF
--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -148,6 +148,7 @@
                 margin: 10px;
                 flex-grow: 0;
                 white-space: nowrap;
+                color: #000000;
             }
             #selectConfig {
                 width: 90%;

--- a/src/components/notification-center/caption-button.vue
+++ b/src/components/notification-center/caption-button.vue
@@ -90,7 +90,7 @@ const clearAll = () => notificationStore.clearAll();
 
 <style lang="scss" scoped>
 .number {
-    background: red;
+    background: #e70404;
     font-size: 0.8em;
 }
 .notification-dropdown {

--- a/src/components/panel-stack/controls/pin.vue
+++ b/src/components/panel-stack/controls/pin.vue
@@ -8,6 +8,9 @@
                 t(active ? 'panels.controls.unpin' : 'panels.controls.pin')
             "
             v-tippy="{ placement: 'bottom', hideOnClick: false }"
+            :aria-label="
+                t(active ? 'panels.controls.unpin' : 'panels.controls.pin')
+            "
         >
             <svg
                 class="fill-current w-16 h-16"

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -252,6 +252,7 @@
                         }"
                         @mouseover.stop
                         @click.stop="reloadIfReady"
+                        :aria-label="t('legend.layer.controls.reload')"
                     >
                         <div class="flex p-8">
                             <svg
@@ -288,6 +289,11 @@
                         }"
                         @mouseover.stop
                         @click.stop="cancelOrRemoveLayer"
+                        :aria-label="
+                            legendItem.type === LegendType.Error
+                                ? t('legend.layer.controls.remove')
+                                : t('legend.layer.controls.cancel')
+                        "
                     >
                         <div class="flex p-8">
                             <svg


### PR DESCRIPTION
### Related Item(s)
Issue #2218

### Changes
- Added aria labels to the Reload and Remove buttons of Legend options
- Changed color of 'Catalogue' link to increase color contrast
- Changed color of notification counter to increase color contrast

### Notes
Not sure if 'Catalogue' in black looks very appealing, but it was one of the few colors I could use without a contrast error. 

### Testing
The WAVE toolbar for Chrome can be found here: https://chromewebstore.google.com/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh

Steps:
1. Open sample 18
2. Open the WAVE toolbar 
3. Observe that there are no errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2225)
<!-- Reviewable:end -->
