### PR TITLE
Replace special html chars with corresponding entities

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -91,6 +91,8 @@ export class InstanceAPI {
         formatNumber: (num: number) => string;
         scrollToInstance: boolean;
         suppressNumberLocalization: boolean;
+        escapeHtml: (content: string) => string;
+        isPlainText: (content: any) => boolean;
     };
     startRequired: boolean = false;
 
@@ -130,7 +132,9 @@ export class InstanceAPI {
             getZoomIcon: () => '',
             formatNumber: () => '',
             scrollToInstance: false,
-            suppressNumberLocalization: false
+            suppressNumberLocalization: false,
+            escapeHtml: () => '',
+            isPlainText: () => true
         };
         this.notify = new NotificationAPI(this);
 
@@ -313,6 +317,30 @@ export class InstanceAPI {
                 return this.ui.suppressNumberLocalization
                     ? num.toString()
                     : this.$i18n.n(num, 'number');
+            };
+
+            /**
+             * Return the string with all special html chars replaced by their corresponding entities
+             */
+            this.ui.escapeHtml = (content: string) => {
+                const specialChars = {
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#039;'
+                };
+                // @ts-ignore
+                return content.replace(/[<>"']/g, m => specialChars[m]);
+            };
+
+            /**
+             * Return whether the string should be interpreted as plain text. Returns false if input is not string
+             */
+            this.ui.isPlainText = (content: any) => {
+                return typeof content === 'string'
+                    ? !this.containsValidHtml(content) &&
+                          !this.representsObject(content)
+                    : false;
             };
         }
 
@@ -697,6 +725,26 @@ export class InstanceAPI {
         } else if (instanceStore.started) {
             console.warn('start has already been called');
         }
+    }
+
+    /**
+     * Return whether the string contains valid html content (i.e. a html element with opening and closing tags)
+     */
+    containsValidHtml(content: string): boolean {
+        // Define a regular expression to match HTML elements with both opening and closing tags
+        const tagPattern = /<(\w+)([^>]*)>(.*?)<\/\1>/;
+
+        // Test if the string contains at least one valid HTML element
+        return tagPattern.test(content);
+    }
+
+    /**
+     * Return whether the string represents an object or array
+     */
+    representsObject(content: string): boolean {
+        const tagPattern =
+            /^(?:\[\s*(?:[\s\S]*?)\s*\]|\{\s*(?:[\s\S]*?)\s*\})$/;
+        return tagPattern.test(content);
     }
 }
 

--- a/src/directives/truncate/truncate.ts
+++ b/src/directives/truncate/truncate.ts
@@ -79,6 +79,17 @@ function onShow(instance: any) {
     }
 }
 
