### PR TITLE
[Option 2] Allow legend items to wrap across multiple lines

### DIFF
--- a/docs/using-ramp4/fixtures/legend.md
+++ b/docs/using-ramp4/fixtures/legend.md
@@ -112,6 +112,9 @@ const config = {
 The following properties exist on the legend configuration object:
 
 - `panelWidth: number`, if a custom legend width is required you can do this here. Otherwise if left blank the legend will use the the default fixture width.
+- `multilineItems`, an object which determines whether legend items are allowed to wrap onto new lines if their text requires more space. Only applies to layer items. Contains two optional properties:
+    - `enabled: boolean`, which determines whether the above setting is enabled (defaults to true; if false, text will truncate at one line).
+    - `maxLines: number`, which determines the max number of lines a legend item can take up. Beyond this number, text will truncate and show a tooltip on hover. Defaults to `3`. Only allows integers `1`-`6` as values. Only applies if the legend property `multilineItems.enabled` is true.
 - `root: Object`, a tree-structured object that represents the layout for the legend. Top-level items can be added to the legend as a child of this object as such:
 
 ```

--- a/schema.json
+++ b/schema.json
@@ -364,6 +364,22 @@
                 },
                 "root": {
                     "$ref": "#/$defs/sectionItem"
+                },
+                "multilineItems": {
+                    "type": "object",
+                    "description": "Determines whether legend items should wrap using multiple lines if necessary. Only applies to layer items.",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean",
+                            "description": "Determines whether the multilineItems setting is enabled.",
+                            "default": true
+                        },
+                        "maxLines": {
+                            "type": "number",
+                            "description": "Determines the max number of lines a legend item can take up before truncating. Only applies if the legend property multilineItems.enabled is true. Only accepts integers 1-6, inclusive.",
+                            "default": 3
+                        }
+                    }
                 }
             },
             "required": ["root"],
@@ -469,6 +485,10 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Indicates if symbology stack is expand by default"
+                },
+                "maxLines": {
+                    "type": "number",
+                    "description": "Determines the max number of lines this legend layer item can take up before truncating. Only applies if the legend-level property multilineItems.enabled is true. Overrides the legend-level property multilineItems.maxLines, and defaults to it if no value is provided here. Only accepts integers 1-6, inclusive."
                 }
             },
             "required": ["layerId"],

--- a/src/directives/truncate/truncate.ts
+++ b/src/directives/truncate/truncate.ts
@@ -19,11 +19,14 @@ const TRIGGER_ATTR = 'truncate-trigger';
  * }
  * ```
  * if externalTrigger is present you must put the attribute `truncate-trigger` on the element you wish to be the tooltip trigger (this element must be an ancestor of the element with v-truncate)
- *
+ * if noTruncateClass is present it will prevent the 'truncate' class from being added (which can break some elements)
  */
 export const Truncate: Directive = {
-    beforeMount(el: HTMLElement) {
-        if (!el.classList.contains('truncate')) {
+    beforeMount(el: HTMLElement, binding: DirectiveBinding) {
+        if (
+            !el.classList.contains('truncate') &&
+            !binding.value?.noTruncateClass
+        ) {
             el.classList.add('truncate');
         }
 
@@ -32,7 +35,7 @@ export const Truncate: Directive = {
     mounted(el: HTMLElement, binding: DirectiveBinding) {
         let triggerElement;
         if (binding.value && binding.value.externalTrigger) {
-            // el.closest gets closes ancestor that maches the selector (moves up the parent chain)
+            // el.closest gets closest ancestor that matches the selector (moves up the parent chain)
             triggerElement = el.closest(`[${TRIGGER_ATTR}]`);
         }
 
@@ -74,7 +77,12 @@ export const Truncate: Directive = {
 function onShow(instance: any) {
     // cancel showing the tooltip if the text isn't truncated
     // clientWidth is the visible width of the element, scrollWidth is the width of the content
-    if (instance.reference.clientWidth >= instance.reference.scrollWidth) {
+    // clientHeight is the visible height of the element, scrollHeight is the height of the content
+    const isTruncated =
+        instance.reference.clientWidth < instance.reference.scrollWidth ||
+        instance.reference.clientHeight < instance.reference.scrollHeight;
+
+    if (!isTruncated) {
         // returning false tells tippy to cancel
         return false;
     }

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -26,6 +26,22 @@ export class LegendAPI extends FixtureInstance {
             return;
         }
 
+        useLegendStore(this.$vApp.$pinia).multilineItems =
+            legendConfig.multilineItems?.enabled ?? true;
+
+        // line-clamp only supports values 1-6, and custom values i.e. line-clamp-[4] don't
+        // seem to work. So we limit it here.
+        const lineClampValues = [1, 2, 3, 4, 5, 6];
+        if (
+            !legendConfig.multilineItems?.maxLines ||
+            !lineClampValues.includes(legendConfig.multilineItems?.maxLines)
+        ) {
+            useLegendStore(this.$vApp.$pinia).maxLines = 3;
+        } else {
+            useLegendStore(this.$vApp.$pinia).maxLines =
+                legendConfig.multilineItems.maxLines;
+        }
+
         this.handlePanelWidths(['legend']);
         this.handlePanelTeleports(['legend']);
 

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -20,7 +20,8 @@
                         getDatagridExists() &&
                         legendItem.type === LegendType.Item)
                         ? 'cursor-pointer'
-                        : 'cursor-default'
+                        : 'cursor-default',
+                    allowMultilineItems ? 'multilined' : 'singlelined'
                 ]"
                 @mouseover.stop="hover($event.currentTarget!)"
                 @mouseout="
@@ -67,7 +68,7 @@
             >
                 <!-- smiley face. very important that we migrate this -->
                 <div
-                    class="flex p-5"
+                    class="flex p-5 mr-[13px]"
                     v-if="legendItem.type !== LegendType.Item"
                 >
                     <svg
@@ -192,7 +193,26 @@
 
                 <!-- name or info section-->
                 <div
-                    v-if="legendItem instanceof LayerItem"
+                    v-if="
+                        legendItem instanceof LayerItem && allowMultilineItems
+                    "
+                    class="flex-1 pointer-events-none m-5"
+                    :class="`line-clamp-${maxLines}`"
+                    v-truncate="{
+                        externalTrigger: true,
+                        noTruncateClass: true
+                    }"
+                >
+                    <span class="h-auto break-words text-ellipsis">{{
+                        legendItem.name ??
+                        (!legendItem?.layer?.name
+                            ? legendItem.layerId
+                            : legendItem.layer?.name)
+                    }}</span>
+                </div>
+                <!-- Version if multiline legend items is turned off -->
+                <div
+                    v-else-if="legendItem instanceof LayerItem"
                     class="flex-1 pointer-events-none p-5"
                     v-truncate="{ externalTrigger: true }"
                 >
@@ -269,6 +289,20 @@
                     </button>
                 </div>
 
+                <!-- options dropdown menu -->
+                <legend-options
+                    v-if="
+                        (legendItem.type === LegendType.Item ||
+                            (legendItem.type === LegendType.Placeholder &&
+                                allowMultilineItems)) &&
+                        legendItem instanceof LayerItem
+                    "
+                    :class="{
+                        invisible: legendItem.type === LegendType.Placeholder
+                    }"
+                    :legendItem="legendItem"
+                />
+
                 <!-- Button only appears for loading or errored LayerItems -->
                 <!-- Morphs depending on state. Cancel for loading, Remove for Errored -->
                 <div
@@ -297,7 +331,7 @@
                                 : t('legend.layer.controls.cancel')
                         "
                     >
-                        <div class="flex p-8">
+                        <div class="flex p-5">
                             <svg
                                 v-if="
                                     legendItem.type === LegendType.Placeholder
@@ -322,15 +356,6 @@
                         </div>
                     </button>
                 </div>
-
-                <!-- options dropdown menu -->
-                <legend-options
-                    v-if="
-                        legendItem.type === LegendType.Item &&
-                        legendItem instanceof LayerItem
-                    "
-                    :legendItem="legendItem"
-                />
 
                 <!-- offscale icon -->
                 <div
@@ -590,6 +615,7 @@ import Checkbox from './checkbox.vue';
 import LegendOptions from './legend-options.vue';
 import { usePanelStore } from '@/stores/panel';
 import { useI18n } from 'vue-i18n';
+import { useLegendStore } from '../store';
 
 // eslint doesn't recognize <symbology-stack> usage
 // eslint-disable-next-line
@@ -610,6 +636,12 @@ const props = defineProps({
         required: true
     }
 });
+
+const legendStore = useLegendStore();
+const allowMultilineItems = legendStore.multilineItems;
+const maxLines =
+    (props.legendItem instanceof LayerItem && props.legendItem.maxLines) ??
+    legendStore.maxLines;
 
 const mobileMode = ref(panelStore.mobileView);
 const layerConfigs = computed(() => layerStore.layerConfigs);
@@ -1008,11 +1040,18 @@ if (props.legendItem instanceof LayerItem) {
 .rotate-180 {
     transform: rotate(-180deg);
 }
+
 @media (hover) {
-    .loaded-item {
+    .loaded-item.singlelined {
         @apply min-h-[39px];
         .options {
             @apply hidden;
+        }
+    }
+    .loaded-item.multilined {
+        @apply min-h-[39px];
+        .options {
+            @apply block;
         }
     }
     .loaded-item:hover {
@@ -1026,10 +1065,62 @@ if (props.legendItem instanceof LayerItem) {
         @apply block;
     }
 }
+
 .non-loaded-item {
     @apply px-5 py-5 pb-10 pr-0 align-middle;
 }
 .disabled {
     @apply text-gray-400 cursor-default;
+}
+
+// Overriding Tailwind's line-clamp classes,
+// which occasionally fail or disappear for no reason
+
+// NOTE: The multiline legend items use the CSS line-clamp
+// property. If padding is used, it will start showing the
+// clamped/hidden text using the padding space, which can lead
+// to fragments of the clamped text showing up. In these cases,
+// refactor to use margin.
+
+.line-clamp-1 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+}
+
+.line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.line-clamp-3 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+}
+
+.line-clamp-4 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+}
+
+.line-clamp-5 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 5;
+}
+
+.line-clamp-6 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 6;
 }
 </style>

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -23,6 +23,7 @@ export class LayerItem extends LegendItem {
     _origLayerDisabledControls: Array<LayerControl> | undefined;
     _layerControls: Array<LayerControl>;
     _layerDisabledControls: Array<LayerControl>;
+    _maxLines: number | undefined; // number of lines this item can take up
 
     _symbologyRenderStyle: string;
     _symbologyStack: Array<LegendSymbology>;
@@ -59,6 +60,10 @@ export class LayerItem extends LegendItem {
                 lastVisibility: true
             };
         });
+        this._maxLines =
+            config.maxLines && [1, 2, 3, 4, 5, 6].includes(config.maxLines)
+                ? config.maxLines
+                : undefined;
     }
 
     /** Returns the id of the parent layer if this item is a sublayer. Otherwise undefined */
@@ -180,6 +185,10 @@ export class LayerItem extends LegendItem {
         return this._symbologyStack;
     }
 
+    get maxLines(): number | undefined {
+        return this._maxLines;
+    }
+
     /**
      * Returns a legend config representation of this item.
      */
@@ -191,7 +200,8 @@ export class LayerItem extends LegendItem {
             disabledLayerControls: this._layerDisabledControls,
             symbologyExpanded: this._symbologyExpanded,
             coverIcon: this._coverIcon,
-            description: this._description
+            description: this._description,
+            maxLines: this._maxLines
         };
         return { ...super.getConfig(), ...config };
     }

