### PR TITLE
Prevent export from failing when timestamp unchecked

### DIFF
--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -239,40 +239,57 @@ export class ExportAPI extends FixtureInstance {
 
         if (selectedState.timestamp && exportTimestampFixture) {
             fbTimestamp = await exportTimestampFixture.make({
-                top: this.options.runningHeight + 20,
+                top: this.options.runningHeight + 40,
                 width: panelWidth
             });
-            this.options.runningHeight += fbTimestamp.height!;
+
+            this.options.runningHeight +=
+                !selectedState.footnote || !exportFootnoteFixture
+                    ? fbTimestamp.height! + 40
+                    : fbTimestamp.height! + 20;
             selectedFabricObjects.timestamp = fbTimestamp;
         }
 
         if (selectedState.footnote && exportFootnoteFixture) {
             fbFootnote = await exportFootnoteFixture.make({
-                top: this.options.runningHeight - 2.5, // Magic number prevents weird vertical offset between timestamp/footer
+                top: this.options.runningHeight - 2.5, // Magic number 2.5 prevents weird vertical offset between timestamp/footer
                 left: panelWidth / this.options.scale + 40
             });
 
             // Extra width to prevent slight overlaps between timestamp and footnote
             const BUFFER = 30;
 
-            // Detect if the footnote overlaps with the timestamp
-            // If they overlap, put footnote on next line; else keep side-by-side
-            if (
-                panelWidth -
-                    (
-                        selectedFabricObjects.timestamp as fabric.Textbox
-                    ).getMinWidth() <=
-                (fbFootnote as fabric.Textbox).getMinWidth() + BUFFER
-            ) {
-                fbFootnote.top! += 40;
-                fbFootnote.left! = 0;
-                fbFootnote.originX! = 'left';
-                this.options.runningHeight += 20;
+            // First determine if timestamp exists
+            if (selectedState.timestamp && exportTimestampFixture) {
+                // CASE: Timestamp exists. Detect if the footnote overlaps with the timestamp
+                // If they overlap, put footnote on next line; else keep side-by-side
+                if (
+                    panelWidth -
+                        (
+                            selectedFabricObjects.timestamp as fabric.Textbox
+                        ).getMinWidth() <=
+                    (fbFootnote as fabric.Textbox).getMinWidth() + BUFFER
+                ) {
+                    // CASE: Overlap
+
+                    fbFootnote.top! += 30;
+                    fbFootnote.left! = 0;
+                    fbFootnote.originX! = 'left';
+                    this.options.runningHeight += 20;
+                } else {
+                    // CASE: No overlap
+
+                    fbFootnote.left! += -fbFootnote.width! * 2;
+                }
             } else {
+                // CASE: Timestamp doesn't exist
+
+                fbFootnote.top! += 20;
                 fbFootnote.left! += -fbFootnote.width! * 2;
+                this.options.runningHeight += 20;
             }
 
-            this.options.runningHeight += fbFootnote.height! + 20;
+            this.options.runningHeight += fbFootnote.height!;
             selectedFabricObjects.footnote = fbFootnote;
         }
 


### PR DESCRIPTION
### Related Item(s)
Issue #2306 
Repairs #2290 

### Changes
- [FIX] Fixes issue caused by #2290, where unselecting the timestamp causes the export to refresh into a blank screen. 
- [FIX] Minor export formatting adjustments. 

### Testing
Steps:
1. Go to any sample with an export (e.g. Sample 1). Open the export.
2. Open the export options in the bottom right (the gear icon) and unselect "timestamp". The export should refresh properly, without the timestamp.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2307)
<!-- Reviewable:end -->
