### PR TITLE
Allow html on result item tooltips, revert to old color picker

### DIFF
--- a/demos/starter-scripts/cam.js
+++ b/demos/starter-scripts/cam.js
@@ -643,8 +643,8 @@ let config = {
             layers: [
                 {
                     id: 'climateActionMap',
-                    layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer',
+                    layerType: 'esri-feature',
+                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/CAM/MapServer/1',
                     tolerance: 20,
                     symbologyExpanded: true,
                     sublayers: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "tiny-emitter": "^2.1.0",
                 "tippy.js": "^6.3.7",
                 "vue": "^3.2.31",
-                "vue-accessible-color-picker": "^5.0.1",
+                "vue-accessible-color-picker": "4.1.4",
                 "vue-i18n": "^9.13.1",
                 "vue-slider-component": "^4.1.0-beta.7",
                 "vue-tippy": "^6.4.4",
@@ -8058,9 +8058,10 @@
             }
         },
         "node_modules/vue-accessible-color-picker": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/vue-accessible-color-picker/-/vue-accessible-color-picker-5.0.1.tgz",
-            "integrity": "sha512-IaxDTzW652blWmaNNbqQZzORQAbP19sdO7oJ5fvJIfVizWr2fVV+3z39ORI210Ee7l8YiD5FhpOY/XrToQCBwg==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/vue-accessible-color-picker/-/vue-accessible-color-picker-4.1.4.tgz",
+            "integrity": "sha512-uq5wPWiR+VeuaZGxWRKuZSKpf2WH1EHa0Oas+rsEdgw35zZ/zotpw5LvyMiqbAagpiHxCp0AzqwDkMJ7dSbGQA==",
+            "license": "MIT",
             "peerDependencies": {
                 "vue": "^3.2.x"
             }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "tiny-emitter": "^2.1.0",
         "tippy.js": "^6.3.7",
         "vue": "^3.2.31",
-        "vue-accessible-color-picker": "^5.0.1",
+        "vue-accessible-color-picker": "4.1.4",
         "vue-i18n": "^9.13.1",
         "vue-slider-component": "^4.1.0-beta.7",
         "vue-tippy": "^6.4.4",

--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -22,6 +22,7 @@
                 v-if="data.loaded"
                 class="pl-3 text-left flex-grow itemName"
                 :content="itemName"
+                v-tippy="{ placement: 'right', allowHTML: true }"
                 v-html="makeHtmlLink(itemName)"
                 v-truncate="{
                     options: { placement: 'right-end' }

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -330,6 +330,8 @@ import {
     type PropType
 } from 'vue';
 
+// below import is causing error because of revert to old version (from 5.0.1 to 4.1.4)
+//@ts-ignore
 import { ColorPicker } from 'vue-accessible-color-picker';
 
 import type { InstanceAPI, PanelInstance } from '@/api';


### PR DESCRIPTION
### Related Item(s)
#2302 
#2370

### Changes
- Allowed HTML content on the tooltips of items in the details panel
- Reverted to older version of `vue-accessible-color-picker` (from 5.0.1 to 4.1.4)


### Notes
- The issue with the tree picker seems to have been introduced here: https://github.com/ramp4-pcar4/ramp4-pcar4/commit/aded4c8fb5dbce4bf202455cdd2f91633451ba4b , where `vue-accessible-color-picker` was upgraded from v4.0.3 to v.5.0.1
- The issues with the color picker are due to a breaking change in v5.0.0 (see https://github.com/kleinfreund/vue-accessible-color-picker/releases/tag/v5.0.0). However, I had trouble pinpointing exactly what was causing the color picker to not render correctly, so I reverted to an older version for the time being. Maybe we should leave #2302 open for now?

### QA Testing
Please test against main branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing
Steps (#2370):
1. Go to classic sample 23
2. Switch to French
3. Zoom in on this point (near Lake Simcoe)
![image](https://github.com/user-attachments/assets/f3d8d96a-9fec-4e35-8117-f701d3ba8bcb)
5. Click the point to open its Details panel
6. Hover over the item's name, and observe that all special HTML chars are displayed correctly (i.e. they are not displayed as their corresponding entities)
7. For further testing, zoom out and click on an area of the map with lots of features
8. Go into list view
9. View the tooltip of each list item and ensure that you don't find one that displays the entity name corresponding to an HTML special char
10. Perform these testing steps in `main`, and observe that special HTML chars are displayed as their corresponding entities


Steps (#2302):
1. Open classic sample 46
2. Upload a file layer (can use [happy.json](https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/public/file-layers/geojson.json))
3. Click through the wizard until step 3
4. Observe that the color picker renders correctly now
5. Perform these testing steps in `main`, and observe that the color picker is broken (i.e. the color space doesn't render)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2381)
<!-- Reviewable:end -->
