### PR TITLE
Aria tags on buttons

### DIFF
--- a/enhance.bat
+++ b/enhance.bat
@@ -1,0 +1,8 @@
+git checkout main
+git pull --ff-only upstream main
+git push origin main
+git checkout jamesparty
+git rebase main
+git status -s
+echo ""
+echo "ENHANCE!"

--- a/miles.bat
+++ b/miles.bat
@@ -1,0 +1,6 @@
+cd node_modules
+rm -r .vite
+cd ..
+npm cache clear --force
+echo ""
+echo "MILES!"

--- a/nuns.bat
+++ b/nuns.bat
@@ -1,0 +1,6 @@
+git add .
+git reset HEAD -- enhance.bat
+git reset HEAD -- nuns.bat
+git reset HEAD -- miles.bat
+git status -s
+echo "nuns have been reversed"

--- a/src/components/panel-stack/controls/left.vue
+++ b/src/components/panel-stack/controls/left.vue
@@ -8,6 +8,7 @@
                 'text-gray-300': !active
             }"
             :content="t('panels.controls.moveLeft')"
+            :aria-label="t('panels.controls.moveLeft')"
             v-tippy="{
                 placement: 'bottom',
                 theme: 'ramp4',
@@ -18,7 +19,6 @@
                 class="fill-current w-16 h-16"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="4 4 16 16"
-                :aria-label="t('panels.controls.moveLeft')"
             >
                 <path
                     d="M 15.41 16.09 L 10.83 11.5 L 15.41 6.91 L 14 5.5 L 8 11.5 L 14 17.5 Z"

--- a/src/components/panel-stack/controls/right.vue
+++ b/src/components/panel-stack/controls/right.vue
@@ -8,6 +8,7 @@
                 'text-gray-300': !active
             }"
             :content="t('panels.controls.moveRight')"
+            :aria-label="t('panels.controls.moveRight')"
             v-tippy="{
                 placement: 'bottom',
                 theme: 'ramp4',
@@ -18,7 +19,6 @@
                 class="fill-current w-16 h-16"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="4 4 16 16"
-                :aria-label="t('panels.controls.moveRight')"
             >
                 <path
                     d="M 8.59 16.34 L 13.17 11.75 L 8.59 7.16 L 10 5.75 L 16 11.75 L 10 17.75 Z"

--- a/src/fixtures/appbar/more-button.vue
+++ b/src/fixtures/appbar/more-button.vue
@@ -6,6 +6,7 @@
             @click="popperSetUp()"
             v-focus-item
             :content="t('appbar.more')"
+            :aria-label="t('appbar.more')"
             v-tippy="{ placement: 'right-end' }"
             ref="dropdownTrigger"
         >

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -6,9 +6,9 @@ grid.splash.loading,Loading data...,1,Chargement des données...,1
 grid.splash.building,Building table...,1,Création du tableau...,1
 grid.splash.cancel,Cancel,1,Annuler,1
 grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,1
-grid.pinColumns,Pin columns,1,Épingler les colonnes,1
-grid.export,Export,1,Exporter,1
 grid.layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
+grid.label.pinColumns,Pin columns,1,Épingler les colonnes,1
+grid.label.export,Export,1,Exporter,1
 grid.label.columns,Hide columns,1,Masquer les colonnes,1
 grid.label.copied,Copied,1,Copié,1
 grid.label.copy,Press ctrl + c or double click to copy,1,Appuyez sur Ctrl + C ou double-cliquez pour copier,1
