### PR TITLE
Localize treeselect clear-all tooltip

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -74,6 +74,7 @@
                         :childrenIgnoreDisabled="true"
                         :placeholder="t('wizard.configure.sublayers.select')"
                         :noResultsText="t('wizard.configure.sublayers.results')"
+                        :clearAllText="t('wizard.configure.sublayers.clearAll')"
                         @select="
                             $nextTick(() => {
                                 handleSelection();

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -38,6 +38,7 @@ wizard.configure.sublayers.label,Layers,1,Couches,1
 wizard.configure.sublayers.results,No results,1,Aucun résultat,1
 wizard.configure.sublayers.search,Search layers,1,Rechercher des couches,1
 wizard.configure.sublayers.select,Select layer(s),1,Sélectionner les couches,1
+wizard.configure.sublayers.clearAll,Clear all,1,Effacer tout,1
 wizard.configure.sublayers.nested,Nested,1,Imbriquées,1
 wizard.configure.colour.label,Colour,1,Couleur,1
 wizard.configure.colour.hue,Hue,1,Teinte,1


### PR DESCRIPTION
### Related Item(s)
Issue #2283 

### Changes
- [FIX] Add localization for the treepicker's `Clear All` button tooltip


### Notes
<img width="344" alt="image" src="https://github.com/user-attachments/assets/19f482e4-72fe-46b8-9ce7-95e80bc4ea3c">

### Testing
Steps:
1. Go to any sample with a wizard (e.g. Sample 1). Stay on English for now.
2. Click '+' to open the wizard, and paste this link: https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer.
3. Click continue twice, stop at step 3.
4. Select any item in the treepicker, e.g. `Milieu naturel`. Hover over the gray `x` button at the rightmost of the picker, until a tooltip pops up. It should be in **english**.
5. Change language to French. Repeat Steps 2-4. The tooltip should now be in **french**.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2291)
<!-- Reviewable:end -->
