### PR TITLE
Prevent export timestamp & footnote overlap on mobile

### DIFF
--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -248,11 +248,29 @@ export class ExportAPI extends FixtureInstance {
 
         if (selectedState.footnote && exportFootnoteFixture) {
             fbFootnote = await exportFootnoteFixture.make({
-                top: this.options.runningHeight,
+                top: this.options.runningHeight - 2.5, // Magic number prevents weird vertical offset between timestamp/footer
                 left: panelWidth / this.options.scale + 40
             });
 
-            fbFootnote.left! += -fbFootnote.width! * 2;
+            // Extra width to prevent slight overlaps between timestamp and footnote
+            const BUFFER = 30;
+
+            // Detect if the footnote overlaps with the timestamp
+            // If they overlap, put footnote on next line; else keep side-by-side
+            if (
+                panelWidth -
+                    (
+                        selectedFabricObjects.timestamp as fabric.Textbox
+                    ).getMinWidth() <=
+                (fbFootnote as fabric.Textbox).getMinWidth() + BUFFER
+            ) {
+                fbFootnote.top! += 40;
+                fbFootnote.left! = 0;
+                fbFootnote.originX! = 'left';
+                this.options.runningHeight += 20;
+            } else {
+                fbFootnote.left! += -fbFootnote.width! * 2;
+            }
 
             this.options.runningHeight += fbFootnote.height! + 20;
             selectedFabricObjects.footnote = fbFootnote;


### PR DESCRIPTION
### Related Item(s)
Issue #2280 

### Changes
- [FIX] Prevent timestamp and footnote of export from overlapping when there isn't enough horizontal space, such as on mobile.

### Notes
No overlap:
<img width="708" alt="image" src="https://github.com/user-attachments/assets/57888a71-e568-49c5-baf7-11a272cc919c">

Tight, but still no overlap:
<img width="273" alt="image" src="https://github.com/user-attachments/assets/6e7c9011-0955-47ad-8887-885f7035bfe2">

Overlap:
<img width="253" alt="image" src="https://github.com/user-attachments/assets/3f5b2190-20ff-4fff-a34b-a9784b9cb3ee">

Multiline timestamp overlap:
<img width="202" alt="image" src="https://github.com/user-attachments/assets/245f4d1f-4fd8-4477-8d0b-91fb6d896f89">

### Testing
Steps:
1. Open any sample with export (e.g. Sample 1).
2. Open devtools, then activate mobile browser emulator mode.
3. Open the export menu, scroll down to the bottom where you can see the timestamp and footnote.
4. Stretch and squeeze the "window" in the emulator, the timestamp and footnote should never overlap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2290)
<!-- Reviewable:end -->
