### PR TITLE
[Option 1] Allow legend items to wrap across multiple lines

### DIFF
--- a/demos/starter-scripts/error-layers.js
+++ b/demos/starter-scripts/error-layers.js
@@ -412,7 +412,7 @@ let config = {
                                 children: [
                                     {
                                         layerId: 'OilFacility',
-                                        name: 'Oil Sands Facility Locations',
+                                        name: 'Oil Sands Facility Locationsdsadasdfnklgdfhgjhdgfdgkljfdglkjfdlgjfdjgfdgj',
                                         disabledLayerControls: ['visibility'],
                                         coverIcon:
                                             'https://cdn-icons-png.flaticon.com/512/3129/3129632.png'
@@ -500,7 +500,8 @@ let config = {
                                     }
                                 ]
                             }
-                        ]
+                        ],
+                        multilineItems: true
                     }
                 },
                 appbar: {

--- a/demos/starter-scripts/exclusive-fields.js
+++ b/demos/starter-scripts/exclusive-fields.js
@@ -316,7 +316,8 @@ let config = {
                             {
                                 layerId: 'CSV'
                             }
-                        ]
+                        ],
+                        multilineItems: true
                     }
                 },
                 appbar: {

--- a/docs/using-ramp4/fixtures/legend.md
+++ b/docs/using-ramp4/fixtures/legend.md
@@ -137,6 +137,7 @@ There are two types of legend component objects for the legend fixture, each one
 Every node in the legend tree structure is an instance of a legend item. All legend items share these properties:
 - `name`: display name for legend item
 - `children`: list of child legend items
+- `multilineItems`: flag which, when set to True, increases the height of all legend options to allow for 2 lines of text (if necessary)
 - `hidden`: indicates if item (and its children) should be hidden from the legend
 - `expanded`: default expanded state of item
 - `exclusive`: indicates if toggling visibility should follow "exclusive" behavior

--- a/schema.json
+++ b/schema.json
@@ -518,6 +518,11 @@
                             }
                         ]
                     }
+                },
+                "multilineItems": {
+                    "type": "boolean",
+                    "description": "Determines whether legend items should wrap using multiple lines if necessary.",
+                    "default": true
                 }
             }
         },

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -39,7 +39,7 @@ export class FixtureAPI extends APIScope {
      * @returns {boolean} whether the fixture identified by 'id' exists
      * @memberof FixtureAPI
      */
-    exists(id: string) : boolean {
+    exists(id: string): boolean {
         return id in useFixtureStore(this.$vApp.$pinia).items;
     }
 

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -26,6 +26,9 @@ export class LegendAPI extends FixtureInstance {
             return;
         }
 
+        useLegendStore(this.$vApp.$pinia).multilineItems =
+            legendConfig.root?.multilineItems ?? false;
+
         this.handlePanelWidths(['legend']);
         this.handlePanelTeleports(['legend']);
 

--- a/src/fixtures/legend/store/legend-state.ts
+++ b/src/fixtures/legend/store/legend-state.ts
@@ -3,7 +3,7 @@ import type { PanelWidthObject } from '@/api';
 export interface LegendConfig {
     isOpen: boolean;
     isPinned: boolean;
-    root: { name: string; children: Array<any> };
+    root: { name: string; children: Array<any>; multilineItems?: boolean };
     headerControls: Array<string>;
     panelWidth: PanelWidthObject | number;
 }

--- a/src/fixtures/legend/store/legend-store.ts
+++ b/src/fixtures/legend/store/legend-store.ts
@@ -10,6 +10,7 @@ interface LegendStore {
     legendConfig: Ref<LegendConfig>;
     children: Ref<[]>;
     headerControls: Ref<string[]>;
+    multilineItems: Ref<Boolean>;
     addItem: (value: {
         item: LegendItem;
         parent: LegendItem | undefined;
@@ -29,6 +30,7 @@ export const useLegendStore = defineStore('legend', () => {
     const legendConfig = ref<LegendConfig>();
     const children = ref<LegendItem[]>([]);
     const headerControls = ref<string[]>([]);
+    const multilineItems = ref<Boolean>(true);
 
     function addItem(value: {
         item: LegendItem;
@@ -104,6 +106,7 @@ export const useLegendStore = defineStore('legend', () => {
 
     return {
         legendConfig,
+        multilineItems,
         children,
         headerControls,
         addItem,


### PR DESCRIPTION
### Related Item(s)
Issue #2232, in particular Option 1

### Changes
- Made all legend items large enough to fit 2 lines of text
- Added a config flag that allows for switching between large (2 line) and small (1 line) legend options

### Notes
Option 2 can be seen here: #2240

### Testing
Steps:
1. Open sample 28, and observe that each legend option has a height large enough to fit 2 lines, allowing for text to wrap onto a second line if necessary. 
2. Open sample 18, and observe (on the 'Oil Sand Facility' legend option) that if the text exceeds the limits of two line, then it will be cut off by ellipses rather than continuing on for more than two lines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2241)
<!-- Reviewable:end -->
