### PR TITLE
Fix tab behavior for focus lists, Fix treepicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,7 +1017,7 @@
         },
         "node_modules/@ramp4-pcar4/vue3-treeselect": {
             "version": "0.1.1",
-            "resolved": "git+ssh://git@github.com/ramp4-pcar4/vue3-treeselect.git#3dccc9e78dca3681289e7cff1cb94464c52443fa",
+            "resolved": "git+ssh://git@github.com/ramp4-pcar4/vue3-treeselect.git#7a77069eaeae2910f00eeb4960205d80c22f7856",
             "license": "MIT",
             "peerDependencies": {
                 "vue": "^3.0.0"


### PR DESCRIPTION
### Related Item(s)
#2266
#2245

### Changes
- Fixed the behavior of Tab for focus lists:
  - When pressing `Tab` on a focus-item, it will now be correctly defocused (only when there are no tabbable children within it)
  - When pressing `Shift+Tab` on a focus-item, focus will return to the focus-list

- Fixed behavior of treepicker by setting vue3-treeselect to the up-to-date version (within package-lock.json)

### Note
- Although the issue is fixed for the appbar, I'm not sure what the ideal behavior is for the other focus lists (ex. notification list, mapnav, panels, etc.). Feel free to drop any suggestions for these.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
#### Focus Lists
1. Open the classic main sample (from Enhanced catalogue)
2. Press `Tab` until keyboard focus is on the appbar
3. Use the down arrow key to move focus to the Legend appbar button
4. Press `Tab` to move focus to the Legend panel, and observe that the blue background is removed from the Legend appbar button. 
5. Try step 4 in `main`, and observe that the blue background remains on the Legend appbar button
6. Press `Shift+Tab` to return focus to the Legend button, and observe that its background is blue again
7. Use the down arrow key to navigate to the Basemap appbar button and press `Tab`. Observe that the focus moves to the Legend panel as expected
8. Try step 7 in `main`, and observe that focus moves to the Legend button
9. Press `Shift+Tab` twice, and observe that focus returns to the appbar 
10. Try step 9 in `main`, and observe that  it would skip the appbar and return to the keyboard instructions button

#### Treepicker
1. Open any sample with a wizard
2. Click on the `+` in the legend to open the wizard
3. Add the following as as a Map Image Layer: 
 ```
https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer
``` 
5. Click though the wizard to reach Step 3, where the tree picker appears
6. Type `natu` 
8. Click the Left arrow key, and observe that the cursor moves to the left on the first click
11.  Click the Right arrow key, and observe that the cursor moves to the right on the first click
12. Click the Home key, and observe that the cursor moves to the very beginning of the search term
13.  Click the End key, and observe that the cursor moves to the very end of the search term
14. Click the Down/Up arrow keys, and observe that the currently selected option is highlighted in gray 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2332)
<!-- Reviewable:end -->
