### PR TITLE
Change tooltip position when dropdown is opened

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -3,14 +3,15 @@
         <button
             type="button"
             class="text-gray-500 hover:text-black dropdown-button"
-            @click="open = !open"
+            @click="toggleDropdown"
             :content="tooltip"
             :aria-label="ariaLabel ? String(ariaLabel) : String(tooltip)"
             v-tippy="{
                 placement: tooltipPlacement,
                 theme: tooltipTheme,
                 animation: tooltipAnimation,
-                appendTo: 'parent'
+                appendTo: 'parent',
+                trigger: 'manual'
             }"
             ref="dropdownTrigger"
         >
@@ -61,6 +62,7 @@ const props = defineProps({
     },
     tooltip: { type: String },
     tooltipPlacement: { type: String, default: 'bottom' },
+    tooltipPlacementAlt: { type: String, default: 'top' },
     tooltipTheme: { type: String, default: 'ramp4' },
     tooltipAnimation: { type: String, default: 'scale' },
     centered: { type: Boolean, default: true },
@@ -72,6 +74,24 @@ watchers.push(
         popper.value.update();
     })
 );
+
+const toggleDropdown = () => {
+    open.value = !open.value;
+    (dropdownTrigger.value as any)._tippy.hide();
+};
+
+const focusDropdownTrigger = () => {
+    (dropdownTrigger.value as any)._tippy.setProps({
+        placement: open.value
+            ? props.tooltipPlacementAlt
+            : props.tooltipPlacement
+    });
+    (dropdownTrigger.value as any)._tippy.show();
+};
+
+const blurDropdownTrigger = () => {
+    (dropdownTrigger.value as any)._tippy.hide();
+};
 
 onMounted(() => {
     window.addEventListener(
@@ -93,6 +113,14 @@ onMounted(() => {
             open.value = false;
         }
     });
+
+    dropdownTrigger.value!.addEventListener('focus', focusDropdownTrigger);
+
+    dropdownTrigger.value!.addEventListener('blur', blurDropdownTrigger);
+
+    dropdownTrigger.value!.addEventListener('mouseover', focusDropdownTrigger);
+
+    dropdownTrigger.value!.addEventListener('mouseleave', blurDropdownTrigger);
 
     // nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
     nextTick(() => {
@@ -160,6 +188,20 @@ onBeforeUnmount(() => {
             open.value = false;
         }
     });
+
+    dropdownTrigger.value!.removeEventListener('focus', focusDropdownTrigger);
+
+    dropdownTrigger.value!.removeEventListener('blur', blurDropdownTrigger);
+
+    dropdownTrigger.value!.removeEventListener(
+        'mouseover',
+        focusDropdownTrigger
+    );
+
+    dropdownTrigger.value!.removeEventListener(
+        'mouseleave',
+        blurDropdownTrigger
+    );
 
     open.value = false;
 });

--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -69,8 +69,8 @@
                 :aria-pressed="scale?.isImperialScale"
                 :aria-label="`
                     ${scale?.label} - ${changeScaleMessage(
-                    scale?.isImperialScale
-                )}
+                        scale?.isImperialScale
+                    )}
                 `"
                 v-tippy="{
                     delay: [300, 0],
@@ -99,6 +99,8 @@
                 :ariaLabel="`${t('map.language.short')} - ${t(
                     'map.changeLanguage'
                 )}`"
+                tooltipPlacement="top-start"
+                tooltipPlacementAlt="left-end"
             >
                 <template #header>
                     <span

--- a/src/fixtures/appbar/nav-button.vue
+++ b/src/fixtures/appbar/nav-button.vue
@@ -4,7 +4,7 @@
         v-focus-item
         position="right-end"
         :tooltip="t('appbar.navigation')"
-        tooltip-placement="right"
+        tooltipPlacement="right"
     >
         <template #header>
             <div class="text-gray-400 w-full h-full hover:text-white p-8">

--- a/src/fixtures/export/settings-button.vue
+++ b/src/fixtures/export/settings-button.vue
@@ -3,7 +3,7 @@
         v-focus-item
         :position="dropdownPlacement"
         :tooltip="t('export.menu')"
-        tooltip-placement="top"
+        tooltipPlacement="top"
     >
         <template #header>
             <div

--- a/src/fixtures/grid/column-dropdown.vue
+++ b/src/fixtures/grid/column-dropdown.vue
@@ -3,7 +3,7 @@
         class="relative"
         position="bottom-end"
         :tooltip="t('grid.label.columns')"
-        :tooltip-placement="'bottom'"
+        tooltipPlacementAlt="left"
         :centered="false"
     >
         <template #header>

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -4,7 +4,8 @@
             class="flex-shrink-0"
             position="bottom-end"
             :tooltip="t('legend.layer.options')"
-            tooltip-placement="left"
+            tooltipPlacement="left"
+            tooltipPlacementAlt="left"
             ref="dropdown"
         >
             <template #header>

--- a/src/fixtures/legend/header.vue
+++ b/src/fixtures/legend/header.vue
@@ -53,9 +53,10 @@
         <dropdown-menu
             class="relative"
             position="left-start"
-            :content="t('legend.header.groups')"
-            v-tippy="{ placement: 'left' }"
+            :tooltip="t('legend.header.groups')"
             v-show="isControlAvailable('groupToggle')"
+            tooltipPlacement="left-start"
+            tooltipPlacementAlt="bottom-end"
         >
             <template #header>
                 <div class="p-8">
@@ -85,8 +86,9 @@
         <dropdown-menu
             class="relative"
             position="left-start"
-            :content="t('legend.header.visible')"
-            v-tippy="{ placement: 'left' }"
+            :tooltip="t('legend.header.visible')"
+            tooltipPlacement="left-start"
+            tooltipPlacementAlt="bottom-end"
             v-show="isControlAvailable('visibilityToggle')"
         >
             <template #header>


### PR DESCRIPTION
### Related Item(s)
#2337

### Changes
- Made the dropdown trigger's tooltip trigger manually, so that its position can be adjusted before it's opened
  - If the dropdown is open, the tooltip will use the `tooltipPositionAlt` prop as its position
  - If the dropdown isn't open, the tooltip will use the `tooltipPosition` prop as its position
- When a dropdown is opened, the dropdown trigger's tooltip will disappear, so that it doesn't block the dropdown (especially useful when in keyboard focus)

### Note
- Below I have listed the testing steps for a few dropdown menus, but you can perform similar steps on the other dropdown menus:
  - Notifications dropdown
  - About RAMP dropdown
  - Datagrid options dropdown
  - Datagrid hide columns dropdown
  - Export settings button
  - Legend layer options button dropdown(s)

### QA Testing
Please test against main branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps:
1. Open the classic main sample
##### Language dropdown
2. Press Tab until you have reached the 'Change Language' button
3. Click Enter, and observe that the tooltip has disappeared. 
4. Hover over the  'Change Language' button with your mouse, and observe that the tooltip appears to the left
5. Perform these testing steps in `main` and observe that the tooltip covers the dropdown when it's open. 
##### Toggle Groups dropdown
6. Press Shift+Tab until you reach the legend panel
7. Press Space/Enter to enter it, and press Tab until you reach the 'Toggle Groups' button
8. Click Enter, and observe that the tooltip has disappeared. 
9.  Hover over the  'Toggle Groups' button with your mouse, and observe that the tooltip appears on the bottom
10. Perform these testing steps in `main` and observe that the tooltip covers the dropdown when it's open. 
##### Toggle Visibility dropdown
11. Press Tab until you reach the 'Toggle Visibility' button
12. Click Enter, and observe that the tooltip has disappeared. 
13.  Hover over the  'Toggle Visibility' button with your mouse, and observe that the tooltip appears on the bottom
14. Perform these testing steps in `main` and observe that the tooltip covers the dropdown when it's open. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2357)
<!-- Reviewable:end -->
