### PR TITLE
Rollback es2023

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
             "@/*": ["./src/*"],
             "vue-slider-component": ["./scripts/vue-slider-component.d.ts"]
         },
-        "lib": ["DOM", "DOM.Iterable", "ES2023"],
+        "lib": ["DOM", "DOM.Iterable", "ES2020"],
         "pretty": true,
         "declaration": true,
         "declarationDir": "./dist/ts",


### PR DESCRIPTION
### Related Item(s)

🚨 🚓 💨 

Updating RAMP to `ES2023` broke the docsite, which doesn't get built on demos. This rolls it back until we can ensure the docsite will be all good.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2292)
<!-- Reviewable:end -->
