### PR TITLE
Display panel title's tooltip on keyboard focus

### DIFF
--- a/src/components/panel-stack/controls/back.vue
+++ b/src/components/panel-stack/controls/back.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative" tabindex="-1">
+    <div class="relative">
         <button
             type="button"
             class="text-gray-500 hover:text-black focus:text-black p-8"

--- a/src/components/panel-stack/controls/close.vue
+++ b/src/components/panel-stack/controls/close.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative" tabindex="-1">
+    <div class="relative">
         <button
             type="button"
             class="text-gray-500 hover:text-black focus:text-black p-8"

--- a/src/components/panel-stack/controls/left.vue
+++ b/src/components/panel-stack/controls/left.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative" tabindex="-1">
+    <div class="relative">
         <button
             type="button"
             class="p-8 move-left"

--- a/src/components/panel-stack/controls/minimize.vue
+++ b/src/components/panel-stack/controls/minimize.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative" tabindex="-1">
+    <div class="relative">
         <button
             type="button"
             class="text-gray-500 hover:text-black focus:text-black p-6"

--- a/src/components/panel-stack/controls/pin.vue
+++ b/src/components/panel-stack/controls/pin.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative" tabindex="-1">
+    <div class="relative">
         <button
             type="button"
             class="text-gray-500 hover:text-black focus:text-black p-8"

--- a/src/components/panel-stack/controls/right.vue
+++ b/src/components/panel-stack/controls/right.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative" tabindex="-1">
+    <div class="relative">
         <button
             type="button"
             class="p-8"

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -1,10 +1,12 @@
 <template>
     <div
         class="h-full flex flex-col items-stretch"
-        :content="t('panels.access')"
+        :content="`<div style='word-break: break-word;'>${t(panel.alertName) + '. ' + t('panels.access')}</div>`"
         v-tippy="{
             trigger: 'manual',
             onShow: checkMode,
+            allowHTML: true,
+            maxWidth: panel.style['flex-basis'] ?? 350,
             popperOptions: {
                 placement: 'top',
                 modifiers: [
@@ -18,7 +20,6 @@
         <header
             v-if="header"
             class="flex flex-shrink-0 items-center border-b border-solid border-gray-600 px-8 h-48 overflow-hidden"
-            tabindex="-1"
         >
             <back
                 :class="
@@ -27,7 +28,11 @@
                 @click="panel.close()"
             ></back>
 
-            <h2 class="flex-grow text-lg py-16 pl-8 min-w-0" v-truncate>
+            <h2
+                class="flex-grow text-lg py-16 pl-8 min-w-0"
+                v-truncate
+                tabIndex="0"
+            >
                 <slot name="header"></slot>
             </h2>
 
@@ -130,7 +135,7 @@ const checkMode = () => !mobileView.value && !props.panel.teleport;
 const move = (direction: PanelDirection) => {
     props.panel.move(direction);
     if (direction === 'left') {
-        // needed to preserve focus on correct panel
+        // needed to preserve focus on correct panel.
         nextTick(() => {
             (el.value?.querySelector('.move-left') as HTMLElement).focus();
         });

--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -10,7 +10,7 @@ const CONTAINER_ATTR = 'focus-container';
 const LIST_ATTR = 'focus-list';
 const ICON_ATTR = 'focus-icon';
 const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
-const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}],[${ICON_ATTR}]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}],[${ICON_ATTR}],[tabIndex]`;
 
 let managers: FocusContainerManager[] = [];
 

--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -23,7 +23,7 @@ const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
 const TRUNCATE_ATTR = 'truncate-text';
 const SHOW_TRUNCATE = 'show-truncate';
 const FOCUSED_CLASS = 'focused';
-const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}],[${ICON_ATTR}]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}],[${ICON_ATTR}],[tabIndex]`;
 
 // TODO: Figure out a way to put the control scheme into the description of the focus-list for screen readers (hidden text?), or see if the help file would be sufficient.
 

--- a/src/directives/truncate/truncate.ts
+++ b/src/directives/truncate/truncate.ts
@@ -41,6 +41,7 @@ export const Truncate: Directive = {
             onShow: onShow,
             allowHTML: true,
             placement: 'bottom-start',
+            maxWidth: 320,
             //flip: false, // can't find a replacement for Vue3
             //boundary: 'window',
             triggerTarget: triggerElement,
@@ -100,11 +101,14 @@ function linkifyContent(content: string | null): TippyContent {
     if (content === null) {
         return '';
     }
-    const escapedContent = escapeHtml(content);
-    return <TippyContent>linkifyHtml(escapedContent, {
+
+    let res = linkifyHtml(content, {
         target: '_blank',
         validate: {
             url: (value: string) => /^https?:\/\//.test(value) // only links that begin with a protocol will be hyperlinked
         }
     });
+    res = `<div style='word-break: break-word;'>${res}</div>`;
+
+    return <TippyContent>res;
 }

--- a/src/fixtures/appbar/button.vue
+++ b/src/fixtures/appbar/button.vue
@@ -10,9 +10,12 @@
                 }
             "
             v-focus-item
-            :content="tooltip"
             :aria-label="String(tooltip)"
-            v-tippy="{ placement: 'right' }"
+            :content="`<div style='word-break: break-word;'>${tooltip}</div>`"
+            v-tippy="{
+                allowHTML: true,
+                placement: 'right'
+            }"
         >
             <slot></slot>
         </button>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -41,8 +41,16 @@
 }
 
 .ramp-styles {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-family:
+        'Montserrat',
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        Helvetica,
+        Arial,
+        sans-serif,
+        Apple Color Emoji,
+        Segoe UI Emoji;
     font-size: 16px;
     line-height: 1.5;
     word-wrap: break-word;
@@ -54,8 +62,16 @@
 
 /* Change ag-grid theme default font (Roboto) to match the rest of the page. */
 .ramp-styles .ag-theme-material * {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-family:
+        'Montserrat',
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        Helvetica,
+        Arial,
+        sans-serif,
+        Apple Color Emoji,
+        Segoe UI Emoji;
 }
 
 .grid-icons {
@@ -101,8 +117,16 @@
 }
 
 .tippy-tooltip.ramp-theme {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-family:
+        'Montserrat',
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        Helvetica,
+        Arial,
+        sans-serif,
+        Apple Color Emoji,
+        Segoe UI Emoji;
     font-size: 14px;
 }
 
@@ -141,8 +165,16 @@
 }
 
 .tippy-box[data-theme~='ramp4'] {
-    font-family: 'Montserrat', -apple-system, BlinkMacSystemFont, Segoe UI,
-        Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji;
+    font-family:
+        'Montserrat',
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        Helvetica,
+        Arial,
+        sans-serif,
+        Apple Color Emoji,
+        Segoe UI Emoji;
     color: white;
     background: #222;
     opacity: 0.9;


### PR DESCRIPTION
### Related Item(s)
#2297 

### Changes
- Set the panel title to be a focus icon in order for it to be tabbable
- Fixed formatting of truncate tooltip by allowing text to wrap

### Notes
- Q: should panel titles be tabbable if they aren't truncated? 

### Testing
Steps:
1. Open the happy sample (from enhanced catalogue)
2. Use tab to navigate to the Legend panel
3. Click enter/space to enter the Legend panel, and observe that keyboard focus now begins at the panel title
5. Open the Geosearch panel, and use tab to navigate to it
6. Click enter/space to enter the Geosearch panel, and observe the Geosearch panel title's truncate tooltip
8. Also note that the tooltip for the Geosearch panel's title (in the appbar and the Geosearch panel) now wraps for very long words. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2321)
<!-- Reviewable:end -->