@@ -29,7 +29,7 @@ grid.filters.date.max,Max Date,1,Date max,1
 grid.filters.date.min,Min Date,1,Date min,1
 grid.filters.label.info,{range} of {total} entries shown,1,{range} de {total} saisies affichées,1
 grid.filters.label.filtered,(filtered from {max} total entries),1,(filtré à partir d'un total de {max} saisies),1
-grid.filters.extent,Filter by extent,1,Filtrer par étendue,1
+grid.filters.label.extent,Filter by extent,1,Filtrer par étendue,1
 grid.cells.zoom,Zoom to feature,1,Zoom à l'élément,1
 grid.cells.zoom.zooming,Zooming...,1,Zoom en cours...,1
 grid.cells.zoom.error,Zoom failed,1,Échec du zoom,1

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -195,6 +195,8 @@
                                 filtersStatus !== 'disabled' &&
                                     toggleFiltersToMap()
                             "
+                            role="button"
+                            :aria-label="t('grid.label.filters.apply')"
                         >
                             <div class="md-icon-small inline items-start">
                                 <svg
@@ -230,6 +232,8 @@
                             href="javascript:;"
                             class="flex leading-snug items-center w-256 hover:text-black"
                             @click="toggleShowFilters()"
+                            role="button"
+                            :aria-label="t('grid.label.filters.show')"
                         >
                             <div class="md-icon-small inline items-start">
                                 <svg
@@ -272,6 +276,8 @@
                                 filtersStatus !== 'disabled' &&
                                     toggleFilterByExtent()
                             "
+                            role="button"
+                            :aria-label="t('grid.filters.label.extent')"
                         >
                             <div class="md-icon-small inline items-start">
                                 <svg
@@ -283,7 +289,7 @@
                                         d="M 4 10 Z M 2 2 L 19.9888 2 L 20 2 L 20 2.0112 L 20 4 L 19.9207 4 L 13 10.9207 L 13 22.909 L 9 18.909 L 9 10.906 L 2.0941 4 L 2 4 L 2 2 Z M 24 13 L 21 14 L 18 13 L 15 14 V 22 L 18 21 l 3 1 l 3 -1 z M 21 21 l -3 -1 V 14 l 3 1.055 z"
                                     />
                                 </svg>
-                                {{ t('grid.filters.extent') }}
+                                {{ t('grid.filters.label.extent') }}
                                 <svg
                                     height="18"
                                     width="18"
@@ -307,6 +313,8 @@
                             class="flex leading-snug items-center w-256"
                             :class="{ hover: 'text-black' }"
                             @click="togglePinned()"
+                            role="button"
+                            :aria-label="t('grid.label.pinColumns')"
                         >
                             <svg
                                 v-if="pinned"
@@ -328,7 +336,7 @@
                                     d="M18 1.5c2.9 0 5.25 2.35 5.25 5.25v3.75a.75.75 0 01-1.5 0V6.75a3.75 3.75 0 10-7.5 0v3a3 3 0 013 3v6.75a3 3 0 01-3 3H3.75a3 3 0 01-3-3v-6.75a3 3 0 013-3h9v-3c0-2.9 2.35-5.25 5.25-5.25z"
                                 />
                             </svg>
-                            {{ t('grid.pinColumns') }}
+                            {{ t('grid.label.pinColumns') }}
                             <svg
                                 height="18"
                                 width="18"
@@ -348,6 +356,8 @@
                             class="flex leading-snug items-center w-256"
                             :class="{ hover: 'text-black' }"
                             @click="exportData()"
+                            role="button"
+                            :aria-label="t('grid.label.export')"
                         >
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"
@@ -360,7 +370,7 @@
                                     ></path>
                                 </g>
                             </svg>
-                            {{ t('grid.export') }}
+                            {{ t('grid.label.export') }}
                         </a>
                     </dropdown-menu>
                 </div>

--- a/src/fixtures/grid/templates/custom-header.vue
+++ b/src/fixtures/grid/templates/custom-header.vue
@@ -12,6 +12,7 @@
                 type="button"
                 @click="onSortRequested($event)"
                 :content="t(`grid.header.sort.${sort}`)"
+                :aria-label="t(`grid.header.sort.${sort}`)"
                 v-tippy="{ placement: 'top', hideOnClick: false }"
                 class="customHeaderLabel hover:bg-gray-300 font-bold p-8 max-w-full"
                 role="columnheader"
@@ -62,7 +63,8 @@
             </span>
             <button
                 type="button"
-                :content="t(`grid.header.reorder.left`)"
+                :content="t('grid.header.reorder.left')"
+                :aria-label="t('grid.header.reorder.left')"
                 v-tippy="{ placement: 'top' }"
                 @click="moveLeft()"
                 class="move-left opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default flex justify-center items-center"
@@ -81,7 +83,8 @@
             </button>
             <button
                 type="button"
-                :content="t(`grid.header.reorder.right`)"
+                :content="t('grid.header.reorder.right')"
+                :aria-label="t('grid.header.reorder.right')"
                 v-tippy="{ placement: 'top' }"
                 @click="moveRight()"
                 class="move-right opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default flex justify-center items-center"

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -29,6 +29,8 @@
                         !getFixtureExists('metadata')
                 }"
                 @click="toggleMetadata"
