### PR TITLE
Ensure accented characters are properly sorted

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -372,6 +372,7 @@
             v-show="!isLoadingGrid && !isErrorGrid"
             class="ag-theme-material flex-grow"
             enableCellTextSelection="true"
+            accentedSort="true"
             :gridOptions="agGridOptions"
             :columnDefs="columnDefs"
             :rowData="rowData"


### PR DESCRIPTION
### Related Item(s)
Issue #2223 

### Changes
- [FEATURE] Ensure that accented characters, such as é, are sorted with their unaccented compatriots.

### Notes
Unscientific test of performance hit when using `accentedSort = true` on [a map service with ~23k entries](https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/StoryRAMP/Cartebsl/MapServer/1):

**TableComponent fully-rendered time**
*Without accentedSort*: 123.9ms
*With accentedSort:* 140.2ms
*Performance penalty:* 13.16%

Geosearch seems to still work fine. Searching for accented character `è` returns results with `e`, and vice versa; searching for unaccented word `ecole` returns results with `école`. See below images.
 
![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/eb3d6022-e95b-498b-961d-60f3660151ed)

![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/c0648b89-2c44-490e-9bab-307065509cc4)

![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/19bb18e7-4e6f-4275-a606-8b2de52547c3)

![image](https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/70e94c82-e6ae-4c2b-8688-d25a37edf060)

### Testing
Steps:
1. Open the default sample.
2. On the Legend, click on the '+' sign to add a service. Use this URL: https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/StoryRAMP/Cartebsl/MapServer/1 (**NOTE**: You need the ECCC VPN for this)
3. Click continue, select 'ESRI Feature Layer', click continue twice.
4. Click into the 'c1aInstallations' legend option. Click the 'Compagnie' column twice to sort descending. Previously, the accented 'e' entries would be listed at the top, but now the 'Z' options are here, as they should.
5. To test the geosearch, enter an accented 'é' in the 'Compagnie' search bar; entries with normal 'e' should still show up. Also, go to the Geolocation Search and enter 'é' to see 'e' entries (and vice versa), and 'ecole' to see 'école' entries.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2235)
<!-- Reviewable:end -->
