### PR TITLE
Fix issues when grid is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "ramp-pcar",
             "version": "4.8.0-beta",
             "dependencies": {
+                "@ag-grid-community/locale": "~32.0.0",
                 "@arcgis/core": "4.29.10",
                 "@popperjs/core": "^2.11.6",
                 "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect",
@@ -90,6 +91,12 @@
             "engines": {
                 "node": ">=16.14.2"
             }
+        },
+        "node_modules/@ag-grid-community/locale": {
+            "version": "32.0.0",
+            "resolved": "https://registry.npmjs.org/@ag-grid-community/locale/-/locale-32.0.0.tgz",
+            "integrity": "sha512-R0LGXzUgy9xArL784IzNPITX3KwFhTGnrz6o+1D3i3O6SuKpz1L8VDiB7ZsYoFBs4jc+sysFuYS/Z/rhTUTrYA==",
+            "license": "MIT"
         },
         "node_modules/@algolia/autocomplete-core": {
             "version": "1.9.2",
@@ -8742,6 +8749,11 @@
         }
     },
     "dependencies": {
+        "@ag-grid-community/locale": {
+            "version": "32.0.0",
+            "resolved": "https://registry.npmjs.org/@ag-grid-community/locale/-/locale-32.0.0.tgz",
+            "integrity": "sha512-R0LGXzUgy9xArL784IzNPITX3KwFhTGnrz6o+1D3i3O6SuKpz1L8VDiB7ZsYoFBs4jc+sysFuYS/Z/rhTUTrYA=="
+        },
         "@algolia/autocomplete-core": {
             "version": "1.9.2",
             "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@tailwindcss/line-clamp": "^0.4.4",
         "@vueform/toggle": "^2.1.3",
         "ag-grid-community": "^27.3.0",
+        "@ag-grid-community/locale": "~32.0.0",
         "ag-grid-vue3": "^27.3.0",
         "animejs": "~3.2.0",
         "await-to-js": "^3.0.0",

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -54,7 +54,10 @@
                 <div class="w-full text-sm" v-truncate>
                     {{
                         t('grid.filters.label.info', {
-                            range: `${filterInfo.firstRow} - ${filterInfo.lastRow}`,
+                            range:
+                                filterInfo.visibleRows !== 0
+                                    ? `${filterInfo.firstRow} - ${filterInfo.lastRow}`
+                                    : '0',
                             total: filterInfo.visibleRows
                         })
                     }}
@@ -369,11 +372,14 @@
 
         <!-- main grid component -->
         <ag-grid-vue
+            v-if="showGrid"
             v-show="!isLoadingGrid && !isErrorGrid"
             class="ag-theme-material flex-grow"
             enableCellTextSelection="true"
             accentedSort="true"
-            :localeText="gridLocale"
+            :localeText="
+                locale === 'en' ? AG_GRID_LOCALE_EN : AG_GRID_LOCALE_FR
+            "
             :gridOptions="agGridOptions"
             :columnDefs="columnDefs"
             :rowData="rowData"
@@ -444,7 +450,10 @@ import CellRendererV from './templates/cell-renderer.vue';
 import { CoreFilter, FieldType } from '@/geo/api';
 
 // grid locales
-import { AG_GRID_LOCALE_EN, AG_GRID_LOCALE_FR } from '@ag-grid-community/locale';
+import {
+    AG_GRID_LOCALE_EN,
+    AG_GRID_LOCALE_FR
+} from '@ag-grid-community/locale';
 
 import { debounce } from 'throttle-debounce';
 import type { RowNode } from 'ag-grid-community';
@@ -544,8 +553,7 @@ const panelStore = usePanelStore();
 const mobileView = computed(() => panelStore.mobileView);
 const pinned = ref<Boolean>(!mobileView.value);
 const el = ref<HTMLElement>();
-const { t } = useI18n();
-const i18nLocale = useI18n();
+const { t, locale } = useI18n();
 const forceUpdate = () => getCurrentInstance()?.proxy?.$forceUpdate();
 
 const props = defineProps({
@@ -565,10 +573,10 @@ const config = ref<GridConfig>({
     state: new TableStateManager(),
     fieldMap: {}
 });
+const showGrid = ref(true);
 const agGridApi = ref<GridApi>(new GridApi());
 const agGridOptions = ref();
 const frameworkComponents = ref();
-const gridLocale = i18nLocale.locale.value === 'en' ? AG_GRID_LOCALE_EN : AG_GRID_LOCALE_FR;
 const isLoadingGrid = ref<boolean>(false);
 const isErrorGrid = ref<boolean>(false);
 const loadedRecordCount = ref<Array<number>>([]);
@@ -1854,6 +1862,17 @@ onBeforeMount(() => {
             iApi.$i18n.t(`layer.filterwarning`)
         );
     }
+
+    // ag-grid does not update automatically when language/locale is changed,
+    // so we force it to update here
+    watchers.value.push(
+        watch(locale, () => {
+            showGrid.value = false;
+            setTimeout(() => {
+                showGrid.value = true;
+            }, 10);
+        })
+    );
 
     watchers.value.push(
         watch(filtersStatus, newStatus => {

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -373,6 +373,7 @@
             class="ag-theme-material flex-grow"
             enableCellTextSelection="true"
             accentedSort="true"
+            :localeText="gridLocale"
             :gridOptions="agGridOptions"
             :columnDefs="columnDefs"
             :rowData="rowData"
@@ -441,6 +442,9 @@ import ZoomButtonRendererV from './templates/zoom-button-renderer.vue';
 import CustomButtonRendererV from './templates/custom-button-renderer.vue';
 import CellRendererV from './templates/cell-renderer.vue';
 import { CoreFilter, FieldType } from '@/geo/api';
+
+// grid locales
+import { AG_GRID_LOCALE_EN, AG_GRID_LOCALE_FR } from '@ag-grid-community/locale';
 
 import { debounce } from 'throttle-debounce';
 import type { RowNode } from 'ag-grid-community';
@@ -541,6 +545,7 @@ const mobileView = computed(() => panelStore.mobileView);
 const pinned = ref<Boolean>(!mobileView.value);
 const el = ref<HTMLElement>();
 const { t } = useI18n();
+const i18nLocale = useI18n();
 const forceUpdate = () => getCurrentInstance()?.proxy?.$forceUpdate();
 
 const props = defineProps({
@@ -563,6 +568,7 @@ const config = ref<GridConfig>({
 const agGridApi = ref<GridApi>(new GridApi());
 const agGridOptions = ref();
 const frameworkComponents = ref();
+const gridLocale = i18nLocale.locale.value === 'en' ? AG_GRID_LOCALE_EN : AG_GRID_LOCALE_FR;
 const isLoadingGrid = ref<boolean>(false);
 const isErrorGrid = ref<boolean>(false);
 const loadedRecordCount = ref<Array<number>>([]);


### PR DESCRIPTION
### Related Item(s)
Issues #2260, #2261  

### Changes
- [FIX] Add grid localization settings, so 'no results' text will follow selected language.
- [FIX] Modify grid row count logic so it will display '0 out of 0 results' instead of '1 out of 0 results'.

### Testing
Steps:
1. Open sample 15.
2. Hide the 'Nature' layer, then click the legend item to open its grid. 
3. The label at the top now says '0 of 0 entries shown'. Before, it would say '1 of 0 entries shown' (which makes no sense).
4. Change the language to French at the bottom-right.
5. Open the wizard by pressing '+'. Add this URL: https://maps-cartes.ec.gc.ca/arcgis/rest/services/CWS_SCF/CriticalHabitat/MapServer/2. Click Continue three times.
6. Click the new legend item. On its grid, the 'No Rows to Show' text will be in French (Aucune Ligne...). Before, it would have still been in English.
7. While this grid is open, swap languages between English and French. The text will correctly change to the current language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2268)
<!-- Reviewable:end -->
