### PR TITLE
Fix cleanup pipeline

### DIFF
--- a/.github/workflows/pages-cleanup.yml
+++ b/.github/workflows/pages-cleanup.yml
@@ -31,7 +31,7 @@ jobs:
                   fi
 
             ## Delete the PR demo from gh-pages when the PR is closed
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   ref: 'gh-pages'
 
@@ -40,6 +40,11 @@ jobs:
               run: |
                   git config --global user.email "miles.petrov@ec.gc.ca"
                   git config --global user.name "Miles Petrov"
-                  git rm -r ${{ github.head_ref }}/*
+                  git pull --ff-only origin gh-pages
+                  if [ -d "${{ github.head_ref }}" ]; then
+                    git rm -r "${{ github.head_ref }}/*" || true
+                  else
+                    echo "Directory ${{ github.head_ref }} does not exist or contains invalid characters."
+                  fi
                   git commit -a -m 'Delete PR demo ${{ github.head_ref }}'
-                  git push origin HEAD:gh-pages
+                  git push -f origin HEAD:gh-pages

--- a/enhance.bat
+++ b/enhance.bat
@@ -1,8 +1,0 @@
-git checkout main
-git pull --ff-only upstream main
-git push origin main
-git checkout jamesparty
-git rebase main
-git status -s
-echo ""
-echo "ENHANCE!"

--- a/miles.bat
+++ b/miles.bat
@@ -1,6 +1,0 @@
-cd node_modules
-rm -r .vite
-cd ..
-npm cache clear --force
-echo ""
-echo "MILES!"

--- a/nuns.bat
+++ b/nuns.bat
@@ -1,6 +1,0 @@
-git add .
-git reset HEAD -- enhance.bat
-git reset HEAD -- nuns.bat
-git reset HEAD -- miles.bat
-git status -s
-echo "nuns have been reversed"


### PR DESCRIPTION
- Reduces chance of race condition between git rm commit and upstream commits being ahead
- Fails safely when the demo directory can't be found (branch name changes, invalid path characters etc)
- Forces cleanup commit to have preference over commits that are ahead of it (unlikely, otherwise the demo lives forever)

### Related Item(s)
#2327 

### Notes
Some random bat files have been removed, unrelated to this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2331)
<!-- Reviewable:end -->
