### PR TITLE
Resolve additional wave errors and increased panel default width.

### DIFF
--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -197,7 +197,7 @@ const itemName = computed<string>(() => {
 // make links look like links and work like links
 const makeHtmlLink = (html: any): any => {
     if (typeof html === 'string') {
-        const classes = 'underline text-blue-600 break-all';
+        const classes = 'underline text-blue-700 break-all';
         const div = document.createElement('div');
         div.innerHTML = html.trim();
 

--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -172,7 +172,7 @@ const makeHtmlLink = (html: string, alias: string): string => {
         )}" />`;
     }
 
-    const classes = 'underline text-blue-600 break-all';
+    const classes = 'underline text-blue-700 break-all';
     const div = document.createElement('div');
     div.innerHTML = html.trim();
 

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -126,7 +126,7 @@ export const usePanelStore = defineStore('panel', () => {
         // TODO: update when panel width system is in place
         let remainingWidth = stackWidth.value;
         const nowVisible: PanelInstance[] = [];
-        const defaultWidth = 350;
+        const defaultWidth = 400;
         const panelMargin = 12;
 
         // add panels until theres no space in the stack


### PR DESCRIPTION
Made a mess of my previous feature branch. Easier to close and re-open the PR than undo the chaos I unleashed.

### Related Item(s)
#2285, #2113 

### Changes
- Fixes an issue where large panels would overlap the mapnav button on smaller screen sizes
- Resolves the WAVE errors on Details panel hyperlinks

### Notes
Didn't fix the alt text error on the empty basemap image.  Samples that don't have the missing image don't have the error. 

### Testing

#2113 
Steps:
1. Open any sample with a legend and other fixtures
2. Open an additional panel
3. Open the grid
4. Resize the window slowly until its below 320 px (Min supported instance size)
5. Witness no overlap

#2285 
Steps:
1. Open the legacy default sample
2. Click on a purple or navy blue map point or open one of the "Releases of cadmium" grids and press a details icon
3. Verify that the WAVE tool is no longer grousin about the hyperlinks

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2359)
<!-- Reviewable:end -->
