### PR TITLE
Prevent certain geosearch inputs from displaying bad results

### DIFF
--- a/src/fixtures/geosearch/lang/lang.csv
+++ b/src/fixtures/geosearch/lang/lang.csv
@@ -7,3 +7,4 @@ geosearch.filters.province,Province,1,Province,1
 geosearch.filters.type,Type,1,Type,1
 geosearch.filters.clear,Clear filters,1,Effacer les filtres,1
 geosearch.serviceError,No response from {services} service(s),1,Pas de réponse de la part des services de {services},1
+geosearch.badChars,The character(s) {chars} are not supported and will be ignored,1,Les caractères {chars} ne sont pas pris en charge et seront ignorés,0

--- a/src/fixtures/geosearch/screen.vue
+++ b/src/fixtures/geosearch/screen.vue
@@ -23,7 +23,7 @@
                 <div
                     class="px-8 mb-10 py-8 flex-grow text-wrap border-y border-gray-600 overflow-y-auto"
                     v-if="
-                        searchVal &&
+                        cleanedSearchVal &&
                         searchResults.length === 0 &&
                         !loadingResults
                     "
@@ -31,7 +31,7 @@
                     <span class="relative h-48"
                         >{{ t('geosearch.noResults')
                         }}<span class="font-bold text-blue-600"
-                            >"{{ searchVal }}"</span
+                            >"{{ cleanedSearchVal }}"</span
                         ></span
                     >
                 </div>
@@ -126,7 +126,9 @@ defineProps({
     }
 });
 
-const searchVal = computed<string>(() => geosearchStore.searchVal);
+const cleanedSearchVal = computed<string>(() =>
+    geosearchStore.searchVal.replace(/["!*$+?^{}()|[\]\\]/g, '').trim()
+);
 const searchResults = computed<Array<any>>(() => geosearchStore.searchResults);
 const loadingResults = computed<boolean>(() => geosearchStore.loadingResults);
 const failedServices = computed<string[]>(() => geosearchStore.failedServices);

--- a/src/fixtures/geosearch/search-bar.vue
+++ b/src/fixtures/geosearch/search-bar.vue
@@ -1,8 +1,9 @@
 <template>
-    <div class="rv-geosearch-bar h-26 mb-8 mx-8">
+    <div class="rv-geosearch-bar relative h-26 mx-8 mb-8">
         <input
-            type="search"
+            type="text"
             class="border-b w-full text-base py-8 outline-none focus:shadow-outline border-gray-600 h-full min-w-0"
+            :class="{ 'border-yellow-500': badChars }"
             :placeholder="t('geosearch.searchText')"
             :value="searchVal"
             @input="
@@ -17,6 +18,17 @@
             @keypress.enter.prevent
             enterkeyhint="done"
         />
+        <span class="absolute inset-y-0 right-8 grid w-10 place-content-center">
+            <button
+                v-if="badChars"
+                class="cursor-default"
+                :aria-label="t('geosearch.badChars', { chars: badChars })"
+                :content="t('geosearch.badChars', { chars: badChars })"
+                v-tippy
+            >
+                ⚠
+            </button>
+        </span>
     </div>
 </template>
 
@@ -32,6 +44,11 @@ const geosearchStore = useGeosearchStore();
 const panelStore = usePanelStore();
 
 const searchVal = computed(() => geosearchStore.searchVal);
+const badChars = computed<string>(() =>
+    ['"', '$', '!', '*', '+', '?', '^', '{', '}', '(', ')', '|', '[', ']']
+        .filter(bc => geosearchStore.searchVal.includes(bc))
+        .join('')
+);
 const setSearchTerm = (value: string) => {
     geosearchStore.setSearchTerm(value);
     geosearchStore.setSearchRegex(value);


### PR DESCRIPTION
### Related Item(s)
#2278

### Changes
- For certain geosearch inputs, namely [, ], ", ^, ?, +, and !, if the default geonames service is being used, the correct result of no results found is now shown instead of displaying the service's nonsense results.

### Notes
- I played around with many combinations of characters, but it is possible I missed something. Hence, if I have missed a character that should be there or if this causes valid results to be hidden, please grouse below.

### Testing
1. Open the geosearch panel.
2. Try out one of the bad inputs.
3. Notice that no results are shown.
4. Now try out a valid input.
5. Verify that the correct result is shown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2313)
<!-- Reviewable:end -->
