### PR TITLE
Exclusive Fields File Layers bugfixes

### DIFF
--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -66,6 +66,7 @@ const openDetails = async () => {
 
     // grid only supports esri features at the moment, so we hardcode that format.
     // use force-open flag.
+
     iApi.event.emit(
         GlobalEvents.DETAILS_TOGGLE,
         {

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -212,15 +212,7 @@ export class AttributeAPI extends APIScope {
         // never part of the layer.
 
         const pluckedAttributes = details.sourceGraphics.map(
-            (g: __esri.Graphic) => {
-                // TODO we may need to strip off attributes here based on what we decide to do.
-                //      there is no network traffic advantage for files (all data is already loaded).
-                //      but we may need to do it for stuff like populating a grid with reduced columns.
-                //      if we do this, we may need to clone the attribute objects then remove properties;
-                //      we don't want to mess with the original source in the layer.
-                // If we do a stripping, use details.attribs as the source for what to keep.
-                return toRaw(g).attributes;
-            }
+            g => toRaw(g).attributes
         );
 
         const attSet: AttributeSet = {


### PR DESCRIPTION
### Related Item(s)

#2299

### Changes
- With file layers, exclusive field culling now happens at ESRI JSON level. Gives more respectful API results, and reduces memory pressure.
- Fixed null de-reference bug in default ESRI Feature detail template.
- Refactor same template to avoid mutating object just to re-use it.

### Testing

Steps:

1. Go to sample 28.
2. Select `File Layer with X and Y` on the Legend to open the grid.
3. Select any of the `Details` icons.
4. Observe detail pane open :owl: . Can see property values `X` and `Y` on display (will have co-ord values). Browser does not hang or freeze.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2303)
<!-- Reviewable:end -->
