### PR TITLE
Properly center details pane no-results text

### DIFF
--- a/src/fixtures/details/details-screen.vue
+++ b/src/fixtures/details/details-screen.vue
@@ -22,7 +22,13 @@
                         :results="layerResults"
                         v-if="!noResults"
                     ></ResultList>
-                    <div class="ml-42 text-center" v-else>
+                    <div
+                        :class="[
+                            'text-center',
+                            { 'ml-42': layerResults.length > 1 }
+                        ]"
+                        v-else
+                    >
                         {{ t('details.layers.results.empty') }}
                     </div>
                 </div>


### PR DESCRIPTION
### Related Item(s)
Issue #2265 

### Changes
- [FIX] Properly centre details pane 'No Results' text when there is no symbology list (AKA when there are no layers).

### Testing
Steps:
1. Go to sample 46.
2. Click anywhere on the map.
3. On the details pane, the `No results found for the selected layer` text is now centred properly.
4. Go to sample 43.
5. Click anywhere on the map **without** any icons/items.
6. On the details pane, the `No results found for the selected layer` text is still centred properly with the symbology list present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2269)
<!-- Reviewable:end -->
