### PR TITLE
Layer doc update

### DIFF
--- a/docs/introduction/instantiation.md
+++ b/docs/introduction/instantiation.md
@@ -15,7 +15,7 @@ Multiple instances can be hosted on a page (each requiring their own page elemen
 The `pageElement` is the HTML element or element id that the instance should be created in on the page. Currently, a page element should not be targeted by `createInstance()` more than once (errors will likely occur). If an existing instance needs to be reset, please use the `.reload()` method on the `InstanceAPI`.
 
 The `config` is an object containing a `configs` object which is keyed by language codes with configurations as values. The configurations must follow [this schema](https://github.com/ramp4-pcar4/ramp4-pcar4/blob/main/schema.json).
-This object can optionally include a `startingFixtures` list which is a set of fixtures that the RAMP instance will load. An example of the `config` object is shown below:
+This object can optionally include a `startingFixtures` list which is a set of fixtures that the RAMP instance will load. A simplified example of the `config` object is shown below:
 
 ```js
 {
@@ -23,12 +23,12 @@ This object can optionally include a `startingFixtures` list which is a set of f
     configs: {
         en: {
             map: {},
-            layers: {},
+            layers: [],
             fixtures: {}
         },
         fr: {
             map: {},
-            layers: {},
+            layers: [],
             fixtures: {}
         }
     }

--- a/docs/using-ramp4/layer-overview.md
+++ b/docs/using-ramp4/layer-overview.md
@@ -1,5 +1,10 @@
 # Layer Configuration Properties
 
+Layer configuration objects define the layers on the map. They typically exist in the [layers array](../introduction/instantiation.md#creating-an-instance) of an instance configuration object, or are provided at runtime using the [LayerAPI](../api-guides/layers.md#creation).
+
+Below is a list of the various properties that can be specified for a layer config. There are also configurations for [Map Image Sublayer](./layers/sublayer-properties.md#map-image-sublayers) and [WMS Sublayer](./layers/sublayer-properties.md#wms-sublayers) definitions.
+
+
 - [caching](./layers/fancy-properties.md#caching)
 - [colour](./layers/fancy-properties.md#colour)
 - [controls](./layers/basic-properties.md#controls)
@@ -34,6 +39,5 @@
 - [touchTolerance](./layers/fancy-properties.md#touchtolerance)
 - [url](./layers/required-properties.md#url)
 - [xyInAttribs](./layers/fancy-properties.md#xyinattribs)
-- [Map Image Sublayers](./layers/sublayer-properties.md#map-image-sublayers)
-- [WMS Sublayers](./layers/sublayer-properties.md#wms-sublayers)
+
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp-pcar",
-    "version": "4.8.0",
+    "version": "4.9.0-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-pcar",
-            "version": "4.8.0",
+            "version": "4.9.0-beta",
             "dependencies": {
                 "@ag-grid-community/locale": "~32.0.0",
                 "@arcgis/core": "4.29.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ramp-pcar",
-    "version": "4.8.0",
+    "version": "4.9.0-beta",
     "description": "RAMP4 - The Reusable Accessible Mapping Platform, is a Javascript based web mapping platform that provides a reusable, responsive and WCAG 2.1 AA compliant common viewer for the Government of Canada. ",
     "type": "module",
     "module": "./dist/lib/ramp.bundle.es.js",


### PR DESCRIPTION
### Changes

- Small update to make landing page of the Layer Config docs less confusing.
- Fixed an incorrect schema in the instantiation sample.

### Testing

Demos don't generate docsites, so if you really want to see it I believe you'll need to clone the PR branch and then do:

```
$ npx vitepress dev docs
```

FWIW, WOMM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2341)
<!-- Reviewable:end -->