+                role="button"
+                :aria-label="t('legend.layer.controls.metadata')"
             >
                 <svg
                     class="inline-block fill-current w-18 h-18 mr-10"
@@ -50,6 +52,8 @@
                         !getFixtureExists('settings')
                 }"
                 @click="toggleSettings"
+                role="button"
+                :aria-label="t('legend.layer.controls.settings')"
             >
                 <svg
                     class="inline-block fill-current w-18 h-18 mr-10"
@@ -73,6 +77,8 @@
                         !getFixtureExists('grid')
                 }"
                 @click="toggleGrid"
+                role="button"
+                :aria-label="t('legend.layer.controls.datatable')"
             >
                 <svg
                     class="inline-block fill-current w-18 h-18 mr-10"
@@ -92,6 +98,8 @@
                     disabled: !legendItem!.layerControlAvailable(LayerControl.Symbology)
                 }"
                 @click="toggleSymbology"
+                role="button"
+                :aria-label="t('legend.layer.controls.symbology')"
             >
                 <svg
                     class="inline-block fill-current w-18 h-18 mr-10"
@@ -111,6 +119,8 @@
                     disabled: !legendItem!.layerControlAvailable(LayerControl.BoundaryZoom)
                 }"
                 @click="zoomToLayerBoundary"
+                role="button"
+                :aria-label="t('legend.layer.controls.boundaryzoom')"
             >
                 <svg
                     class="inline-block fill-current w-18 h-18 mr-10"
@@ -132,6 +142,8 @@
                     disabled: !legendItem!.layerControlAvailable(LayerControl.Remove)
                 }"
                 @click="removeLayer"
+                role="button"
+                :aria-label="t('legend.layer.controls.remove')"
             >
                 <svg
                     class="inline-block fill-current w-18 h-18 mr-10"
@@ -167,6 +179,8 @@
                     aria: 'describedby'
                 }"
                 @click="reloadLayer"
+                role="button"
+                :aria-label="t('legend.layer.controls.reload')"
             >
                 <svg
                     class="inline-block fill-current w-18 h-18 mr-10"

--- a/src/fixtures/mapnav/button.vue
+++ b/src/fixtures/mapnav/button.vue
@@ -9,6 +9,7 @@
             @click="onClickFunction()"
             v-focus-item
             :content="tooltip"
+            :aria-label="typeof tooltip === 'string' ? tooltip : ''"
             v-tippy="{ placement: 'left' }"
         >
             <slot></slot>


### PR DESCRIPTION
### Related Item(s)

#2273

### Changes
- Adds `aria-label` tags to buttons so they exist prior to tooltip (making a11y scanners happy)
- Adds `role: button` to menus that are anchor tags instead of button tags
- Changed two language keys that were not respecting social conformance.

### Testing

Steps:
1. Open sample 27
2. Can do inspection (right click, inspect) of the following stuff to see that `aria-label` tags are lurking. 

- Menu items in the legend `...` dropdown for layer entries
- Menu items in the vertical `...` dropdown of the data grid (upper right corner)
- The buttons in the nav bar (lower right of map)
- Shrink the browser window size until the icons in navbar get hidden and the `...` button appears. This button is the the button to check.

If anyone has a Wave Toolbar or the [COEwatt](https://github.com/n-chadder/COEwatt) tool installed, can give that a whirl

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2274)
<!-- Reviewable:end -->