--- a/src/fixtures/legend/store/legend-state.ts
+++ b/src/fixtures/legend/store/legend-state.ts
@@ -6,4 +6,5 @@ export interface LegendConfig {
     root: { name: string; children: Array<any> };
     headerControls: Array<string>;
     panelWidth: PanelWidthObject | number;
+    multilineItems?: { enabled?: boolean; maxLines?: number };
 }

--- a/src/fixtures/legend/store/legend-store.ts
+++ b/src/fixtures/legend/store/legend-store.ts
@@ -10,6 +10,8 @@ interface LegendStore {
     legendConfig: Ref<LegendConfig>;
     children: Ref<[]>;
     headerControls: Ref<string[]>;
+    multilineItems: Ref<boolean>;
+    maxLines: Ref<number>;
     addItem: (value: {
         item: LegendItem;
         parent: LegendItem | undefined;
@@ -29,6 +31,8 @@ export const useLegendStore = defineStore('legend', () => {
     const legendConfig = ref<LegendConfig>();
     const children = ref<LegendItem[]>([]);
     const headerControls = ref<string[]>([]);
+    const multilineItems = ref<boolean>(true);
+    const maxLines = ref<number>(3);
 
     function addItem(value: {
         item: LegendItem;
@@ -104,6 +108,8 @@ export const useLegendStore = defineStore('legend', () => {
 
     return {
         legendConfig,
+        multilineItems,
+        maxLines,
         children,
         headerControls,
         addItem,


### PR DESCRIPTION
### Related Item(s)
#2232 
#2351 

### Changes
- [FEATURE] Change legend items to fit around text, wrapping across multiple lines if necessary to show all text
- [FEATURE] Add option in legend-level config to turn this behaviour off (default to on)
- [FEATURE] Add option in legend-level config to set the max number of lines a multiline item can take before it truncates (default to 3). Also add a legend item-level setting to set this per-item.
- [FIX] Adjust position of subitems in loading legend item, so that the text no longer shifts after loading completes. As a nice side effect, this also adjusts the text of error'd/loading items so it is aligned with those of regular items.

### Notes
This is option 2 in the issue. The option 1 demo was created by @IshavSohal and can be found here: #2241 

Default view/when `multilineItems = true`:
<img width="350" alt="image" src="https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/ff7dcde8-1c9a-4d41-ba26-b8d07770f9ec">

When `multilineItems = false`:
<img width="346" alt="image" src="https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/94d6e48e-2bae-47aa-a19b-33afb03106c0">

Default view/When `itemMaxLines = 3`:
<img width="351" alt="image" src="https://github.com/user-attachments/assets/558027f9-94a0-4a1b-90af-3247feecad36">

When `itemMaxLines = 2`:
<img width="351" alt="image" src="https://github.com/user-attachments/assets/03ab926b-1d52-4be6-9eb4-0c01e6b10bf3">

QA Testing
Please use the updated QA PR
#2413 

### Testing
Steps:
1. Open sample 28. See how the legend items add additional lines if their text is too long.
2. Using the wizard, add this service: https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/6c790f53d57e43bf8e0e3d58a2d3d0c3/MapServer/2/, and **quickly** look over at the legend. Notice how, after loading, the text does not shift around/requisition extra lines anymore.
3. Open sample 05. See how the legend items truncate the text if it gets too long, remaining only one line in height.
4. Open sample 18 (error state). The text for the error'd items should now align with regular items (before, it would be shifted to the left).
5. Open sample 26. Scroll down and notice how legend items longer than 3 lines will truncate. Hover over it, and the tooltip should appear. **Also notice that `Average sulfur dioxide concentrations...` is only two lines, as its individual item-level `itemMaxLines` setting has been set to 2.**
6. Open sample 24. The `itemMaxLines` setting has been set to 2, so all items longer than two lines should be truncated, and their tooltips shown when hovered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2240)
<!-- Reviewable:end -->
