### PR TITLE
Fix export footer overflowing

### DIFF
--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -68,7 +68,7 @@
 
         <div
             v-if="footer"
-            class="px-16 py-16 border-t border-gray-400 default-focus-style"
+            class="px-8 py-16 border-t border-gray-400 default-focus-style"
             v-focus-item
         >
             <slot name="footer"></slot>

--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -13,7 +13,7 @@
                 <button
                     type="button"
                     @click="fixture?.export()"
-                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-8 sm:px-16 mr-8 sm:mr-16"
+                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-4 sm:px-16 mr-8 sm:mr-16"
                     :aria-label="t('export.download')"
                 >
                     {{ t('export.download') }}


### PR DESCRIPTION
### Related Item(s)
#2294

### Changes
- [FIX] The settings button will no longer overflow on very small screen sizes.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
1. Open your favourite sample (that has the export fixture).
2. Open the export panel.
3. In your browser's devtools, shrink the screen to the minimum supported app size of 320px.
4. Verify that the export footer looks respectful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2339)
<!-- Reviewable:end -->
