### PR TITLE
Set RAMP2 upgrader to use 'field' instead of 'name'

### DIFF
--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -920,7 +920,7 @@ function layerCommonPropertiesUpgrader(r2layer: any) {
                 r4layer.fixtures.grid.columns = [];
                 r2layer.table.columns.forEach((r2tableColumn: any) => {
                     const r4tableColumn: any = {
-                        name: r2tableColumn.data
+                        field: r2tableColumn.data
                     };
                     if (r2tableColumn.title) {
                         r4tableColumn.title = r2tableColumn.title;


### PR DESCRIPTION
### Related Item(s)
Issue #2276 

### Changes
- [FIX] Set the RAMP2/3 config upgrader to use the key `field` instead of `name` for layer --> fixture --> grid --> column instances.

### Notes
Example of change:
![image](https://github.com/user-attachments/assets/892e3c14-09c4-402e-a7fb-ba5044350cb3)


### Testing
Steps:
1. Open sample 17.
2. Open the console in devtools.
3. Click into the object in the console (could be called `{startingFixtures: Array(16), configs: {…}}` or simply `Object`). Click down the following: 
a. `configs` --> `en` -> `layers` -> `4` --> `fixtures` --> `grid` --> `columns`
4. The item with key `0` in `columns` should have a property called `fields` with value `'OBJECTID'` (before, the property was called `name`, which was incorrect).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2288)
<!-- Reviewable:end -->
