### PR TITLE
Fixed (most) tree picker search box issues, Updated to ES2023

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -71,6 +71,8 @@
                         :open-direction="'bottom'"
                         :max-height="300"
                         :limit="4"
+                        :disableFuzzyMatching="true"
+                        :searchable="searchable"
                         :childrenIgnoreDisabled="true"
                         :placeholder="t('wizard.configure.sublayers.select')"
                         :noResultsText="t('wizard.configure.sublayers.results')"
@@ -95,6 +97,7 @@
                                 {{ truncateVal(node.label) }}
                             </label>
                         </template>
+
                         <template
                             v-slot:[optionLabel]="{ node, labelClassName }"
                         >
@@ -301,7 +304,7 @@ const resizeObserver = ref<ResizeObserver | undefined>(undefined);
 
 if (props.defaultOption && props.modelValue === '' && props.options.length) {
     // regex to guess closest default value for lat/long fields
-    // eslint has beef with the following line for unknown reasons
+    // eslint has beef with the following line for unknown reasons.
     // eslint-disable-next-line
     let defaultValue = props.options[0].value;
     if (props.name === 'latField') {
@@ -427,6 +430,34 @@ onBeforeUnmount(() => {
 
 :deep(.vue-treeselect__input:focus) {
     @apply ring-transparent pl-0 #{!important};
+}
+
+:deep(.vue-treeselect__multi-value) {
+    display: flex;
+    flex-wrap: wrap;
+}
+
+:deep(.vue-treeselect__input-container) {
+    flex: 1;
+    display: flex;
+    min-width: 50%;
+}
+
+:deep(.vue-treeselect__input) {
+    padding-left: 0px;
+    flex: 1;
+}
+
+:deep(.vue-treeselect__sizer) {
+    flex: 1;
+}
+
+:deep(.vue-treeselect__x-container) {
+    padding-left: 10px;
+}
+
+:deep(.vue-treeselect__multi-value-item-container) {
+    padding-right: 5px;
 }
 
 .error-border {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
             "@/*": ["./src/*"],
             "vue-slider-component": ["./scripts/vue-slider-component.d.ts"]
         },
-        "lib": ["DOM", "DOM.Iterable", "ES2020"],
+        "lib": ["DOM", "DOM.Iterable", "ES2023"],
         "pretty": true,
         "declaration": true,
         "declarationDir": "./dist/ts",


### PR DESCRIPTION
### Related Item(s)
#2245, #1890 

### Changes
For #1890
- Updated build to ES2023

For #2245
- Disabled fuzzy matching, so that only substring matching is performed
- Fixed the width of input div, so that text isn't clipped prematurely and highlighting text works correctly
- Set left padding of input field to 0 to remove the unwanted indent

### Notes
Fixes for the behavior of Left/Right arrow keys and Home/End keys are handled in the vue3-treeselect repo: https://github.com/ramp4-pcar4/vue3-treeselect/pull/1

### Testing
Steps (for #2245):
1. Open any sample with a wizard (ex. Sample 27)
2. Click on the `+` in the legend to open the wizard
3. Add https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer as a Map Image Layer
4. Click though the wizard to reach Step 3, where the tree picker appears
5. Type `natu`
6. Observe that only options which contain `natu` as a substring will appear
7. Continue typing to get `naturel funnnnnnnnnnnnnnn`, and observe that the text does not clip
8. Add a few more letters to observe the text being clipped only when the outer edge of the input field is reached
9. Put the cursor up into the "Layer Name" text box
10. Observe that there is no indent preceding the entered text
11. Replace input text with `naturel fun`
12. Highlight the text, then click to the right of the text, but within the input box
13. Observe that the highlight gets removed as expected

Steps (for #1890)
Not sure how to test within a running instance of RAMP, but I will provide steps for how to test on a local repo:
1. Go to tsconfig.json
2. Replace `ES2020` with `ES2023`
3. Use `npm run dev` to launch an instance of RAMP
4. Go to src/fixtures/legend/screen.vue
5. Following the import statements, use console.log's to test each feature from: [ES2021](https://h3manth.com/ES2021/), [ES2022](https://h3manth.com/ES2022/), [ES2023](https://h3manth.com/ES2023/).
6. Observe that these features don't result in typescript errors, and produce the expected output

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2264)
<!-- Reviewable:end -->
