### PR TITLE
QA - True Load Cancel

### DIFF
--- a/demos/enhanced-scripts/003-simple-feature.js
+++ b/demos/enhanced-scripts/003-simple-feature.js
@@ -19,6 +19,14 @@ const runPreTest = (config, options, utils) => {
     utils.addLayerLegend(nature);
     utils.addLayerLegend(water);
 
+    // remove ~@~
+    config.configs.en.map.layerTimeDefault = {
+        expectedLoadTime: 25000,
+        expectedDrawTime: 25000
+    };
+    options.initDelay = 4000;
+    options.loadDelay = 4000;
+
     return { config, options };
 };
 

--- a/demos/enhanced-scripts/004-simple-mil.js
+++ b/demos/enhanced-scripts/004-simple-mil.js
@@ -22,6 +22,14 @@ const runPreTest = (config, options, utils) => {
         sublayerIndex: 8
     });
 
+    // remove ~@~
+    config.configs.en.map.layerTimeDefault = {
+        expectedLoadTime: 25000,
+        expectedDrawTime: 25000
+    };
+    options.initDelay = 4000;
+    options.loadDelay = 4000;
+
     return { config, options };
 };
 

--- a/demos/enhanced-scripts/005-simple-file.js
+++ b/demos/enhanced-scripts/005-simple-file.js
@@ -31,6 +31,14 @@ const runPreTest = (config, options, utils) => {
     utils.addLayerLegend(geoJson);
     utils.addLayerLegend(shape);
 
+    // remove ~@~
+    config.configs.en.map.layerTimeDefault = {
+        expectedLoadTime: 25000,
+        expectedDrawTime: 25000
+    };
+    options.initDelay = 4000;
+    options.loadDelay = 4000;
+
     return { config, options };
 };
 

--- a/demos/enhanced-scripts/007-main-classic.js
+++ b/demos/enhanced-scripts/007-main-classic.js
@@ -197,6 +197,14 @@ const runPreTest = (config, options, utils) => {
         });
     });
 
+    // remove ~@~
+    config.configs.en.map.layerTimeDefault = {
+        expectedLoadTime: 25000,
+        expectedDrawTime: 25000
+    };
+    options.initDelay = 4000;
+    options.loadDelay = 4000;
+
     return { config, options };
 };
 

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -74,6 +74,10 @@ export interface RampOptions {
     loadDefaultFixtures?: boolean;
     loadDefaultEvents?: boolean;
     startRequired?: boolean;
+
+    // remove ~@~
+    initDelay?: number;
+    loadDelay?: number;
 }
 
 export class InstanceAPI {
@@ -108,11 +112,19 @@ export class InstanceAPI {
 
     private _isFullscreen: boolean;
 
+    // remove ~@~
+    initDelay: number;
+    loadDelay: number;
+
     constructor(
         element: HTMLElement,
         configs?: RampConfigs,
         options?: RampOptions
     ) {
+        // remove ~@~
+        this.initDelay = options?.initDelay || 0;
+        this.loadDelay = options?.loadDelay || 0;
+
         this.event = new EventAPI(this);
 
         const appInstance = createApp(element, this);

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -255,13 +255,6 @@ export class AttribLayer extends MapLayer {
             .map(field => field.name);
     }
 
-    /**
-     * Invokes the process to get the full set of attribute values for the layer,
-     * formatted in a tabular format. Additional data properties are also included.
-     * Repeat calls will re-use the downloaded values unless the values have been explicitly cleared.
-     *
-     * @returns {Promise} resolves with set of tabular attribute values
-     */
     getTabularAttributes(): Promise<TabularAttributeSet> {
         // this call will generate the tabular format, or return the cache if
         // it exists

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -144,6 +144,15 @@ export class CommonLayer extends LayerInstance {
         });
     }
 
+    // remove ~@~
+    async sleep(millsecs: number): Promise<void> {
+        return new Promise(resolve => {
+            setTimeout(() => {
+                resolve();
+            }, millsecs);
+        });
+    }
+
     // need this so initiate encapsulates the entire initiation process regardless of which inherited layer type is being initiated
     async initiate(): Promise<void> {
         this.updateInitiationState(InitiationState.INITIATING);
@@ -183,6 +192,11 @@ export class CommonLayer extends LayerInstance {
             }
         }, this.expectedTime.fail);
 
+        // remove ~@~
+        if (!this.isCosmetic) {
+            await this.sleep(this.$iApi.initDelay);
+        }
+
         const [initiateErr] = await to(this.onInitiate()); // Need this because some layers don't do error handling things
 
         // we're done timing regardless. a) already timed out. b) init ok. c) init errored so already errored.
@@ -198,6 +212,14 @@ export class CommonLayer extends LayerInstance {
                 );
             } else {
                 this.updateInitiationState(InitiationState.INITIATED);
+            }
+
+            // remove ~@~
+            if (!this.isCosmetic) {
+                this.$iApi.notify.show(
+                    NotificationType.INFO,
+                    'Finished init phase: ' + (this.name || this.id)
+                );
             }
         }
     }
@@ -280,6 +302,14 @@ export class CommonLayer extends LayerInstance {
                                 sublayer.onLoad()
                             );
                             this.updateLayerState(LayerState.LOADED);
