### PR TITLE
Fix typescript errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
                 "@types/lodash": "^4.14.149",
                 "@types/lodash.clonedeep": "^4.5.7",
                 "@types/marked": "^4.0.1",
-                "@types/node": "^16.11.26",
+                "@types/node": "^17.0.29",
                 "@types/proj4": "^2.5.2",
                 "@types/throttle-debounce": "~2.1.0",
                 "@vitejs/plugin-vue": "^4.0.0",
@@ -1242,9 +1242,9 @@
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
         },
         "node_modules/@types/node": {
-            "version": "16.11.26",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-            "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
+            "version": "17.0.45",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+            "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
             "dev": true
         },
         "node_modules/@types/normalize-package-data": {
@@ -9694,9 +9694,9 @@
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
         },
         "@types/node": {
-            "version": "16.11.26",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
-            "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
+            "version": "17.0.45",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+            "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
             "dev": true
         },
         "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "@types/lodash": "^4.14.149",
         "@types/lodash.clonedeep": "^4.5.7",
         "@types/marked": "^4.0.1",
-        "@types/node": "^16.11.26",
+        "@types/node": "^17.0.29",
         "@types/proj4": "^2.5.2",
         "@types/throttle-debounce": "~2.1.0",
         "@vitejs/plugin-vue": "^4.0.0",

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -352,17 +352,17 @@ function mapUpgrader(r2Map: any, r4c: any): void {
                     logo: {}
                 };
                 if (r2bm.attribution.text) {
-                    r4bm.attribution.text.disabled =
+                    r4bm.attribution.text!.disabled =
                         !r2bm.attribution.text.enabled;
-                    r4bm.attribution.text.value = r2bm.attribution.text.value;
+                    r4bm.attribution.text!.value = r2bm.attribution.text.value;
                 }
                 if (r2bm.attribution.logo) {
-                    r4bm.attribution.logo.disabled =
+                    r4bm.attribution.logo!.disabled =
                         !r2bm.attribution.logo.enabled;
-                    r4bm.attribution.logo.altText =
+                    r4bm.attribution.logo!.altText =
                         r2bm.attribution.logo.altText;
-                    r4bm.attribution.logo.value = r2bm.attribution.logo.value;
-                    r4bm.attribution.logo.link = r2bm.attribution.logo.link;
+                    r4bm.attribution.logo!.value = r2bm.attribution.logo.value;
+                    r4bm.attribution.logo!.link = r2bm.attribution.logo.link;
                 }
             }
 

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -1,9 +1,6 @@
 import { APIScope, GlobalEvents, PanelInstance } from './internal';
-import {
-    usePanelStore,
-    type PanelConfigStyle,
-    type PanelDirection
-} from '@/stores/panel';
+import type { PanelConfigStyle, PanelDirection } from '@/stores/panel';
+import { usePanelStore } from '@/stores/panel';
 import type { PanelConfig, PanelConfigRoute } from '@/stores/panel';
 
 import type { I18nComponentOptions } from '@/lang';

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -11,25 +11,25 @@
 
         <span
             class="relative top-2 sm:top-1 ml-4 sm:ml-0 shrink-0"
-            v-if="!attribution?.logo.disabled"
+            v-if="!attribution?.logo!.disabled"
         >
             <a
                 class="pointer-events-auto cursor-pointer"
-                :href="attribution?.logo.link"
+                :href="attribution?.logo!.link"
                 target="_blank"
-                :aria-label="attribution?.logo.altText"
+                :aria-label="attribution?.logo!.altText"
             >
                 <img
                     class="object-contain h-18 sm:h-26"
-                    :src="attribution?.logo.value"
-                    :alt="attribution?.logo.altText"
+                    :src="attribution?.logo!.value"
+                    :alt="attribution?.logo!.altText"
                 />
             </a>
         </span>
 
         <span
             class="relative ml-10 top-2 text-sm sm:text-base"
-            v-if="!attribution?.text.disabled"
+            v-if="!attribution?.text!.disabled"
             v-truncate="{
                 options: {
                     placement: 'top',
@@ -39,7 +39,7 @@
                 }
             }"
         >
-            {{ attribution?.text.value }}
+            {{ attribution?.text!.value }}
         </span>
 
         <span class="flex-grow w-15"></span>

