### PR TITLE
Implement pagination in details list view

### DIFF
--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -3,12 +3,12 @@
     <div class="relative flex flex-grow truncate">
         <div
             class="flex flex-grow items-center truncate"
-            v-if="data.loaded && supportsFeatures"
+            v-if="supportsFeatures"
         >
             <!-- display symbol if it has loaded, otherwise display a loading spinner -->
             <div class="flex p-8 items-center">
                 <span
-                    v-if="icon"
+                    v-if="data.loaded && icon"
                     class="flex-none symbologyIcon"
                     v-html="icon"
                 ></span>
@@ -19,14 +19,18 @@
 
             <!-- display name of the data point -->
             <span
+                v-if="data.loaded"
                 class="itemName pl-3 text-left flex-grow truncate"
                 :content="itemName"
                 v-tippy="{ placement: 'right' }"
                 v-html="makeHtmlLink(itemName)"
             ></span>
+            <div v-else class="flex p-6 flex-grow">
+                {{ t('details.loading') }}
+            </div>
 
             <!-- zoom icon -->
-            <span class="zoomButton text-center p-3"
+            <span class="zoomButton text-center p-3" v-if="data.loaded"
                 ><button
                     type="button"
                     :content="

--- a/src/fixtures/details/components/result-list.vue
+++ b/src/fixtures/details/components/result-list.vue
@@ -32,12 +32,11 @@
         <!-- paginator and list button for multiple features -->
         <div
             class="flex flex-col justify-between p-8 mb-8 bg-gray-100"
-            v-if="
-                layerExists && getLayerIdentifyItems().length > 1 && !showList
-            "
+            v-if="showPaginator"
         >
-            <div class="flex justify-between">
+            <div class="flex">
                 <button
+                    v-if="!showList"
                     type="button"
                     class="px-8 font-bold hover:bg-gray-200 focus:bg-gray-200"
                     :aria-label="t('details.item.see.list')"
@@ -45,14 +44,29 @@
                 >
                     {{ t('details.item.see.list') }}
                 </button>
-                <div class="flex bg-gray-200 py-8 items-center">
+                <div
+                    class="flex ml-auto bg-gray-200 py-8 items-center"
+                    :class="{ 'w-full': showList }"
+                >
                     <button
                         type="button"
-                        :content="t('details.item.previous.item')"
+                        :content="
+                            t(
+                                showList
+                                    ? 'details.items.previous'
+                                    : 'details.item.previous.item'
+                            )
+                        "
                         v-tippy="{ placement: 'top' }"
                         @click="advanceItemIndex(-1)"
                         class="mx-2 opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
-                        :aria-label="t('details.item.previous.item')"
+                        :aria-label="
+                            t(
+                                showList
+                                    ? 'details.items.previous'
+                                    : 'details.item.previous.item'
+                            )
+                        "
                         :disabled="currentIdx === 0"
                     >
                         <svg height="24" width="24" viewBox="0 0 23 23">
@@ -63,23 +77,48 @@
                             </g>
                         </svg>
                     </button>
-                    <span class="px-8">
+                    <span class="px-3 text-center flex-grow">
                         {{
-                            t('details.item.count', [
-                                currentIdx + 1,
-                                getLayerIdentifyItems().length
-                            ])
+                            showList
+                                ? t('details.items.range', [
+                                      currentIdx + 1,
+                                      Math.min(
+                                          endIdx,
+                                          getLayerIdentifyItems().length
+                                      ),
+                                      getLayerIdentifyItems().length
+                                  ])
+                                : t('details.item.count', [
+                                      currentIdx + 1,
+                                      getLayerIdentifyItems().length
+                                  ])
                         }}
                     </span>
                     <button
                         type="button"
-                        :content="t('details.item.next.item')"
+                        :content="
+                            t(
+                                showList
+                                    ? 'details.items.next'
+                                    : 'details.item.next.item'
+                            )
+                        "
                         v-tippy="{ placement: 'top' }"
                         @click="advanceItemIndex(1)"
                         class="mx-2 rotate-180 opacity-60 hover:opacity-90 disabled:opacity-30 disabled:cursor-default"
-                        :aria-label="t('details.item.next.item')"
+                        :aria-label="
+                            t(
+                                showList
+                                    ? 'details.items.next'
+                                    : 'details.item.next.item'
+                            )
+                        "
                         :disabled="
-                            currentIdx === getLayerIdentifyItems().length - 1
+                            (!showList &&
+                                currentIdx ===
+                                    getLayerIdentifyItems().length - 1) ||
+                            (showList &&
+                                endIdx >= getLayerIdentifyItems().length)
                         "
                     >
                         <svg height="24" width="24" viewBox="0 0 23 23">
@@ -100,9 +139,12 @@
                 <div v-if="showList" class="flex flex-col" v-focus-list>
                     <button
                         class="flex flex-grow truncate default-focus-style hover:bg-gray-200"
-                        v-for="(item, idx) in getLayerIdentifyItems()"
+                        v-for="(item, idx) in getLayerIdentifyItems().slice(
+                            currentIdx,
+                            endIdx
+                        )"
                         :key="idx"
