### PR TITLE
Switch basemap background color correctly

### DIFF
--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -46,6 +46,7 @@ import EsriSymbol from '@arcgis/core/symbols/Symbol';
 import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jsonUtils';
 import EsriFeatureFilter from '@arcgis/core/layers/support/FeatureFilter';
 import EsriMapView from '@arcgis/core/views/MapView';
+import EsriColorBackground from '@arcgis/core/webmap/background/ColorBackground';
 
 // sorted by name
 export {
@@ -53,6 +54,7 @@ export {
     EsriClassBreakInfo,
     EsriClassBreaksRenderer,
     EsriColour,
+    EsriColorBackground,
     EsriConfig,
     EsriExtent,
     EsriFeatureFilter,

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -37,7 +37,7 @@ import type {
     Screenshot
 } from '@/geo/api';
 
-import { EsriMapView } from '@/geo/esri';
+import { EsriColorBackground, EsriMapView } from '@/geo/esri';
 import type { EsriGraphic, EsriLOD } from '@/geo/esri';
 
 import { useLayerStore } from '@/stores/layer';
@@ -511,10 +511,9 @@ export class MapAPI extends CommonMapAPI {
             this.applyBasemap(bm);
 
             // When schema changes, the recreation of the view will also set the background colour.
-            this.esriView.set(
-                'background.color',
-                new Colour(bm.backgroundColour).toESRI()
-            );
+            this.esriView.background = new EsriColorBackground({
+                color: new Colour(bm.backgroundColour).toESRI()
+            });
 
             // fire the basemap change event
             this.$iApi.event.emit(GlobalEvents.MAP_BASEMAPCHANGE, {


### PR DESCRIPTION
### Related Item(s)
#2254

### Changes
- Fixed the code that changes the basemaps background color when switching between basemaps of the same projection (i.e. both Lambert or both Mercator)

### Testing
Steps:
1. Go to Sample 15. 
2. Open basemap picker. Select the first Lambert one (transport with labels).
3. Observe a white background beyond the "ocean tile"
4. Select the fourth Lambert basemap (transport, no labels). 
5. Observe a blue background beyond the "ocean tile"
6. Select the Mercator Satellite basemap to reset things.
7. Select the fourth Lambert basemap. 
8. Observe a blue background beyond the "ocean tile".
9. Select the first Lambert basemap. 
10. Observe a white background beyond the "ocean tile".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2287)
<!-- Reviewable:end -->
