### PR TITLE
Tile layer respectful draw

### DIFF
--- a/demos/starter-scripts/simple-feature.js
+++ b/demos/starter-scripts/simple-feature.js
@@ -133,6 +133,7 @@ let config = {
                                 url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
+                        backgroundColour: '#BFE8FE',
                         tileSchemaId:
                             'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
                     },

--- a/src/geo/geo.ts
+++ b/src/geo/geo.ts
@@ -40,6 +40,25 @@ export class GeoAPI extends APIScope {
         this.attributes = new AttributeAPI(iApi);
         this.query = new QueryAPI(iApi);
         this.symbology = new SymbologyAPI(iApi);
+
+        if (!Array.isArray(EsriConfig.request.interceptors)) {
+            EsriConfig.request.interceptors = [];
+        }
+
+        // This will stop tile services from blasting 404s when tiles don't exist.
+        // https://developers.arcgis.com/rest/services-reference/enterprise/map-tile/#request-parameters
+        // See issue #2231 for more context.
+        // If ESRI ever patches the bug described in that issue then we can probably remove this.
+        EsriConfig.request.interceptors.push({
+            before: prams => {
+                if (prams.url.includes('?blankTile=false')) {
+                    prams.url = prams.url.replace(
+                        '?blankTile=false',
+                        '?blankTile=true'
+                    );
+                }
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
### Related Item(s)

#2231

### Changes

- Prevents 404s from breaking the layer if tiles don't exist

### Testing

Wizard URL

```
https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT_TXT_3978/MapServer
```

1. Open any sample. Turn off layer visibility for sample layers.
2. Change basemap to Lambert - Simple. This is so the example is visible and in correct projection
3. Open wizard. Add the above url as an ESRI Tile
4. Zoom map into southern Ontario. Let the tile draw.
5. Hit the Home 🏠 icon in the nav bar to zoom back to Canada view. Observe the tile redraw with Canada-level labels over Ontario.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2234)
<!-- Reviewable:end -->
