### PR TITLE
Modify scale range of grid attributes to include 0

### DIFF
--- a/src/geo/utils/renderer.ts
+++ b/src/geo/utils/renderer.ts
@@ -304,29 +304,36 @@ export class ClassBreaksRenderer extends BaseRenderer {
         super(esriRenderer, layerFields, falseRenderer);
 
         this.valField = this.cleanFieldName(esriRenderer.field, layerFields);
-        esriRenderer.classBreakInfos.forEach((cbi: EsriClassBreakInfo) => {
-            // TODO see if it's possible to have an undefined min/max value that represents inf or -inf
+        esriRenderer.classBreakInfos.forEach(
+            (cbi: EsriClassBreakInfo, i: number) => {
+                // TODO see if it's possible to have an undefined min/max value that represents inf or -inf
+                const first = i === 0;
+                const su = new ClassBreaksSymbolUnit(
+                    this,
+                    cbi.minValue,
+                    cbi.maxValue,
+                    first
+                );
+                su.label = cbi.label || '';
+                su.symbol = cbi.symbol;
 
-            const su = new ClassBreaksSymbolUnit(
-                this,
-                cbi.minValue,
-                cbi.maxValue
-            );
-            su.label = cbi.label || '';
-            su.symbol = cbi.symbol;
+                // Convert fields/values into sql clause. First item has inclusive lower bound (see PR #2239)
+                if (!this.falseRenderer) {
+                    su.definitionClause = `(${this.valField} >${
+                        first ? '=' : ''
+                    }  ${cbi.minValue} AND ${this.valField} <= ${
+                        cbi.maxValue
+                    })`;
+                }
 
-            // convert fields/values into sql clause
-            if (!this.falseRenderer) {
-                su.definitionClause = `(${this.valField} > ${cbi.minValue} AND ${this.valField} <= ${cbi.maxValue})`;
+                this.symbolUnits.push(su);
             }
-
-            this.symbolUnits.push(su);
-        });
+        );
 
         // do default last so we can collate the other SQL for the NOT
         // the 0 values will be ignored
         if (esriRenderer.defaultSymbol) {
-            const su = new ClassBreaksSymbolUnit(this, 0, 0);
+            const su = new ClassBreaksSymbolUnit(this, 0, 0, false);
             su.isDefault = true;
             su.label = esriRenderer.defaultLabel || '';
             su.symbol = esriRenderer.defaultSymbol;
@@ -342,14 +349,24 @@ export class ClassBreaksRenderer extends BaseRenderer {
 }
 
 export class ClassBreaksSymbolUnit extends BaseSymbolUnit {
-    minValue: number; // min is exclusive
-    maxValue: number; // max is inclusive
+    /** min is exclusive, unless first class break */
+    minValue: number;
 
-    constructor(parent: BaseRenderer, minValue: number, maxValue: number) {
+    /** max is inclusive */
+    maxValue: number;
+    firstBreak: boolean;
+
+    constructor(
+        parent: BaseRenderer,
+        minValue: number,
+        maxValue: number,
+        firstBreak: boolean
+    ) {
         super(parent);
 
         this.minValue = minValue;
         this.maxValue = maxValue;
+        this.firstBreak = firstBreak;
     }
 
     match(searchParams: any): boolean {
@@ -357,6 +374,9 @@ export class ClassBreaksSymbolUnit extends BaseSymbolUnit {
         if (this.minValue === this.maxValue) {
             return this.maxValue === searchParams;
         }
-        return this.minValue < searchParams && this.maxValue >= searchParams;
+
+        return this.firstBreak
+            ? this.minValue <= searchParams && this.maxValue >= searchParams
+            : this.minValue < searchParams && this.maxValue >= searchParams;
     }
 }


### PR DESCRIPTION
### Related Item(s)
Issue #2224

### Changes
- Modified the scale range of the grid attributes to include 0

### Testing
Steps:
1. Open any sample with a legend
2. Open the legend from the appbar on the left hand side (if not already open)
3. Click on the 'Add Layer' button to open the wizard
4. Paste https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/6c790f53d57e43bf8e0e3d58a2d3d0c3/MapServer/2/ into the 'URL to file or service' field
5. Click continue twice
6. In the legend, click on the new 'NPE Releases 2012-2021' legend option
7. In the grid, observe that for all features with a 'Quantity (kg)' value of 0, there is a corresponding blue circle visible to the right of the 'Zoom to feature' button
8. Click on the 'Details' button of a feature with a 'Quantity (kg)' value of 0, and observe that the icon to the left of the feature's name is loaded in (before it was a spinning load icon)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2239)
<!-- Reviewable:end -->
