### PR TITLE
Escape round/square brackets during column filtering

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -938,7 +938,9 @@ const setUpTextFilter = (
     // default to regex filtering for text columns
     colDef.filterParams.textMatcher = function (params: any) {
         // treat * as a regular special character
-        const newFilterText = params.filterText.replace(/\*/, '\\*');
+        const newFilterText = params.filterText
+            .replace(/\*/, '\\*')
+            .replace(/[()\[\]]/g, '\\$&');
         // surround filter text with .* to match anything before and after
         const re = new RegExp(`^.*${newFilterText}.*`);
         return re.test(params.value);


### PR DESCRIPTION
### Related Item(s)
#2353

### Changes
- Replace round and square brackets with empty strings within the regex used for column filtering, so that they don't interfere with the column filtering

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html

### Testing
Steps:
1. Open classic sample 1
2. Click on the Releases of Mercury layer in the legend to open its grid
3. Use round and square brackets as you search for specific fields in the Facility column's (or any text-based column's) filter field, and observe that they don't interfere with the filtering

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2386)
<!-- Reviewable:end -->
