### PR TITLE
Exclusive grid column fixes

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -1563,7 +1563,7 @@ const setUpColumns = () => {
                             );
                             tabularAttrSet.columns =
                                 tabularAttrSet.columns.filter(column =>
-                                    selectedColumnNames.includes(column.title)
+                                    selectedColumnNames.includes(column.data)
                                 );
                         }
 

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -90,7 +90,11 @@ const zoomToFeature = () => {
     const oidPair = props.params.layerCols[layer.id].find(
         (pair: AttributeMapPair) => pair.origAttr === layer.oidField
     );
-    const oid = props.params.data[oidPair.mappedAttr ?? oidPair.origAttr];
+
+    const oid =
+        props.params.data[
+            oidPair ? (oidPair.mappedAttr ?? oidPair.origAttr) : layer.oidField
+        ];
 
     const zoomUsingGraphic = () => {
         const opts = { getGeom: true };

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -373,9 +373,10 @@ export class AttribLayer extends MapLayer {
                 }
             }
 
-            const webFeat = await this.$iApi.geo.attributes.loadSingleFeature(
-                serviceParams
-            );
+            const webFeat =
+                await this.$iApi.geo.attributes.loadSingleFeature(
+                    serviceParams
+                );
             if (needWebGeom) {
                 // save our result in the cache
                 this.attribs.quickCache.setGeom(
@@ -662,7 +663,8 @@ export class AttribLayer extends MapLayer {
 
             esriConfig.orderBy = rampConfig.drawOrder.map(dr => {
                 // pick ascending if no value was defined.
-                const order = dr.ascending ?? true ? 'ascending' : 'descending';
+                const order =
+                    (dr.ascending ?? true) ? 'ascending' : 'descending';
 
                 if (dr.field) {
                     return {


### PR DESCRIPTION
### Related Item(s)
#2318 #2319

### Changes
- Switched the `title` attribute to `data` attribute when filtering the columns of `TabularAttributeSet` objects
- Used the `LayerInstance`'s oid field to obtain the oid of the feature when the `oidPair` object is undefined/null

### QA Testing
Please test against main branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps:
1. Open any sample with a legend
2. Press `f12` and run the following in the devtools console:
```
const coulson = {
  "name": "Sand Pond National Wildlife Area",
  "nameField": "NAME_E",  
  "permanentFilteredQuery": "Zone_ID=730011100",
  "fixtures": {
    "grid": {
      "filterByExtent": true,
      "columnMetadata": {
        "exclusiveColumns": true
      },
      "columns": [
        {
          "field": "NAME_E"
        }
      ]
    },   
  },
  "id": "1",
  "url": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CWS_SCF/CPCAD/MapServer/0",  
  "layerType": "esri-feature"
}

const lay = debugInstance.geo.layer.createLayer(coulson);
debugInstance.geo.map.addLayer(lay).then(()=> { 
  debugInstance.event.emit('user/layeradded', lay);
});
```
3. Once the layer has loaded within the legend, click on it
4. Observe that the datagrid contains one column (with title 'Name - English'), and one row
5. Click on the 'zoom to feature' button
6. Observe that the map successfully zooms in on the corresponding feature (previously it loaded forever). Also observe that there aren't any errors in the console.
7. Perform these testing steps in `main`, and observe that there are no columns in the grid, the 'zoom to feature' button loads forever when clicked, and an error appears in the console (press `F12` to see it)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2342)
<!-- Reviewable:end -->
