### PR TITLE
make export fixture dynamically load

### DIFF
--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -1,11 +1,7 @@
 import { FixtureInstance } from '@/api/internal';
 import { useExportStore } from '../store';
 import type { ExportConfig } from '../store';
-
-import { fabric } from 'fabric';
-// prevents blurriness <https://stackoverflow.com/questions/47513180/fabricjs-lines-in-group-become-blurry>
-fabric.Object.prototype.objectCaching = false;
-
+import type { fabric } from 'fabric';
 import FileSaver from 'file-saver';
 
 const DEFAULT_WIDTH = 1200;
@@ -130,6 +126,9 @@ export class ExportAPI extends FixtureInstance {
      * @memberof ExportAPI
      */
     async make(canvas: HTMLCanvasElement, panelWidth: number): Promise<void> {
+        const { fabric } = await import('fabric');
+        // prevents blurriness <https://stackoverflow.com/questions/47513180/fabricjs-lines-in-group-become-blurry>
+        fabric.Object.prototype.objectCaching = false;
         const exportStore = useExportStore(this.$vApp.$pinia);
 
         // stores the individual fabric objects for use with a custom render function

--- a/src/fixtures/export/index.ts
+++ b/src/fixtures/export/index.ts
@@ -11,19 +11,33 @@ import type ExportTimestampFixture from '../export-timestamp';
 import type ExportTitleFixture from '../export-title';
 import type ExportNorthArrowFixture from '../export-northarrow';
 import type ExportScalebarFixture from '../export-scalebar';
+import type { PanelInstance } from '@/api';
 import { useAppbarStore } from '../appbar/store';
 import { useExportStore } from './store';
+import { GlobalEvents } from '@/api';
 
 class ExportFixture extends ExportAPI {
     initialized(): void {
         // load sub-fixtures required by the export
-        this.$iApi.fixture.add('export-title');
-        this.$iApi.fixture.add('export-map');
-        this.$iApi.fixture.add('export-legend');
-        this.$iApi.fixture.add('export-northarrow');
-        this.$iApi.fixture.add('export-scalebar');
-        this.$iApi.fixture.add('export-timestamp');
-        this.$iApi.fixture.add('export-footnote');
+    }
+
+    async needed() {
+        const exportTitle = (await import('../export-title')).default;
+        const exportMap = (await import('../export-map')).default;
+        const exportLegend = (await import('../export-legend')).default;
+        const exportNorthArrow = (await import('../export-northarrow')).default;
+        const exportScalebar = (await import('../export-scalebar')).default;
+        const exportTimestamp = (await import('../export-timestamp')).default;
+        const exportFootnote = (await import('../export-footnote')).default;
+
+        // any type is needed to suppress TS errors, not able to find a better solution/type for use
+        this.$iApi.fixture.add('export-title', exportTitle as any);
+        this.$iApi.fixture.add('export-map', exportMap as any);
+        this.$iApi.fixture.add('export-legend', exportLegend as any);
+        this.$iApi.fixture.add('export-northarrow', exportNorthArrow as any);
+        this.$iApi.fixture.add('export-scalebar', exportScalebar as any);
+        this.$iApi.fixture.add('export-timestamp', exportTimestamp as any);
+        this.$iApi.fixture.add('export-footnote', exportFootnote as any);
     }
 
     added(): void {
@@ -49,6 +63,17 @@ class ExportFixture extends ExportAPI {
                 }
             },
             { i18n: { messages } }
+        );
+
+        const neededHandler = this.$iApi.event.on(
+            GlobalEvents.PANEL_OPENED,
+            async (panel: PanelInstance) => {
+                if (panel.id === 'export') {
+                    this.$iApi.event.off(neededHandler);
+                    await this.needed();
+                    (panel as any).exportMake();
+                }
+            }
         );
 
         // parse export section of config and store in the config store

--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -61,7 +61,7 @@ import ExportSettings from './settings-button.vue';
 import { useExportStore } from './store';
 import { useI18n } from 'vue-i18n';
 
-defineProps({
+const props = defineProps({
     panel: {
         type: Object as PropType<PanelInstance>,
         required: true
@@ -124,6 +124,7 @@ const make = debounce(300, () => {
 });
 
 onBeforeMount(() => {
+    (props.panel as any).exportMake = make;
     // Set up watchers
     watchers.value.push(
         // Listen for any changes to the settings, and refresh the image when they do change


### PR DESCRIPTION
### Related Item(s)
#1528 

### Changes
- [FEATURE] Export fixture now dynamically loads when needed

### Notes 
This PR reduces the initial download size of our es build by changing how the export fixture starts and how it loads dependencies. The export fixture loads fabric.js and the sub-export fixtures only when the export panel is opened. This lets the build separate these dynamic imports so they only get pulled down when needed.

Saves about 1.1 MB total, 230 KB gzip

Note that `iife` and the single file `es` builds do not support dynamic loading. 

I don't really like adding `exportMake` to the panel instance, let me know if there's a better way.

### Testing
Open enhanced-samples.html (01) and open dev console -> network (reload page if needed to see all assets). Now click on the export appbar icon and see the additional files being pulled in.

Also works on index-samples.html (45) Custom Export

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2387)
<!-- Reviewable:end -->