+const escapeHtml = (content: string) => {
+    const specialChars = {
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    };
+    // @ts-ignore
+    return content.replace(/[<>"']/g, m => specialChars[m]);
+};
+
 /**
  * Applies hyperlinks to any URLs in the provided content.
  *
@@ -89,8 +100,8 @@ function linkifyContent(content: string | null): TippyContent {
     if (content === null) {
         return '';
     }
-
-    return <TippyContent>linkifyHtml(content, {
+    const escapedContent = escapeHtml(content);
+    return <TippyContent>linkifyHtml(escapedContent, {
         target: '_blank',
         validate: {
             url: (value: string) => /^https?:\/\//.test(value) // only links that begin with a protocol will be hyperlinked

--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -22,8 +22,8 @@
                 class="itemName pl-3 text-left flex-grow truncate"
                 :content="itemName"
                 v-tippy="{ placement: 'right' }"
-                >{{ makeHtmlLink(itemName) }}</span
-            >
+                v-html="makeHtmlLink(itemName)"
+            ></span>
 
             <!-- zoom icon -->
             <span class="zoomButton text-center p-3"
@@ -45,7 +45,12 @@
                         )
                     "
                     ref="zoomButton"
-                    @click="(e: MouseEvent) => { e.stopPropagation(); zoomToFeature() }"
+                    @click="
+                        (e: MouseEvent) => {
+                            e.stopPropagation();
+                            zoomToFeature();
+                        }
+                    "
                     class="text-gray-600 w-24 h-24 p-2 flex justify-center items-center"
                     v-if="isMapLayer"
                 >
@@ -176,9 +181,17 @@ const isMapLayer = computed<Boolean>(() => {
  */
 const itemName = computed<string>(() => {
     const nameField = getLayerInfo()?.nameField;
-    return nameField && props.data.loaded
-        ? props.data.data[nameField]
-        : iApi.$i18n.t('details.items.title');
+    let returnValue =
+        nameField && props.data.loaded
+            ? props.data.data[nameField]
+            : iApi.$i18n.t('details.items.title');
+
+    // only replace html special chars if string represents plain text
+    if (iApi!.ui.isPlainText(returnValue)) {
+        returnValue = iApi!.ui.escapeHtml(returnValue);
+    }
+
+    return returnValue;
 });
 
 // make links look like links and work like links

--- a/src/fixtures/details/components/result-list.vue
+++ b/src/fixtures/details/components/result-list.vue
@@ -217,6 +217,7 @@ const activeGreedy = computed<number>(() => detailsStore.activeGreedy);
 const detailProperties = computed<{ [id: string]: DetailsItemInstance }>(
     () => detailsStore.properties
 );
+
 /**
  * Return the LayerInstance that cooresponds with the UID provided in props.
  */
@@ -262,6 +263,7 @@ const getLayerIdentifyItems = () => {
     const results = props.results.find((layerResult: IdentifyResult) => {
         return layerResult.uid === props.uid;
     });
+
     return results ? results.items : [];
 };
 

--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -131,6 +131,15 @@ const itemData = () => {
         }
     });
 
+    for (const [key] of Object.entries(displayMetadata)) {
+        // only replace html special chars if string represents plain text
+        if (iApi!.ui.isPlainText(displayMetadata[key].value)) {
+            displayMetadata[key].value = iApi!.ui.escapeHtml(
+                displayMetadata[key].value
+            );
+        }
+    }
+
     return displayMetadata;
 };
 

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1617,6 +1617,22 @@ const setUpColumns = () => {
                             return row;
                         })
                     );
+                    for (let i = 0; i < mergedTableAttrs.rows.length; i++) {
+                        for (const [key] of Object.entries(
+                            mergedTableAttrs.rows[i]
+                        )) {
+                            if (
+                                iApi.ui.isPlainText(
+                                    mergedTableAttrs.rows[i][key]
+                                )
+                            ) {
+                                mergedTableAttrs.rows[i][key] =
+                                    iApi.ui.escapeHtml(
+                                        mergedTableAttrs.rows[i][key]
+                                    );
+                            }
+                        }
+                    }
 
                     mergedTableAttrs.fields = mergedTableAttrs.fields.concat(
                         ta.fields.map(field => {
@@ -1795,7 +1811,8 @@ const setUpColumns = () => {
                 // the grid is now ready to be displayed
                 isLoadingGrid.value = false;
             })
-            .catch(() => {
+            .catch(e => {
+                console.error(e);
                 isErrorGrid.value = true;
                 isLoadingGrid.value = false;
             });

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -11,8 +11,8 @@
                     legendItem.type === LegendType.Item
                         ? 'loaded-item'
                         : legendItem.type === LegendType.Error
-                        ? 'non-loaded-item bg-red-200'
-                        : 'non-loaded-item',
+                          ? 'non-loaded-item bg-red-200'
+                          : 'non-loaded-item',
                     (isGroup && controlAvailable(LegendControl.Expand)) ||
                     (!isGroup &&
                         legendItem instanceof LayerItem &&
@@ -52,11 +52,11 @@
                                   : 'legend.group.expand'
                           )
                         : legendItem instanceof LayerItem &&
-                          legendItem.type === LegendType.Item &&
-                          controlAvailable(LayerControl.Datatable) &&
-                          getDatagridExists()
-                        ? t('legend.layer.data')
-                        : ''
+                            legendItem.type === LegendType.Item &&
+                            controlAvailable(LayerControl.Datatable) &&
+                            getDatagridExists()
+                          ? t('legend.layer.data')
+                          : ''
                 "
                 v-tippy="{
                     placement: 'top-start',

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -25,8 +25,9 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem!.layerControlAvailable(LayerControl.Metadata) ||
-                        !getFixtureExists('metadata')
+                        !legendItem!.layerControlAvailable(
+                            LayerControl.Metadata
+                        ) || !getFixtureExists('metadata')
                 }"
                 @click="toggleMetadata"
                 role="button"
@@ -48,8 +49,9 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem!.layerControlAvailable(LayerControl.Settings) ||
-                        !getFixtureExists('settings')
+                        !legendItem!.layerControlAvailable(
+                            LayerControl.Settings
+                        ) || !getFixtureExists('settings')
                 }"
                 @click="toggleSettings"
                 role="button"
@@ -73,8 +75,9 @@
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
                     disabled:
-                        !legendItem!.layerControlAvailable(LayerControl.Datatable) ||
-                        !getFixtureExists('grid')
+                        !legendItem!.layerControlAvailable(
+                            LayerControl.Datatable
+                        ) || !getFixtureExists('grid')
                 }"
                 @click="toggleGrid"
                 role="button"
@@ -95,7 +98,9 @@
                 href="javascript:;"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem!.layerControlAvailable(LayerControl.Symbology)
+                    disabled: !legendItem!.layerControlAvailable(
+                        LayerControl.Symbology
+                    )
                 }"
                 @click="toggleSymbology"
                 role="button"
