### PR TITLE
Stop raster identify

### DIFF
--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -194,6 +194,7 @@ export class AttribLayer extends MapLayer {
         } else {
             // raster layer
             this.supportsFeatures = false;
+            this.supportsIdentify = false;
         }
     }
 
@@ -373,9 +374,10 @@ export class AttribLayer extends MapLayer {
                 }
             }
 
-            const webFeat = await this.$iApi.geo.attributes.loadSingleFeature(
-                serviceParams
-            );
+            const webFeat =
+                await this.$iApi.geo.attributes.loadSingleFeature(
+                    serviceParams
+                );
             if (needWebGeom) {
                 // save our result in the cache
                 this.attribs.quickCache.setGeom(
@@ -662,7 +664,8 @@ export class AttribLayer extends MapLayer {
 
             esriConfig.orderBy = rampConfig.drawOrder.map(dr => {
                 // pick ascending if no value was defined.
-                const order = dr.ascending ?? true ? 'ascending' : 'descending';
+                const order =
+                    (dr.ascending ?? true) ? 'ascending' : 'descending';
 
                 if (dr.field) {
                     return {


### PR DESCRIPTION
### Related Item(s)

#2379

### Changes

- Stops Raster MIL sublayers from sneaking into the layer candidates for identify.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Wizard URL 

```
https://maps-cartes.ec.gc.ca/arcgis/rest/services/STB_AST_Dec2016/Projected_change_temperature/MapServer
```

1. Go to Enhanced Sample 1.
2. Open Add Layer Wizard `+` via legend.
3. Add above URL as Map Image Layer.
4. Just select one sublayer in Step 3.
5. After layer loads, click the map. (If you want to see the obscured Happy layer, adjust the new layer opacity or use the layer re-order panel).
6. If clicking on Happy item, see one-layer result.
7. If clicking nowhere, see general "no results" screen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2380)
<!-- Reviewable:end -->
