### PR TITLE
Prevent legend tooltip getting stuck

### DIFF
--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -23,7 +23,7 @@
                         : 'cursor-default'
                 ]"
                 @mouseover.stop="hover($event.currentTarget!)"
-                @mouseout.self="
+                @mouseout="
                     //@ts-ignore
                     mobileMode ? null : $event.currentTarget?._tippy?.hide(),
                         (hovered = false)

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -156,7 +156,7 @@
                         : ''
                 "
                 @mouseover.stop="hover($event.currentTarget!)"
-                @mouseout.self="
+                @mouseout="
                     //@ts-ignore
                     mobileMode ? null : $event.currentTarget?._tippy?.hide(),
                         (hovered = false)


### PR DESCRIPTION
### Related Item(s)
Issue #1899 

### Changes
- [FIX] Prevent `Expand/Collapse Group` legend tooltip from getting stuck when mouse leaves element too fast

### Testing
Steps:
1. Open sample 1 (default)
2. Hover over the `Open me for a surprise!` legend option until the `Expand Group` tooltip appears. 
3. **Very quickly** move your mouse out of the legend option, to the right. The tooltip should disappear properly.
4. Repeat steps 2 and 3 multiple times. The tooltip should always disappear upon exiting the legend option.
5. You can open the `Open me for a surprise!` option and try this on the `Keep opening!` option. Its tooltip should be the same as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2233)
<!-- Reviewable:end -->