@@ -116,7 +121,9 @@
                 href="javascript:;"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem!.layerControlAvailable(LayerControl.BoundaryZoom)
+                    disabled: !legendItem!.layerControlAvailable(
+                        LayerControl.BoundaryZoom
+                    )
                 }"
                 @click="zoomToLayerBoundary"
                 role="button"
@@ -139,7 +146,9 @@
                 href="javascript:;"
                 class="flex leading-snug items-center text-left w-auto"
                 :class="{
-                    disabled: !legendItem!.layerControlAvailable(LayerControl.Remove)
+                    disabled: !legendItem!.layerControlAvailable(
+                        LayerControl.Remove
+                    )
                 }"
                 @click="removeLayer"
                 role="button"


### PR DESCRIPTION
### Related Item(s)
 #2267

### Changes
Replaced html special chars with their corresponding entities within:
- Datagrid panel (all content that represents plain text)
- Legend panel (content in item tooltips)
- Details panel (all content that represents plain text)

### Notes
- I decided not to replace the '&' special char, because when the code that calls `escapeHtml()` is called consecutively (ex. `getLayerIdentityItems()`, within `result-list.vue`), it replaces the '&'s from the previously placed entities with its entity 

### Testing
### Symbology Tooltip

Wizard url

```
https://agriculture.canada.ca/atlas/rest/services/servicesimage/utilisation_des_terres_30m_2020/ImageServer
```

1. Open Sample 46
5. Launch `+` wizard from legend. Add above URL as an Imagery Server layer
6. After layer loads, expand symbol stack in the legend.
7. Mouse over long legend names. Observe that the tooltips now include the entire name (including the text following the <)

Real legend names can be seen [here](https://agriculture.canada.ca/atlas/rest/services/servicesimage/utilisation_des_terres_30m_2020/ImageServer/legend?bandIds=&renderingRule=&f=html)

### Attribute Data

1. Take a copy of [happy.json](https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/public/file-layers/geojson.json) to a local text file.
2. Edit name attribute `Happy Mouth` to `Big < small`.
3. Open Sample 46
4. Launch `+` wizard from legend. Add the local `.json` file.
5. Pick `name` as the display field during Step 3
6. Click the mouth on the map. Observe that the name correctly displays as `Big < small`
7. Open the datagrid, and observe that the name for the mouth (3rd row) correctly displays as `Big < small`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2310)
<!-- Reviewable:end -->
