### PR TITLE
Wrap geosearch no-results text, add tooltips

### DIFF
--- a/src/fixtures/geosearch/screen.vue
+++ b/src/fixtures/geosearch/screen.vue
@@ -21,7 +21,7 @@
                     }}
                 </div>
                 <div
-                    class="px-8 mb-10 truncate"
+                    class="px-8 mb-10 py-8 flex-grow text-wrap border-y border-gray-600 overflow-y-auto"
                     v-if="
                         searchVal &&
                         searchResults.length === 0 &&
@@ -51,10 +51,15 @@
                             @click="zoomIn(result)"
                             v-focus-item="'show-truncate'"
                             style="border-bottom: 1px solid lightgray"
+                            truncate-trigger
                         >
-                            <div class="rv-result-description px-8" v-truncate>
+                            <div class="rv-result-description px-8">
                                 <div
-                                    class="flex-1 text-left truncate font-bold"
+                                    class="flex-1 text-left truncate font-bold leading-tight"
+                                    v-truncate="{
+                                        externalTrigger: true,
+                                        options: { placement: 'top-start' }
+                                    }"
                                 >
                                     <span
                                         v-html="
@@ -78,12 +83,14 @@
                                                   result.location.province.abbr
                                         }}</span
                                     >
-                                </div>
-                                <div
-                                    class="flex-1 text-left truncate text-sm"
-                                    v-if="result.type"
-                                >
-                                    {{ result.type }}
+                                    <span v-if="result.type" class="hidden"
+                                        >;
+                                    </span>
+                                    <span
+                                        v-if="result.type"
+                                        class="text-sm font-normal"
+                                        ><br />{{ result.type }}</span
+                                    >
                                 </div>
                             </div>
                         </button>


### PR DESCRIPTION
### Related Item(s)
#2246 

### Changes
- [FIX] Allow the geosearch no-results text to break across multiple lines (and create scrollbars if necessary), so it's always fully visible no matter the input text.
- [FIX] Add tooltip to search result items when name + province combo gets too long.

### Notes
I chose the line-break option over the tooltip option as I think it better uses the empty whitespace on this page, which isn't used for anything else anyway.

### Testing
Steps:
1. Go to any sample with a search. Open it.
2. Enter any search term that shows results, e.g. 'h'. Results should show as expected. 
3. Search 'Hamilton', then scroll to any result item that has been truncated. If you hover over it, you should see a tooltip with the item name and province.
4. Enter a short nonsense search term, e.g. 'dadadadada'. The one-line no-results text should show fine.
5. Enter a longer nonsense search term, e.g. 'dadadadadadadadadadadadadadadadadadadada'. The text should now break lines instead of being hidden.
6. Enter a very long search term. Once it gets long enough, the no-results text should be scrollable, with the search area/checkbox on the top/bottom stickied.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2249)
<!-- Reviewable:end -->
