### PR TITLE
Account for accented characters in geosearch highlighting

### DIFF
--- a/src/fixtures/geosearch/screen.vue
+++ b/src/fixtures/geosearch/screen.vue
@@ -147,7 +147,7 @@ const zoomIn = (result: any) => {
 const highlightSearchTerm = (name: string, province: any) => {
     // wrap matched search term in results inside span with styling
     const highlightedResult = name.replace(
-        new RegExp(`${searchVal.value}`, 'gi'),
+        new RegExp(`${geosearchStore.searchRegex}`, 'gi'),
         match => '<span class="font-bold text-blue-600">' + match + '</span>'
     );
     // add comma to new highlighted result if a province/location is provided

--- a/src/fixtures/geosearch/search-bar.vue
+++ b/src/fixtures/geosearch/search-bar.vue
@@ -32,7 +32,11 @@ const geosearchStore = useGeosearchStore();
 const panelStore = usePanelStore();
 
 const searchVal = computed(() => geosearchStore.searchVal);
-const setSearchTerm = (value: string) => geosearchStore.setSearchTerm(value);
+const setSearchTerm = (value: string) => {
+    geosearchStore.setSearchTerm(value);
+    geosearchStore.setSearchRegex(value);
+};
+
 const onSearchTermChange = debounce(500, (searchTerm: string) => {
     setSearchTerm(searchTerm);
 });


### PR DESCRIPTION
### Related Item(s)
Issue #2252 

### Changes
- [FEATURE] Highlight accented versions of character in geosearch when regular character is inputted, and vice versa

### Notes
Accented character highlight:
<img width="341" alt="image" src="https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/6fe02b7b-83b8-468f-b64c-06a59395e0ab">

Regular character highlight:
<img width="339" alt="image" src="https://github.com/ramp4-pcar4/ramp4-pcar4/assets/75815453/73796871-4d44-4e44-9922-d9c6652888ad">


### Testing
Steps:
1. Go to sample 1. Open geosearch.
2. Type in "Evai". Any "É" in the results should be highlighted.
3. Type in "à". Any "a" or "A" in the results should be highlighted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2272)
<!-- Reviewable:end -->
