### PR TITLE
Global Layer Time Defaults

### DIFF
--- a/demos/index-all.html
+++ b/demos/index-all.html
@@ -307,6 +307,11 @@
                 data layer, and one esri table data layer.
                 <span class="tag layer">Data Layers</span>
             </li>
+            <li>
+                46.
+                <a href="index-samples.html?sample=46">No Layers</a>. A map with
+                the typical fixins, but no layers.
+            </li>
         </ul>
 
         <h2>Respect for Apps</h2>

--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -110,6 +110,9 @@
                     <option value="export-custom-renderer">
                         45. Custom Export
                     </option>
+                    <option value="no-layers">
+                        46. Normal Map with No Layers
+                    </option>
                 </select>
                 <a class="linky" href="index-all.html">Catalogue</a>
             </div>

--- a/demos/starter-scripts/no-layers.js
+++ b/demos/starter-scripts/no-layers.js
@@ -1,0 +1,631 @@
+import { createInstance, geo } from '@/main';
+
+window.debugInstance = null;
+
+let config = {
+    configs: {
+        en: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'CANADA_ATLAS_LAMBERT'
+                    },
+                    scaleBar: {
+                        imperialScale: false
+                    }
+                },
+                mapMouseThrottle: 50,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true,
+                        recoveryBasemap: {
+                            basemapId: 'baseProvinces_3978'
+                        }
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75'],
+                        recoveryBasemap: {
+                            basemapId: 'baseOpenStreetMap'
+                        }
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseProvinces_3978',
+                        name: 'Provincial and Territorial Boundaries',
+                        description:
+                            "A basic outline of Canada's provincial and territorial boundaries.",
+                        altText:
+                            'Canada Base Map - Provincial and Territorial outlines',
+                        hideThumbnail: true,
+                        layers: [
+                            {
+                                id: 'provinces_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseNrCan'
+            },
+            layers: [],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                infoType: 'text',
+                                content: 'I start with no layers'
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                export: {
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        },
+        fr: {
+            map: {
+                extentSets: [
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857',
+                        default: {
+                            xmax: -5007771.626060756,
+                            xmin: -16632697.354854,
+                            ymax: 10015875.184845109,
+                            ymin: 5022907.964742964,
+                            spatialReference: {
+                                wkid: 102100,
+                                latestWkid: 3857
+                            }
+                        }
+                    },
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978',
+                        default: {
+                            xmax: 3549492,
+                            xmin: -2681457,
+                            ymax: 3482193,
+                            ymin: -883440,
+                            spatialReference: {
+                                wkid: 3978
+                            }
+                        }
+                    }
+                ],
+                caption: {
+                    mapCoords: {
+                        formatter: 'CANADA_ATLAS_LAMBERT'
+                    },
+                    scaleBar: {
+                        imperialScale: false
+                    }
+                },
+                mapMouseThrottle: 200,
+                lodSets: [
+                    {
+                        id: 'LOD_NRCAN_Lambert_3978',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[0])
+                    },
+                    {
+                        id: 'LOD_ESRI_World_AuxMerc_3857',
+                        lods: geo.defaultLODs(geo.defaultTileSchemas()[1])
+                    }
+                ],
+                tileSchemas: [
+                    {
+                        id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
+                        name: 'Lambert Maps',
+                        extentSetId: 'EXT_NRCAN_Lambert_3978',
+                        lodSetId: 'LOD_NRCAN_Lambert_3978',
+                        thumbnailTileUrls: [
+                            '/tile/8/285/268',
+                            '/tile/8/285/269'
+                        ],
+                        hasNorthPole: true
+                    },
+                    {
+                        id: 'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857',
+                        name: 'Web Mercator Maps',
+                        extentSetId: 'EXT_ESRI_World_AuxMerc_3857',
+                        lodSetId: 'LOD_ESRI_World_AuxMerc_3857',
+                        thumbnailTileUrls: ['/tile/8/91/74', '/tile/8/91/75']
+                    }
+                ],
+                basemaps: [
+                    {
+                        id: 'baseNrCan',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseSimple',
+                        name: 'Canada Base Map - Simple',
+                        description: 'Canada Base Map - Simple',
+                        altText: 'Canada base map - Simple',
+                        layers: [
+                            {
+                                id: 'SMR',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBME_CBCE_HS_RO_3978',
+                        name: 'Canada Base Map - Elevation (CBME)',
+                        description:
+                            'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Elevation (CBME)',
+                        layers: [
+                            {
+                                id: 'CBME_CBCE_HS_RO_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseCBMT_CBCT_GEOM_3978',
+                        name: 'Canada Base Map - Transportation (CBMT)',
+                        description:
+                            ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
+                        layers: [
+                            {
+                                id: 'CBMT_CBCT_GEOM_3978',
+                                layerType: 'esri-tile',
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
+                    },
+                    {
+                        id: 'baseEsriWorld',
+                        name: 'World Imagery',
+                        description:
+                            'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
+                        altText: 'World Imagery',
+                        layers: [
+                            {
+                                id: 'World_Imagery',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriPhysical',
+                        name: 'World Physical Map',
+                        description:
+                            'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
+                        altText: 'World Physical Map',
+                        layers: [
+                            {
+                                id: 'World_Physical_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Physical_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriRelief',
+                        name: 'World Shaded Relief',
+                        description:
+                            'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
+                        altText: 'World Shaded Relief',
+                        layers: [
+                            {
+                                id: 'World_Shaded_Relief',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Shaded_Relief/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriStreet',
+                        name: 'World Street Map',
+                        description:
+                            'This worldwide street map presents highway-level data for the world.',
+                        altText: 'ESWorld Street Map',
+                        layers: [
+                            {
+                                id: 'World_Street_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Street_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTerrain',
+                        name: 'World Terrain Base',
+                        description:
+                            'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
+                        altText: 'World Terrain Base',
+                        layers: [
+                            {
+                                id: 'World_Terrain_Base',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Terrain_Base/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseEsriTopo',
+                        name: 'World Topographic Map',
+                        description:
+                            'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
+                        altText: 'World Topographic Map',
+                        layers: [
+                            {
+                                id: 'World_Topo_Map',
+                                layerType: 'esri-tile',
+                                url: 'https://services.arcgisonline.com/arcgis/rest/services/World_Topo_Map/MapServer'
+                            }
+                        ],
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    },
+                    {
+                        id: 'baseOpenStreetMap',
+                        name: 'OpenStreetMap',
+                        description: 'Open sourced topographical map.',
+                        altText: 'OpenStreetMap',
+                        layers: [
+                            {
+                                id: 'Open_Street_Map',
+                                layerType: 'osm-tile'
+                            }
+                        ],
+                        thumbnailUrl:
+                            'https://www.openstreetmap.org/assets/about/osm-a74d2c94082260032c133b9d206ee2fdd911e5c82bf03daae10393a02d7b4809.png',
+                        tileSchemaId:
+                            'EXT_ESRI_World_AuxMerc_3857#LOD_ESRI_World_AuxMerc_3857'
+                    }
+                ],
+                initialBasemapId: 'baseNrCan'
+            },
+            layers: [],
+            fixtures: {
+                legend: {
+                    root: {
+                        children: [
+                            {
+                                infoType: 'text',
+                                content: 'Bonjour, I start with no layers'
+                            }
+                        ]
+                    }
+                },
+                appbar: {
+                    items: [
+                        'legend',
+                        'geosearch',
+                        'basemap',
+                        'export',
+                        'layer-reorder'
+                    ]
+                },
+                mapnav: {
+                    items: [
+                        'fullscreen',
+                        'geolocator',
+                        'help',
+                        'home',
+                        'basemap',
+                        'legend',
+                        'geosearch'
+                    ]
+                },
+                export: {
+                    fileName: 'ramp-pcar-4-map-carte'
+                },
+                help: {
+                    location: '../help'
+                }
+            },
+            panels: {
+                open: [{ id: 'legend', pin: true }]
+            },
+            system: { animate: true }
+        }
+    }
+};
+
+let options = {
+    loadDefaultFixtures: true,
+    loadDefaultEvents: true,
+    startRequired: false
+};
+
+const rInstance = createInstance(
+    document.getElementById('app'),
+    config,
+    options
+);
+
+// add export fixtures
+rInstance.fixture.add('export');
+
+window.debugInstance = rInstance;

--- a/demos/starter-scripts/perm-filter.js
+++ b/demos/starter-scripts/perm-filter.js
@@ -42,6 +42,10 @@ let config = {
                     }
                 },
                 mapMouseThrottle: 200,
+                layerTimeDefault: {
+                    expectedLoadTime: 500,
+                    expectedDrawTime: 500
+                },
                 lodSets: [
                     {
                         id: 'LOD_NRCAN_Lambert_3978',

--- a/docs/using-ramp4/layers/basic-properties.md
+++ b/docs/using-ramp4/layers/basic-properties.md
@@ -48,7 +48,7 @@ Generally speaking, this config option is useful when there is a small list of c
 
 *integer*, only applies to [map layers](./additional-layer-sections.md#layer-abilities)
 
-Defines a time limit, in milliseconds, for the expected time it would take for the layer to draw itself (i.e. the fetching and processing of data to render the layer in the current extent). If the limit is exceeded, a notification will be issued in the app. If missing, a default of 10 seconds will be used. Setting to `0` will disable the notification.
+Defines a time limit, in milliseconds, for the expected time it would take for the layer to draw itself (i.e. the fetching and processing of data to render the layer in the current extent). If the limit is exceeded, a notification will be issued in the app. If missing, the map level configuration will be used. This defaults to 10000 (10 seconds). Setting to `0` will disable the notification.
 
 ```js
 {
@@ -60,7 +60,7 @@ Defines a time limit, in milliseconds, for the expected time it would take for t
 
 *integer*
 
-Defines a time limit, in milliseconds, for the expected time it would take for the layer load (i.e. establishing contact with a server, the fetching of metadata, the downloading of data for file or WFS type layers). If the limit is exceeded, a notification will be issued in the app. If missing, a default of 4 seconds will be used. Setting to `0` will disable the notification.
+Defines a time limit, in milliseconds, for the expected time it would take for the layer load (i.e. establishing contact with a server, the fetching of metadata, the downloading of data for file or WFS type layers). If the limit is exceeded, a notification will be issued in the app. If missing, the map level configuration will be used. This defaults to 10000 (10 seconds). Setting to `0` will disable the notification.
 
 ```js
 {

--- a/schema.json
+++ b/schema.json
@@ -809,13 +809,11 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 10000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to draw' notification is shown for any drawing layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -885,13 +883,11 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 10000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to draw' notification is shown for any drawing layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -962,13 +958,11 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 10000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to draw' notification is shown for any drawing layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -1169,13 +1163,11 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 10000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to draw' notification is shown for any drawing layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -1294,13 +1286,11 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 10000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to draw' notification is shown for any drawing layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -1422,8 +1412,7 @@
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -1514,13 +1503,11 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 10000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to draw' notification is shown for any drawing layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -1634,13 +1621,11 @@
                 },
                 "expectedDrawTime": {
                     "type": "number",
-                    "default": 10000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to draw' notification is shown for any drawing layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "expectedLoadTime": {
                     "type": "number",
-                    "default": 4000,
-                    "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications."
+                    "description": "The time span (in milliseconds) after which a 'slow to load' notification is shown for any loading layer. Zero will disable notifications. If missing, will use the map default."
                 },
                 "maxLoadTime": {
                     "type": "number",
@@ -2826,6 +2811,22 @@
                 "labelsDefault": {
                     "$ref": "#/$defs/labels",
                     "description": "If provided, will override any service defaults. Will not override values on a layer config."
+                },
+                "layerTimeDefault": {
+                    "type": "object",
+                    "description": "Instance defaults for layer timers.",
+                    "properties": {
+                        "expectedDrawTime": {
+                            "type": "number",
+                            "default": 10000,
+                            "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications. Values on individual layer configs will override."
+                        },
+                        "expectedLoadTime": {
+                            "type": "number",
+                            "default": 10000,
+                            "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications. Values on individual layer configs will override."
+                        }
+                    }
                 }
             },
             "required": ["tileSchemas", "baseMaps"],

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -327,6 +327,20 @@ export interface MapMove {
     moveTime: number;
 }
 
+export interface LayerTimes {
+    /**
+     * Expected time to draw
+     */
+    draw: number;
+
+    /**
+     * Expected time to load
+     */
+    load: number;
+
+    // TODO pr for #1491 will add 'fail' here
+}
+
 // needs to align to esri values for GoToOptions2D.easing
 export type ZoomEasing =
     | 'linear'
@@ -746,4 +760,8 @@ export interface RampMapConfig {
     pointZoomScale?: number;
     mapMouseThrottle?: number;
     labelsDefault?: RampLabelsConfig;
+    layerTimeDefault?: {
+        expectedDrawTime?: number;
+        expectedLoadTime?: number;
+    };
 }

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -42,7 +42,12 @@ const enum TimerType {
  */
 export class CommonLayer extends LayerInstance {
     // common layer properties
+
+    /**
+     * Tracks load and draw elapsed time
+     */
     timers: {
+        // TODO when implementing #1491, look into converting this type to LayerTimes
         draw: number | undefined;
         load: number | undefined;
     };
@@ -66,8 +71,12 @@ export class CommonLayer extends LayerInstance {
         this.dataFormat = DataFormat.UNKNOWN;
         this.layerType = LayerType.UNKNOWN;
         this.layerFormat = LayerFormat.UNKNOWN;
-        this.expectedTime.draw = rampConfig.expectedDrawTime ?? 10000;
-        this.expectedTime.load = rampConfig.expectedLoadTime ?? 4000;
+
+        const defaultTimes = $iApi.geo.map.layerDefaultTimes;
+        this.expectedTime.draw =
+            rampConfig.expectedDrawTime ?? defaultTimes.draw;
+        this.expectedTime.load =
+            rampConfig.expectedLoadTime ?? defaultTimes.draw;
         this.timers = {
             draw: undefined,
             load: undefined
@@ -490,6 +499,7 @@ export class CommonLayer extends LayerInstance {
     protected stopTimer(type: TimerType): void {
         if (this.timers[type]) {
             clearTimeout(this.timers[type]);
+            this.timers[type] = undefined;
         }
     }
 }

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -25,6 +25,7 @@ import type {
     FieldDefinition,
     GetGraphicParams,
     IdentifyParameters,
+    LayerTimes,
     LegendSymbology,
     TabularAttributeSet
 } from '@/geo/api';
@@ -139,10 +140,7 @@ export class LayerInstance extends APIScope {
     /**
      * Object that contains values for the expected draw/response time.
      */
-    expectedTime: {
-        draw: number;
-        load: number;
-    };
+    expectedTime: LayerTimes;
 
     /**
      * If the layer has Sublayers


### PR DESCRIPTION
### Related Item(s)

#2248

### Changes

- Adds instance-level default configuration for layer warning times.
- Increased the default time for load warnings from 4 to 10 seconds
- Squashed a mild whoops in timer manager code
- Added a no-layer sample for QA / Load Testing

### Notes

Chose 10 as new default, since WFS & File sources do all the heavy lifting in the load phase.

### Testing

Steps:
1. Start with default Sample 1. Once you see RAMP sort-of appear, start counting seconds in your head.
2. If you get to 10 and all layers are loaded, you should not see any warning alerts saying they were slow. If layers happen to take longer, it becomes unscientific since you mostly cannot tell what time was counted as loading and what time as drawing. Code looks good tho eh!
3. Switch to Sample 34. This sample has the global default set to half a second.
4. Watch layers load, pan and zoom map around. Unless your connection is a real rocket, should be getting plenty of warning alerts in the :bell: bucket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2251)
<!-- Reviewable:end -->