-                        @click="clickListItem(idx)"
+                        @click="clickListItem(currentIdx + idx)"
                         v-focus-item
                     >
                         <ResultItem
@@ -205,10 +247,15 @@ const hilightToggle = ref<boolean>(true);
 const showList = ref<boolean>(false);
 
 /**
- * Index of the item we are displaying within the result's item array.
+ * Index of the item we are displaying within the result's item array
  * Persists in list view
  */
 const currentIdx = ref<number>(0);
+
+/**
+ * Number of items to display at once in list view
+ */
+const itemsPerPage = ref<number>(20);
 
 const handlers = ref<Array<string>>([]);
 const watchers = ref<Array<Function>>([]);
@@ -217,6 +264,7 @@ const activeGreedy = computed<number>(() => detailsStore.activeGreedy);
 const detailProperties = computed<{ [id: string]: DetailsItemInstance }>(
     () => detailsStore.properties
 );
+const endIdx = computed<number>(() => currentIdx.value + itemsPerPage.value);
 
 /**
  * Return the LayerInstance that cooresponds with the UID provided in props.
@@ -241,6 +289,14 @@ const itemRequestTime = computed<Number | undefined>(() => {
     });
     return results?.requestTime;
 });
+
+const showPaginator = computed<boolean>(
+    () =>
+        layerExists.value &&
+        ((!showList.value && getLayerIdentifyItems().length > 1) ||
+            (showList.value &&
+                getLayerIdentifyItems().length > itemsPerPage.value))
+);
 
 const layerName = computed<string>(() => {
     const layer = getBoundLayer();
@@ -322,7 +378,11 @@ const initDetails = () => {
  * Advance the item index by direction (an integer)
  */
 const advanceItemIndex = (direction: number) => {
-    currentIdx.value += direction;
+    if (showList.value) {
+        currentIdx.value += direction * itemsPerPage.value;
+    } else {
+        currentIdx.value += direction;
+    }
 };
 
 /**
@@ -344,7 +404,10 @@ const updateHighlight = () => {
         if (showList.value) {
             // highlight entire list
             // TODO once pagination becomes a thing, this needs to just highlight what is on current page of the list.
-            detailsFixture.value.hilightDetailsItems(resultItems, props.uid);
+            detailsFixture.value.hilightDetailsItems(
+                resultItems.slice(currentIdx.value, endIdx.value),
+                props.uid
+            );
         } else {
             // highlight current item being displayed.
             // being extra careful just incase our index went beyond the array bounds
@@ -365,6 +428,8 @@ const updateHighlight = () => {
  */
 const clickShowList = () => {
     showList.value = true;
+    currentIdx.value =
+        Math.floor(currentIdx.value / itemsPerPage.value) * itemsPerPage.value;
     updateHighlight();
 };
 
@@ -438,7 +503,7 @@ onBeforeMount(() => {
     // Keep an eye to see if the currently selected identify item has been changed.
     watchers.value.push(
         watch(
-            currentIdentifyItem,
+            () => getLayerIdentifyItems(),
             () => {
                 // Re-initialize the details panel if the layer has changed.
                 initDetails();

--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -8,7 +8,12 @@ details.layers.results.empty,No results found for any layer.,1,Aucun résultat t
 details.layers.results.empty.currentLayer,No results found for the selected layer.,1,Aucun résultat trouvé pour la couche sélectionnée.,1
 details.layers.results.empty.noLayers,No layers for identification.,1,Pas de couches pour l'identification.,0
 details.result.default.name,Identify Item {0},1,Désigner l'élément {0},1
+details.loading,Loading...,1,Chargement en cours...,1
 details.items.title,Details,1,Détails,1
+details.items.range,{0} - {1} of {2},1,{0} - {1} de {2},0
+details.items.next,Next page,1,Page suivante,0
+details.items.previous,Previous page,1,Page précédente,0
+details.items.page,Items per page,1,éléments par page,0
 details.item.see.list,See List,1,Voir la liste,1
 details.item.zoom,Zoom to feature,1,Zoom à l'élément,1
 details.item.zoom.zooming,Zooming...,1,Zoom en cours...,1


### PR DESCRIPTION
### Related Item(s)
#2156

### Changes
- [FEATURE] Added pagination to the details list view. This prevents hundreds of identify requests being triggered at once and the user's IP getting banhammered due to being considered a bot.
- [FIX] Fixed an issue where items in list view would be rendered sequentially as they loaded. Now, all items will be instantly rendered and loading spinners will be shown for items that are still loading.

### Notes
- The options for how many items to display per page i.e. `[5, 10, 25, 50]` is something I have just hardcoded based on a whim for now. People can debate on what we should do with this. It can be as fancy as making it configurable, or just having a different set of options to pick from.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
1. Perform an identify on your favourite sample. An ideal sample to try would be sample 23 around Toronto as there are many points clumped together.
2. When the details panel opens, try going to list view and ensure everything is respectful.
3. Attempt to switch between list/item view by clicking on items, the number of items per page option and any other way you can think of to try and break things. 
4. Verify that everything works respectfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2358)
<!-- Reviewable:end -->