--- a/src/components/panel-stack/panel-container.vue
+++ b/src/components/panel-stack/panel-container.vue
@@ -50,7 +50,7 @@ onMounted(() => {
 });
 
 const animateTransition = (
-    el: HTMLElement,
+    el: Element,
     done: () => void,
     value: number[]
 ): void => {
@@ -69,11 +69,11 @@ const animateTransition = (
     });
 };
 
-const enter = (el: HTMLElement, done: () => void): void => {
+const enter = (el: Element, done: () => void): void => {
     animateTransition(el, done, [0, 1]);
 };
 
-const beforeLeave = (el: HTMLElement): void => {
+const beforeLeave = (el: Element): void => {
     // this will also trigger when the loading component is transitioning out; in such cases skip executing this function
     if (el.classList.contains('screen-spinner')) {
         return;
@@ -91,7 +91,7 @@ const beforeLeave = (el: HTMLElement): void => {
         );
 };
 
-const leave = (el: HTMLElement, done: () => void): void => {
+const leave = (el: Element, done: () => void): void => {
     animateTransition(el, done, [0, 1]);
 };
 </script>

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -86,6 +86,7 @@ import {
     onMounted,
     ref
 } from 'vue';
+import type { PanelDirection } from '@/stores/panel';
 import type { PropType } from 'vue';
 import { usePanelStore } from '@/stores/panel';
 import { useI18n } from 'vue-i18n';
@@ -126,7 +127,7 @@ const mobileView = computed(() => panelStore.mobileView);
 const reorderable = computed(() => panelStore.reorderable);
 
 const checkMode = () => !mobileView.value && !props.panel.teleport;
-const move = (direction: string) => {
+const move = (direction: PanelDirection) => {
     props.panel.move(direction);
     if (direction === 'left') {
         // needed to preserve focus on correct panel

--- a/src/fixtures/legend/store/legend-store.ts
+++ b/src/fixtures/legend/store/legend-store.ts
@@ -4,6 +4,19 @@ import type { LegendItem } from './legend-item';
 import { SectionItem } from './section-item';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import type { Ref } from 'vue';
+
+interface LegendStore {
+    legendConfig: Ref<LegendConfig>;
+    children: Ref<[]>;
+    headerControls: Ref<string[]>;
+    addItem: (value: {
+        item: LegendItem;
+        parent: LegendItem | undefined;
+    }) => void;
+    removeItem: (item: LegendItem) => void;
+    replaceItem: (value: { oldItem: LegendItem; newItem: LegendItem }) => void;
+}
 
 // NOTE: Pinia and/or Typescript are dumb because when you provide a type like LegendItem, it does not save it as LegendItem.
 // Instead, it is saved as type { _uid: string, ...} i.e. it just saves it as an object with the properties.
@@ -96,5 +109,5 @@ export const useLegendStore = defineStore('legend', () => {
         addItem,
         removeItem,
         replaceItem
-    };
+    } as LegendStore;
 });

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -469,7 +469,7 @@ export class CommonLayer extends LayerInstance {
     protected startTimer(type: TimerType): void {
         this.stopTimer(type); // reset the timer if a timing is already in progress.
         if (this.expectedTime[type] > 0) {
-            this.timers[type] = setTimeout(
+            this.timers[type] = window.setTimeout(
                 () =>
                     this.$iApi.notify.show(
                         NotificationType.WARNING,

--- a/src/geo/map/caption.ts
+++ b/src/geo/map/caption.ts
@@ -47,7 +47,7 @@ export class MapCaptionAPI extends APIScope {
         const mapCaptionStore = useMapCaptionStore(this.$vApp.$pinia);
         mapCaptionStore.coords.disabled = false; // default
         mapCaptionStore.scale.disabled = false; // default
-        mapCaptionStore.scale.imperialScale = false; // default
+        mapCaptionStore.scale.isImperialScale = false; // default
 
         // check if map coords exists, and has been disabled
         if (captionConfig.mapCoords) {
@@ -108,7 +108,7 @@ export class MapCaptionAPI extends APIScope {
             link: this.$iApi.$i18n.t(`caption.attributionLink`),
             value: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEEAAAAkCAYAAADWzlesAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAADO9JREFUeNq0Wgl0jlca/pfvzyo6qNBSmhLLKE1kKEUtB9NTat+OYnBacwwJY19DZRC7sR41th60lWaizFSqRTOEw0lsrQSJGFIESSxJ/uRfv3nef+7Vt9f3p2E695z3fMt97/3ufe+7PO+9n9n0UzELsjKyiHdUdMZnVHTl2VyFe9nO7Kc/Io+4epUxmpWxeVkbr3hvUebgFf15GL9XUwZHndtAAYI09jGvIghOuoEwLOLeYiBoXrwGfZjYYOWAvWyMGlsk2YebXeV3NUEW1qcT5BBX4jUbCYEmHwwKEfdW1gEXgoWtiIlNRFeezcrkrQaTNSuraRYDdImrR1ylAALZBPnkXIJ0wRskeG2Cj3jsoFI2HhcfDDFWA9UBNdZZyc/PP4Z3HZYsWTLGbrffond0Xb9+/Qy6P3jw4F+HDx8+mu7XrVs3c+7cuX+i+3nz5o3n/Rw4cGAdf/7hhx9SZ8yYEcffHT9+/G/8uaSkJGvDhg3D8P3moNdXrlw5UtYVFxfnXL9+/V8PHz68grr2N2/eTC4tLb2E+9+Cotq1a/dOenr6njt37nxPdOrUqd0dO3bsjromoHBQKBPkEyFUB71MH6SPbNy4cRqfkMvlenzixImtqO/x3XffbXc6nSW5ubnpOTk5J1NTU/cQH91//fXXu3/88ccLy5cvj6d34B8gaBA9JyQk/OWjjz5aIu8Fz2DiWbZs2QLx/A4m0Qf9f/n48eNsPEeDfrdly5Y/U31UVNT7dJ04ceIsGseNGzfS6DkuLq4v8YE6Y/G+93g8XKZ6QUHBRVHfAPQC0xJfCRAv65EkeUP6gFx11JEkfw/qTc8ff/zxKofDUXrv3r08rOIBeU9CWbx48SLej5y4LGlpaf9YuHDhUv5OtqH+6Vty0riPAbWjheH8n3322VYpuG+//Xa5mGB7CGM8hKN7vV5dLfHx8WNI20E1aN4WP97YZyc7d+6MM5vNHRs2bDg3NjY23e12l5w8eZJWzIUJ9IdmlI4bNy4tICAgtHbt2hGdOnXaSe3oftu2bWmBgYFOn3MwmwcQLViwIJOeYVYJGGAZVuW2zWZzCZ6hoIGapnmknUMTQnr16vUeTOKydHqyHrx9t27dunro0KEfzJw5M4Pe3bp166Z0pHXr1g0Fj2EYCw8PD+N+SjNwUuSAKnxexOkswOWxZN63b9/MAQMGzIUwx5WXl99eunTpFLx+hJU/K9o/yM7OPhgZGdk5KSkpp0WLFv+Vrq7/na5nz57dR1dM6t7hw4e3DRkyJG7WrFlxgudzukIw58TzV3SF3Z+ByUzFbTk5O9j8fVH/JV3PnTv3uRijSdSR5/empKRkT5kypQxCC+UTxMKVQXuyWBT5WbiS4VFjIZLHWQsLN1ZFgFbm0U1KSNWUUMlDp9kAh0iNdCkRwiva2FjUsjJeJ5sYRYQwCGIYNGk8tC1UCuDQoUOb+vbtuxuPRUJ4FVwIFhZ7pUD45OXEbUpo9DIz8hgAFk0BORblWypm8BiQzkKnpoRnM+PxsEWhiYfFxMTUHTx4cDOYhg7tzM7IyLhNCiYEUEbCMxsAGYuCGjl4ClKE4GY+xCnIw95zBKqxvmyCOJqT7dws5ntZzLcoaJEjQiPUahMaESzudWEqhBEeiSuZvUvzA1+lxIMEhbD7QGYKUl0rBAgxC9vlq6IzNZZ9BYt+rMw8pBDLmSZZFBPQmBC8imaofo1roa5oKH82aQaaIH0CDTZM0sCBAxvBKbZ+7bXXGr3yyisN4ZjMDx48uAeAkofQdHbt2rUXhIpJKevMJwSLfqq3bt365enTp3eFh365SZMmBGpMFRUVZcAV1wFmzs2ZMyddtCkXk9ESExOjq1Wr9iLCbwAilA9xwrnlwimS4G2ffvppj1atWrWoWbNmbWCKAtj9V5MnT84cMWJEvTfeeKM+wqSFzCEoKMgJ3HEVgO6SkTlKMwgUgImwArn2DpMmTYrDALP0XyjEA9sbjTZtQZGij7qghqBWoK4AWPswkbLK+qHIsWPHjoXgfwvUhsZAAEflg+dfg0kuBlosUuvoO2jXl65qXWZm5g7UNRPIOIQLQqpcmECMJIAuRp1UVmiCACmTxAReFx+LhnPqV1hY+O9n6evIkSObSXCEHI0WASDtMMJ0uVHb7du3E6p9HxpxQK0DjN4r0Gc9kSZYeZiSNkuaUOv06dPTO3fuPNj0DAWgKWTFihVL+vfvT0J8kfohAsobV6tWrYbP0hf460pnLE2AF2jB21DvIKO2gO6FNB+ERJtaB+xjY37NN3+LogmkHi9s2rTp3bZt277LG8NuK5AopXbv3n0O7Gtsjx49ZmNye6GOD1RBwD9MFUKoSQSc30UdzJUrV26uWrVqP7D/lt27d+9/9OhRMas7gjYbhROzkv9R2wcHBwdWshjkYL1G7SBQTXGwTwQQLLIqWsGeGFAhVyFSO6C7Naj7ADRUJENDQGMjIiLmQl0LVLUbNWrUItSPhBNcodYhFyFklwAiYf0RNKZZs2YfFhUVXYcAvhFm0FFc++fl5eX4Mxto7JnRo0cvID4yHWSz70dHRw+khAxZ6yGVH8ndftS9DWokciWNx15fTN2zZ0+f6tWr1+LS279/fwYgcz4LPzJvdyGVLUFidFiVOIRAqx8KlQysZCdKboJUXL58uRAmMLFp06aLRbh1cGhrVEiD3nzzzTXIcU5R6gC6vXfv3kuIGgSIyq1Wq6cqpmdhiNAXFtu0adNeZVq9enUWA0xywyVECC4AicwttQ2SrvpkYnfv3i1X6xo0aPAiJv2H+fPnt27UqFEN4YsCDBCk33Lt2rW8kSNHJuP2LqUc4kq+4KFAgg6LxeKtSl+a4hMC6tSp85QD27VrVy9I1U2SJaKYS/ZG8Rf5uhVXq91ud4aEhATINo0bN46glUQMv4aQV46MMpj3iRVvsGjRohFEENQtygCRmZ5B6DsqNNPFANJT5cyZM5RoPRBE/qREaJYEYm4aZ1WFwDG9ppoClebNm9czPV/xYXOo6J4xY8Z84I8Jgq9HBCDVfsKECR+mpqZ+gSQnRVQHGTm4CxcuXBP9l4qrneUNPtheVSFYKtkF/jUKqWbx2LFjUxBJViA82asSZvv06TPq+PHjE/D4GzI70jiVT+xDyBzDo8DhZyoWNXsD4Cn/FYVQLKgIofCfMIkhgKyr4bhO8pBoVGgvsEuXLq+SEIw0Qayyl5H+vIPUmJf2ZYOwz5twXE05U/369TfBZu+wvMBpkH7L3dwyYZ+l4uoRPL50FzCcQuAJstvIyMjacG5Rw4YN64b7V9XBxcbGdgJq/cZIE4TT0/2ceTyzJsiMj0JSxfnz50+rTECBUUq2aGd2WC7Izib+WFwdLJs0sczT1w+Q3d34+PhTSKQ2w4GeVL9LTtefY1Q2YEz/qxC8LIe3f/LJJ2kqU79+/WIGDRpUj+0L8N0lG7B6N+QGiS1btgxR9ha8gi949uzZ0UiENgBSR4iQyFNiL0zkrh+V/78XfjJDq1aWnJx85dixY8kqRE1KSopNSUkZ0K1btwjhsGpMmzatbVZW1nTy/JQbQHUXA26HMRul/gOQHkcBUK1BBGiJFHgtcMV7YqeXeEM7dOhQB4lXh6dCS1kZaZbDSBjinV6ZhsBkdAMz0o00SO4hhIrUl7K/7vfv37+hP0eBw8tBftFRpNNNExMThyMqlKp8SEXsADy5t1GM+qF6CHwe+hifm5t7Ta1PSEiYj7rWIhsMZaCPEkDyL+2PHj36hdqO3lGd4KkuYbN0jC5h22TPRT179pwCZ5j9rKqF0FWtd+/eL0kBA9Y2kRudvBB4og2al1CM+iFsgQFfJTCkaZrboL2DhUfd4NjAadROvHPyvUsLayxNghxaMWw0D1EhFiguqSrxXWZ/EN7IyZMnX5QHn127dk0Gxo+nnd6q9EHf2rx58zJgC1oxSrQKgR1cKl9YWJhdOFg329TlC1oBM3YYZJ8OubcozVZTJPjkzEEwOBGr1yIr+xz23xX23i48PPxVjiqRQV6GRuetXLkSbiPpCsPuTulzEAYPAh+cnzp1ao+YmJi31D5gevkwo3sZGRmn0M+RzMzMAhFtaGG0ixcvfpmfn39WbpNBC1zILK8KHqdykCsXszQ7O/sE8WMBNKGlbrxLF1HsSeQyV5JQBSrJUghLdDQmKB46ywTJFTKzfqqxftScwM1OjGXY/Vl0UU7IHcq3XMrutkz0QsX3bOwEWo5TfsNj9hMxjP5VCFR2fPl/AS4xMH7u71X6CWR92JQjer5t72AHLrpyKGRRhKbCZrNybhJg8HvBU+385Qv8DMKi/BjBEaKuHJK42YDU/x789cFhu1s5cFH/hTAp3/UqhzMm5cTM6G8br/qnyi8lTWYDoZiUP1TUEyc1Ble1D5OSA+gG7U0GR3b+fhUy+kVIN0Kb/xFgANrk0XIqRaL0AAAAAElFTkSuQmCC'
         };
-        // Initial attribution
+        // Initial attribution (guaranteed to not be undefined)
         const attribution: Attribution = {
             text: {
                 value: '',
@@ -125,32 +125,32 @@ export class MapCaptionAPI extends APIScope {
         if (newAttribution) {
             // Check if attribution logo does not exists. If so, set to esri logo
             if (!newAttribution.logo) {
-                attribution.logo.altText = esriLogo.altText;
-                attribution.logo.link = esriLogo.link;
-                attribution.logo.value = esriLogo.value;
+                attribution.logo!.altText = esriLogo.altText;
+                attribution.logo!.link = esriLogo.link;
+                attribution.logo!.value = esriLogo.value;
             } else if (!newAttribution.logo.disabled) {
                 // Need to add OR (||) incase newAttribution values are undefined/empty.
                 // In those cases, use esri logo values
-                attribution.logo.altText =
+                attribution.logo!.altText =
                     newAttribution.logo.altText || esriLogo.altText;
-                attribution.logo.link =
+                attribution.logo!.link =
                     newAttribution.logo.link || esriLogo.link;
-                attribution.logo.value =
+                attribution.logo!.value =
                     newAttribution.logo.value || esriLogo.value;
             } else {
-                attribution.logo.disabled = true; // logo is disabled, so keep logo empty
+                attribution!.logo!.disabled = true; // logo is disabled, so keep logo empty
             }
 
             // Check if attribution text does not exists. If so, set to default esri text
             if (!newAttribution.text) {
-                attribution.text.value = esriText.value;
+                attribution.text!.value = esriText.value;
             } else if (!newAttribution.text.disabled) {
                 // Need to add OR (||) incase newAttribution value is undefined/empty
                 // In those cases, use default esri text
-                attribution.text.value =
+                attribution.text!.value =
                     newAttribution.text.value || esriText.value;
             } else {
-                attribution.text.disabled = true; // text is disabled, so keep text empty (for now)
+                attribution.text!.disabled = true; // text is disabled, so keep text empty (for now)
             }
 
             // Update attribution
@@ -158,10 +158,10 @@ export class MapCaptionAPI extends APIScope {
             mapCaptionStore.setAttribution(attribution);
         } else {
             // set logo and text to default esri if there is no new attribution provided
-            attribution.logo.altText = esriLogo.altText;
-            attribution.logo.link = esriLogo.link;
-            attribution.logo.value = esriLogo.value;
-            attribution.text.value = esriText.value;
+            attribution.logo!.altText = esriLogo.altText;
+            attribution.logo!.link = esriLogo.link;
+            attribution.logo!.value = esriLogo.value;
+            attribution.text!.value = esriText.value;
         }
 
         // If the new attribution is undefined, or its text is disabled, or it has no text defined,
@@ -216,8 +216,8 @@ export class MapCaptionAPI extends APIScope {
                     .map((bl: any) => bl.copyright)
                     .join(' | ');
 
-                attribution.text.value =
-                    copyrightText || attribution.text.value || esriText.value;
+                attribution.text!.value =
+                    copyrightText || attribution.text!.value || esriText.value;
 
                 // Update attribution
                 const mapCaptionStore = useMapCaptionStore(this.$vApp.$pinia);

--- a/src/stores/layer/layer-store.ts
+++ b/src/stores/layer/layer-store.ts
@@ -2,6 +2,21 @@ import type { RampLayerConfig } from '@/geo/api';
 import type { LayerInstance } from '@/api/internal';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import type { Ref } from 'vue';
+
+interface LayerStore {
+    layers: Ref<[]>;
+    layerConfigs: Ref<RampLayerConfig[]>;
+    mapOrder: Ref<string[]>;
+    getLayerByUid: (uid: string) => LayerInstance | undefined;
+    getLayerById: (id: string) => LayerInstance | undefined;
+    getLayerByAny: (idOrUid: string) => LayerInstance | undefined;
+    addLayerConfig: (value: RampLayerConfig) => void;
+    addLayer: (value: LayerInstance, index: number | undefined) => void;
+    reorderLayer: (layer: LayerInstance, index: number) => void;
+    removeLayer: (value: LayerInstance) => void;
+    removeLayerConfig: (layerId: string) => void;
+}
 
 // searches layers and sublayers using BFS and returns the first layer to satisfy the given predicate.
 // Our initial array is just layers, this lets us crawl into sublayers before moving to the next layer.
@@ -175,5 +190,5 @@ export const useLayerStore = defineStore('layer', () => {
         removeLayer,
 
         removeLayerConfig
-    };
+    } as LayerStore;
 });

--- a/src/stores/map-caption/map-caption-store.ts
+++ b/src/stores/map-caption/map-caption-store.ts
@@ -20,12 +20,12 @@ export const useMapCaptionStore = defineStore('map-caption', () => {
         // note: the 'text' property of an Attribution object is an object that has
         // a property named 'value'. This is different from the Vue 'value' property used
         // to access the value of a ref
-        attribution.value.text.value = newAttribution.text.value;
-        attribution.value.text.disabled = newAttribution.text.disabled;
-        attribution.value.logo.altText = newAttribution.logo.altText;
-        attribution.value.logo.link = newAttribution.logo.link;
-        attribution.value.logo.value = newAttribution.logo.value;
-        attribution.value.logo.disabled = newAttribution.logo.disabled;
+        attribution.value.text!.value = newAttribution!.text!.value;
+        attribution.value.text!.disabled = newAttribution!.text!.disabled;
+        attribution.value.logo!.altText = newAttribution!.logo!.altText;
+        attribution.value.logo!.link = newAttribution!.logo!.link;
+        attribution.value.logo!.value = newAttribution!.logo!.value;
+        attribution.value.logo!.disabled = newAttribution!.logo!.disabled;
     }
 
     return {

--- a/src/stores/notification/notification-store.ts
+++ b/src/stores/notification/notification-store.ts
@@ -2,6 +2,21 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import type { Notification } from './notification-state';
 import { NotificationGroup } from '@/api';
+import type { ComputedRef, Ref } from 'vue';
+
+export interface NotificationStore {
+    notificationStack: Ref<(Notification | NotificationGroup)[]>;
+    groups: Ref<{ [id: string]: NotificationGroup }>;
+    notificationNumber: ComputedRef<number>;
+    showNotification: (notification: Notification) => void;
+    removeNotification: (
+        notification: Notification | NotificationGroup
+    ) => void;
+    registerGroup: (group: NotificationGroup) => void;
+    addToGroup: (id: string, message: string) => void;
+    clearAll: () => void;
+    removeGroup: (group: NotificationGroup) => void;
+}
 
 export const useNotificationStore = defineStore('notification', () => {
     const notificationStack = ref<(Notification | NotificationGroup)[]>([]);
@@ -71,5 +86,5 @@ export const useNotificationStore = defineStore('notification', () => {
         registerGroup,
         addToGroup,
         clearAll
-    };
+    } as NotificationStore;
 });

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -3,6 +3,38 @@ import { computed, ref } from 'vue';
 import type { PanelInstance } from '@/api';
 import { DefPromise } from '@/geo/api';
 import type { PanelDirection } from './panel-state';
+import type { PanelConfig } from '@/stores/panel';
+import type { ComputedRef, Ref } from 'vue';
+
+export interface PanelStore {
+    pinned: Ref<PanelInstance | undefined>;
+    priority: Ref<PanelInstance | undefined>;
+    stackWidth: Ref<number>;
+    remWidth: Ref<number>;
+    mobileView: Ref<boolean>;
+    reorderable: Ref<boolean>;
+    items: Ref<{ [name: string]: PanelInstance }>;
+    regPromises: Ref<{ [name: string]: DefPromise }>;
+    orderedItems: Ref<[]>;
+    teleported: Ref<[]>;
+    visible: Ref<[]>;
+    getRemainingWidth: ComputedRef<number>;
+    getVisible: (screenSize: string) => PanelConfig[];
+    getRegPromises: (panelIds: string[]) => Promise<void>[];
+    openPanel: (panel: PanelInstance) => void;
+    closePanel: (panel: PanelInstance) => void;
+    movePanel: (panel: PanelInstance, direction: PanelDirection) => void;
+    removePanel: (panel: PanelInstance) => void;
+    setStackWidth: (value: number) => void;
+    setMobileView: (value: boolean) => void;
+    updateVisible: () => void;
+    registerPanel: (panel: PanelInstance) => void;
+    open: (panel: PanelInstance) => void;
+    close: (panel: PanelInstance) => void;
+    move: (panel: PanelInstance, direction: PanelDirection) => void;
+    remove: (panel: PanelInstance) => void;
+    addRegPromise: (panelId: string) => void;
+}
 
 export const usePanelStore = defineStore('panel', () => {
     const pinned = ref<PanelInstance | undefined>(undefined);
@@ -32,7 +64,7 @@ export const usePanelStore = defineStore('panel', () => {
      * @param screenSize the size of the app's screen as a string
      * @returns {PanelConfig[]}
      */
-    function getVisible(screenSize: string) {
+    function getVisible(screenSize: string): PanelConfig[] {
         if (screenSize === 'xs' && visible.value.length > 0) {
             return [visible.value.slice().pop()!];
         }
@@ -289,5 +321,5 @@ export const usePanelStore = defineStore('panel', () => {
         updateVisible,
         registerPanel,
         addRegPromise
-    };
+    } as PanelStore;
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
         "lib": ["DOM", "DOM.Iterable", "ES2020"],
         "pretty": true,
         "declaration": true,
-        "declarationDir": "./dist/ts"
+        "declarationDir": "./dist/ts",
+        "types": ["node"]
     },
 
     "typedocOptions": {
@@ -31,7 +32,6 @@
         "githubPages": true,
         "cleanOutputDir": true,
         "exclude": [
-            "**/*/store/*.ts",
             "**/*/index.ts",
             "**/tests",
             "**/api/internal.ts",


### PR DESCRIPTION
### Related Item(s)
Issue #1052

### Changes
Fixed all typescript errors that appeared when `npm run build` (or `npm run ts:generate`) was called.

### Testing
Not sure how to test this on the RAMP instance, but I'll provide steps as to how I tested in the console:

Steps:
1. Open RAMP repo in your console
2. Run `npm run build` or `npm run ts:generate`
3. Observe that there are no type errors anymore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2230)
<!-- Reviewable:end -->