+
+                            // remove ~@~
+                            if (!this.isCosmetic) {
+                                this.$iApi.notify.show(
+                                    NotificationType.INFO,
+                                    'Finished load phase: ' + this.name
+                                );
+                            }
                         }
                     } else {
                         this.visibility = false;
@@ -347,7 +377,12 @@ export class CommonLayer extends LayerInstance {
         // currently nothing, but we have the option to insert
         // an async setup that is global for all layers
 
-        return [];
+        // remove ~@~
+        if (this.isCosmetic) {
+            return [];
+        } else {
+            return [this.sleep(this.$iApi.loadDelay)];
+        }
     }
 
     cancelLoad(): void {

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -130,13 +130,15 @@ export class FeatureLayer extends AttribLayer {
                 this.tooltipField =
                     this.origRampConfig.tooltipField || this.nameField;
 
-            this.$iApi.geo.attributes.applyFieldMetadata(
-                this,
-                this.origRampConfig.fieldMetadata
-            );
-            this.attribs.attLoader.updateFieldList(this.fieldList);
-            this.attribs.attLoader.updateFieldsToTrim(this.getFieldsToTrim());
-        }
+                this.$iApi.geo.attributes.applyFieldMetadata(
+                    this,
+                    this.origRampConfig.fieldMetadata
+                );
+                this.attribs.attLoader.updateFieldList(this.fieldList);
+                this.attribs.attLoader.updateFieldsToTrim(
+                    this.getFieldsToTrim()
+                );
+            }
         });
 
         const pFC = this.$iApi.geo.layer


### PR DESCRIPTION
## Related Item(s)

donethankses https://github.com/ramp4-pcar4/ramp4-pcar4/issues/1491 https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2199 https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2200
QA PR of #2314

## Changes

`tldr` Implements true layer cancellation. Removes lots of timeouts and visibility trickery that managed ESRI layers doing as they pleased. Layer now drives cancellation instead of the legend, simplifying more code.

- Added layer method `cancelLoad()`
  - Added cancel kickouts to every asynch step of layer initialize / load process
  - ESRI layers no longer wait in secret to finish loaded, then cancel
- Added safety kickouts to legend cleanups to avoid forever-spinning intervals.
- Changes to timeout limits on layer loading now that we have instant cancel power.
  - Merged the layer `maxLoadTime` timeout and hardcoded 20 seconds initiation timer on `MapAPI.addLayer()`.
  - Boosted map default from 20 seconds to 90 seconds.
  - Changed layer default to inherit from the map default.
    - This makes it easier to globally adjust a load threshold. Otherwise every layer needs to be changed, and wizard layers will disrespect.
  - Both timeout values are now configurable (per instance, per layer, combos).
- Feature, File, and WFS now report their `layerIdx` instead of `-1`.
- Emit Layer Registered event when it registers (was delaying until it loaded).
- Emit Reload Start event regardless of current layer state (was only doing it for initialized layers).
- Layer Load Status Change event now has additional property on the payload so a listener can determine if an Error report was due to a user cancelling a layer.
- Fixed bad falsey logic in legend surrounding MIL sublayer indexes being 0.
- Fixed some other legend bugs that I didn't log.
- Removed a lot of duplicate method doc.
- Corrected an alphabet crime.

## Notes

If cancelling an ESRI server layer during the faked delay of the Load phase, ESRI will screech errors to the console. This is out of our control, but is also a manufactured scenario. In most real cases where layer needs to be cancelled it's stalled, so errors are legit. Also only `F12` devs will notice. 

## QA Testing

Please test using the demo links in the first comment.

## Testing

This change covers a lot of ground, so no "simple steps". Will present a bunch of ways to try to break things.

### General

All samples will ping notifications when the init and load phases finish for a layer, so you can watch for the number icon to bump if you want to ensure you cancel during a specific phase.

Enhanced Sample 3, 4, 5, and 7 have delays on both initialize and load phases set to 4 seconds. This will apply to anything added via the wizard as well.

These four samples will help cover the main scenarios.

- Sample 3: Feature layer in config
- Sample 4: MIL children in config
- Sample 5: File layer in config
- Sample 7: Layer medley, including WMS. Also good for testing reorder fixture with cancelled layers.

Reminder that Feature & MIL layers have very simple initialization, and more work in the load phase. File & WFS do heavy lifting in initialization, and have basic load work. But it's important to try to break all combos.

Other layers can be added via the wizard for more tests. If anyone wants custom delays on their wizard-added layers, they can mod stuff in the console.

```
debugInstance.loadDelay = 8000;
debugInstance.initDelay = 7000;
```

### Load Timeout

To test the load timeout hard-limit, dropping this in the console of Enhanced Sample 3 will simulate it.

```
const failfastConf = {
	id: 'iFailFast',
	name: 'I will always fail',
	layerType: 'ogc-wfs',
	url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=150&province__province=on',
	maxLoadTime: 400
};

const failFastLyr = debugInstance.geo.layer.createLayer(failfastConf);
debugInstance.geo.map.addLayer(failFastLyr); // will put uncaught promise error on console. all good
debugInstance.event.emit('user/layeradded', failFastLyr); // adds to legend
```

### MIL Child Detection

A tricky area is legend configs waiting for MIL children who don't exist until after the parent loads.

Enhanced Sample 4 is the best to test this on. Both legend entries are bound to children that won't exist until various phases complete.

### MIL TreeGrow

To test the growing of MIL tree structures, run this code in the console for Enhanced Sample 4.

```
const treeGrowConf = {
	id: 'iGrowTrees',
	name: 'Tree Grower Layer',
	layerType: 'esri-map-image',
	url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Nest/MapServer',
	sublayers: [{ index: 0 }]
	
};

const treeGrowLyr = debugInstance.geo.layer.createLayer(treeGrowConf);
debugInstance.geo.map.addLayer(treeGrowLyr); // may put uncaught promise error on console. all good
debugInstance.event.emit('user/layeradded', treeGrowLyr); // adds to legend
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2391)
<!-- Reviewable:end -->
