### PR TITLE
Add option to trim layer attributes

### DIFF
--- a/docs/using-ramp4/layers/fancy-properties.md
+++ b/docs/using-ramp4/layers/fancy-properties.md
@@ -92,7 +92,7 @@ Specifies the mime type of the result when running an identify (i.e. a `GetFeatu
 
 Specifies additional attribute field information that will override the default values of the layer. Here we can specify custom field name aliases, and can instruct the layer to only use a subset of the available fields.
 
-- `fieldInfo`: An array that contians objects having valid field names and a custom field alias. If using the `exclusiveFields` option, the alias can be left blank to use the field as-is. Field names are case sensitive.
+- `fieldInfo`: An array that contians objects having valid field names, a custom field alias, and optionally a `trim` property to determine if preceding/trailing whitespaces should be removed for the attributes (for strings only). If using the `exclusiveFields` option, the alias can be left blank to use the field as-is. Field names are case sensitive.
 - `exclusiveFields`: A boolean, if true, only fields in the `fieldInfo` array will be used in the layer.
 - `enforceOrder`: A boolean, if true, the order of the fields in the `fieldInfo` array will be enforced when the grid is displayed. If not all fields are specified in the `fieldInfo` array and the `exclusiveFields` option is not used or is false, then only the specified columns will be displayed in order, followed by the rest of the columns in the order as it appears in the source.
 
@@ -104,7 +104,8 @@ Note that if the system requires additional fields that are missing in the `excl
         fieldInfo: [
             {
                 name: "comp_name",
-                alias: "Company Name"
+                alias: "Company Name",
+                trim: true
             },
             {
                 name: "addr",

--- a/schema.json
+++ b/schema.json
@@ -1813,6 +1813,11 @@
                     "type": "string",
                     "default": "",
                     "description": "Specifies the field title. If missing, attempts to use the service alias, then defaults to the field name."
+                },
+                "trim": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies whether trailing/preceding spaces should be trimmed from the string attribute."
                 }
             },
             "required": ["name"]

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -375,6 +375,7 @@ export interface FieldDefinition {
     alias?: string;
     type: string;
     length?: number;
+    trim?: boolean;
 }
 
 export interface TabularAttributeSet {
@@ -435,6 +436,7 @@ export interface GetGraphicServiceDetails {
     mapSR?: string; // stringified spatial reference of the map
     geometryPrecision?: number; // number of decimal places to keep in result geometry
     oid: number; // oid of the feature to find
+    fieldsToTrim?: Array<string>; // list of fields to trim
 }
 
 export interface DiscreteGraphicResult {
@@ -604,6 +606,7 @@ export interface RampLayerStateConfig {
 export interface RampLayerFieldInfoConfig {
     name: string;
     alias?: string;
+    trim?: boolean;
 }
 
 export interface RampLayerFieldMetadataConfig {

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -245,6 +245,21 @@ export class AttribLayer extends MapLayer {
         }
     }
 
+    getFieldsToTrim(): Array<string> {
+        return this.fields
+            .filter(field => {
+                return field.trim;
+            })
+            .map(field => field.name);
+    }
+
+    /**
+     * Invokes the process to get the full set of attribute values for the layer,
+     * formatted in a tabular format. Additional data properties are also included.
+     * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
+     *
+     * @returns {Promise} resolves with set of tabular attribute values
+     */
     getTabularAttributes(): Promise<TabularAttributeSet> {
         // this call will generate the tabular format, or return the cache if
         // it exists
@@ -332,7 +347,8 @@ export class AttribLayer extends MapLayer {
                 oid: objectId,
                 serviceUrl: this.serviceUrl,
                 includeGeometry: needWebGeom,
-                attribs: this.fieldList
+                attribs: this.fieldList,
+                fieldsToTrim: this.getFieldsToTrim()
             };
 
             if (needWebGeom) {

--- a/src/geo/layer/data-layer.ts
+++ b/src/geo/layer/data-layer.ts
@@ -145,7 +145,8 @@ export class DataLayer extends CommonLayer {
                 batchSize: -1, // mandatory to avoid easy bugs in server process; not used here
                 sourceDataJson: realJson,
                 oidField: this.oidField,
-                attribs: '*' // even required?
+                attribs: '*', // even required?
+                fieldsToTrim: this.getFieldsToTrim()
             };
             this.attribs.attLoader = new DataLayerAttributeLoader(
                 this.$iApi,

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -130,12 +130,13 @@ export class FeatureLayer extends AttribLayer {
                 this.tooltipField =
                     this.origRampConfig.tooltipField || this.nameField;
 
-                this.$iApi.geo.attributes.applyFieldMetadata(
-                    this,
-                    this.origRampConfig.fieldMetadata
-                );
-                this.attribs.attLoader.updateFieldList(this.fieldList);
-            }
+            this.$iApi.geo.attributes.applyFieldMetadata(
+                this,
+                this.origRampConfig.fieldMetadata
+            );
+            this.attribs.attLoader.updateFieldList(this.fieldList);
+            this.attribs.attLoader.updateFieldsToTrim(this.getFieldsToTrim());
+        }
         });
 
         const pFC = this.$iApi.geo.layer

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -422,7 +422,8 @@ export class FileLayer extends AttribLayer {
             sourceGraphics: l.source,
             oidField: this.oidField,
             attribs: '*', // * as default. layer loader may update after processing config overrides
-            batchSize: -1
+            batchSize: -1,
+            fieldsToTrim: [] // fields already trimmed at layer initiation
         };
         this.attribs.attLoader = new FileLayerAttributeLoader(
             this.$iApi,

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -27,6 +27,7 @@ import type {
     IdentifyParameters,
     LayerTimes,
     LegendSymbology,
+    RampLayerFieldMetadataConfig,
     TabularAttributeSet
 } from '@/geo/api';
 
@@ -359,6 +360,14 @@ export class LayerInstance extends APIScope {
      */
     get layerExists(): boolean {
         return false;
+    }
+
+    /**
+     * Gets the fields whose string values should be trimmed.
+     * @returns {Array<string>} the field names.
+     */
+    getFieldsToTrim(): Array<string> {
+        return [];
     }
 
     /**

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -397,6 +397,7 @@ export class MapImageLayer extends MapLayer {
             if (miSL.supportsFeatures) {
                 // ensure our massaged field lists get updated inside the sublayer
                 miSL.updateFieldList();
+                miSL.updateFieldsToTrim();
 
                 // get feature count
                 const count = await this.$iApi.geo.layer.loadFeatureCount(

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -294,6 +294,15 @@ export class MapImageSublayer extends AttribLayer {
     }
 
     /**
+     * A utility method to allow a parent layer to request this layer to
+     * update its fields to be trimmed after field data is processed.
+     * Generally should only be called internally.
+     */
+    updateFieldsToTrim(): void {
+        this.attribs.attLoader.updateFieldsToTrim(this.getFieldsToTrim());
+    }
+
+    /**
      * Visibility of labels on this layer
      */
     get labelVisibility(): boolean {

--- a/src/geo/layer/support/file-utils.ts
+++ b/src/geo/layer/support/file-utils.ts
@@ -586,6 +586,25 @@ export class FileUtils extends APIScope {
             });
         }
 
+        // Determine which fields to trim
+        const trimFields =
+            options.fieldMetadata?.fieldInfo &&
+            options.fieldMetadata?.fieldInfo.length > 0
+                ? options.fieldMetadata.fieldInfo
+                      .filter(fi => fi.trim && validFields.includes(fi.name))
+                      .map(fi => fi.name)
+                : [];
+
+        // Trim the field string values
+        trimFields.forEach(trimName => {
+            for (let i = 0; i < esriJson.length; i++) {
+                const attr = esriJson[i].attributes;
+                if (typeof attr[trimName] === 'string') {
+                    attr[trimName] = attr[trimName].trim();
+                }
+            }
+        });
+
         configPackage.source = <any>esriJson;
         configPackage.spatialReference = fancySR;
         configPackage.id = layerId;

--- a/src/geo/layer/table-layer.ts
+++ b/src/geo/layer/table-layer.ts
@@ -100,7 +100,8 @@ export class TableLayer extends DataLayer {
                     oidField: this.oidField,
                     batchSize: -1,
                     attribs: this.fieldList,
-                    permanentFilter: this.getSqlFilter(CoreFilter.PERMANENT)
+                    permanentFilter: this.getSqlFilter(CoreFilter.PERMANENT),
+                    fieldsToTrim: this.getFieldsToTrim()
                 };
                 this.attribs.attLoader = new ArcServerAttributeLoader(
                     this.$iApi,

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -30,6 +30,7 @@ export interface AttributeLoaderDetails {
     batchSize: number; // calculated maximum amount of attributes that can be downloaded in a single request
     oidField: string; // attribute name of the OID field
     permanentFilter?: string; // SQL to restrict the attributes to download
+    fieldsToTrim?: Array<string>; // All string fields whose values should be trimmed
 }
 
 /**
@@ -107,7 +108,8 @@ export class AttributeAPI extends APIScope {
             );
         }
 
-        const feats: Array<any> = serviceResult.data.features;
+        let feats: Array<any> = serviceResult.data.features;
+
         const len = feats.length;
 
         if (len > 0) {
@@ -124,11 +126,18 @@ export class AttributeAPI extends APIScope {
                 moreDataToLoad = len >= details.batchSize;
             }
 
+            // Trim values in current batch
+            feats = this.trimFeatureSetAttributes(
+                feats,
+                details.fieldsToTrim ?? []
+            );
+
             if (moreDataToLoad) {
                 // call the service again for the next batch of data.
                 // max id becomes last object id in the current batch
 
                 details.maxId = feats[len - 1].attributes[details.oidField];
+
                 const futureFeats = await this.arcGisBatchLoad(
                     details,
                     controller
@@ -141,6 +150,7 @@ export class AttributeAPI extends APIScope {
             } else {
                 // done thanks
                 // return empty list if aborted
+
                 return controller.loadAbortFlag ? [] : feats;
             }
         } else {
@@ -211,6 +221,9 @@ export class AttributeAPI extends APIScope {
         // which is true, but a permanent filter ideally should present things as if they were
         // never part of the layer.
 
+        // NOTE: All attribute string trimming is done at layer creation, not here.
+        // See file-utils.js --> geoJsonToEsriJson() for details/implementation.
+
         const pluckedAttributes = details.sourceGraphics.map(
             g => toRaw(g).attributes
         );
@@ -246,12 +259,19 @@ export class AttributeAPI extends APIScope {
 
         const fields = details.sourceDataJson.fields;
 
+        const fieldsToTrim = details.fieldsToTrim ?? [];
+
         // TODO is there a more efficient way to translate from compact json to attribute objects? Do we care?
         const rampAttributes: Array<Attributes> =
             details.sourceDataJson.data.map(attRow => {
                 const attNugget: any = {};
                 attRow.forEach((val: any, i: number) => {
-                    attNugget[fields[i]] = val;
+                    // Can just trim the values directly here
+                    attNugget[fields[i]] =
+                        typeof val === 'string' &&
+                        fieldsToTrim.includes(fields[i])
+                            ? val.trim()
+                            : val;
                 });
 
                 return attNugget;
@@ -333,8 +353,12 @@ export class AttributeAPI extends APIScope {
 
         const feats: Array<any> = serviceResult.data.features;
         if (feats.length > 0) {
-            const feat = feats[0];
             let geom: BaseGeometry;
+
+            let feat = this.trimFeatureSetAttributes(
+                [feats[0]],
+                details.fieldsToTrim ?? []
+            )[0];
 
             if (details.includeGeometry) {
                 // server result omits spatial reference
@@ -356,6 +380,29 @@ export class AttributeAPI extends APIScope {
                 `Could not locate feature ${details.oid} for layer ${details.serviceUrl}`
             )
         );
+    }
+
+    /**
+     * Trims the desired attribute values for a feature set's attribute groups.
+     * @param features The featureset to be trimmed.
+     * @param fieldsToTrim Array of string names of the attributes to be trimmed.
+     * @returns The featureset, trimmed.
+     */
+    trimFeatureSetAttributes(
+        features: Array<any>,
+        fieldsToTrim: Array<string>
+    ): Array<any> {
+        // For each attribute (column) to be trimmed, trim all fields in that column
+        fieldsToTrim.forEach(attrToTrim => {
+            features.forEach(feat => {
+                // Only trim if value is a string
+                if (typeof feat.attributes[attrToTrim] === 'string') {
+                    feat.attributes[attrToTrim] =
+                        feat.attributes[attrToTrim].trim();
+                }
+            });
+        });
+        return features;
     }
 
     /**
@@ -425,6 +472,18 @@ export class AttributeAPI extends APIScope {
             layer.fieldList = '*';
             return;
         }
+
+        // Find the fields that should be trimmed (have trim = true)...
+        let fieldsToTrim = fieldMetadata.fieldInfo
+            .filter(elem => elem.trim)
+            .map(elem => elem.name);
+
+        // ...and set their trim properties on the layer
+        layer.fields.forEach(field => {
+            if (fieldsToTrim.includes(field.name)) {
+                field.trim = true;
+            }
+        });
 
         // if order enforced, order the fields first before doing exclusive fields check
         if (
@@ -747,6 +806,10 @@ export class AttributeLoaderBase extends APIScope {
      */
     updateFieldList(newList: string): void {
         this.details.attribs = newList;
+    }
+
+    updateFieldsToTrim(newFieldsToTrim: Array<string>): void {
+        this.details.fieldsToTrim = newFieldsToTrim;
     }
 
     getAttribs(): Promise<AttributeSet> {


### PR DESCRIPTION
### Related Item(s)
Issue #2147 

### Changes
- [FEATURE] Add a property `trim` to each fieldMetadata fieldInfo object. If true, it will strip out preceding/trailing whitespaces from the corresponding field's attributes.

### Notes
The `console.log()`s and the modifications to the `.js` files will be removed after reviews; they're there just for testing purposes.

### QA Testing
Please use the updated QA PR 
#2392 

### Testing
Steps:
1. Open sample `28. Layers with exclusive fields`.
2. Open the console.
3. In the legend, click to open `Feature Layer with Name and Description`. I've temporarily added preceding/trailing whitespaces to all string fields, and set `trim: true` for the `Name` field. 
4. Open the console, and you'll see a `FEATURE ATTRIBUTES BEFORE` and a `FEATURE ATTRIBUTES AFTER` object. Click into each of them to index 0: you'll see that whitespace for the name field has been stripped out.
5. Go to Sample 1, and repeat the process with `WFSLayer`. The field `year_range__annees` has its whitespace trimmed out, as its `trim` property is set to `true`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2228)
<!-- Reviewable:end -->
