### PR TITLE
Restore respect to the panel boundary and resolve WAVE errors

### DIFF
--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -259,7 +259,7 @@ export class PanelInstance extends APIScope {
     }
 
     /**
-     * true iff the panel is currently visible
+     * true if the panel is currently visible
      *
      * @readonly
      * @type {boolean}

--- a/src/components/controls/toggle-switch-control.vue
+++ b/src/components/controls/toggle-switch-control.vue
@@ -6,39 +6,41 @@
             {{ name }}
         </div>
         <div class="flex-1"></div>
-        <toggle
-            @change="(value: any) => emit('toggled', value)"
-            @keyup.enter.capture.stop="handleKeyup"
-            @keyup.space.capture.stop="handleKeyup"
-            :disabled="isDisabled"
-            :key="toggleKey"
-            v-model="isOn"
-            :classes="{
-                container:
-                    'inline-block rounded-full outline-none focus:ring focus:ring-blue-500 focus:ring-opacity-30',
-                toggle: 'flex w-40 h-15 rounded-full relative cursor-pointer transition items-center box-content border-2 text-xs leading-none',
-                toggleOn:
-                    'bg-blue-500 border-blue-500 justify-start text-white',
-                toggleOff:
-                    'bg-gray-200 border-gray-200 justify-end text-gray-700',
-                toggleOnDisabled:
-                    'bg-gray-300 border-gray-300 justify-start text-gray-400 cursor-not-allowed',
-                toggleOffDisabled:
-                    'bg-gray-200 border-gray-200 justify-end text-gray-400 cursor-not-allowed',
-                handle: 'inline-block bg-white w-15 h-15 top-0 rounded-full absolute transition-all',
-                handleOn: 'left-full transform -translate-x-full',
-                handleOff: 'left-0',
-                handleOnDisabled:
-                    'bg-gray-100 left-full transform -translate-x-full',
-                handleOffDisabled: 'bg-gray-100 left-0',
-                label: 'text-center w-8 border-box whitespace-nowrap select-none'
-            }"
-        />
+        <div ref="toggleWrapper">
+            <toggle
+                @change="(value: any) => emit('toggled', value)"
+                @keyup.enter.capture.stop="handleKeyup"
+                @keyup.space.capture.stop="handleKeyup"
+                :disabled="isDisabled"
+                :key="toggleKey"
+                v-model="isOn"
+                :classes="{
+                    container:
+                        'inline-block rounded-full outline-none focus:ring focus:ring-blue-500 focus:ring-opacity-30',
+                    toggle: 'flex w-40 h-15 rounded-full relative cursor-pointer transition items-center box-content border-2 text-xs leading-none',
+                    toggleOn:
+                        'bg-blue-500 border-blue-500 justify-start text-white',
+                    toggleOff:
+                        'bg-gray-200 border-gray-200 justify-end text-gray-700',
+                    toggleOnDisabled:
+                        'bg-gray-300 border-gray-300 justify-start text-gray-400 cursor-not-allowed',
+                    toggleOffDisabled:
+                        'bg-gray-200 border-gray-200 justify-end text-gray-400 cursor-not-allowed',
+                    handle: 'inline-block bg-white w-15 h-15 top-0 rounded-full absolute transition-all',
+                    handleOn: 'left-full transform -translate-x-full',
+                    handleOff: 'left-0',
+                    handleOnDisabled:
+                        'bg-gray-100 left-full transform -translate-x-full',
+                    handleOffDisabled: 'bg-gray-100 left-0',
+                    label: 'text-center w-8 border-box whitespace-nowrap select-none'
+                }"
+            />
+        </div>
     </div>
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, toRef, watch, onBeforeUnmount } from 'vue';
+import { onBeforeUnmount, reactive, ref, toRef, watch } from 'vue';
 import Toggle from '@vueform/toggle';
 import type { PropType } from 'vue';
 
@@ -50,13 +52,15 @@ const props = defineProps({
         required: true
     },
     name: String,
-    icon: String
+    icon: String,
+    ariaLabel: String
 });
 
 const isOn = ref<boolean>(props.config.value);
 const isDisabled = ref<boolean>(!!props.config.disabled);
 const toggleKey = ref<number>(0); // this key forces Vue to rerender Toggle
 const watchers = reactive<Array<Function>>([]);
+const toggleWrapper = ref<HTMLElement | null>(null);
 
 watchers.push(
     watch(
@@ -69,13 +73,29 @@ watchers.push(
             toggleKey.value += isDisabled.value !== oConf.disabled ? 1 : 0;
         },
         { deep: true }
-    )
+    ),
+    watch(toggleWrapper, newValue => {
+        if (newValue) {
+            addAriaLabel();
+        }
+    })
 );
 
 const handleKeyup = () => {
     if (!isDisabled.value) {
         isOn.value = !isOn.value;
         emit('toggled', isOn.value);
+    }
+};
+
+const addAriaLabel = () => {
+    if (toggleWrapper.value) {
+        const checkbox = toggleWrapper.value.querySelector(
+            'input[type="checkbox"]'
+        );
+        if (checkbox && props.ariaLabel) {
+            checkbox.setAttribute('aria-label', props.ariaLabel);
+        }
     }
 };
 

--- a/src/components/panel-stack/controls/minimize.vue
+++ b/src/components/panel-stack/controls/minimize.vue
@@ -5,6 +5,7 @@
             class="text-gray-500 hover:text-black focus:text-black p-6"
             :class="{ 'text-gray-700': active }"
             :content="t('panels.controls.minimize')"
+            :aria-label="t('panels.controls.minimize')"
             v-tippy="{
                 placement: 'bottom',
                 theme: 'ramp4',

--- a/src/fixtures/geosearch/top-filters.vue
+++ b/src/fixtures/geosearch/top-filters.vue
@@ -8,6 +8,7 @@
             <select
                 class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
                 :value="queryParams.province"
+                :aria-label="t('geosearch.filters.province')"
                 v-on:change="
                     setProvince({
                         province: ($event.target as HTMLSelectElement).value
@@ -31,6 +32,7 @@
             <select
                 class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer max-w-150"
                 :value="queryParams.type"
+                :aria-label="t('geosearch.filters.type')"
                 v-on:change="
                     setType({
                         type: ($event.target as HTMLSelectElement).value
@@ -47,10 +49,11 @@
             </select>
             <button
                 type="button"
-                class="text-gray-500 w-1/8 h-24 pl-8 pr-16 sm:pr-8 hover:text-black disabled:cursor-default disabled:text-gray-300"
+                class="text-gray-500 w-1/8 h-24 pl-8 pr-16 sm:pr-8 hover:text-black disabled:cursor-default disabled:text-gray-400"
                 :disabled="!queryParams.type && !queryParams.province"
                 v-on:click="clearFilters"
                 :content="t('geosearch.filters.clear')"
+                :aria-label="t('geosearch.filters.clear')"
                 v-tippy="{ placement: 'bottom' }"
             >
                 <div class="rv-geosearch-icon">

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -12,6 +12,7 @@ grid.label.export,Export,1,Exporter,1
 grid.label.columns,Hide columns,1,Masquer les colonnes,1
 grid.label.copied,Copied,1,Copié,1
 grid.label.copy,Press ctrl + c or double click to copy,1,Appuyez sur Ctrl + C ou double-cliquez pour copier,1
+grid.label.specialColumn,Special Column,1,Colonne spéciale,0
 grid.label.filters.show,Show filters,1,Afficher les filtres,1
 grid.label.filters.hide,Hide filters,1,Masquer les filtres,1
 grid.label.filters.apply,Apply filters to map,1,Appliquer les filtres à la carte,1

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -638,6 +638,26 @@ const onGridReady = (params: any) => {
         columnApi.value.autoSizeAllColumns();
     }
 
+    const addAriaLabels = () => {
+        const checkboxInputs = document.querySelectorAll(
+            '.ag-input-field-input.ag-checkbox-input'
+        );
+        checkboxInputs.forEach((input, index) => {
+            const allColumns = columnApi.value.getAllDisplayedColumns();
+            const column = allColumns[index].getColDef();
+
+            input.setAttribute(
+                'aria-label',
+                column.headerName ?? t('grid.label.specialColumn')
+            );
+        });
+    };
+
+    // Initial load
+    addAriaLabels();
+
+    agGridApi.value.addEventListener('rowDataChanged', addAriaLabels);
+
     // listen for layer filter and visibility events and update grid appropriately
     handlers.value.push(
         iApi.event.on(

--- a/src/fixtures/settings/component.vue
+++ b/src/fixtures/settings/component.vue
@@ -4,6 +4,7 @@
         :icon="icons[icon]"
         :name="name"
         :config="config"
+        :aria-label="ariaLabel"
     />
 </template>
 
@@ -33,6 +34,10 @@ defineProps({
         type: String as PropType<
             'visibility' | 'opacity' | 'box' | 'location' | 'refresh'
         >,
+        required: true
+    },
+    ariaLabel: {
+        type: String,
         required: true
     }
 });

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -26,6 +26,7 @@
                             value: visibilityModel,
                             disabled: !controlAvailable(LayerControl.Visibility)
                         }"
+                        :ariaLabel="t('settings.label.visibility')"
                     />
 
                     <div class="rv-settings-divider"></div>
@@ -40,6 +41,7 @@
                             value: opacityModel,
                             disabled: !controlAvailable(LayerControl.Opacity)
                         }"
+                        :ariaLabel="t('settings.label.opacity')"
                     ></settings-component>
 
                     <div class="rv-settings-divider"></div>
@@ -78,6 +80,7 @@
                             value: identifyModel,
                             disabled: !controlAvailable(LayerControl.Identify)
                         }"
+                        :ariaLabel="t('settings.label.identify')"
                     ></settings-component>
 
                     <div class="rv-settings-divider"></div>
@@ -233,8 +236,8 @@ const controlAvailable = (control: LayerControl): boolean => {
     return settingsConfig?.disabledControls?.includes(control)
         ? false
         : settingsConfig?.controls
-        ? settingsConfig?.controls?.includes(control)
-        : true;
+          ? settingsConfig?.controls?.includes(control)
+          : true;
 };
 
 /**

--- a/src/fixtures/wizard/form-footer.vue
+++ b/src/fixtures/wizard/form-footer.vue
@@ -9,7 +9,7 @@
         </button>
 
         <button
-            class="button bg-blue-500 hover:bg-blue-700 text-white font-bold py-8 px-16 m-2 disabled:bg-gray-200 disabled:cursor-default disabled:text-gray-400"
+            class="button bg-blue-700 hover:bg-blue-700 text-white font-bold py-8 px-16 m-2 disabled:bg-gray-200 disabled:cursor-default disabled:text-gray-400"
             ref="submitButton"
             type="button"
             :disabled="disabled"

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -20,6 +20,7 @@
                             :label="t('wizard.upload.file.label')"
                             :help="t('wizard.upload.file.help')"
                             @upload="updateFile"
+                            :aria-label="t('wizard.upload.file.label')"
                         />
                         <span class="block text-center mb-10">or</span>
 
@@ -35,6 +36,7 @@
                                 required: t('wizard.upload.url.error.required'),
                                 invalid: t('wizard.upload.url.error.url')
                             }"
+                            :aria-label="t('wizard.upload.url.label')"
                         />
                         <wizard-form-footer
                             @submit="onUploadContinue"
@@ -111,6 +113,7 @@
                                 }${' ' + t('wizard.format.warn.vpn') + '.'}`
                             }"
                             @keydown.stop
+                            :aria-label="t('wizard.format.type.service')"
                         />
                         <wizard-form-footer
                             @submit="onSelectContinue"
@@ -145,6 +148,7 @@
                             v-model="layerInfo.config.name"
                             @link="updateLayerName"
                             :label="t('wizard.configure.name.label')"
+                            :aria-label="t('wizard.configure.name.label')"
                             :validation="true"
                             :validation-messages="{
                                 required: t(
@@ -160,6 +164,7 @@
                             name="nameField"
                             v-model="layerInfo.config.nameField"
                             :label="t('wizard.configure.nameField.label')"
+                            :aria-label="t('wizard.configure.nameField.label')"
                             :defaultOption="true"
                             :options="fieldOptions()"
                         />
@@ -173,6 +178,9 @@
                             name="tooltipField"
                             v-model="layerInfo.config.tooltipField"
                             :label="t('wizard.configure.tooltipField.label')"
+                            :aria-label="
+                                t('wizard.configure.tooltipField.label')
+                            "
                             :options="fieldOptions()"
                         />
                         <wizard-input
@@ -182,6 +190,7 @@
                             v-model="layerInfo.config.latField"
                             :defaultOption="true"
                             :label="t('wizard.configure.latField.label')"
+                            :aria-label="t('wizard.configure.latField.label')"
                             :options="latLonOptions('lat')"
                         />
                         <wizard-input
@@ -193,6 +202,7 @@
                             v-model="layerInfo.config.longField"
                             :defaultOption="true"
                             :label="t('wizard.configure.longField.label')"
+                            :aria-label="t('wizard.configure.longField.label')"
                             :options="latLonOptions('lon')"
                         />
                         <!-- For map image layers -->
@@ -206,6 +216,9 @@
                                 name="nested"
                                 @nested="updateNested"
                                 :label="t('wizard.configure.sublayers.nested')"
+                                :aria-label="
+                                    t('wizard.configure.sublayers.nested')
+                                "
                             />
                             <wizard-input
                                 type="select"
@@ -214,6 +227,9 @@
                                 v-model="layerInfo.config.sublayers"
                                 @select="updateSublayers"
                                 :label="t('wizard.configure.sublayers.label')"
+                                :aria-label="
+                                    t('wizard.configure.sublayers.label')
+                                "
                                 :options="layerInfo.layers!"
                                 :selectedValues="selectedValues"
                                 :sublayerOptions="sublayerOptions"

--- a/src/fixtures/wizard/stepper-item.vue
+++ b/src/fixtures/wizard/stepper-item.vue
@@ -4,7 +4,7 @@
             <!-- step number -->
             <div
                 v-if="!done()"
-                class="w-24 h-24 bg-gray-400 rounded-full flex justify-center items-center text-white text-xs font-semibold"
+                class="w-24 h-24 bg-gray-500 rounded-full flex justify-center items-center text-white text-xs font-semibold"
                 :class="{ 'bg-blue-500': active }"
             >
                 {{ index + 1 }}

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -126,14 +126,16 @@ export const usePanelStore = defineStore('panel', () => {
         // TODO: update when panel width system is in place
         let remainingWidth = stackWidth.value;
         const nowVisible: PanelInstance[] = [];
+        const defaultWidth = 350;
+        const panelMargin = 12;
 
         // add panels until theres no space in the stack
         for (let i = orderedItems.value.length - 1; i >= 0; i--) {
-            let panelWidth = orderedItems.value[i].width || 350;
+            let panelWidth = orderedItems.value[i].width || defaultWidth;
 
             // if not in mobile view, all panels have a 12px margin to the right
             if (!mobileView.value) {
-                panelWidth += 12;
+                panelWidth += panelMargin;
             } else {
                 // if in mobile view, a single panel will take up the whole view
                 panelWidth = remainingWidth;
@@ -162,14 +164,15 @@ export const usePanelStore = defineStore('panel', () => {
             for (
                 let i = 0;
                 i < nowVisible.length - 1 &&
-                remainingWidth < (pinned.value.width || 350);
+                remainingWidth <
+                    (pinned.value.width || defaultWidth) + panelMargin;
                 i++
             ) {
                 lastElement = nowVisible.shift()!;
-                remainingWidth += lastElement.width || 350;
+                remainingWidth += lastElement.width || defaultWidth;
             }
 
-            if (remainingWidth >= (pinned.value.width || 350)) {
+            if (remainingWidth >= (pinned.value.width || defaultWidth)) {
                 // if theres room insert pinned element
                 //@ts-ignore
                 nowVisible.unshift(pinned.value);


### PR DESCRIPTION
### Related Item(s)
#2285, #2113

### Changes
- Resolves a series of WAVE errors. 
- Large panels will no longer open partially out of view when multiple panels are open

### Notes
Some of these WAVE resolutions are a touch hacky, especially on the Grid and Toggle libraries as they disrespect the aria-label. Open to UI wizard suggestions

### Testing
Steps:

For #2113 (This issue occurs more prominently on smaller screen sizes)
1. Open the main sample 
2. Open some of the smaller panels 
3. Open the export panel and the happy grid
4. The grid should no longer spill out of view. 

For #2285
1. Ensure you have the WAVE plugin installed
2. Open the main sample 
3. Open the Geolocation search and verify there are no WAVE errors
5. Open the Settings panel (select the ... icon on the happy layer) and verify there are no WAVE errors NOTE: Didn't get the contrast errors on my end
6. Select the + icon to open the wizard, go through each step and verify there are no WAVE errors or contrast errors (Didn't test with every service type so please report any errors you find). You can use this [service ]( https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer) to start. 
7. Open Classic Main Sample (7)
8. Open the grids and verify that there are no WAVE errors. Inspect the hidden checkboxes and verify that the aria-labels match the column name.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2312)
<!-- Reviewable:end -->
