### PR TITLE
Update node to version 22.5.1

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -40,7 +40,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: latest
+                  node-version: '22.5.1'
                   cache: 'npm'
 
             - name: Try to restore node_modules folder from cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: latest
+                  node-version: '22.5.1'
                   cache: 'npm'
                   registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,7 +11,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: latest
+                  node-version: '22.5.1'
                   cache: 'npm'
 
             - name: Try to restore node_modules folder from cache

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ RAMP should still work on most other browsers, but we cannot promise support or 
 
 ### Project Setup
 
-Download the latest [Node version](https://nodejs.org/en/download/), currently `v18.3.0` or later.
+Download [Node v22.5.1](https://nodejs.org/en/blog/release/v22.5.1).
 
 ```sh
 npm ci

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -2,7 +2,7 @@
 
 ## Project Setup
 
-Download the latest [Node version](https://nodejs.org/en/download/), currently `v18.3.0` or later.
+Download [Node v22.5.1](https://nodejs.org/en/blog/release/v22.5.1).
 
 ```sh
 npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
                 "@cypress/vue": "^3.1.1",
                 "@rushstack/eslint-patch": "^1.2.0",
                 "@tailwindcss/forms": "^0.5.0",
-                "@tsconfig/node20": "^20.1.4",
+                "@tsconfig/node22": "^22.0.0",
                 "@types/animejs": "~3.1.0",
                 "@types/clone-deep": "~4.0.1",
                 "@types/debounce": "^1.2.0",
@@ -90,7 +90,7 @@
                 "vue-tsc": "^2.0.26"
             },
             "engines": {
-                "node": ">=16.14.2"
+                "node": "=22.5.1"
             }
         },
         "node_modules/@ag-grid-community/locale": {
@@ -1100,10 +1100,10 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@tsconfig/node20": {
-            "version": "20.1.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.4.tgz",
-            "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
+        "node_modules/@tsconfig/node22": {
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.0.tgz",
+            "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
             "dev": true
         },
         "node_modules/@types/animejs": {

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
         "vite-docs:generate": "npx vitepress build docs"
     },
     "dependencies": {
+        "@ag-grid-community/locale": "~32.0.0",
         "@arcgis/core": "4.29.10",
         "@popperjs/core": "^2.11.6",
         "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@vueform/toggle": "^2.1.3",
         "ag-grid-community": "^27.3.0",
-        "@ag-grid-community/locale": "~32.0.0",
         "ag-grid-vue3": "^27.3.0",
         "animejs": "~3.2.0",
         "await-to-js": "^3.0.0",
@@ -73,7 +73,7 @@
         "vuedraggable": "next"
     },
     "engines": {
-        "node": ">=16.14.2"
+        "node": "=22.5.1"
     },
     "overrides": {
         "minimist": ">=1.2.6",
@@ -88,7 +88,7 @@
         "@cypress/vue": "^3.1.1",
         "@rushstack/eslint-patch": "^1.2.0",
         "@tailwindcss/forms": "^0.5.0",
-        "@tsconfig/node20": "^20.1.4",
+        "@tsconfig/node22": "^22.0.0",
         "@types/animejs": "~3.1.0",
         "@types/clone-deep": "~4.0.1",
         "@types/debounce": "^1.2.0",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node20/tsconfig.json",
+    "extends": "@tsconfig/node22/tsconfig.json",
     "include": [
         "vite.config.*",
         "vitest.config.*",


### PR DESCRIPTION
### Related Item(s)
#2317 

### Changes
- [CHORE] Pin node version to v22.5.1 across local dev and build pipelines

### Notes
All maintainers should install and run v22.5.1 once this is pulled. [NVM](https://github.com/coreybutler/nvm-windows) is recommended if you need multiple node versions installed for various projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2325)
<!-- Reviewable:end -->
