### PR TITLE
Move PR status checks to org repo

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,7 @@ jobs:
               if: steps.cache-node-modules.outputs.cache-hit != 'true'
               run: npm ci
 
-            - uses: milespetrov/status-checks@main
+            - uses: ramp4-pcar4/status-checks@main
               id: pr-checks
               with:
                   gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Related Item(s)
Issue #2256 

### Changes
- [FEATURE] Fork PR status checks repo to RAMP4 org, and set it as the new target when running the Action.

### Testing
Steps:
1. The PR uses the GitHub Actions file in the current PR (i.e. the newly modified YAML file). If this works, the PR status checks for this PR should work and pass.
2. Click into the `Details` of the PR status checks. It should show it ran with the RAMP org repo: `Run ramp4-pcar4/status-checks@main`, and that it passed this test. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2270)
<!-- Reviewable:end -->
