### PR TITLE
Language Change/Instance Reload Fixes

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -911,7 +911,7 @@ let config = {
                             }
                         },
                         {
-                            title: 'CN Tower',
+                            title: 'CN Tower French',
                             thumbnail:
                                 'https://upload.wikimedia.org/wikipedia/commons/9/9c/Toronto_-_ON_-_CN_Tower_Turmkorb.jpg',
                             description:
@@ -955,6 +955,11 @@ const rInstance = createInstance(
 //     rInstance.panel.pin('legend');
 // });
 
+rInstance.fixture.isLoaded('basemap').then(() => {
+    const bm = rInstance.fixture.get('basemap');
+    bm.persist = false;
+});
+
 rInstance.$element.component('WFSLayer-Custom', {
     props: ['identifyData'],
     template: `
@@ -966,7 +971,9 @@ rInstance.$element.component('WFSLayer-Custom', {
 });
 
 // add export fixtures
-rInstance.fixture.add('export');
+rInstance.fixture.add('export').then(xportFixture => {
+    xportFixture.persist = false;
+});
 
 // add areas of interest fixture
 rInstance.fixture.add('areas-of-interest');

--- a/docs/using-ramp4/default-setup.md
+++ b/docs/using-ramp4/default-setup.md
@@ -24,6 +24,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed                             |
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added                         |
 | FIXTURE_REMOVED<br>'fixture/removed'               | FixtureInstance object                                         | A fixture has been removed                       |
+| LANG_CHANGE<br>'lang/change'                       | _oldLang_: old language, _newLang_: new language               | The language was changed                         |
 | LAYER_DRAWSTATECHANGE<br>'layer/drawstatechange'   | _state_: new value, _layer_: LayerInstance object                | The layer draw state changed                     |
 | LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, _layer_: LayerInstance object      | The layer layer state changed |
 | LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange' | _state_: new value, _layer_: LayerInstance object, _userCancel_: boolean                | The layer load state changed |                     |

--- a/docs/using-ramp4/fixtures/custom-fixtures.md
+++ b/docs/using-ramp4/fixtures/custom-fixtures.md
@@ -4,6 +4,16 @@ This covers various ways to create fixtures.
 
 ## Interface
 
+The fixture interface has one optional property: `persist`. This indicates whether the fixture should remain in the instance upon language change. Defaults to `true`. Note that if only one config is provided for all languages, the fixture will remain in the instance on language change, regardless of the value of the flag.
+Here is a code snippet that shows how to use this property:
+```JS
+rInstance.fixture.isLoaded('basemap').then(() => {
+    const bm = rInstance.fixture.get('basemap');
+    bm.persist = false;
+});
+rInstance.setLanguage('fr') // basemap fixture will be removed
+``` 
+
 The fixture interface has three methods, all optional. They take no parameters and return no value. If a custom fixture implements them, the RAMP instance will run them at the appropriate time.
 
 - `added()` is run when the fixture has been added to the RAMP instance

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -94,6 +94,12 @@ export enum GlobalEvents {
     HELP_TOGGLE = 'help/toggle',
 
     /**
+     * Fires when the language of the app changes.
+     * Payload: `({ oldLang: string, newLang: string })`
+     */
+    LANG_CHANGE = 'lang/change',
+
+    /**
      * Fires when the drawing state of a layer changes.
      * Payload: `({ layer: LayerInstance, state: string })`
      */
@@ -341,10 +347,9 @@ export enum GlobalEvents {
 }
 
 // Default Event Handler Names
-// IMPORTANT: if changing the enum values, be sure to update the documentation to reflect it.
-//            after v4.0.0 release, best to never edit them unless no other alternative,
+// IMPORTANT: These values are part of the public API, best to never edit them unless no other alternative,
 //            as it will be a breaking change to API usage.
-const enum DefEH {
+enum DefEH {
     CONFIG_CHANGE_UPDATES_MAP_ATTRIBS = 'ramp_config_change_updates_map_attribs',
     LAYER_ERROR_UPDATES_LEGEND = 'ramp_layer_error_updates_legend',
     LAYER_REGISTER_BINDS_LEGEND = 'ramp_layer_register_binds_legend',
@@ -545,6 +550,15 @@ export class EventAPI extends APIScope {
     }
 
     /**
+     * Removes all default event handlers.
+     */
+    removeDefaultEvents(): void {
+        Object.values(DefEH).forEach((handlerName: string) => {
+            this.off(handlerName);
+        });
+    }
+
+    /**
      * Triggers an event.
      *
      * @param {string} event the name of the event
@@ -618,44 +632,7 @@ export class EventAPI extends APIScope {
             eventHandlerNames.length === 0
         ) {
             // use all the default event handlers
-
-            eventHandlerNames = [
-                DefEH.CONFIG_CHANGE_UPDATES_MAP_ATTRIBS,
-                DefEH.LAYER_ERROR_UPDATES_LEGEND,
-                DefEH.LAYER_REGISTER_BINDS_LEGEND,
-                DefEH.LAYER_RELOAD_END_BINDS_LEGEND,
-                DefEH.LAYER_RELOAD_START_UPDATES_LEGEND,
-                DefEH.LAYER_REMOVE_UPDATES_DETAILS,
-                DefEH.LAYER_REMOVE_CHECKS_GRID,
-                DefEH.LAYER_REMOVE_UPDATES_LEGEND,
-                DefEH.LAYER_USERADD_UPDATES_LEGEND,
-                DefEH.MAP_BASEMAP_CHECKS_TILE_PROJ,
-                DefEH.MAP_BASEMAP_UPDATES_MAP_ATTRIBS,
-                DefEH.MAP_BLUR_UPDATES_KEY_HANDLER,
-                DefEH.MAP_CLICK_RUNS_IDENTIFY,
-                DefEH.MAP_CREATED_INITIALIZES_FIXTURES,
-                DefEH.MAP_CREATED_UPDATES_MAP_ATTRIBS,
-                DefEH.MAP_EXTENT_UPDATES_MAPTIP,
-                DefEH.MAP_GRAPHICHIT_CREATES_MAPTIP,
-                DefEH.MAP_IDENTIFY_OPENS_IDENTIFY_RESULTS,
-                DefEH.MAP_KEYDOWN_UPDATES_COORDS,
-                DefEH.MAP_KEYDOWN_UPDATES_KEY_HANDLER,
-                DefEH.MAP_KEYUP_UPDATES_KEY_HANDLER,
-                DefEH.MAP_MOUSE_UPDATES_COORDS,
-                DefEH.MAP_MOUSE_UPDATES_MAPTIP,
-                DefEH.MAP_MOUSELEAVE_REMOVES_MAPTIP,
-                DefEH.MAP_RESIZE_UPDATES_SCALEBAR,
-                DefEH.MAP_SCALE_UPDATES_SCALEBAR,
-                DefEH.PANEL_CLOSE_UPDATES_APPBAR,
-                DefEH.PANEL_OPEN_UPDATES_APPBAR,
-                DefEH.TOGGLE_DETAILS,
-                DefEH.TOGGLE_GRID,
-                DefEH.TOGGLE_HELP,
-                DefEH.TOGGLE_METADATA,
-                DefEH.TOGGLE_REORDER,
-                DefEH.TOGGLE_SETTINGS,
-                DefEH.TOGGLE_WIZARD
-            ];
+            eventHandlerNames = Object.values(DefEH);
         }
 
         // add all the requested default event handlers.

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -34,12 +34,12 @@ export class FixtureAPI extends APIScope {
 
     /**
      * Returns whether a given fixture exists.
-     * 
+     *
      * @param {string} id the fixture ID to be checked
      * @returns {boolean} whether the fixture identified by 'id' exists
      * @memberof FixtureAPI
      */
-    exists(id: string) : boolean {
+    exists(id: string): boolean {
         return id in useFixtureStore(this.$vApp.$pinia).items;
     }
 
@@ -113,6 +113,49 @@ export class FixtureAPI extends APIScope {
 
         this.$iApi.event.emit(GlobalEvents.FIXTURE_REMOVED, fixture);
         return fixture;
+    }
+
+    // See https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2296#issuecomment-2262964384 for background of flush and restore.
+
+    /**
+     * Remove every fixture whose persist flag is set to false from the R4MP instance.
+     * For all other fixtures, simply call their removed hook.
+     */
+    flush(): void {
+        const fixtureStore = useFixtureStore(this.$vApp.$pinia);
+        const fixtureIds = Object.keys(fixtureStore.items);
+        fixtureIds.forEach((id: string) => {
+            const fixture = this.get(id);
+            if (fixture?.persist && typeof fixture?.removed === 'function') {
+                // call the `removed` life hook if available
+                fixture.removed();
+            } else if (!!fixture) {
+                this.remove(id);
+            }
+        });
+    }
+
+    /**
+     * Restores every remaining fixture by calling its added/initialized hooks.
+     */
+    restore(): void {
+        // See https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2296#issuecomment-2262964384 for background
+        // on why this was done.
+        const fixtureStore = useFixtureStore(this.$vApp.$pinia);
+        const fixtureIds = Object.keys(fixtureStore.items);
+        fixtureIds.forEach((id: string) => {
+            const fixture = fixtureStore.items[id];
+            // call the `added` life hook if available
+            if (typeof fixture.added === 'function') {
+                fixture.added();
+            }
+            if (
+                this.$iApi.geo.map.created &&
+                typeof fixture.initialized === 'function'
+            ) {
+                fixture.initialized();
+            }
+        });
     }
 
     /**
@@ -249,15 +292,16 @@ export class FixtureInstance extends APIScope implements FixtureBase {
      * @memberof FixtureInstance
      */
     static updateBaseToInstance(
-        value: FixtureBase,
+        rawFixture: FixtureBase,
         id: string,
         $iApi: InstanceAPI
     ): FixtureInstance {
         const instance = new FixtureInstance(id, $iApi);
 
-        Object.defineProperties(value, {
+        Object.defineProperties(rawFixture, {
             id: { value: id },
             $iApi: { value: $iApi },
+            persist: { value: rawFixture.persist ?? true },
             $vApp: {
                 get() {
                     return instance.$vApp;
@@ -273,7 +317,7 @@ export class FixtureInstance extends APIScope implements FixtureBase {
             mount: { value: instance.mount }
         });
 
-        return value as FixtureInstance;
+        return rawFixture as FixtureInstance;
     }
 
     /**
@@ -283,6 +327,8 @@ export class FixtureInstance extends APIScope implements FixtureBase {
      * @memberof FixtureInstance
      */
     readonly id: string;
+
+    persist: boolean;
 
     /**
      * Creates an instance of FixtureInstance.
@@ -295,6 +341,7 @@ export class FixtureInstance extends APIScope implements FixtureBase {
         super(iApi);
 
         this.id = id;
+        this.persist = true;
     }
 
     /**

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -94,6 +94,7 @@ export class InstanceAPI {
         isPlainText: (content: any) => boolean;
     };
     startRequired: boolean = false;
+    private _eventsOn: boolean = false; // internal tracker that indicates whether default event handlers are on.
 
     /**
      * The instance of Vue R4MP application controlled by this InstanceAPI.
@@ -154,17 +155,22 @@ export class InstanceAPI {
             });
         }
 
-        this.initialize(configs, options);
+        this.initialize(true, configs, options);
     }
 
     /**
      * Initializes a Vue R4MP instance with the given config and options
      *
      * @private
+     * @param {boolean} first whether this is the first time initialize is being called for this R4MP instance
      * @param {RampConfigs | undefined} configs language-keyed R4MP config
      * @param {RampOptions | undefined} options startup options for this R4MP instance
      */
-    private initialize(configs?: RampConfigs, options?: RampOptions): void {
+    private initialize(
+        first: boolean,
+        configs?: RampConfigs,
+        options?: RampOptions
+    ): void {
         const configStore = useConfigStore(this.$vApp.$pinia);
         const panelStore = usePanelStore(this.$vApp.$pinia);
         const maptipStore = useMaptipStore(this.$vApp.$pinia);
@@ -365,13 +371,17 @@ export class InstanceAPI {
         // run the default setup functions unless flags have been set to false.
         // override the loadDefaultFixtures flag if startingFixtures is provided
         if (
-            !(options.loadDefaultFixtures === false) ||
-            configs?.startingFixtures !== undefined
+            first &&
+            (options.loadDefaultFixtures !== false ||
+                configs?.startingFixtures !== undefined)
         ) {
             this.fixture.addDefaultFixtures(configs?.startingFixtures);
+        } else if (!first) {
+            this.fixture.restore();
         }
-        if (!(options.loadDefaultEvents === false)) {
+        if (options.loadDefaultEvents !== false && !this._eventsOn) {
             this.event.addDefaultEvents();
+            this._eventsOn = true;
         }
     }
 
@@ -389,16 +399,26 @@ export class InstanceAPI {
         const layerStore = useLayerStore(this.$vApp.$pinia);
         const gridStore = useGridStore(this.$vApp.$pinia);
 
-        // remove all fixtures
-        // get list of all fixture ids currently added
-        const addedFixtures: Array<string> = Object.keys(fixtureStore.items);
-        // remove each fixture
-        addedFixtures.forEach((id: string) => {
-            // check if the fixture exists first otherwise it will error
-            if (this.fixture.exists(id)) {
-                this.fixture.remove(id);
-            }
-        });
+        // if a user provides their own config, we pretend that RAMP is initializing for the first time
+        const first = !!configs;
+
+        if (first) {
+            // remove all fixtures
+            // get list of all fixture ids currently added
+            const addedFixtures: Array<string> = Object.keys(
+                fixtureStore.items
+            );
+            // remove each fixture
+            addedFixtures.forEach((id: string) => {
+                // check if the fixture exists first otherwise it will error
+                if (this.fixture.exists(id)) {
+                    this.fixture.remove(id);
+                }
+            });
+        } else {
+            // remove all fixtures which we do not want to persist, otherwise just call the removed hook
+            this.fixture.flush();
+        }
 
         // remove all grids
         // get list of all grid ids currently added
@@ -418,8 +438,11 @@ export class InstanceAPI {
         // reset the layer store
         layerStore.$reset();
 
-        // remove all event handlers
-        this.event.offAll();
+        // remove all default event handlers if new config wants them off
+        if (options?.loadDefaultEvents === false) {
+            this.event.removeDefaultEvents();
+            this._eventsOn = false;
+        }
 
         // if configs is not provided, use the current configs
         if (configs === undefined) {
@@ -439,7 +462,7 @@ export class InstanceAPI {
         this.geo.map.maptip.clear();
 
         // re-initalize ramp
-        this.initialize(configs, options);
+        this.initialize(first, configs, options);
     }
 
     /**
@@ -607,19 +630,21 @@ export class InstanceAPI {
         const configStore = useConfigStore(this.$vApp.$pinia);
         const langs = configStore.registeredLangs;
 
-        // prevent full map reload if the new language uses the same config
-        if (langs[language] === langs[this.$i18n.locale.value]) {
-            this.$i18n.locale.value = language;
-            return;
-        }
-
+        const old = this.$i18n.locale.value;
         this.$i18n.locale.value = language;
 
         const activeConfig = this.getConfig();
-        this.event.emit(GlobalEvents.CONFIG_CHANGE, activeConfig);
 
-        // reload the map to apply new config
-        this.reload();
+        // reload the map and emit event if configs are different
+        if (langs[old] !== langs[language]) {
+            this.event.emit(GlobalEvents.CONFIG_CHANGE, activeConfig);
+            this.reload();
+        }
+
+        this.event.emit(GlobalEvents.LANG_CHANGE, {
+            oldLang: old,
+            newLang: language
+        });
     }
 
     /**

--- a/src/stores/fixture/fixture-state.ts
+++ b/src/stores/fixture/fixture-state.ts
@@ -10,6 +10,15 @@ export interface FixtureBase {
     id: string;
 
     /**
+     * Indicates whether to keep the fixture when the language changes. Defaults to true.
+     * If only one config is provided for all languages, the fixture will be kept on language change, regardless of the value of the flag.
+     *
+     * @type {boolean}
+     * @memberof Fixture
+     */
+    persist: boolean;
+
+    /**
      * [Optional] Called synchronously when the fixture is added to R4MP.
      *
      * @memberof Fixture


### PR DESCRIPTION
### Related Item(s)
#2296

### Changes
- Fixed an issue where fixtures added via the API would not persist after language change. Now, the user can decide whether they want the fixtures to persist via the `persist` flag. 
- Fixed an issue where external event handlers would not persist after language change.
- Added a new `LANG_CHANGE` event that fires upon language change.
- Added the ability to remove all default event handlers via the events API. This was done to accommodate the case where a user may want to reload with the same config but without loading all default events.

### Notes
* With the introduction of the `LANG_CHANGE` event, the `CONFIG_CHANGE` event in its current form does not correctly capture all the cases where we may want to fire this event. Because of the several edge cases I encountered, I have opted to keep the current behavior for now, and have posted discussion #2324.
* Another edge case I ran into is what to do with fixtures if `reload()` is called with a new config i.e. should the fixtures added via API persist or not. I decided to go with the simple route of new config = new instance so nuke all existing fixtures. But feel free to grouse if this is not the correct approach.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

#### Fixtures

1. Go to the [classic sample 1](https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=1).
2. Switch to French.
3. Notice that the export and basemap fixtures will no longer be there but the areas of interest fixture will be there.

You can also do some testing via the API.

1. Go to the [classic sample 1](https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=1).
2. Remove the legend fixture via `debugInstance.fixture.remove('legend')`
3. Switch to French.
4. Notice that the legend fixture is not there.
5. Add the legend fixture again via `debugInstance.fixture.add('legend')`
6. Switch to English.
7. Notice that the legend is now there.

#### Events

Try adding your own event handlers, particularly to the `LANG_CHANGE` event and verify that they work on language change. Here is an example script.

```JS
debugInstance.event.on('lang/change', (args) => {
    debugInstance.notify.show('info', `Switched from ${args.old} to ${args.new}.`)
    if (debugInstance.fixture.exists('legend')) {
            debugInstance.fixture.remove('legend') // alternate way to make fixtures not persist
   }
})
```

Finally, you can also test instance reloading via the API with different cases of same config, same options, different config, different options, etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2323)
<!-- Reviewable:end -->
