### PR TITLE
Fix various details panel issues

### DIFF
--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -36,6 +36,11 @@ export class DetailsAPI extends FixtureInstance {
         // Save the provided identify result in the store.
         this.detailsStore.payload = payload;
 
+        const panel = this.$iApi.panel.get('details-panel');
+        // Indicate this request for the details panel comes from clicking on the map
+        this.detailsStore.origin = 'identify';
+        panel.button.tooltip = 'details.layers.title.identifyOrigin';
+
         // Check to see if each layer has a fixture config in the store.
         payload.forEach(p => {
             const layer: LayerInstance | undefined = (this as any).$iApi
@@ -69,7 +74,11 @@ export class DetailsAPI extends FixtureInstance {
      * @memberof DetailsAPI
      */
     toggleFeature(
-        featureData: { data: any; uid: string; format: IdentifyResultFormat },
+        featureData: {
+            data: any;
+            uid: string;
+            format: IdentifyResultFormat;
+        },
         open: boolean | undefined
     ): void {
         const panel = this.$iApi.panel.get('details-panel');
@@ -104,6 +113,11 @@ export class DetailsAPI extends FixtureInstance {
         }
 
         // at this point, we are showing the payload
+
+        // Indicate this request for the details panel comes from a grid item
+        this.detailsStore.origin = 'toggleEvent';
+
+        panel.button.tooltip = 'details.layers.title.gridOrigin';
 
         this.detailsStore.currentFeatureId = currFeatureId;
 

--- a/src/fixtures/details/components/result-list.vue
+++ b/src/fixtures/details/components/result-list.vue
@@ -8,6 +8,8 @@
         <h1
             class="layerName w-full flex-grow p-5 pb-8 font-bold truncate"
             v-if="layerExists"
+            v-truncate="{ options: { placement: 'top-start' } }"
+            tabIndex="0"
         >
             {{ layerName }}
         </h1>
@@ -117,8 +119,8 @@
                     v-else
                 ></ResultItem>
             </div>
-            <div class="ml-42 text-center" v-else>
-                {{ t('details.layers.results.empty') }}
+            <div class="text-center" v-else>
+                {{ t('details.layers.results.empty.currentLayer') }}
             </div>
         </div>
         <!-- layer does not exist anymore, show no data text -->

--- a/src/fixtures/details/details-screen.vue
+++ b/src/fixtures/details/details-screen.vue
@@ -1,7 +1,12 @@
 <template>
     <panel-screen :panel="panel">
         <template #header>
-            {{ t('details.layers.title') }}
+            {{
+                // Show different titles based on what requested the panel
+                detailsStore.origin === 'toggleEvent'
+                    ? t('details.layers.title.gridOrigin')
+                    : t('details.layers.title.identifyOrigin')
+            }}
         </template>
 
         <template #content>
@@ -29,7 +34,11 @@
                         ]"
                         v-else
                     >
-                        {{ t('details.layers.results.empty') }}
+                        {{
+                            layerResults.length >= 1
+                                ? t('details.layers.results.empty')
+                                : t('details.layers.results.empty.noLayers')
+                        }}
                     </div>
                 </div>
             </div>

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -18,7 +18,7 @@ class DetailsFixture extends DetailsAPI {
                         width: '425px'
                     },
                     button: {
-                        tooltip: 'details.items.title',
+                        tooltip: 'details.layers.title.identifyOrigin',
                         // https://fonts.google.com/icons?selected=Material%20Icons%3Aarticle%3A
                         icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none" /><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-5 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z" /></svg>'
                     },

--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -1,9 +1,12 @@
 key,enValue,enValid,frValue,frValid
-details.layers.title,Identified Layers,1,Couches désignées,1
+details.layers.title.identifyOrigin,Identify Details,1,Identifier les détails,0
+details.layers.title.gridOrigin,Details,1,Détails,1
 details.layers.found,Found {numResults} results in {numLayers} layers,1,{numResults} résultats trouvés dans {numLayers} couches,1
 details.layers.loading,The layer is loading...,1,La couche est en cours de chargement...,1
 details.layers.error,Error,1,Erreur,1
-details.layers.results.empty,No results found for the selected layer.,1,Aucun résultat trouvé pour la couche sélectionnée.,1
+details.layers.results.empty,No results found for any layer.,1,Aucun résultat trouvé pour aucune couche.,0
+details.layers.results.empty.currentLayer,No results found for the selected layer.,1,Aucun résultat trouvé pour la couche sélectionnée.,1
+details.layers.results.empty.noLayers,No layers for identification.,1,Pas de couches pour l'identification.,0
 details.result.default.name,Identify Item {0},1,Désigner l'élément {0},1
 details.items.title,Details,1,Détails,1
 details.item.see.list,See List,1,Voir la liste,1

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -2,6 +2,13 @@ import type { PanelWidthObject } from '@/api';
 
 export type DetailsItemSet = { [name: string]: DetailsItemInstance };
 
+/**
+ * Types of requests for the details panel. Currently, consists of requests
+ * from the toggle events, such as the grid (details for a single item) and 
+ * requests from a map click (details for all items at a point).
+ */
+export type DetailsRequestOrigin = 'toggleEvent' | 'identify';
+
 export interface DetailsConfig {
     /**
      * The dictionary of default templates indexed by identify result format with value as the template component id.

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -1,5 +1,8 @@
 import { defineStore } from 'pinia';
-import type { DetailsItemInstance } from './details-state';
+import type {
+    DetailsItemInstance,
+    DetailsRequestOrigin
+} from './details-state';
 import type { IdentifyResult, LayerInstance } from '@/api';
 import { ref } from 'vue';
 
@@ -44,6 +47,11 @@ export const useDetailsStore = defineStore('details', () => {
      */
     const hilightToggle = ref<boolean>(true);
 
+    /**
+     * The source of the last details panel opening call. Can be 'grid' or 'identify'.
+     */
+    const origin = ref<DetailsRequestOrigin>();
+
     function removeLayer(layer: LayerInstance) {
         // check if this layer's results are in the payload
         const idx = payload.value.findIndex(res => res.uid === layer.uid);
@@ -66,6 +74,7 @@ export const useDetailsStore = defineStore('details', () => {
         activeGreedy,
         lastHilight,
         hilightToggle,
+        origin,
         removeLayer,
         addConfigProperty
     };

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -45,6 +45,7 @@ import { MapCaptionAPI } from './caption';
 import { markRaw, toRaw } from 'vue';
 import { useConfigStore } from '@/stores/config';
 import { debounce, throttle } from 'throttle-debounce';
+import { useDetailsStore } from '@/fixtures/details/store';
 
 export class MapAPI extends CommonMapAPI {
     // API for managing the maptip


### PR DESCRIPTION
### Related Item(s)
Issues:
#2148 
#2286 
#2279 

### Changes
- [#2148] Set title of details panel to be dynamic: `Details` if opened from the grid and `Identify Details` if clicked from the map
- [#2286] Set details panel `Nothing Found` text to be dynamic, with different text for selecting with no layers, one or more layers, and no results for current layer (but having results for other layers).
- [#2279] Add tooltip for details panel title, to show up when truncated.

### Notes
No results for any layer (+panel title for map click identify):
<img width="436" alt="image" src="https://github.com/user-attachments/assets/9498b6be-8682-4211-a109-288e119edc78">

No results for a certain layer (but results for others):
<img width="428" alt="image" src="https://github.com/user-attachments/assets/039376d9-748b-44e4-b4ec-e1d1a9a637c0">

One layer, but no results:
<img width="430" alt="image" src="https://github.com/user-attachments/assets/e9f7409d-213d-458c-8bdf-fbb0f4f2e7ae">

No layers:
<img width="422" alt="image" src="https://github.com/user-attachments/assets/6c8b84c5-333e-4087-bf82-149e0f6b622d">

Panel title for opening from grid:
<img width="963" alt="image" src="https://github.com/user-attachments/assets/5108c269-2750-47d4-98dc-c7a6c1511c05">

### Testing
Steps:
1. Open sample 28.
2. Click any of the blue water-droplet icons on the map to open the details panel. Notice the title of the panel is truncated (`Map Image Sublayer with...`), hover over it to see a tooltip above.
3. Do the following to test the dynamic titles:
a. Click anywhere on the map. The title should be `Identify Details`. (Change to French, it says `Identifier les détails`).
b. On the legend, click the item with the leaf icon to open its grid. On a random grid row, click the details icon. On the details panel that opens, the title should be `Details` (with equivalent in French).
5. Do the following to test the `Nothing Found` texts:
a. Click any empty spot on the map (no icons). It should say `No results for any layer`.
b. Click any icon that's alone (no other icons nearby), then click one of the empty (0 results) layers on the sidebar of the identify panel. It should say `No results found for the selected layer`.
c. Delete all layers, then click on the map again. Text will say `No layers for identification`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2298)
<!-- Reviewable:end -->
