### PR TITLE
True Layer Load Cancel

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,21 @@
 ### Notes
 *Additional comments about the changes in this PR, including screenshots/gifs*
 
+### QA Testing
+
+*See https://hackmd.io/@james-rae/HJhylgGpA for details on qa test scenarios and procedures*
+
+*If this PR is not the last category (does not require special qa demo branch), put the next line in this section*
+Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html
+
+*If this PR will require a future qa branch & PR, put the next line in this section*
+QA demo in future PR.
+
+*If this PR is the qa branch & special demo, put the next line in this section. Link the OG PR in Related Items above.*
+Please test using the demo links in the first comment.
+
 ### Testing
+
 Steps:
 1. ...
 2. ...

--- a/docs/api-guides/panels.md
+++ b/docs/api-guides/panels.md
@@ -354,7 +354,7 @@ The API provides the following methods:
     These properties are the same as the ones described in the [`PanelInstance` object](#panelinstance-object).
 
     Additionally, the `PanelRegistrationOptions` object has one optional property of `i18n`, where you should include the localized strings for the panel. For more details on localization, please see the [localization documentation](../using-ramp4/config-language.md)
-* `isRegistered(panelId: string | string[]): Promise<any>` - provides a promise that resolves when panels with the specified panel ID(s) have completed registration.
+* `isRegistered(panelId: string | string[]): Promise<void>` - provides a promise that resolves when panels with the specified panel ID(s) have completed registration.
 * `remove(value: string | PanelInstance): void` - removes the specified panel from the panel stack.
 * `get(value: string | PanelInstance): PanelInstance` - finds and returns the specified panel.
 * `open(value: string | PanelInstance | PanelInstancePath)` - opens the specified panel.

--- a/docs/using-ramp4/default-setup.md
+++ b/docs/using-ramp4/default-setup.md
@@ -24,16 +24,16 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed                             |
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added                         |
 | FIXTURE_REMOVED<br>'fixture/removed'               | FixtureInstance object                                         | A fixture has been removed                       |
-| LAYER_DRAWSTATECHANGE<br>'layer/drawstatechange'   | _state_: new value, layer: LayerInstance object                | The layer draw state changed                     |
-| LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, layer: LayerInstance object      | The layer layer state changed |
-| LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange' | _state_: new value, layer: LayerInstance object                | The layer load state changed |                     |
-| LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, layer: LayerInstance object              | The layer opacity changed                        |
-| LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was added to the map                   |
+| LAYER_DRAWSTATECHANGE<br>'layer/drawstatechange'   | _state_: new value, _layer_: LayerInstance object                | The layer draw state changed                     |
+| LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, _layer_: LayerInstance object      | The layer layer state changed |
+| LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange' | _state_: new value, _layer_: LayerInstance object, _userCancel_: boolean                | The layer load state changed |                     |
+| LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, _layer_: LayerInstance object              | The layer opacity changed                        |
+| LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was registered with the instance                   |
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
 | LAYER_RELOAD_START<br>'layer/reloadstart'          | LayerInstance object                                           | The layer started reloading                      |
 | LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |
-| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, layer: LayerInstance object           | The layer visibility changed                     |
-| MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | basemapId: string, schemaChanged: boolean                      | The basemap was changed                          |
+| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _layer_: LayerInstance object           | The layer visibility changed                     |
+| MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | _basemapId_: string, _schemaChanged_: boolean                      | The basemap was changed                          |
 | MAP_BLUR<br>'map/blur'                             | KeyboardEvent object                                           | The map lost focus                               |
 | MAP_CLICK<br>'map/click'                           | MapClick object                                                | The map was clicked                              |
 | MAP_CREATED<br>'map/created'                       | none                                                           | The map was created                              |
@@ -41,7 +41,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_DOUBLECLICK<br>'map/doubleclick'               | MapClick object                                                | The map was double clicked                       |
 | MAP_EXTENTCHANGE<br>'map/extentchanged'            | RAMP Extent object                                             | The map extent changed                           |
 | MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                                |
-| MAP_GRAPHICHIT<br>'map/graphichit'                 | `{ layer, graphicHit, attributes, icon, screenPoint}`            | A graphic was found where the mouse/crosshair is |
+| MAP_GRAPHICHIT<br>'map/graphichit'                 | _layer_: LayerInstance object, _graphicHit_: object, _attributes_: object, _icon_: string, _screenPoint_: object            | A graphic was found where the mouse/crosshair is |
 | MAP_IDENTIFY<br>'map/identify'                     | MapIdentifyResult object                                       | A map identify was requested                     |
 | MAP_KEYDOWN<br>'map/keydown'                       | KeyboardEvent object                                           | A key was pressed                                |
 | MAP_KEYUP<br>'map/keyup'                           | KeyboardEvent object                                           | A key was released                               |
@@ -52,30 +52,28 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_MOUSEMOVE_START<br>'map/mousemovestart'        | MapMove object                                                 | The mouse stopped moving over the map            |
 | MAP_REFRESH_END<br>'map/refreshend'                | none                                                           | The map view started refreshing                  |
 | MAP_REFRESH_START<br>'map/refreshstart'            | none                                                           | The map view finished refreshing                 |
-| MAP_REORDER<br>'map/reorder'                       | _newIndex_: z-index, layer: LayerInstance object               | A layer was reordered |
+| MAP_REORDER<br>'map/reorder'                       | _newIndex_: z-index, _layer_: LayerInstance object               | A layer was reordered |
 | MAP_RESIZED<br>'map/resized'                       | _height_: new height, _width_: new width                       | The map view changed size                        |
-| MAP_SCALECHANGE<br>'map/scalechanged'              | scale denominator: number                                      | The map scale changed                            |
+| MAP_SCALECHANGE<br>'map/scalechanged'              | scale (denominator) number                                      | The map scale changed                            |
 | MAP_START<br>'map/start'                           | none                                                           | The map startup was requested                    |
 | PANEL_CLOSED<br>'panel/closed'                     | PanelInstance object                                           | A panel was closed                               |
 | PANEL_MINIMIZED<br>'panel/closed'                  | PanelInstance object                                           | A panel was minimized                             |
 | PANEL_OPENED<br>'panel/opened'                     | PanelInstance object                                           | A panel was opened                               |
-| RAMP_MOBILEVIEW_CHANGE<br>'ramp/mobile'            | mobileMode: boolean                                            | The screen changes to/from mobile resolution     |
+| RAMP_MOBILEVIEW_CHANGE<br>'ramp/mobile'            | mobileMode boolean                                            | The screen changes to/from mobile resolution     |
 | USER_LAYER_ADDED<br>'user/layeradded'              | LayerInstance object                                           | A layer was added during the session             |
 
 ### Core Fixture Events
 
 These events will be present if the associated core fixtures are running
 
-TODO add stuff as we make events that core fixtures raise
-
 | Event Name                           | Payload                                                 | Event Announces                                                |
 | ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------- |
 | DETAILS_TOGGLE<br>'details/toggle'   | { data: any, uid: string, format: string }, boolean (optional)         | A feature's details panel toggle was requested with optional force open/close       |
-| GRID_TOGGLE<br>'grid/toggle'         | layer: LayerInstance, _open_: boolean (optional)        | Grid panel toggle was requested with optional force open/close |
+| GRID_TOGGLE<br>'grid/toggle'         | _layer_: LayerInstance, _open_: boolean (optional)        | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |
-| METADATA_TOGGLE<br>'metadata/toggle' | { type: string, layerName: string, url: string, layer: LayerInstance }, open: boolean (optional)        | Metadata panel toggle was requested with optional force open/close                                 |
+| METADATA_TOGGLE<br>'metadata/toggle' | { type: string, layerName: string, url: string, _layer_: LayerInstance }, open: boolean (optional)        | Metadata panel toggle was requested with optional force open/close                                 |
 | REORDER_TOGGLE<br>'reorder/toggle'   | boolean (optional)                                      | Layer reorder panel toggle was requested with optional force open/close |
-| SETTINGS_TOGGLE<br>'settings/toggle' | layer: LayerInstance, _open_: boolean (optional)        | Settings panel toggle was requested for a layer with optional force open/close |
+| SETTINGS_TOGGLE<br>'settings/toggle' | _layer_: LayerInstance, _open_: boolean (optional)        | Settings panel toggle was requested for a layer with optional force open/close |
 | WIZARD_TOGGLE<br>'wizard/open'       | boolean (optional)                                      | Wizard panel toggle was requested with optional force open/close |
 
 ## Default Events Handlers

--- a/docs/using-ramp4/layers/basic-properties.md
+++ b/docs/using-ramp4/layers/basic-properties.md
@@ -94,7 +94,7 @@ The object structure matches the ArcGIS Server [2D Envelope](https://developers.
 
 *integer*
 
-Defines a time limit, in milliseconds, for the max amount of time it would take for the layer load (i.e. establishing contact with a server, the fetching of metadata, the downloading of data for file or WFS type layers). If the limit is exceeded, the layer will stop loading and produce an error. If missing, a default of 20 seconds will be used. Setting to `0` will allow the layer to load forever.
+Defines a time limit, in milliseconds, for the max amount of time it would take for the layer load (i.e. establishing contact with a server, the fetching of metadata, the downloading of data for file or WFS type layers). If the limit is exceeded, the layer will stop loading and produce an error. The value must be greater than 0. If 0 or missing, the map level configuration will be used. This defaults to 90000 (90 seconds).
 
 ```js
 {

--- a/schema.json
+++ b/schema.json
@@ -817,8 +817,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -891,8 +891,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -966,8 +966,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -1171,8 +1171,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -1294,8 +1294,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "layerType": {
                     "type": "string",
@@ -1416,8 +1416,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "layerType": {
                     "type": "string",
@@ -1511,8 +1511,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "colour": {
                     "type": "string",
@@ -1629,8 +1629,8 @@
                 },
                 "maxLoadTime": {
                     "type": "number",
-                    "default": 20000,
-                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will allow the layer to load forever"
+                    "default": 0,
+                    "description": "The time span (in milliseconds) a layer can load for before entering the 'error' state. Zero will defer to the map default."
                 },
                 "metadata": {
                     "$ref": "#/$defs/layerMetadata"
@@ -2568,7 +2568,7 @@
                             "enum": ["glow", "lift", "fog", "none"]
                         },
                         "options": {
-                            "description": "Options for the selected hilight mode.",
+                            "description": "Options for the selected hilight mode. The below schema is for fog mode. In glow mode, the options object should conform to an ESRI MapView HighlightOptions type.",
                             "type": "object",
                             "properties": {
                                 "onOpacity": {
@@ -2825,6 +2825,11 @@
                             "type": "number",
                             "default": 10000,
                             "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications. Values on individual layer configs will override."
+                        },
+                        "maxLoadTime": {
+                            "type": "number",
+                            "description": "Time limit (in milliseconds) to wait for any added layer to load. Layer errors if time exceeds. Value must be greater than 0.",
+                            "default": 90000
                         }
                     }
                 }

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -25,7 +25,6 @@ import {
     PanelAPI,
     NotificationAPI
 } from './internal';
-import type { LayerInstance } from './internal';
 
 import PanelScreenV from '@/components/panel-stack/panel-screen.vue';
 import PinV from '@/components/panel-stack/controls/pin.vue';
@@ -229,7 +228,10 @@ export class InstanceAPI {
                         langConfig.layers.forEach(layerConfig => {
                             const layer =
                                 this.geo.layer.createLayer(layerConfig);
-                            this.geo.map.addLayer(layer, mapOrderPos);
+                            this.geo.map
+                                .addLayer(layer, mapOrderPos)
+                                // just to silence console about unhandled rejections.
+                                .catch(() => {});
                             if (layer.mapLayer) {
                                 // we only increment for map layers. Data layers get added but do not live in the map stack.
                                 // so no ++. We pass the param to map.addLayer above out of lazyness. It gets ignored for data layers.

--- a/src/api/panel-instance.ts
+++ b/src/api/panel-instance.ts
@@ -11,13 +11,13 @@ import {
 } from './internal';
 
 import type {
+    AsyncComponentEh,
+    AsyncComponentFactoryEh,
     PanelConfig,
     PanelConfigRoute,
     PanelConfigScreens,
     PanelConfigStyle,
-    PanelDirection,
-    AsyncComponentFactoryEh,
-    AsyncComponentEh
+    PanelDirection
 } from '@/stores/panel';
 
 import ScreenSpinnerV from '@/components/panel-stack/screen-spinner.vue';

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -88,7 +88,7 @@ export class PanelAPI extends APIScope {
      * @param {(string | string[])} panelId the panel ID(s) for which the promise is requested
      * @memberof PanelAPI
      */
-    isRegistered(panelId: string | string[]): Promise<any> {
+    async isRegistered(panelId: string | string[]): Promise<void> {
         // We first need to create a registration promise for all panels that currently don't have one
         const idsToCheck = Array.isArray(panelId) ? panelId : [panelId];
         idsToCheck.forEach((id: string) => {
@@ -96,10 +96,11 @@ export class PanelAPI extends APIScope {
                 this.panelStore.addRegPromise(id);
             }
         });
-        // Now, get all the promises and return
-        return Promise.all(
-            this.panelStore.getRegPromises(idsToCheck) // not sure how to get typescript to stop yelling
-        );
+
+        // Wait for all promises
+        await Promise.all(this.panelStore.getRegPromises(idsToCheck));
+
+        // return nothing (stops a nonsense array from appearing in the result promise)
     }
 
     /**

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -241,7 +241,9 @@
                 <!-- reload for error'd items -->
                 <div
                     class="relative"
-                    v-if="legendItem.type === LegendType.Error"
+                    v-if="
+                        legendItem.type === LegendType.Error && reloadableLayer
+                    "
                 >
                     <button
                         type="button"
@@ -251,7 +253,7 @@
                             placement: 'top-start'
                         }"
                         @mouseover.stop
-                        @click.stop="reloadIfReady"
+                        @click.stop="reloadLayer"
                         :aria-label="t('legend.layer.controls.reload')"
                     >
                         <div class="flex p-8">
@@ -575,7 +577,7 @@
 <script setup lang="ts">
 import { GlobalEvents, InstanceAPI } from '@/api';
 import type { LegendSymbology, RampLayerConfig } from '@/geo/api';
-import { LayerControl } from '@/geo/api';
+import { InitiationState, LayerControl } from '@/geo/api';
 import { useLayerStore } from '@/stores/layer';
 import to from 'await-to-js';
 import { marked } from 'marked';
@@ -632,6 +634,29 @@ const modifiableLayer = computed((): boolean => {
         props.legendItem instanceof LayerItem &&
         toRaw(props.legendItem!.layer)?.canModifyLayer
     );
+});
+
+/**
+ * Determine if the layer is reloadable
+ */
+const reloadableLayer = computed((): boolean => {
+    if (props.legendItem instanceof LayerItem) {
+        const rawLayer = toRaw(props.legendItem.layer);
+        if (rawLayer) {
+            return rawLayer.canReload;
+        } else {
+            // funny logic: if layer doesn't exist, it hasn't been registered and
+            // linked yet. Main scenario is MIL children who don't get created
+            // until after parent loads.
+            // Non-reloadability is typically due to file stuff via wizard or
+            // using rawData + no caching config. Their RAMP layer will register
+            // prior to failpoints.
+            // So return true, else child-bound entries won't be able to reload
+            return true;
+        }
+    } else {
+        return false;
+    }
 });
 
 /**
@@ -742,61 +767,49 @@ const getDatagridExists = (): boolean => {
 };
 
 /**
- * Reloads layer if its "ready" to be reloaded.
- * If a layer has not been cancelled, it is ready to be reloaded.
- * If it has been cancelled by the user, then we wait for any currently in progress load to finish.
- */
-const reloadIfReady = () => {
-    // reload legend item state back to placeholder state
-    props.legendItem.reload();
-    if ((props.legendItem as LayerItem)._loadCancelled) {
-        const readyWatcher = setInterval(() => {
-            if ((props.legendItem as LayerItem).layer) {
-                Promise.allSettled([
-                    (props.legendItem as LayerItem).layer.loadPromise
-                ]).then(() => {
-                    clearInterval(readyWatcher);
-                    reloadLayer();
-                });
-            }
-        }, 250);
-    } else {
-        reloadLayer();
-    }
-};
-/**
  * Reloads a layer on the map.
+ * Layer is in an error'd state for that UI to be available.
  */
 const reloadLayer = () => {
+    props.legendItem.reload();
     // want the animation to play for half a second because a reload can fail "instantly", making it look like nothing happened to the user
     setTimeout(() => {
-        (props.legendItem as LayerItem)._loadCancelled = false;
-        // call reload on layer if it exists
-        if ((props.legendItem as LayerItem).layer !== undefined) {
-            toRaw((props.legendItem as LayerItem).layer!).reload();
-        } else {
-            // otherwise attempt to re-create layer with layer config
-            const layerConfig =
-                (props.legendItem as LayerItem).layerIdx === undefined ||
-                (props.legendItem as LayerItem).layerIdx === -1
-                    ? layerConfigs.value.find(
-                          (lc: RampLayerConfig) =>
-                              lc.id === (props.legendItem as LayerItem).layerId
-                      )
-                    : layerConfigs.value.find(
-                          (lc: RampLayerConfig) =>
-                              lc.id ===
-                              (props.legendItem as LayerItem).parentLayerId
-                      );
+        const layerItemProp = props.legendItem as LayerItem;
+        let recreateFromConfig = true;
+
+        if (layerItemProp.layer) {
+            // layer exists, reload it
+            toRaw(layerItemProp.layer).reload();
+            recreateFromConfig = false;
+        } else if (layerItemProp.isSublayer && layerItemProp.parentLayerId) {
+            // see if parent exists, if so, reload it.
+            const testParent = iApi.geo.layer.getLayer(
+                layerItemProp.parentLayerId
+            );
+            if (testParent) {
+                toRaw(testParent).reload();
+                recreateFromConfig = false;
+            }
+        }
+
+        if (recreateFromConfig) {
+            // were unable to find any layers. Attempt to re-create layer with layer config
+
+            const targetId = layerItemProp.isSublayer
+                ? layerItemProp.parentLayerId
+                : layerItemProp.layerId;
+
+            const layerConfig = layerConfigs.value.find(
+                (lc: RampLayerConfig) => lc.id === targetId
+            );
             if (layerConfig !== undefined) {
                 recreateLayer(layerConfig);
             }
         }
-        // catch error if reload fails
-        props.legendItem.loadPromise.catch(() => {
-            console.error('Failed to reload layer -', props.legendItem.name);
-        });
-    }, 500);
+
+        // just to silence console about unhandled rejections.
+        props.legendItem.loadPromise.catch(() => {});
+    }, 400);
 };
 
 /**
@@ -818,9 +831,13 @@ const recreateLayer = async (layerConfig: RampLayerConfig) => {
         } else {
             // try to re-create new layer based on layerConfig
             // same code to how layers are initialized when layer config array changes, expose this as layer API method?
+
+            // TODO low priority investigation: now that layers get registered right away,
+            // can this ELSE block even get hit anymore? I think we'll always find checkLayer.
+            // if layer got removed, legend block should have vanished.
             const layer = iApi.geo.layer.createLayer(layerConfig);
 
-            await iApi.geo.map.addLayer(layer!).catch(() => {
+            await iApi.geo.map.addLayer(layer).catch(() => {
                 throw new Error();
             });
 
@@ -838,20 +855,41 @@ const recreateLayer = async (layerConfig: RampLayerConfig) => {
  */
 const cancelOrRemoveLayer = () => {
     const layerItem: LayerItem = toRaw(props.legendItem as LayerItem); // so that typescript doesn't yell in the whole method
+    let safetyCount = 0;
+
     if (layerItem.type === LegendType.Error) {
         // layer in error state, remove layer permanently
-        // layer could appear in store later, so we need to keep checking if its there
+        // layer could appear later, so we need to keep checking if its there.
+        // It will typically be in the store (now happens soon as its added),
+        // but the ESRI layer may appear later if things get wacky.
+        // given we can also cancel prior to initiation finishing, we consider
+        // layers in that state.
 
         props.legendItem.toggleHidden(true); // temporarily hide item until we can remove it
 
         const removalWatcher = setInterval(() => {
-            // layer is gone from everywhere, so we are done
-            if (layerItem.layer && layerItem.layer.layerExists) {
+            // test: we can find the Ramp layer AND ...
+            //           the Esri layer exists OR layer is not on the path to have an Esri layer
+            //       OR if it's been 5 minutes, stop and try ur best (1200 * 250 === five mins)
+
+            const rampL = layerItem.layer;
+
+            if (
+                (rampL &&
+                    (rampL.layerExists ||
+                        rampL.initiationState === InitiationState.NEW ||
+                        rampL.initiationState === InitiationState.TERMINATING ||
+                        rampL.initiationState ===
+                            InitiationState.TERMINATED)) ||
+                safetyCount > 1200
+            ) {
                 // stop the interval
                 clearInterval(removalWatcher);
 
-                // layer is now there, time to remove!
-                iApi.geo.map.removeLayer(layerItem.layer);
+                if (rampL) {
+                    // remove from the map, which will de-register and remove anything from the map
+                    iApi.geo.map.removeLayer(rampL);
+                }
 
                 // remove layer config from store
                 layerStore.removeLayerConfig(layerItem.layerId);
@@ -861,46 +899,49 @@ const cancelOrRemoveLayer = () => {
                     .get<LegendAPI>('legend')
                     ?.removeLayerItem(layerItem.layerId);
             }
+
+            safetyCount++;
         }, 250);
     } else {
         // layer in loading state, "cancel" layer
         // this puts it in error state. user can then reload or remove
+
         props.legendItem.error();
-        (props.legendItem as LayerItem)._loadCancelled = true;
+
         // if a sublayer or parent layer was cancelled, cancel the parent layer and all other sublayers.
         // need to keep polling for the parent layer since some sublayers may not be in the config (stuff that came from a group)
 
-        // TODO: revisit the need for this watcher. Now that every registered layer is returned by allLayers, it should always
-        //       find the parent first find(). Unless I'm mis-understanding what parentLayerId is and that can be a
-        //       temporary group node thing. Possibly .parentLayerId on an MIL group isn't set until after load? Sorta makes sense.
+        // This should find stuff real quick now that layers are immediately registered. But keeping the watcher to handle
+        // any weird scenarios (e.g. RampMapAPI.addLayer had critical failure)
+        // The interval is at a faster rate to account for any rapid cancel & reload clicks. setInterval always waits the interval
+        // before first check.
         const cancelWatcher = setInterval(() => {
-            const parentLayer = iApi.geo.layer
-                .allLayers()
-                .find(
-                    l =>
-                        l.id === layerItem.parentLayerId ||
-                        l.id === layerItem.layerId
-                );
+            const parentmostId = layerItem.parentLayerId || layerItem.layerId;
+            const parentLayer = iApi.geo.layer.getLayer(parentmostId);
+
             if (parentLayer) {
                 clearInterval(cancelWatcher);
-                const layerItemToCancel = iApi.fixture
-                    .get<LegendAPI>('legend')
-                    ?.getLayerItem(parentLayer);
-                if (layerItemToCancel) {
-                    layerItemToCancel.error();
-                    layerItemToCancel._loadCancelled = true;
-                }
-                parentLayer.sublayers?.forEach(sl => {
-                    const sublayerItemToCancel = iApi.fixture
+
+                // cancel the ramp layer
+                parentLayer.cancelLoad();
+
+                // cancel any blocks tied to the layer or sublayers.
+
+                const affectedBlocks =
+                    iApi.fixture
                         .get<LegendAPI>('legend')
-                        ?.getLayerItem(sl);
-                    if (sublayerItemToCancel) {
-                        sublayerItemToCancel.error();
-                        sublayerItemToCancel._loadCancelled = true;
-                    }
-                });
+                        ?.getLayerBoundItems(parentLayer) || [];
+
+                affectedBlocks.forEach(block => block.error());
             }
-        }, 250);
+
+            if (safetyCount > 1200) {
+                // 1 minute
+                clearInterval(cancelWatcher);
+            }
+
+            safetyCount++;
+        }, 50);
     }
 };
 

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -407,8 +407,17 @@ export class LegendItem extends APIScope {
      * Sets legend item to an error state
      */
     error() {
-        this._type = LegendType.Error;
-        this._loadPromise.rejectMe();
-        this.checkVisibilityRules();
+        // there are many routes that call .error(), easy to have one action trigger a few.
+        // Load updaters, layer status event handlers, manual cancels.
+        // Only do the logic if the block isn't already in the error state
+        if (this._type !== LegendType.Error) {
+            this._type = LegendType.Error;
+
+            // just to silence console about unhandled rejections.
+            this._loadPromise.getPromise().catch(() => {});
+
+            this._loadPromise.rejectMe();
+            this.checkVisibilityRules();
+        }
     }
 }

--- a/src/fixtures/northarrow/northarrow.vue
+++ b/src/fixtures/northarrow/northarrow.vue
@@ -184,15 +184,17 @@ const updateNortharrow = async (newExtent: Extent) => {
                 });
                 iApi.geo.map.addLayer(poleLayer);
 
-                const poleGraphic = new Graphic(projPole, 'northpole');
-                const poleStyle = new PointStyle(
-                    poleStyleParams as
-                        | PointIconStyleOptions
-                        | PointMarkerStyleOptions
-                );
-                poleGraphic.style = poleStyle;
+                poleLayer.loadPromise().then(() => {
+                    const poleGraphic = new Graphic(projPole, 'northpole');
+                    const poleStyle = new PointStyle(
+                        poleStyleParams as
+                            | PointIconStyleOptions
+                            | PointMarkerStyleOptions
+                    );
+                    poleGraphic.style = poleStyle;
 
-                (poleLayer as CommonGraphicLayer).addGraphic(poleGraphic);
+                    (poleLayer as CommonGraphicLayer).addGraphic(poleGraphic);
+                });
             }
         }
     } else {

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -644,10 +644,10 @@ const onConfigureContinue = async (data: any) => {
     selectedValues.value = [];
     displayFormat.value = '';
 
-    // config.url =
-    //     'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign';
     const layer = iApi.geo.layer.createLayer(config);
-    iApi.geo.map.addLayer(layer);
+
+    // just to silence console about unhandled rejections.
+    iApi.geo.map.addLayer(layer).catch(() => {});
     layer.userAdded = true;
 
     // notify the legend to prepare a legend item

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -338,7 +338,10 @@ export interface LayerTimes {
      */
     load: number;
 
-    // TODO pr for #1491 will add 'fail' here
+    /**
+     * Max load time until forced failure
+     */
+    fail: number;
 }
 
 // needs to align to esri values for GoToOptions2D.easing
@@ -458,11 +461,22 @@ export interface IdentifyParameters {
     hitTest?: Promise<Array<GraphicHitResult>>; // Optional results of local hits to incorporate in the identify
 }
 
-//TODO: Enhance this when a RAMP Graphic is properly defined
+// this would need to expand if we start supporting hits from Graphic Layers (they have no concept of OID)
 export interface GraphicHitResult {
-    oid: number; // graphic OBJECTID
-    layerIdx: number; // layer index of the graphic
-    layerId: string; // graphic layer id
+    /**
+     * graphic Object ID value
+     */
+    oid: number;
+
+    /**
+     * layer index of the layer the graphic lives in
+     */
+    layerIdx: number;
+
+    /**
+     * layer id of layer the graphic lives in
+     */
+    layerId: string;
 }
 
 export interface MaptipProperties {
@@ -763,5 +777,6 @@ export interface RampMapConfig {
     layerTimeDefault?: {
         expectedDrawTime?: number;
         expectedLoadTime?: number;
+        maxLoadTime?: number;
     };
 }

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -65,11 +65,6 @@ export class AttribLayer extends MapLayer {
         this.attribs = new AttribSource();
     }
 
-    protected notLoadedErr(): void {
-        console.error('Attempted to manipulate the layer before it was loaded');
-        console.trace();
-    }
-
     /**
      * Take a layer config from the RAMP application and derives a configuration for an ESRI layer
      *
@@ -106,9 +101,16 @@ export class AttribLayer extends MapLayer {
             return;
         }
 
+        const startTime = Date.now();
+
         const sData = await this.$iApi.geo.layer.loadLayerMetadata(
             this.serviceUrl
         );
+
+        if (startTime < this.lastCancel) {
+            // we cancelled and are already in error state.
+            return;
+        }
 
         // properties for all endpoints
         this.geomType = sData.geometryType;
@@ -146,7 +148,7 @@ export class AttribLayer extends MapLayer {
                 }
             });
 
-            // add renderer and legend
+            // add RAMP renderer and legend
             // use custom renderer if defined. Otherwise use server.
             // If server does not have a renderer defined, it's not drawing on the map. Can use ! to avoid extra checks, since
             // layer is already roont.
@@ -219,26 +221,14 @@ export class AttribLayer extends MapLayer {
         */
     }
 
-    /**
-     * Requests that an attribute load request be aborted. Useful when encountering a massive dataset or a runaway process.
-     *
-     */
     abortAttributeLoad(): void {
         this.attribs.attLoader.abortAttribLoad();
     }
 
-    /**
-     * Requests that any downloaded attribute sets or cached geometry be removed from memory. The next requests will pull from the server again.
-     *
-     */
     clearFeatureCache(): void {
         this.attribs.clearAll();
     }
 
-    /**
-     * The number of attributes currently downloaded (will update as download progresses)
-     * @returns current download count
-     */
     downloadedAttributes(): number {
         if (this.isLoaded) {
             return this.attribs.attLoader.loadCount();
@@ -247,10 +237,6 @@ export class AttribLayer extends MapLayer {
         }
     }
 
-    /**
-     * Indicates if the attribute load has been aborted.
-     * @returns boolean if the process has been stopped
-     */
     attribLoadAborted(): boolean {
         if (this.isLoaded) {
             return this.attribs.attLoader.isLoadAborted();
@@ -259,13 +245,6 @@ export class AttribLayer extends MapLayer {
         }
     }
 
-    /**
-     * Invokes the process to get the full set of attribute values for the layer,
-     * formatted in a tabular format. Additional data properties are also included.
-     * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
-     *
-     * @returns {Promise} resolves with set of tabular attribute values
-     */
     getTabularAttributes(): Promise<TabularAttributeSet> {
         // this call will generate the tabular format, or return the cache if
         // it exists
@@ -275,19 +254,9 @@ export class AttribLayer extends MapLayer {
         );
     }
 
-    /**
-     * Gets information on a graphic in the most efficient way possible. Options object properties:
-     * - getGeom ; a boolean to indicate if the result should include graphic geometry
-     * - getAttribs ; a boolean to indicate if the result should include graphic attributes
-     * - getStyle ; a boolean to indicate if the result should graphical styling information
-     *
-     * @param {Integer} objectId the object id of the graphic to find
-     * @param {Object} options options object for the request, see above
-     * @returns {Promise} resolves with a Graphic containing the requested information
-     */
     async getGraphic(
         objectId: number,
-        opts: GetGraphicParams
+        options: GetGraphicParams
     ): Promise<Graphic> {
         // see https://github.com/fgpv-vpgf/fgpv-vpgf/issues/2190 for reasons why
         // things are done the way they are in this function.
@@ -302,7 +271,7 @@ export class AttribLayer extends MapLayer {
         let needWebGeom = false;
         let scale = 0;
 
-        if (opts.getAttribs || opts.getStyle) {
+        if (options.getAttribs || options.getStyle) {
             // attempt to get attributes from fastest source.
             const aCache = this.attribs.quickCache.getAttribs(objectId);
             if (aCache) {
@@ -319,7 +288,7 @@ export class AttribLayer extends MapLayer {
             }
         }
 
-        if (opts.getGeom) {
+        if (options.getGeom) {
             scale = map.getScale();
 
             // first locate the appropriate cache due to simplifications.
@@ -373,9 +342,10 @@ export class AttribLayer extends MapLayer {
                 }
             }
 
-            const webFeat = await this.$iApi.geo.attributes.loadSingleFeature(
-                serviceParams
-            );
+            const webFeat =
+                await this.$iApi.geo.attributes.loadSingleFeature(
+                    serviceParams
+                );
             if (needWebGeom) {
                 // save our result in the cache
                 this.attribs.quickCache.setGeom(
@@ -411,10 +381,10 @@ export class AttribLayer extends MapLayer {
         const resGraphic = new Graphic(
             resultGeom,
             '',
-            opts.getAttribs ? resultAttribs : undefined
+            options.getAttribs ? resultAttribs : undefined
         );
 
-        if (opts.getStyle) {
+        if (options.getStyle) {
             const esriSymb = toRaw(
                 this.renderer!.getGraphicSymbol(resultAttribs)
             );
@@ -424,12 +394,6 @@ export class AttribLayer extends MapLayer {
         return resGraphic;
     }
 
-    /**
-     * Gets the icon for a specific feature, as an SVG string.
-     *
-     * @param {Integer} objectId the object id of the feature to find
-     * @returns {Promise} resolves with an svg string encoding of the icon
-     */
     async getIcon(objectId: number): Promise<string> {
         if (!this.renderer) {
             throw new Error('getIcon called before renderer is defined');
@@ -441,13 +405,6 @@ export class AttribLayer extends MapLayer {
         );
     }
 
-    /**
-     * Applies an SQL filter to the layer. Will overwrite any existing filter for the given key.
-     * Use `1=2` for a "hide all" where clause.
-     *
-     * @param {String} filterKey the filter key / named filter to apply the SQL to
-     * @param {String} whereClause the WHERE clause of the filter
-     */
     setSqlFilter(filterKey: string, whereClause: string): void {
         // dirty test
         const currentFilter = this.filter.getSql(filterKey);
@@ -478,24 +435,12 @@ export class AttribLayer extends MapLayer {
         setTimeout(refreshCheck, 100);
     }
 
-    /**
-     * Applies the current filter settings to the physical map layer.
-     *
-     * @function applySqlFilter
-     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all keys
-     */
     applySqlFilter(exclusions: Array<string> = []): void {
         throw new Error(
             `attempted to apply sql filter ${exclusions} to a layer not equipped for it. likely a new subclass of AttribLayer did not override applySqlFilter`
         );
     }
 
-    /**
-     * Returns the value of a named SQL filter on the layer.
-     *
-     * @param {String} filterKey the filter key / named filter to view
-     * @returns {String} the value of the where clause for the filter. Empty string if not defined.
-     */
     getSqlFilter(filterKey: string): string {
         return this.filter.getSql(filterKey);
     }
@@ -511,15 +456,6 @@ export class AttribLayer extends MapLayer {
         return this.filter.getCombinedSql(exclusions);
     }
 
-    /**
-     * Gets array of object ids that currently pass any filters
-     *
-     * @function getFilterOIDs
-     *
-     * @param {Array} [exclusions] list of any filters keys to exclude from the result. omission includes all filters
-     * @param {Extent} [extent] if provided, the result list will only include features intersecting the extent
-     * @returns {Promise} resolves with array of object ids that pass the filter. if no filters are active, resolves with undefined.
-     */
     async getFilterOIDs(
         exclusions: Array<string> = [],
         extent: Extent | undefined = undefined
@@ -662,7 +598,8 @@ export class AttribLayer extends MapLayer {
 
             esriConfig.orderBy = rampConfig.drawOrder.map(dr => {
                 // pick ascending if no value was defined.
-                const order = dr.ascending ?? true ? 'ascending' : 'descending';
+                const order =
+                    (dr.ascending ?? true) ? 'ascending' : 'descending';
 
                 if (dr.field) {
                     return {

--- a/src/geo/layer/class-structure.md
+++ b/src/geo/layer/class-structure.md
@@ -1,5 +1,7 @@
 # Guide for devs on how layer classes hang together
 
+## Inheritance Chain
+
 LayerInstance: RAMP's internal "base class" for layers. Any code dealing with generic layers should use this class.
 
 ~ CommonLayer: The generic class for layers that are implemented inside RAMP core.
@@ -30,10 +32,41 @@ LayerInstance: RAMP's internal "base class" for layers. Any code dealing with ge
 
 ~ ~ ~ ~ ~ ShapefileLayer: Handles layers populated by a zipped shapefile.
 
+~ ~ ~ CommonGraphicLayer: The generic class for Graphic layers.
+
+~ ~ ~ ~ GraphicLayer: Handles basic client-side Graphic layer.
+
 ~ ~ DataLayer: The generic class for layers that do not have a layer on the map.
 
-~ ~ ~ CsvDataLayer: Handles data layers populated by a CSV file.
+~ ~ ~ CsvDataLayer: Handles data layers populated by a CSV file. (Not created yet)
 
 ~ ~ ~ JsonDataLayer: Handles data layers populated by a Compact Json dataset
 
 ~ ~ ~ TableLayer: Handles data layers populated by an ArcGIS Table
+
+## Initiation Chain
+
+Useful for figuring out where to put checkpoints for "cancel load" kickouts.
+This chain is the `onInitiate()` calls. They tend to go backwards (subclass --> superclass) with the exception of MapLayer calling CommonLayer as an early step.
+
+~ CommonLayer: Just saftey checks.
+
+~ ~ MapLayer: Just wires up layer events, sets statuses.
+
+~ ~ ~ FeatureLayer, MapImageLayer, WMSLayer, TileLayer, ImageryLayer, GraphicLayer: Generates ESRI layer.
+
+~ ~ ~ FileLayer: Converts GeoJSON to EsriJSON. Blocks, but only for projection validation
+
+~ ~ ~ ~ GeoJsonLayer, CsvLayer, ShapefileLayer: Gets data, converts to GeoJSON. Blocks if file is server based. Some converters block but processing is local.
+
+~ ~ ~ ~ WfsLayer: Blocks as it downloads GeoJSON.
+
+~  MapImageSublayer: Just sets status.
+
+~ DataLayer: Just data setup, local processing.
+
+~ ~ JsonDataLayer: Gets data. Blocks if file is server based.
+
+~ TableLayer: Does nothing.
+
+~ AttributeLayer, CommonGraphicLayer: No method. Drills through to superclass.

--- a/src/geo/layer/common-graphic-layer.ts
+++ b/src/geo/layer/common-graphic-layer.ts
@@ -71,11 +71,6 @@ export class CommonGraphicLayer extends MapLayer {
         return this.esriLayer?.graphics.find((g: any) => g.id === graphicId);
     }
 
-    protected notLoadedErr(): void {
-        console.error('Attempted to manipulate the layer before it was loaded');
-        console.trace();
-    }
-
     /** Returns a copy of the graphics in the layer. */
     get graphics(): Array<Graphic> {
         return this._graphics.slice();
@@ -89,7 +84,7 @@ export class CommonGraphicLayer extends MapLayer {
      * @returns {Promise} resolves when graphics have been added
      */
     async addGraphic(graphics: Graphic | Array<Graphic>): Promise<void> {
-        if (!this.esriLayer) {
+        if (!this.layerExists) {
             this.noLayerErr();
             return;
         }
@@ -133,7 +128,7 @@ export class CommonGraphicLayer extends MapLayer {
         });
 
         // TODO raise event?
-        this.esriLayer.addMany(esriGraphics);
+        this.esriLayer!.addMany(esriGraphics);
     }
 
     /**
@@ -142,13 +137,13 @@ export class CommonGraphicLayer extends MapLayer {
      * @param {Graphic | string | Array<Graphic | string>} graphics Valid formats: A Graphic object, a graphic ID in string form, or an array of Graphic objects and/or graphic ID strings
      */
     removeGraphic(graphics?: Array<string | Graphic> | string | Graphic): void {
-        if (!this.esriLayer) {
+        if (!this.layerExists) {
             this.noLayerErr();
             return;
         }
         if (typeof graphics === 'undefined') {
             // TODO remove hover stuff once supported
-            this.esriLayer.removeAll();
+            this.esriLayer!.removeAll();
             this._graphics = [];
             // TODO raise event?
             return;

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -47,7 +47,6 @@ export class CommonLayer extends LayerInstance {
      * Tracks load and draw elapsed time
      */
     timers: {
-        // TODO when implementing #1491, look into converting this type to LayerTimes
         draw: number | undefined;
         load: number | undefined;
     };
@@ -56,7 +55,10 @@ export class CommonLayer extends LayerInstance {
 
     protected loadDefProm: DefPromise; // a deferred promise that resolves when layer is fully ready and safe to use. for convenience of caller
 
-    protected loadPromFulfilled: boolean; // a boolean to track whether the promise has fulfilled or not
+    /**
+     * A boolean to track whether the promise is pending (false) or fulfilled/rejected (true)
+     */
+    protected loadPromDone: boolean;
     protected layerTree: TreeNode;
 
     // ----------- LAYER CONSTRUCTION AND INITIALIZAION -----------
@@ -76,7 +78,12 @@ export class CommonLayer extends LayerInstance {
         this.expectedTime.draw =
             rampConfig.expectedDrawTime ?? defaultTimes.draw;
         this.expectedTime.load =
-            rampConfig.expectedLoadTime ?? defaultTimes.draw;
+            rampConfig.expectedLoadTime ?? defaultTimes.load;
+
+        // falsey || , 0 means defer to map default
+        this.expectedTime.fail = rampConfig.maxLoadTime || defaultTimes.fail;
+
+        this.lastCancel = 0;
         this.timers = {
             draw: undefined,
             load: undefined
@@ -100,25 +107,27 @@ export class CommonLayer extends LayerInstance {
         this.loadDefProm = new DefPromise();
         this.url = this.origRampConfig.url;
         this.canReload = !!(this.url || this.origRampConfig.caching);
-        this.loadPromFulfilled = false;
+        this.loadPromDone = false;
 
         this.layerTree = new TreeNode(0, this.uid, this.name, true); // is a layer with layer index 0 by default. subclasses will change this when they load
-        this.maxLoadTime = rampConfig.maxLoadTime ?? 20000;
     }
 
     updateInitiationState(newState: InitiationState): void {
         this.initiationState = newState;
+
         this.$iApi.event.emit(GlobalEvents.LAYER_INITIATIONSTATECHANGE, {
             state: newState,
             layer: this
         });
     }
 
-    updateLayerState(newState: LayerState): void {
+    updateLayerState(newState: LayerState, userCancel: boolean = false): void {
         this.layerState = newState;
+
         this.$iApi.event.emit(GlobalEvents.LAYER_LAYERSTATECHANGE, {
             state: newState,
-            layer: this
+            layer: this,
+            userCancel
         });
     }
 
@@ -139,15 +148,58 @@ export class CommonLayer extends LayerInstance {
     async initiate(): Promise<void> {
         this.updateInitiationState(InitiationState.INITIATING);
         this.startTimer(TimerType.LOAD);
+
+        const failStepsHelper = (consoleMessage: string) => {
+            // state check is for saftey. Typically will be in initializing state
+            // when this gets called. But if someone decides to force a layer
+            // into error via API, could get a timeout error doubling at a later time without
+            // the check.
+            if (this.layerState !== LayerState.ERROR) {
+                console.error(consoleMessage);
+                this.onError();
+            }
+        };
+
+        const startTime = Date.now();
+
+        // this timer is different than the one in MapAPI.addLayer() .
+        // that one is tracking "did I get added to the map" for the return value of addLayer.
+        // this timer works in tandem with the similar timer in onLoad() of this class.
+        // they share the same timer value, but typically a layer is all work in initiation or all work in load
+        const initTimeout = setTimeout(() => {
+            // took too long to init, send layer into error state
+
+            // need to ensure this timeout didn't keep running after a real cancel.
+            // if it was cancelled, stuffs already handled. We do nothing
+            if (startTime > this.lastCancel) {
+                // using lastCancel is a bit of trickery. We are timing out but server processes can still be running.
+                // if they return much later, the layer will flicker into existence on the map.
+                // doing this prevents that (everything async in init-load is respecting this var).
+                // However we do treat the error as genuine, so the notification will ping.
+                this.lastCancel = Date.now();
+                failStepsHelper(
+                    'Layer timed out during initialize. Id: ' + this.id
+                );
+            }
+        }, this.expectedTime.fail);
+
         const [initiateErr] = await to(this.onInitiate()); // Need this because some layers don't do error handling things
-        if (this.drawState !== DrawState.UP_TO_DATE) {
-            this.startTimer(TimerType.DRAW);
+
+        // we're done timing regardless. a) already timed out. b) init ok. c) init errored so already errored.
+        clearTimeout(initTimeout);
+
+        if (startTime > this.lastCancel) {
+            if (this.drawState !== DrawState.UP_TO_DATE) {
+                this.startTimer(TimerType.DRAW);
+            }
+            if (initiateErr) {
+                failStepsHelper(
+                    `Init error on layer id: ${this.id} . ${initiateErr.message}`
+                );
+            } else {
+                this.updateInitiationState(InitiationState.INITIATED);
+            }
         }
-        if (initiateErr) {
-            console.error(initiateErr.message);
-            this.onError();
-        }
-        this.updateInitiationState(InitiationState.INITIATED);
     }
 
     protected async onInitiate(): Promise<void> {
@@ -170,7 +222,7 @@ export class CommonLayer extends LayerInstance {
         await Promise.all(this.sublayers.map(s => s.terminate()));
 
         this.loadDefProm = new DefPromise();
-        this.loadPromFulfilled = false;
+        this.loadPromDone = false;
 
         this.updateLayerState(LayerState.NEW);
         this.updateDrawState(DrawState.NOT_LOADED);
@@ -184,15 +236,20 @@ export class CommonLayer extends LayerInstance {
     onLoad(): void {
         // magic happens here. other layers will override onLoadActions,
         // meaning this will run the function appropriate for the layer who inherited LayerBase
+
+        const startTime = Date.now();
+
         let timedOut = false;
+
+        // this timer is different than the one in MapAPI.addLayer() .
+        // that one is tracking "did I get added to the map" for the return value of addLayer.
+        // this timer works in tandem with the similar timer in initiate() of this class.
+        // they share the same timer value, but typically a layer is all work in initiation or all work in load
         const loadTimeout = setTimeout(() => {
-            // if timeout is not 0, layer will go into error state after loading past timeout
-            // otherwise timeout is turned off (0), and layer can load forever
-            if (this.maxLoadTime) {
-                timedOut = true;
-                this.onError();
-            }
-        }, this.maxLoadTime); // configurable time limit for actions to execute
+            // took too long to load, send layer into error state
+            timedOut = true;
+            this.onError();
+        }, this.expectedTime.fail);
 
         // handling for any errors that are thrown when executing layer onLoadActions call
         // For issue https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2103, without proper error handling here any subsequent
@@ -204,17 +261,26 @@ export class CommonLayer extends LayerInstance {
                 .then(() => {
                     clearTimeout(loadTimeout);
                     if (!timedOut) {
-                        // if promise was previously not in pending status, make a new one
-                        // otherwise we're trying to resolve a resolved/rejected promise
-                        if (this.loadPromFulfilled) {
-                            this.loadDefProm = new DefPromise();
-                        }
-                        this.loadDefProm.resolveMe();
-                        this.loadPromFulfilled = true;
                         this.stopTimer(TimerType.LOAD);
-                        // This will just trigger the above statements for each sublayer
-                        this.sublayers.forEach(sublayer => sublayer.onLoad());
-                        this.updateLayerState(LayerState.LOADED);
+
+                        // only finalize if this load was not cancelled
+                        if (startTime > this.lastCancel) {
+                            // if promise was previously not in pending status, make a new one
+                            // otherwise we're trying to resolve a resolved/rejected promise.
+                            // Anything watching the old promise already handled it. This ensures
+                            // anything looking at it going forward will get a resolved promise.
+                            if (this.loadPromDone) {
+                                this.loadDefProm = new DefPromise();
+                            }
+                            this.loadDefProm.resolveMe();
+                            this.loadPromDone = true;
+
+                            // This will just trigger the above statements for each sublayer
+                            this.sublayers.forEach(sublayer =>
+                                sublayer.onLoad()
+                            );
+                            this.updateLayerState(LayerState.LOADED);
+                        }
                     } else {
                         this.visibility = false;
                     }
@@ -231,58 +297,92 @@ export class CommonLayer extends LayerInstance {
         }
     }
 
-    // TODO what happens if the error state is hit after the layer is loaded?
-    //      Probably ok (rejecting a resolved promise that nobody is listening for).
-    //      Putting the layer in error status is what is important.
-    // when esri layer load errors
-    onError(): void {
+    onError(genuineError: boolean = true): void {
+        if (this.layerState === LayerState.ERROR) {
+            // we're already in Error. Different handlers are reporting the same scenario.
+            // do nothing to avoid event spam and conflicting event states from user cancel
+            // that has funny timing.
+            return;
+        }
+
+        if (this.initiationState === InitiationState.INITIATING) {
+            // something happened while initiating. push back to New
+            this.updateInitiationState(InitiationState.NEW);
+        }
+
         // if promise was previously not in pending status, make a new one
         // otherwise we're trying to reject a resolved promise
-        if (this.loadPromFulfilled) {
+        if (this.loadPromDone) {
             this.loadDefProm = new DefPromise();
         }
         this.loadDefProm.rejectMe();
-        this.loadPromFulfilled = true;
-        this.sublayers.forEach(sublayer => sublayer.onError());
-        this.$iApi.notify.show(
-            NotificationType.ERROR,
-            this.$iApi.$i18n.t('layer.error', {
-                id: this.id
-            })
-        );
+        this.loadPromDone = true;
+        this.sublayers.forEach(sublayer => sublayer.onError(genuineError));
+
+        // manually cancelling a loading layer will put in error state. We don't
+        // want to ping the user; they did the cancel click.
+        if (genuineError) {
+            this.$iApi.notify.show(
+                NotificationType.ERROR,
+                this.$iApi.$i18n.t('layer.error', {
+                    id: this.id
+                })
+            );
+        }
+
         this.stopTimer(TimerType.DRAW);
         this.stopTimer(TimerType.LOAD);
-        this.updateLayerState(LayerState.ERROR);
-    }
-
-    // performs setup on the layer that needs to occur after the esri layer
-    // exists, but before we mark the layer as loaded. Any async tasks must
-    // include their promise in the return array.
-    protected onLoadActions(): Array<Promise<void>> {
-        // currently nothing, but we have the option to insert
-        // an async setup that is global for all layers
-        return [];
+        this.updateLayerState(LayerState.ERROR, !genuineError);
     }
 
     /**
-     * Provides a promise that resolves when the layer has finished loading. If accessing layer properties that
-     * depend on the layer being loaded, wait on this promise before accessing them.
+     * Performs setup on the layer that needs to occur after initialization and
+     * the esri layer (if a map layer) loads, but before we mark the layer as loaded.
+     * Any async tasks must include their promise in the return array.
      *
-     * @method loadPromise
-     * @returns {Promise} resolves when the layer has finished loading
+     * @private
+     * @returns {Array<Promise<void>>} List of things to wait on.
      */
+    protected onLoadActions(): Array<Promise<void>> {
+        // currently nothing, but we have the option to insert
+        // an async setup that is global for all layers
+
+        return [];
+    }
+
+    cancelLoad(): void {
+        if (
+            this.isLoaded ||
+            this.initiationState === InitiationState.NEW ||
+            this.initiationState === InitiationState.TERMINATING ||
+            this.initiationState === InitiationState.TERMINATED
+        ) {
+            // we are loaded, terminating, terminated, or never initiated.
+            // do nothing.
+            return;
+        }
+
+        // set flag for other async load stuff to see
+        this.lastCancel = Date.now();
+
+        if (this.esriLayer && this.esriLayer.loadStatus === 'loading') {
+            // ESRI API is doing something. stop it.
+            this.esriLayer.cancelLoad();
+        }
+
+        // remove layer from map if it was there. this prevents cancelled layer
+        // that actually loaded (and its the ramp stuff thats slow/broken holding up LOAD)
+        // from showing when legend says Error.
+        this.removeEsriLayer();
+
+        // put layer in Errorland, flag to stop notification from pinging
+        this.onError(false);
+    }
+
     loadPromise(): Promise<void> {
         return this.loadDefProm.getPromise();
     }
 
-    /**
-     * Indicates if the layer is in a state that is makes sense to interact with.
-     * I.e. False if layer has not done it's initial load, or is in error state.
-     * Acts as a handy shortcut to inspecting the layerState.
-     *
-     * @method isLoaded
-     * @returns {Boolean} true if layer is loaded
-     */
     get isLoaded(): boolean {
         return this.layerState === LayerState.LOADED;
     }
@@ -338,30 +438,14 @@ export class CommonLayer extends LayerInstance {
         });
     }
 
-    /**
-     * Requests that an attribute load request be aborted. Useful when encountering a massive dataset or a runaway process.
-     *
-     */
     abortAttributeLoad(): void {
         this.stubError();
     }
 
-    /**
-     * Requests that any downloaded attribute sets or cached geometry be removed from memory. The next requests will pull from the server again.
-     *
-     */
     clearFeatureCache(): void {
         this.stubError();
     }
 
-    // formerly known as getFormattedAttributes
-    /**
-     * Invokes the process to get the full set of attribute values for the layer,
-     * formatted in a tabular format. Additional data properties are also included.
-     * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
-     *
-     * @returns {Promise} resolves with set of tabular attribute values
-     */
     getTabularAttributes(): Promise<TabularAttributeSet> {
         this.stubError();
 
@@ -389,46 +473,20 @@ export class CommonLayer extends LayerInstance {
         return Promise.resolve(new Graphic(new NoGeometry()));
     }
 
-    /**
-     * Gets the icon for a specific feature, as an SVG string.
-     *
-     * @param {Integer} objectId the object id of the feature to find
-     * @returns {Promise} resolves with an svg string encoding of the icon
-     */
     getIcon(objectId: number): Promise<string> {
         this.stubError();
         return Promise.resolve('');
     }
 
-    /**
-     * Returns the value of a named SQL filter on a layer.
-     *
-     * @param {String} filterKey the filter key / named filter to view
-     * @returns {String} the value of the where clause for the filter. Empty string if not defined.
-     */
     getSqlFilter(filterKey: string): string {
         this.stubError();
         return '';
     }
 
-    /**
-     * Applies an SQL filter to the layer. Will overwrite any existing filter for the given key.
-     * Use `1=2` for a "hide all" where clause.
-     *
-     * @param {String} filterKey the filter key / named filter to apply the SQL to
-     * @param {String} whereClause the WHERE clause of the filter
-     */
     setSqlFilter(filterKey: string, whereClause: string): void {
         this.stubError();
     }
 
-    /**
-     * Gets array of object ids that currently pass any filters for the layer
-     *
-     * @param {Array} [exclusions] list of any filters keys to exclude from the result. omission includes all filters
-     * @param {Extent} [extent] if provided, the result list will only include features intersecting the extent
-     * @returns {Promise} resolves with array of object ids that pass the filter. if no filters are active, resolves with undefined.
-     */
     getFilterOIDs(
         exclusions: Array<string> = [],
         extent: Extent | undefined = undefined
@@ -449,12 +507,6 @@ export class CommonLayer extends LayerInstance {
         return Promise.resolve(Extent.fromParams('fake', 0, 0, 0, 0));
     }
 
-    /**
-     * Applies the current filter settings to the physical map layer.
-     *
-     * @function applySqlFilter
-     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all keys
-     */
     applySqlFilter(exclusions: Array<string> = []): void {
         this.stubError();
     }
@@ -467,7 +519,11 @@ export class CommonLayer extends LayerInstance {
      * @param {String} value value of the key
      * @param {Boolean} forceRefresh show the new fancy version of the layer or not
      */
-    setCustomParameter(key: string, value: string, forceRefresh = true): void {
+    setCustomParameter(
+        key: string,
+        value: string,
+        forceRefresh: boolean = true
+    ): void {
         this.stubError();
     }
 

--- a/src/geo/layer/data-layer.ts
+++ b/src/geo/layer/data-layer.ts
@@ -188,14 +188,9 @@ export class DataLayer extends CommonLayer {
     }
 
     async reload(): Promise<void> {
-        if (this.initiationState === InitiationState.INITIATED) {
-            // TODO might need to store layer state. If we want layer to look the same as it was prior to re-loading,
-            //      could do that here. Alternative is to not, and let whomever is calling this save state before
-            //      and restore state after. Might be more flexible.
-            this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_START, this);
+        this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_START, this);
 
-            await this.terminate();
-        }
+        await this.terminate();
 
         await this.initiate();
 
@@ -211,9 +206,6 @@ export class DataLayer extends CommonLayer {
         }, 300);
     }
 
-    // performs setup on the layer that needs to occur after server load but
-    // before we mark the layer as loaded. Any async tasks must
-    // include their promise in the return array.
     protected onLoadActions(): Array<Promise<void>> {
         const proms = super.onLoadActions();
 
@@ -247,13 +239,6 @@ export class DataLayer extends CommonLayer {
         return this.attribs.attLoader.getAttribs();
     }
 
-    /**
-     * Invokes the process to get the full set of attribute values for the layer,
-     * formatted in a tabular format. Additional data properties are also included.
-     * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
-     *
-     * @returns {Promise} resolves with set of tabular attribute values
-     */
     getTabularAttributes(): Promise<TabularAttributeSet> {
         // this call will generate the tabular format, or return the cache if
         // it exists
@@ -263,21 +248,14 @@ export class DataLayer extends CommonLayer {
         );
     }
 
-    /**
-     * Gets information on a graphic in the most efficient way possible.
-     * The options parameter is ignored for data layers, since attributes is the only valid item
-     * to request
-     *
-     * @param {Integer} objectId the object id of the graphic to find
-     * @param {Object} options options object for the request. Ignored for data layers
-     * @returns {Promise} resolves with a Graphic containing the requested information
-     */
     async getGraphic(
         objectId: number,
         options: GetGraphicParams
     ): Promise<Graphic> {
         // note: this methods supports data layers not tied to an ArcGIS server.
         //      class TableLayer will override.
+
+        // note: the options is ignored, data layers only have attributes and they always get returned
 
         // the layer should have pre-populated its attribute store during load.
 
@@ -296,12 +274,6 @@ export class DataLayer extends CommonLayer {
         return new Graphic(new NoGeometry(), '', resultAttribs);
     }
 
-    /**
-     * Gets the icon for a specific feature, as an SVG string.
-     *
-     * @param {Integer} objectId the object id of the feature to find
-     * @returns {Promise} resolves with an svg string encoding of the icon
-     */
     async getIcon(objectId: number): Promise<string> {
         // TODO decide what we want as the icon.
         //      other options can be .generateBlankSymbology()
@@ -330,42 +302,23 @@ export class DataLayer extends CommonLayer {
         return undefined;
     }
 
-    /**
-     * Since data layers (except table layers) do not have asynch attribute loading, there is nothing to do here.
-     * However, we have it there just so that calling this method for a giant list is peaceful, and filtering
-     * by layer type is not required.
-     */
+    // Since data layers (except table layers) do not have asynch attribute loading, there is nothing to do in the following methods.
+    // However, we have it there just so that calling this method for a giant list is peaceful, and filtering
+    // by layer type is not required.
+
     abortAttributeLoad(): void {}
 
-    /**
-     * Since data layers (except table layers) do not have asynch attribute loading, there is nothing to do here.
-     * However, we have it there just so that calling this method for a giant list is peaceful, and filtering
-     * by layer type is not required.
-     */
     attribLoadAborted(): boolean {
         return false;
     }
 
-    /**
-     * Since data layers (except table layers) do not have asynch attribute loading, there is nothing to do here.
-     * However, we have it there just so that calling this method for a giant list is peaceful, and filtering
-     * by layer type is not required.
-     */
     clearFeatureCache(): void {}
 
-    /**
-     * The number of attributes currently downloaded (will update as download progresses)
-     * @returns current download count
-     */
     downloadedAttributes(): number {
         // non-table data layer has downloaded everything after initialize.
         return this.featureCount;
     }
 
-    /**
-     * Override for data layers.
-     * Used to determine if layer is available for use.
-     */
     get layerExists(): boolean {
         return this.isLoaded;
     }

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -68,6 +68,7 @@ export class FileLayer extends AttribLayer {
         this.dataFormat = DataFormat.ESRI_FEATURE;
         this.layerFormat = LayerFormat.FEATURE;
         this.tooltipField = '';
+        this.layerIdx = 0;
 
         if (
             rampConfig.identifyMode &&
@@ -184,12 +185,7 @@ export class FileLayer extends AttribLayer {
         return esriConfig;
     }
 
-    /**
-     * Triggers when the layer loads.
-     *
-     * @function onLoadActions
-     */
-    onLoadActions(): Array<Promise<void>> {
+    protected onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
         // setting custom renderer here (if one is provided)
@@ -434,18 +430,6 @@ export class FileLayer extends AttribLayer {
         );
     }
 
-    /**
-     * Fetches a graphic from the given layer.
-     * This overrides the baseclass method, as we are all local and dont need quick caches or server hits
-     *
-     * @function getGraphic
-     * @param  {Integer} objectId      ID of object being searched for
-     * @param {Object} opts            object containing option parametrs
-     *                 - map           map wrapper object of current map. only required if requesting geometry
-     *                 - getGeom          boolean. indicates if return value should have geometry included. default to false
-     *                 - getAttribs       boolean. indicates if return value should have attributes included. default to false
-     * @returns {Promise} resolves with a Graphic
-     */
     async getGraphic(
         objectId: number,
         opts: GetGraphicParams
@@ -539,12 +523,6 @@ export class FileLayer extends AttribLayer {
         );
     }
 
-    /**
-     * Applies the current filter settings to the physical map layer.
-     *
-     * @function applySqlFilter
-     * @param {Array} [exclusions] list of any filters to exclude from the result. omission includes all keys
-     */
     applySqlFilter(exclusions: Array<string> = []): void {
         if (!this.esriView) {
             this.noLayerErr();

--- a/src/geo/layer/geojson-layer.ts
+++ b/src/geo/layer/geojson-layer.ts
@@ -15,13 +15,16 @@ export class GeoJsonLayer extends FileLayer {
         // get geojson from appropriate source and set to special property.
         // then initiate the FileLayer
 
+        let gj: any;
+        const startTime = Date.now();
+
         if (this.origRampConfig.rawData) {
-            this.sourceGeoJson = this.$iApi.geo.layer.files.rawDataJsonParser(
+            gj = this.$iApi.geo.layer.files.rawDataJsonParser(
                 this.origRampConfig.rawData,
                 this.origRampConfig.caching
             );
         } else if (this.origRampConfig.url) {
-            this.sourceGeoJson = await this.$iApi.geo.layer.files.fetchFileData(
+            gj = await this.$iApi.geo.layer.files.fetchFileData(
                 this.origRampConfig.url,
                 this.layerType
             );
@@ -29,6 +32,9 @@ export class GeoJsonLayer extends FileLayer {
             throw new Error('GeoJson layer config contains no raw data or url');
         }
 
-        await super.onInitiate();
+        if (startTime > this.lastCancel) {
+            this.sourceGeoJson = gj;
+            await super.onInitiate();
+        }
     }
 }

--- a/src/geo/layer/graphic-layer.ts
+++ b/src/geo/layer/graphic-layer.ts
@@ -41,16 +41,11 @@ export class GraphicLayer extends CommonGraphicLayer {
         return esriConfig;
     }
 
-    /**
-     * Triggers when the layer loads.
-     *
-     * @function onLoadActions
-     */
-    onLoadActions(): Array<Promise<void>> {
+    protected onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
-        // TODO if we ever have a way to "configure" initial graphics in the layer config,
-        //      would probably want to create them here.
+        // if we ever have a way to "configure" initial graphics in the layer config,
+        // would probably want to create them here.
 
         this.layerTree.name = this.name;
         this.updateDrawState(DrawState.UP_TO_DATE);

--- a/src/geo/layer/imagery-layer.ts
+++ b/src/geo/layer/imagery-layer.ts
@@ -40,20 +40,19 @@ export class ImageryLayer extends MapLayer {
         return esriConfig;
     }
 
-    /**
-     * Triggers when the layer loads.
-     *
-     * @function onLoadActions
-     */
-    onLoadActions(): Array<Promise<void>> {
+    protected onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
         this.layerTree.name = this.name;
 
+        const startTime = Date.now();
+
         const legendPromise = this.$iApi.geo.symbology
             .mapServerToLocalLegend(this.origRampConfig.url!)
             .then(legArray => {
-                this.legend = legArray;
+                if (startTime > this.lastCancel) {
+                    this.legend = legArray;
+                }
             });
 
         loadPromises.push(legendPromise);

--- a/src/geo/layer/json-data-layer.ts
+++ b/src/geo/layer/json-data-layer.ts
@@ -11,17 +11,20 @@ export class JsonDataLayer extends DataLayer {
     }
 
     protected async onInitiate(): Promise<void> {
+        const startTime = Date.now();
+        let gj: any;
+
         // get json from appropriate source and set to special property.
         // then initiate the DataLayer to complete setup
         if (this.origRampConfig.rawData) {
             // json has been passed in as static string or JSON object
 
-            this.sourceJson = this.$iApi.geo.layer.files.rawDataJsonParser(
+            gj = this.$iApi.geo.layer.files.rawDataJsonParser(
                 this.origRampConfig.rawData,
                 this.origRampConfig.caching
             );
         } else if (this.origRampConfig.url) {
-            this.sourceJson = await this.$iApi.geo.layer.files.fetchFileData(
+            gj = await this.$iApi.geo.layer.files.fetchFileData(
                 this.origRampConfig.url,
                 this.layerType
             );
@@ -31,6 +34,9 @@ export class JsonDataLayer extends DataLayer {
             );
         }
 
-        await super.onInitiate();
+        if (startTime > this.lastCancel) {
+            this.sourceJson = gj;
+            await super.onInitiate();
+        }
     }
 }

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -78,7 +78,8 @@ export class LayerInstance extends APIScope {
     drawState: DrawState;
 
     /**
-     * Index of the layer. Aligns to index of arcgis server, or defaults to 0 on other layers
+     * Index of the layer. Aligns to index of arcgis server source, or defaults to 0 on other layers.
+     * Map Image Layers and layers that do not support attributes have a value of -1
      */
     layerIdx: number;
 
@@ -143,6 +144,12 @@ export class LayerInstance extends APIScope {
     expectedTime: LayerTimes;
 
     /**
+     * Timecode value for the start of most recent cancel request.
+     * Used to avoid races between async things returning after layers cancel or reload.
+     */
+    lastCancel: number;
+
+    /**
      * If the layer has Sublayers
      */
     supportsSublayers: boolean;
@@ -196,11 +203,6 @@ export class LayerInstance extends APIScope {
      * Legend symbols of the layer
      */
     legend: Array<LegendSymbology>;
-
-    /**
-     * How long layer can load for before error (milliseconds)
-     */
-    maxLoadTime: number;
 
     /**
      *  The internal ESRI API layer
@@ -282,8 +284,8 @@ export class LayerInstance extends APIScope {
         this.geomType = GeometryType.UNKNOWN;
         this.legend = [];
         this._sublayers = [];
-        this.expectedTime = { draw: 0, load: 0 };
-        this.maxLoadTime = 0;
+        this.expectedTime = { draw: 0, load: 0, fail: 0 };
+        this.lastCancel = 0;
         this.canModifyLayer = true;
         this.canReload = true;
         this.url = '';
@@ -318,6 +320,18 @@ export class LayerInstance extends APIScope {
     }
 
     /**
+     * Cancels an in-progress initialize or load of the layer and places it in an Error state.
+     * Has no effect on a layer that is loaded, has been terminated, or never initiazed.
+     */
+    cancelLoad(): void {}
+
+    /**
+     * If layer is map bound, and has an esri layer in the esri map, remove it from esri map.
+     * Typically should only be called by RAMP internals.
+     */
+    removeEsriLayer(): void {}
+
+    /**
      * Provides a promise that resolves when the layer has finished loading. If accessing layer properties that
      * depend on the layer being loaded, wait on this promise before accessing them.
      *
@@ -331,8 +345,10 @@ export class LayerInstance extends APIScope {
     /**
      * Indicates if the layer is in a state that is makes sense to interact with.
      * I.e. False if layer has not done it's initial load, or is in error state.
+     * Acts as a handy shortcut to inspecting the layerState.
      *
-     * @returns {Boolean} true if layer is in an interactive state
+     * @method isLoaded
+     * @returns {Boolean} true if layer is loaded
      */
     get isLoaded(): boolean {
         return false;
@@ -519,13 +535,11 @@ export class LayerInstance extends APIScope {
 
     /**
      * Requests that an attribute load request be aborted. Useful when encountering a massive dataset or a runaway process.
-     *
      */
     abortAttributeLoad(): void {}
 
     /**
      * Requests that any downloaded attribute sets or cached geometry be removed from memory. The next requests will pull from the server again.
-     *
      */
     clearFeatureCache(): void {}
 
@@ -567,6 +581,9 @@ export class LayerInstance extends APIScope {
      * Gets information on a graphic in the most efficient way possible. Options object properties:
      * - getGeom ; a boolean to indicate if the result should include graphic geometry
      * - getAttribs ; a boolean to indicate if the result should include graphic attributes
+     * - getStyle ; a boolean to indicate if the result should graphical styling information
+     *
+     * All option properties are optional and default to false
      *
      * @param {Integer} objectId the object id of the graphic to find
      * @param {Object} options options object for the request, see above
@@ -688,14 +705,17 @@ export class LayerInstance extends APIScope {
     /**
      * Initiates actions after layer load error.
      * Should generally only be called internally by the RAMP core.
+     * @param {boolean} [genuineError=true] Flag to detect error setting due to manual cancellation. Only genuine errors will raise notifications.
      */
-    onError(): void {}
+    onError(genuineError: boolean = true): void {}
 
     /**
      * Updates layer load state and raises events.
      * Should generally only be called internally by the RAMP core.
+     * @param {LayerState} newState load state the layer is entering
+     * @param {Boolean} [userCancel=false] optional flag to indicate if an error state was intentional due to a user cancel request
      */
-    updateLayerState(newState: LayerState): void {}
+    updateLayerState(newState: LayerState, userCancel: boolean = false): void {}
 
     /**
      * Updates layer draw state and raises events.

--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -65,14 +65,23 @@ export class MapLayer extends CommonLayer {
 
     protected noLayerErr(): void {
         console.error(
-            'Attempted to manipulate the layer but no layer found. Likely .initiate() was not finished or failed.'
+            'Attempted to manipulate the layer but no layer found. Likely .initiate() was not finished or failed. Layer id ' +
+                this.id
+        );
+        console.trace();
+    }
+
+    protected notLoadedErr(): void {
+        console.error(
+            'Attempted to manipulate the layer before it was loaded. Layer id ' +
+                this.id
         );
         console.trace();
     }
 
     protected async onInitiate(): Promise<void> {
-        // NOTE MapLayer a superclass and this method should be called via super.initiate()
-        //      in subclass.initiate() at the appropriate time. A general rule is that at
+        // NOTE MapLayer is a superclass and this method should be called via super.initiate()
+        //      in subclass.onInitiate() at the appropriate time. A general rule is that at
         //      minimum the subclass should instantiate the Esri layer object and assign it
         //      to .esriLayer before calling this.
 
@@ -83,6 +92,7 @@ export class MapLayer extends CommonLayer {
         // NOTE current limitation: the event setup here only support one layer view. Any attempt to make
         //      RAMP have two map views rendering the same Layer will require some major refactoring.
 
+        // all this super call does is some safety checks.
         await super.onInitiate();
 
         if (!this.esriLayer) {
@@ -124,9 +134,12 @@ export class MapLayer extends CommonLayer {
                 };
 
                 if (newval === 'loaded') {
-                    // loaded is a special case. the Layer object (subclasses of BaseLayer) need to do
-                    // additional asynch work to fully set things up, so we delay firing the event until
-                    // that is done.
+                    // loaded is a special case. this layer may need to do
+                    // additional asynch work to fully set things up, so we
+                    // trigger that process now. it will fire the RAMP event
+                    // when it's done done.
+                    // Re: load cancel. If we cancelled earlier the esri layer shouldn't hit this state.
+                    //     If we cancelled later, the onLoad stuff will deal with it.
                     this.onLoad();
                 } else if (newval === 'failed') {
                     this.onError();
@@ -156,7 +169,7 @@ export class MapLayer extends CommonLayer {
     }
 
     async terminate(): Promise<void> {
-        // TODO null out esrilayer objects? or make orchestrator handle that stuff.
+        this.esriLayer = undefined;
 
         await super.terminate();
 
@@ -172,29 +185,31 @@ export class MapLayer extends CommonLayer {
             return;
         }
 
-        if (this.initiationState === InitiationState.INITIATED) {
-            if (this.esriLayer) {
-                // attempt to find esri layer in esri map. remove if found
-                const tempPosition =
-                    this.$iApi.geo.map.esriMap.layers.findIndex(
-                        l => l.id === this.id
-                    );
-                if (tempPosition > -1) {
-                    this.$iApi.geo.map.esriMap.layers.remove(this.esriLayer);
-                }
-            }
+        // must be called before terminate()
+        this.removeEsriLayer();
 
-            // TODO might need to store layer state. If we want layer to look the same as it was prior to re-loading,
-            //      could do that here. Alternative is to not, and let whomever is calling this save state before
-            //      and restore state after. Might be more flexible.
-            this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_START, this);
-            this.sublayers.forEach(sublayer =>
-                this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_START, sublayer)
-            );
-            await this.terminate();
-        }
+        // If we ever consider restoring layer state to look the same as it was prior to re-loading,
+        // could do that here. Alternative is to not, and let whomever is calling this save state before
+        // and restore state after. Might be more flexible.
+
+        const startTime = Date.now();
+
+        this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_START, this);
+        this.sublayers.forEach(sublayer =>
+            this.$iApi.event.emit(GlobalEvents.LAYER_RELOAD_START, sublayer)
+        );
+
+        // need to terminate even if initiation failed. Termination
+        // does cleanups that are required.
+        await this.terminate();
 
         await this.initiate();
+
+        if (this.lastCancel > startTime) {
+            // layer was cancelled before it could initiate.
+            // exit. No warnings since it was deliberate.
+            return;
+        }
 
         if (!this.esriLayer) {
             console.error('ESRI layer failed to re-create during reload.');
@@ -235,11 +250,20 @@ export class MapLayer extends CommonLayer {
         return esriConfig;
     }
 
+    removeEsriLayer(): void {
+        if (this.esriLayer && this.$iApi.geo.map.esriMap) {
+            // attempt to find esri layer in esri map. remove if found
+            const tempPosition = this.$iApi.geo.map.esriMap.layers.findIndex(
+                l => l.id === this.id
+            );
+            if (tempPosition > -1) {
+                this.$iApi.geo.map.esriMap.layers.remove(this.esriLayer);
+            }
+        }
+    }
+
     // ----------- LAYER LOAD -----------
 
-    // performs setup on the layer that needs to occur after the esri layer
-    // exists, but before we mark the layer as loaded. Any async tasks must
-    // include their promise in the return array.
     protected onLoadActions(): Array<Promise<void>> {
         const proms = super.onLoadActions();
         if (!this.name) {
@@ -254,7 +278,8 @@ export class MapLayer extends CommonLayer {
         }
 
         // layer base class doesnt have spatial ref, but we will assume all our layers do.
-        // consider adding fancy checks if its missing, and if so just promise.resolve
+        // consider adding fancy checks if its missing, and if so just promise.resolve .
+        // given the layer is dead without a success, we don't bother with any cancel-checking here.
         const lookupPromise = this.$iApi.geo.proj
             .checkProj(this.getSR())
             .then(goodSR => {
@@ -436,7 +461,10 @@ export class MapLayer extends CommonLayer {
      * Indicates if the Esri map layer exists
      */
     get layerExists(): boolean {
-        return this.esriLayer ? true : false;
+        return (
+            this.initiationState === InitiationState.INITIATED &&
+            !!this.esriLayer
+        );
     }
 
     /**
@@ -452,12 +480,11 @@ export class MapLayer extends CommonLayer {
      * @returns {Boolean} visibility of the layer
      */
     get visibility(): boolean {
-        // basic case - sublayer vis === layer vis
-        if (this.esriLayer) {
-            return this.esriLayer.visible;
+        // basic case - esri layer vis === layer vis
+        if (this.layerExists) {
+            return this.esriLayer!.visible;
         } else {
-            this.noLayerErr();
-            return false; // default to chill things.
+            return false;
         }
     }
 
@@ -468,8 +495,8 @@ export class MapLayer extends CommonLayer {
      */
     set visibility(value: boolean) {
         // basic case - set layer visibility
-        if (this.esriLayer) {
-            this.esriLayer.visible = value;
+        if (this.layerExists) {
+            this.esriLayer!.visible = value;
         } else {
             this.noLayerErr();
         }
@@ -482,7 +509,7 @@ export class MapLayer extends CommonLayer {
      * @function checkVisibility
      */
     checkVisibility(): void {
-        if (this.supportsSublayers) {
+        if (this.supportsSublayers && this.layerExists) {
             this.visibility = this.sublayers.some(
                 sublayer => sublayer.visibility
             );
@@ -495,12 +522,11 @@ export class MapLayer extends CommonLayer {
      * @returns {number} opacity of the layer (range between 0 and 1)
      */
     get opacity(): number {
-        // basic case - sublayer opac === layer opac
-        if (this.esriLayer) {
-            return this.esriLayer.opacity;
+        // basic case - esri layer opac === layer opac
+        if (this.layerExists) {
+            return this.esriLayer!.opacity;
         } else {
-            this.noLayerErr();
-            return 0; // default to chill things.
+            return 0;
         }
     }
 
@@ -511,8 +537,8 @@ export class MapLayer extends CommonLayer {
      */
     set opacity(value: number) {
         // basic case - set layer opacity
-        if (this.esriLayer) {
-            this.esriLayer.opacity = value;
+        if (this.layerExists) {
+            this.esriLayer!.opacity = value;
         } else {
             this.noLayerErr();
         }

--- a/src/geo/layer/osm-tile-layer.ts
+++ b/src/geo/layer/osm-tile-layer.ts
@@ -47,12 +47,7 @@ export class OsmTileLayer extends MapLayer {
         return esriConfig;
     }
 
-    /**
-     * Triggers when the layer loads.
-     *
-     * @function onLoadActions
-     */
-    onLoadActions(): Array<Promise<void>> {
+    protected onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
 
         this.layerTree.name = this.name;

--- a/src/geo/layer/shapefile-layer.ts
+++ b/src/geo/layer/shapefile-layer.ts
@@ -12,6 +12,7 @@ export class ShapefileLayer extends FileLayer {
 
     protected async onInitiate(): Promise<void> {
         let shapefileData: any; // data type is actually an ArrayBuffer
+        const startTime = Date.now();
 
         if (
             this.origRampConfig.rawData &&
@@ -38,9 +39,17 @@ export class ShapefileLayer extends FileLayer {
         }
 
         // convert shapefile to geojson, store in property for FileLayer to consume.
-        this.sourceGeoJson =
-            await this.$iApi.geo.layer.files.shapefileToGeoJson(shapefileData);
+        if (startTime > this.lastCancel) {
+            const gj =
+                await this.$iApi.geo.layer.files.shapefileToGeoJson(
+                    shapefileData
+                );
 
-        await super.onInitiate();
+            if (startTime > this.lastCancel) {
+                this.sourceGeoJson = gj;
+
+                await super.onInitiate();
+            }
+        }
     }
 }

--- a/src/geo/layer/support/file-utils.ts
+++ b/src/geo/layer/support/file-utils.ts
@@ -567,8 +567,9 @@ export class FileUtils extends APIScope {
 
             Object.keys(gr.attributes).forEach(attName => {
                 if (validFields.includes(attName)) {
-                    // TEMPORARY hunt any complex datatypes and replace with a string
-                    // TODO figure out how to actually handle arrays or objects as attribute values
+                    // if we encounter any complex datatypes (objects, arrays),
+                    // stringify them. Any custom template can re-parse them if they need
+                    // the original structure.
                     if (
                         (Array.isArray(gr.attributes[attName]) ||
                             typeof gr.attributes[attName] === 'object') &&

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -41,20 +41,18 @@ export class TileLayer extends MapLayer {
         return esriConfig;
     }
 
-    /**
-     * Triggers when the layer loads.
-     *
-     * @function onLoadActions
-     */
-    onLoadActions(): Array<Promise<void>> {
+    protected onLoadActions(): Array<Promise<void>> {
         const loadPromises: Array<Promise<void>> = super.onLoadActions();
+        const startTime = Date.now();
 
         this.layerTree.name = this.name;
 
         const legendPromise = this.$iApi.geo.symbology
             .mapServerToLocalLegend(this.origRampConfig.url!)
             .then(legArray => {
-                this.legend = legArray;
+                if (startTime > this.lastCancel) {
+                    this.legend = legArray;
+                }
             });
 
         loadPromises.push(legendPromise);

--- a/src/geo/layer/wfs-layer.ts
+++ b/src/geo/layer/wfs-layer.ts
@@ -14,12 +14,13 @@ export class WfsLayer extends FileLayer {
     }
 
     protected async onInitiate(): Promise<void> {
+        const startTime = Date.now();
         const wrapper = new UrlWrapper(this.config.url);
 
         // get start index and limit set on the url
         const { offset, limit } = wrapper.queryMap;
 
-        this.sourceGeoJson = await this.$iApi.geo.layer.ogc.loadWfsData(
+        const gj = await this.$iApi.geo.layer.ogc.loadWfsData(
             this.config.url,
             -1,
             parseInt(offset) || 0,
@@ -27,8 +28,9 @@ export class WfsLayer extends FileLayer {
             undefined,
             this.config.xyInAttribs
         );
-
-        // TODO error handling? set layer state to error if above call fails?
-        await super.onInitiate();
+        if (startTime > this.lastCancel) {
+            this.sourceGeoJson = gj;
+            await super.onInitiate();
+        }
     }
 }

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -188,8 +188,10 @@ export class OverviewMapAPI extends CommonMapAPI {
         }
 
         this.overviewGraphicLayer.removeGraphic();
-        await this.overviewGraphicLayer.terminate();
         this.esriMap.remove(this.overviewGraphicLayer.esriLayer);
+
+        // This removes the reference to .esriLayer so must happen after the esriMap.remove()
+        await this.overviewGraphicLayer.terminate();
     }
 
     /**

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -66,7 +66,8 @@ export class MapAPI extends CommonMapAPI {
     layerDefaultTimes: LayerTimes = {
         // DEV NOTE these values get updated in createMap(). Using 0 here to avoid having defaults in two spots.
         draw: 0,
-        load: 0
+        load: 0,
+        fail: 0
     };
 
     /**
@@ -95,6 +96,10 @@ export class MapAPI extends CommonMapAPI {
             config.layerTimeDefault?.expectedDrawTime ?? 10000;
         this.layerDefaultTimes.load =
             config.layerTimeDefault?.expectedLoadTime ?? 10000;
+
+        // using falsey || since a 0 would cause every layer to fail instantly
+        this.layerDefaultTimes.fail =
+            config.layerTimeDefault?.maxLoadTime || 90000;
 
         this.viewPromise.then(() => {
             // Timing issues beginning at ESRI v4.26 make us need to wait until the initial view gets created.
@@ -309,12 +314,15 @@ export class MapAPI extends CommonMapAPI {
             type: 'pointer-leave',
             handler: this.esriView.on('pointer-leave', esriMouseLeave => {
                 // guarantee that no mouse move start/end event fires after the mouse leave event
-                setTimeout(() => {
-                    this.$iApi.event.emit(
-                        GlobalEvents.MAP_MOUSELEAVE,
-                        esriMouseLeave.native
-                    );
-                }, Math.max(this.mapMouseThrottle, 100) + 1);
+                setTimeout(
+                    () => {
+                        this.$iApi.event.emit(
+                            GlobalEvents.MAP_MOUSELEAVE,
+                            esriMouseLeave.native
+                        );
+                    },
+                    Math.max(this.mapMouseThrottle, 100) + 1
+                );
             })
         });
 
@@ -564,7 +572,9 @@ export class MapAPI extends CommonMapAPI {
     }
 
     /**
-     * Adds a layer to the map. The layer is considered "registered" with RAMP until it is removed.
+     * Registers a layer with the instance and attempts to add it to the the map.
+     * The return value provides an async indicator if the map add was successful,
+     * but the layer is registered regardless.
      * Optionally can specify the layer order index for map layers.
      *
      * @param {LayerInstance} layer the Ramp layer to add
@@ -630,6 +640,10 @@ export class MapAPI extends CommonMapAPI {
             const layerStore = useLayerStore(this.$vApp.$pinia);
             layerStore.addLayer(layer, index);
 
+            // layer is in the store, so is registered.
+            this.$iApi.event.emit(GlobalEvents.LAYER_REGISTERED, layer);
+
+            const startTime = Date.now();
             let timeElapsed = 0;
             // This interval waits for layer initiation, and has a kickout for layers that initiate forever.
             // After it initiates the callback will start the next step in the loading pipeline.
@@ -637,14 +651,25 @@ export class MapAPI extends CommonMapAPI {
             const layerWatcher = setInterval(() => {
                 timeElapsed += 250;
                 if (
-                    timeElapsed >= 20000 ||
+                    timeElapsed >= layer.expectedTime.fail ||
                     layer.layerState === LayerState.ERROR
                 ) {
                     // Layer took too long to initiate. Move to error to avoid infinite load animation.
-                    // Issue #1491 Ponders making the 20 second timeout configurable.
                     clearInterval(layerWatcher);
-                    layer.onError(); // need this thanks to an edge case where the legend sometimes doesnt update
-                    console.error(`Failed to add layer: ${layer.id}.`);
+
+                    if (layer.lastCancel < startTime) {
+                        // only ping this message if the layer wasn't cancelled.
+                        // might seem a bit much, but it is a useful console msg for debugging.
+
+                        console.error(`Failed to add layer: ${layer.id}.`);
+                    }
+
+                    // no longer call layer.onError() here.
+                    // is now handled by layer initiate() timer.
+
+                    // this is a bit redundant, but our API was minted to return a promise that resolves/rejects depending
+                    // on if the layer is Added To The Map.  RAMP itself doesn't care. Layer already registered, will
+                    // see and react to events on the layer.
                     reject();
                 } else if (
                     layer.initiationState === InitiationState.INITIATED &&
@@ -652,6 +677,8 @@ export class MapAPI extends CommonMapAPI {
                 ) {
                     // we have initiated, and confirm either the map layer exists or layer doesn't live on the map.
                     // carry on with resolution steps.
+                    // Re: cancelling a load - would have gotten caught in error block above. if comes after, layer load
+                    //     process will handle it.
                     clearInterval(layerWatcher);
                     if (layer.mapLayer) {
                         // ramp layer is map ready, add it at the correct position
@@ -660,11 +687,11 @@ export class MapAPI extends CommonMapAPI {
                         // data layer
                         // there is no esri layer "load" first, so we trigger
                         // the data layer load now.
+
                         layer.onLoad();
                     }
 
-                    // layer has been added to the map, fire layer registered event
-                    this.$iApi.event.emit(GlobalEvents.LAYER_REGISTERED, layer);
+                    // finish the promise result (indicates layer is inside the map or equivalent)
                     resolve();
                 }
             }, 250);
@@ -905,16 +932,12 @@ export class MapAPI extends CommonMapAPI {
         if (!layer) {
             throw new Error('Sublayer could not be found for removal.');
         }
-        this.$iApi.event.emit(GlobalEvents.LAYER_REMOVE, sublayer);
         layer.visibility = false; // make the sublayer invisible
         layer.isRemoved = true; // mark sublayer as removed
+        this.$iApi.event.emit(GlobalEvents.LAYER_REMOVE, sublayer);
 
         // If this sublayer is the last removed layer, then remove the parent layer as well
-        if (
-            layer.parentLayer?.sublayers.every(
-                (sub: LayerInstance) => sub.isRemoved
-            )
-        ) {
+        if (layer.parentLayer?.sublayers.every(sub => sub.isRemoved)) {
             // all sublayers have been marked for removal
             // delete the parent
             this.removeLayer(layer.parentLayer!);
@@ -953,23 +976,25 @@ export class MapAPI extends CommonMapAPI {
             return;
         }
 
+        // now that we can cancel before an initiation finishes, this error will cause more problems than good
+        /*
         if (layerInstance.mapLayer && !layerInstance.esriLayer) {
             throw new Error(
                 'Attempted to remove layer from the map without an esri layer. Likely layer.initiate() was not called or had not finished.'
             );
         }
+        */
 
-        // if layer is parent layer, then remove all its sublayers first if there is at least one active sublayer
-        if (
-            layerInstance.supportsSublayers &&
-            layerInstance.sublayers.some(sl => !sl.isRemoved)
-        ) {
-            layerInstance.sublayers.forEach(sl => this.removeSublayer(sl));
+        // if layer is parent layer, then remove any remaining active sublayers first
+        if (layerInstance.supportsSublayers) {
+            layerInstance.sublayers.forEach(sl => {
+                if (!sl.isRemoved) {
+                    this.removeSublayer(sl);
+                }
+            });
         }
 
         // Now we start the layer removal process
-        // Clean up layer
-        layerInstance.terminate();
 
         const layerStore = useLayerStore(this.$vApp.$pinia);
         layerStore.removeLayer(layerInstance);
@@ -977,9 +1002,13 @@ export class MapAPI extends CommonMapAPI {
         // Clean up the layer config store
         layerStore.removeLayerConfig(layerInstance.id);
 
-        // Remove the layer from the map
-        if (layerInstance.mapLayer) {
-            this.esriMap.remove(layerInstance.esriLayer!);
+        // Remove the layer from the map, if its there
+        layerInstance.removeEsriLayer();
+
+        // Clean up layer.
+        // This removes the reference to .esriLayer so must happen after removeEsriLayer()
+        if (layerInstance.initiationState === InitiationState.INITIATED) {
+            layerInstance.terminate();
         }
 
         layerInstance.isRemoved = true;
@@ -1249,9 +1278,8 @@ export class MapAPI extends CommonMapAPI {
      *
      * @param {MapClick | Point} targetPoint the place on the map to execute the identify
      * @memberof MapAPI
-     * @returns MapIdentifyResult
+     * @returns {MapIdentifyResult} results of the identify
      */
-
     runIdentify(targetPoint: MapClick | Point): MapIdentifyResult {
         const layers = this.$iApi.geo.layer
             .allLayersOnMap(false)
@@ -1424,7 +1452,7 @@ export class MapAPI extends CommonMapAPI {
             return {
                 oid: topGraphic.getObjectId(),
                 layerId: hitLayer.id,
-                layerIdx: hitLayer.getLayerTree().layerIdx
+                layerIdx: hitLayer.layerIdx
             };
         }
     }

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -11,7 +11,7 @@ import type {
     RampLayerFieldMetadataConfig,
     TabularAttributeSet
 } from '@/geo/api';
-import { DataFormat, Graphic, NoGeometry } from '@/geo/api';
+import { DataFormat, GeometryType, Graphic, NoGeometry } from '@/geo/api';
 import { EsriGeometryFromJson, EsriRequest } from '@/geo/esri';
 import to from 'await-to-js';
 import deepmerge from 'deepmerge';
@@ -872,13 +872,18 @@ export class QuickCache {
     // extents for feature layer graphics that do not have a point geometry
     private extents: { [key: number]: Extent };
 
+    /**
+     * Used to determine if we need to cache geometry at different scales.
+     */
     readonly isPoint: boolean;
 
-    constructor(geomType: string) {
+    constructor(geomType: GeometryType) {
         this.attribs = {};
         this.geoms = {};
         this.extents = {};
-        this.isPoint = geomType === 'point';
+        this.isPoint =
+            geomType === GeometryType.POINT ||
+            geomType === GeometryType.MULTIPOINT;
     }
 
     private getScaleStore(scale: number): { [key: number]: any } {

--- a/src/geo/utils/renderer.ts
+++ b/src/geo/utils/renderer.ts
@@ -73,10 +73,6 @@ export class BaseRenderer {
         return this.searchRenderer(attributes).symbol;
     }
 
-    rendererToLegend(): any {
-        throw new Error('rendererToLegend not implemented in subclass');
-    }
-
     // worker function. determines if a field value should be wrapped in
     // any character and returns the character. E.g. string would return ', numbers return empty string.
     protected getFieldDelimiter(

--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -203,9 +203,8 @@ export class SymbologyAPI extends APIScope {
                 .viewbox(0, 0, 0, 0);
         }
 
-        const dataUri = await this.$iApi.geo.shared.convertImagetoDataURL(
-            imageUri
-        );
+        const dataUri =
+            await this.$iApi.geo.shared.convertImagetoDataURL(imageUri);
         if (dataUri === imageUri) {
             // Something went wrong
             return '';
@@ -251,9 +250,8 @@ export class SymbologyAPI extends APIScope {
         }
 
         // need to draw the image to get its size (technically not needed if we have a url, but this is simpler)
-        const convertedUrl = await this.$iApi.geo.shared.convertImagetoDataURL(
-            imageUri
-        );
+        const convertedUrl =
+            await this.$iApi.geo.shared.convertImagetoDataURL(imageUri);
 
         const { image } = await this.svgDrawImage(draw, convertedUrl);
 

--- a/src/stores/layer/layer-store.ts
+++ b/src/stores/layer/layer-store.ts
@@ -127,12 +127,12 @@ export const useLayerStore = defineStore('layer', () => {
         }
 
         // find current position of layer id
-        const layerIdx = mapOrder.value.findIndex(
+        const layerOrderIdx = mapOrder.value.findIndex(
             layerId => layerId === layer.id
         );
-        if (layerIdx !== -1 && layerIdx !== index) {
+        if (layerOrderIdx !== -1 && layerOrderIdx !== index) {
             // remove from current position. re-insert at new position
-            mapOrder.value.splice(layerIdx, 1);
+            mapOrder.value.splice(layerOrderIdx, 1);
             mapOrder.value.splice(index, 0, layer.id);
             // copy to new array to trigger reactivity
             mapOrder.value = [...mapOrder.value];


### PR DESCRIPTION
## Related Item(s)

donethankses #1491 #2199 #2200

## Changes

`tldr` Implements true layer cancellation. Removes lots of timeouts and visibility trickery that managed ESRI layers doing as they pleased. Layer now drives cancellation instead of the legend, simplifying more code.

- Added layer method `cancelLoad()`
  - Added cancel kickouts to every asynch step of layer initialize / load process
  - ESRI layers no longer wait in secret to finish loaded, then cancel
- Added safety kickouts to legend cleanups to avoid forever-spinning intervals.
- Changes to timeout limits on layer loading now that we have instant cancel power.
  - Merged the layer `maxLoadTime` timeout and hardcoded 20 seconds initiation timer on `MapAPI.addLayer()`.
  - Boosted map default from 20 seconds to 90 seconds.
  - Changed layer default to inherit from the map default.
    - This makes it easier to globally adjust a load threshold. Otherwise every layer needs to be changed, and wizard layers will disrespect.
  - Both timeout values are now configurable (per instance, per layer, combos).
- Feature, File, and WFS now report their `layerIdx` instead of `-1`.
- Emit Layer Registered event when it registers (was delaying until it loaded).
- Emit Reload Start event regardless of current layer state (was only doing it for initialized layers).
- Layer Load Status Change event now has additional property on the payload so a listener can determine if an Error report was due to a user cancelling a layer.
- Fixed bad falsey logic in legend surrounding MIL sublayer indexes being 0.
- Fixed some other legend bugs that I didn't log.
- Removed a lot of duplicate method doc.
- Corrected an alphabet crime.


## Notes

The delay on layer initiation (and other testing trickery) will be removed prior to merging. Everything is marked with `~@~` for easy finding.

If cancelling an ESRI server layer during the faked delay of the Load phase, ESRI will screech errors to the console. This is out of our control, but is also a manufactured scenario. In most real cases where layer needs to be cancelled it's stalled, so errors are legit. Also only `F12` devs will notice. 

### Breaking Changes to put in Release Notes

- The `layer/registered` event is now raised at registration, not post-initiation. Previously these two things happened at the same time. The doc page unfortunately used the words "added to map" which is the big lie and what makes this breaking.
- The `layer/reloadstart` event is now always raised when a reload starts. Previously it would only fire if the layer had initiated. Since a layer can be cancelled or fail prior to that, this didn't make sense.
- With no configuration, the maximum load time before erroring is now 90 seconds. It was previously 20 seconds. This number is configurable at both layer and map level.
- The layer config property `maxLoadTime` no longer supports infinite load (`0`). Setting an enormous value can approximate. This can be done at the layer or map configuration level.

## QA Testing

Please use the updated QA PR
https://github.com/ramp4-pcar4/ramp4-pcar4/pull/2391

## Testing

This change covers a lot of ground, so no "simple steps". Will present a bunch of ways to try to break things.

### General

All samples will ping notifications when the init and load phases finish for a layer, so you can watch for the number icon to bump if you want to ensure you cancel during a specific phase.

Enhanced Sample 3, 4, 5, and 7 have delays on both initialize and load phases set to 4 seconds. This will apply to anything added via the wizard as well.

These four samples will help cover the main scenarios.

- Sample 3: Feature layer in config
- Sample 4: MIL children in config
- Sample 5: File layer in config
- Sample 7: Layer medley, including WMS. Also good for testing reorder fixture with cancelled layers.

Reminder that Feature & MIL layers have very simple initialization, and more work in the load phase. File & WFS do heavy lifting in initialization, and have basic load work. But it's important to try to break all combos.

Other layers can be added via the wizard for more tests. If anyone wants custom delays on their wizard-added layers, they can mod stuff in the console.

```
debugInstance.loadDelay = 8000;
debugInstance.initDelay = 7000;
```

### Load Timeout

To test the load timeout hard-limit, dropping this in the console of Enhanced Sample 3 will simulate it.

```
const failfastConf = {
	id: 'iFailFast',
	name: 'I will always fail',
	layerType: 'ogc-wfs',
	url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=150&province__province=on',
	maxLoadTime: 400
};

const failFastLyr = debugInstance.geo.layer.createLayer(failfastConf);
debugInstance.geo.map.addLayer(failFastLyr); // will put uncaught promise error on console. all good
debugInstance.event.emit('user/layeradded', failFastLyr); // adds to legend
```

### MIL Child Detection

A tricky area is legend configs waiting for MIL children who don't exist until after the parent loads.

Enhanced Sample 4 is the best to test this on. Both legend entries are bound to children that won't exist until various phases complete.

### MIL TreeGrow

To test the growing of MIL tree structures, run this code in the console for Enhanced Sample 4.

```
const treeGrowConf = {
	id: 'iGrowTrees',
	name: 'Tree Grower Layer',
	layerType: 'esri-map-image',
	url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Nest/MapServer',
	sublayers: [{ index: 0 }]
	
};

const treeGrowLyr = debugInstance.geo.layer.createLayer(treeGrowConf);
debugInstance.geo.map.addLayer(treeGrowLyr); // may put uncaught promise error on console. all good
debugInstance.event.emit('user/layeradded', treeGrowLyr); // adds to legend
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2314)
<!-- Reviewable:end -->
