### PR TITLE
Fix WAVE error from keyboard instructions button

### DIFF
--- a/src/components/shell.vue
+++ b/src/components/shell.vue
@@ -8,7 +8,7 @@
             <div class="absolute top-8 w-full flex justify-center">
                 <button
                     type="button"
-                    class="bg-white opacity-0 focus:opacity-100 z-50 shadow-md px-10"
+                    class="bg-white hidden-until-focus z-50 shadow-md px-10"
                     @click="openKeyboardInstructions"
                 >
                     {{ t('keyboardInstructions.open') }}
@@ -80,5 +80,24 @@ const teleported = (): PanelInstance[] =>
     width: 100px;
     height: 100px;
     animation: spin 2s ease-in-out infinite;
+}
+
+/* Compared to using `opacity: 0`, this method prevents WAVE contrast errors.*/
+
+.hidden-until-focus {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(100%);
+}
+
+.hidden-until-focus:focus {
+    position: static;
+    width: auto;
+    height: auto;
+    clip: auto;
+    clip-path: none;
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
Issue #2326 

### Changes
- [FIX] Prevent WAVE constrast error from the `Show Keyboard Instructions` button, by replacing the old `opacity` method with `clip`/`clip-path`

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps:
1. Go to the default sample.
2. Open the WAVE tool. Notice there are no WAVE constrast errors.
3. Tab to the keyboard instructions button. It should still work properly: hidden until tabbed to, opens modal on keyboard `enter`, etc. There should also be no WAVE accessibility errors when the button is visible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2364)
<!-- Reviewable:end -->
