### PR TITLE
Cleanup dist folder and add esDynamic build

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,23 @@ Legacy Samples: `https://localhost:5173/demos/index-samples.html`.
 npm run dev-http
 ```
 
-### Build for production
+### Building the application
 
 ```sh
 npm run build
 ```
 
-The production files will be placed in the `dist` folder.
+This command runs four parallel builds, each with a different target mode and use case. This is done because Vite and Rollup do not support multiple build configurations at the same time. The modes are:
+
+- `npm run build:npm`: This build generates the `dist/ramp.bundle.es.js` file which is the file that would be used if ramp is installed via npm. All `package.json` dependencies are excluded from this file, the consuming applications npm manager and build process will handle this.
+
+- `npm run build:esDynamic`: This build generates the `dist/esDynamic` folder which contains the ramp library split into ES modules. This is useful for web applications that want dynamic imports to reduce the size of the initial bundle.
+
+- `npm run build:inline`: This build generates the `dist/ramp.browser.es.js` and `dist/ramp.browser.iife.js` files which contain the entire ramp library as a single file. These files don't support dynamic imports and should only be used if the consuming environment doesn't support ES modules (use iife) and/or only one ramp file can be hosted.
+
+- `npm run build:demos`: This build generates the `dist/demos` folder which contains the demo files. These files are the closest representation of a local develop serve.
+
+You can also run these commands separately if you only need to build one of the modes.
 
 ### Preview production build (after running build)
 
@@ -115,7 +125,7 @@ npm run preview
 
 Then open `http://localhost:5050/index.html` in your browser.
 
-The `demos` folder **is** processed by vite and can therefore reference any source file in the repo. This is the starting point for local development. For example, the `demos/starter-scripts/main.js` file imports `{ createInstance, geo } from '@/main';` whereas `public/starter-scripts/index.js` doesn't since RAMP is globally defined by the `index.html` file when it loads `<script src="./lib/ramp.js"></script>`.
+The `demos` folder **is** processed by vite and can therefore reference any source file in the repo. This is the starting point for local development. For example, the `demos/starter-scripts/main.js` file imports `{ createInstance, geo } from '@/main';` whereas `public/starter-scripts/index.js` doesn't since RAMP is globally defined by the `index.html` file when it loads `<script src="./ramp.browser.iife.js"></script>`.
 
 Run `npm run dev` then open `http://localhost:3000/demos/index.html` in your browser.
 

--- a/docs/introduction/instantiation.md
+++ b/docs/introduction/instantiation.md
@@ -61,14 +61,14 @@ The HTML template below shows a very basic example of how to setup and use RAMP 
         <title>Basic RAMP Sample</title>
 
         <!-- Load RAMP stylesheet -->
-        <link rel="stylesheet" href="./lib/ramp.css" />
+        <link rel="stylesheet" href="./ramp.css" />
     </head>
     <body style="margin: 0">
         <!-- The page element that the RAMP instance will be created in -->
         <div id="ramp-instance" style="height: 100vh; max-height: -webkit-fill-available"></div>
 
         <!-- Load the compiled RAMP script-->
-        <script src="./lib/ramp.js"></script>
+        <script src="./ramp.browser.iife.js"></script>
 
         <!-- Create simple RAMP instance-->
         <script>

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -85,7 +85,7 @@ npm run preview
 
 Then open `http://localhost:5050/index.html` in your browser.
 
-The `demos` folder **is** processed by vite and can therefore reference any source file in the repo. This is the starting point for local development. For example, the `demos/starter-scripts/main.js` file imports `{ createInstance, geo } from '@/main';` whereas `public/starter-scripts/index.js` doesn't since RAMP is globally defined by the `index.html` file when it loads `<script src="./lib/ramp.js"></script>`.
+The `demos` folder **is** processed by vite and can therefore reference any source file in the repo. This is the starting point for local development. For example, the `demos/starter-scripts/main.js` file imports `{ createInstance, geo } from '@/main';` whereas `public/starter-scripts/index.js` doesn't since RAMP is globally defined by the `index.html` file when it loads `<script src="./ramp.browser.iife.js"></script>`.
 
 Run `npm run dev` then open `http://localhost:3000/demos/index.html` in your browser.
 

--- a/docs/using-ramp4/fixtures/custom-fixtures.md
+++ b/docs/using-ramp4/fixtures/custom-fixtures.md
@@ -89,7 +89,7 @@ For more information about how to use `Vue`, click [here](https://vuejs.org/guid
 > <script src="https://unpkg.com/vue"></script>
 >
 > <!-- load RAMP after loading Vue -->
-> <script src="./lib/ramp.js"></script>
+> <script src="./ramp.browser.iife.js"></script>
 >
 > <!-- load script that creates RAMP instance-->
 > <script type="module" src="./starter-scripts/index.js"></script>
@@ -127,7 +127,7 @@ window.hostFixtures['myfixture'] = MyFixture;
 
 <!-- load Vue and RAMP -->
 <script src="https://unpkg.com/vue"></script>
-<script src="./lib/ramp.js"></script>
+<script src="./ramp.browser.iife.js"></script>
 
 <script>
     const rInstance = RAMP.createInstance(...);

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "version": "4.9.0-beta",
     "description": "RAMP4 - The Reusable Accessible Mapping Platform, is a Javascript based web mapping platform that provides a reusable, responsive and WCAG 2.1 AA compliant common viewer for the Government of Canada. ",
     "type": "module",
-    "module": "./dist/esInline/ramp.bundle.es.js",
-    "browser": "./dist/esChunked/ramp.js",
-    "style": "./dist/esChunked/ramp.css",
+    "module": "./dist/ramp.bundle.es.js",
+    "browser": "./dist/esDynamic/ramp.js",
+    "style": "./dist/esDynamic/ramp.css",
     "types": "./dist/ts/main.d.ts",
     "files": [
         "dist"
@@ -17,8 +17,8 @@
         "build": "rm -rf dist && run-p -c -s build:* ts:generate",
         "postbuild": "(rm dist/bad.css || true) && cp -a public/. dist/",
         "build:npm": "vite build --mode npm",
-        "build:esChunk": "vite build --mode esChunk",
-        "build:esInline": "vite build --mode esInline",
+        "build:esDynamic": "vite build --mode esDynamic",
+        "build:inline": "vite build --mode inline",
         "build:demos": "vite build --mode demos",
         "preview": "vite preview --port 5050",
         "test:e2e": "start-server-and-test preview http://127.0.0.1:5050/ 'cypress open'",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
     "version": "4.9.0-beta",
     "description": "RAMP4 - The Reusable Accessible Mapping Platform, is a Javascript based web mapping platform that provides a reusable, responsive and WCAG 2.1 AA compliant common viewer for the Government of Canada. ",
     "type": "module",
-    "module": "./dist/lib/ramp.bundle.es.js",
-    "browser": "./dist/lib/ramp.browser.es.js",
-    "style": "./dist/lib/ramp.css",
+    "module": "./dist/esInline/ramp.bundle.es.js",
+    "browser": "./dist/esChunked/ramp.js",
+    "style": "./dist/esChunked/ramp.css",
     "types": "./dist/ts/main.d.ts",
     "files": [
         "dist"
@@ -17,8 +17,8 @@
         "build": "rm -rf dist && run-p -c -s build:* ts:generate",
         "postbuild": "(rm dist/bad.css || true) && cp -a public/. dist/",
         "build:npm": "vite build --mode npm",
-        "build:cdn": "vite build --mode cdn",
-        "build:prod": "vite build --mode prod",
+        "build:esChunk": "vite build --mode esChunk",
+        "build:esInline": "vite build --mode esInline",
         "build:demos": "vite build --mode demos",
         "preview": "vite preview --port 5050",
         "test:e2e": "start-server-and-test preview http://127.0.0.1:5050/ 'cypress open'",

--- a/public/index-cam.html
+++ b/public/index-cam.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
-        <link rel="stylesheet" href="./lib/ramp.css" />
+        <link rel="stylesheet" href="./ramp.css" />
     </head>
     <body style="margin: 0">
         <style>
@@ -26,7 +26,7 @@
             id="app"
             style="height: 100vh; max-height: -webkit-fill-available"
         ></div>
-        <script src="./lib/ramp.browser.iife.js"></script>
+        <script src="./ramp.browser.iife.js"></script>
         <script type="module" src="./starter-scripts/cam.js"></script>
     </body>
 </html>

--- a/public/index-cesi.html
+++ b/public/index-cesi.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
-        <link rel="stylesheet" href="./lib/ramp.css" />
+        <link rel="stylesheet" href="./ramp.css" />
     </head>
     <body style="margin: 0">
         <style>
@@ -26,7 +26,7 @@
             id="app"
             style="height: 100vh; max-height: -webkit-fill-available"
         ></div>
-        <script src="./lib/ramp.browser.iife.js"></script>
+        <script src="./ramp.browser.iife.js"></script>
         <script type="module" src="./starter-scripts/cesi.js"></script>
     </body>
 </html>

--- a/public/index-esm.html
+++ b/public/index-esm.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
-        <link rel="stylesheet" href="./lib/ramp.css" />
+        <link rel="stylesheet" href="./esChunked/ramp.css" />
     </head>
     <body style="margin: 0">
         <style>

--- a/public/index-esm.html
+++ b/public/index-esm.html
@@ -5,7 +5,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
-        <link rel="stylesheet" href="./esChunked/ramp.css" />
+        <link rel="stylesheet" href="./esDynamic/ramp.css" />
     </head>
     <body style="margin: 0">
         <style>

--- a/public/index-simple.html
+++ b/public/index-simple.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="utf-8" />
@@ -7,7 +7,7 @@
         <title>Basic RAMP Sample</title>
 
         <!-- Load RAMP stylesheet -->
-        <link rel="stylesheet" href="./lib/ramp.css" />
+        <link rel="stylesheet" href="./ramp.css" />
     </head>
     <body style="margin: 0">
         <!-- The page element that the RAMP instance will be created in -->
@@ -17,7 +17,7 @@
         ></div>
 
         <!-- Load the compiled RAMP script-->
-        <script src="./lib/ramp.browser.iife.js"></script>
+        <script src="./ramp.browser.iife.js"></script>
 
         <!-- Create simple RAMP instance-->
         <script>

--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <title>ramp-core</title>
-        <link rel="stylesheet" href="./lib/ramp.css" />
+        <link rel="stylesheet" href="./ramp.css" />
     </head>
     <body style="margin: 0">
         <style>
@@ -26,7 +26,7 @@
             id="app"
             style="height: 100vh; max-height: -webkit-fill-available"
         ></div>
-        <script src="./lib/ramp.browser.iife.js"></script>
+        <script src="./ramp.browser.iife.js"></script>
         <script type="module" src="./starter-scripts/index.js"></script>
     </body>
 </html>

--- a/public/starter-scripts/esm.js
+++ b/public/starter-scripts/esm.js
@@ -1,4 +1,4 @@
-import { createInstance, geo } from '../esChunked/ramp.js';
+import { createInstance, geo } from '../esDynamic/ramp.js';
 
 window.debugInstance = null;
 

--- a/public/starter-scripts/esm.js
+++ b/public/starter-scripts/esm.js
@@ -1,4 +1,4 @@
-import { createInstance, geo } from '../lib/ramp.browser.es.js';
+import { createInstance, geo } from '../esChunked/ramp.js';
 
 window.debugInstance = null;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,19 +48,22 @@ const baseConfig = {
     }
 } as Record<string, any>;
 
-function cdnBundleConfig() {
+function esInlineConfig() {
     return mergeConfig(baseConfig, {
         build: {
             cssMinify: true,
+            minify: true,
+            sourcemap: true,
             lib: {
-                fileName: (format: string) => `lib/ramp.browser.${format}.js`,
+                fileName: (format: string) =>
+                    `esInline/ramp.browser.${format}.js`,
                 formats: ['es', 'iife']
             },
             rollupOptions: {
                 output: {
                     assetFileNames: (assetInfo: any) => {
                         return assetInfo.name === 'style.css'
-                            ? 'lib/ramp.css'
+                            ? 'esInline/ramp.css'
                             : assetInfo.name;
                     }
                 }
@@ -69,14 +72,26 @@ function cdnBundleConfig() {
     });
 }
 
-function prodBundleConfig() {
+function esChunkConfig() {
     return mergeConfig(baseConfig, {
         build: {
+            outDir: `${distName}/esChunked`,
             minify: true,
+            sourcemap: true,
+            cssMinify: true,
             lib: {
-                fileName: (format: string) =>
-                    `lib/ramp.browser.${format}.prod.js`,
-                formats: ['es', 'iife']
+                fileName: `ramp`,
+                formats: ['es']
+            },
+            rollupOptions: {
+                output: {
+                    inlineDynamicImports: false,
+                    assetFileNames: (assetInfo: any) => {
+                        return assetInfo.name === 'style.css'
+                            ? 'ramp.css'
+                            : assetInfo.name;
+                    }
+                }
             }
         }
     });
@@ -90,7 +105,7 @@ function npmBundleConfig() {
     const config = mergeConfig(baseConfig, {
         build: {
             lib: {
-                fileName: 'lib/ramp.bundle.es',
+                fileName: 'esInline/ramp.bundle.es',
                 formats: ['es']
             },
             rollupOptions: {
@@ -141,10 +156,10 @@ export default defineConfig(viteConfig => {
     if (command === 'build') {
         if (mode === 'npm') {
             return npmBundleConfig();
-        } else if (mode === 'cdn') {
-            return cdnBundleConfig();
-        } else if (mode === 'prod') {
-            return prodBundleConfig();
+        } else if (mode === 'esChunk') {
+            return esChunkConfig();
+        } else if (mode === 'esInline') {
+            return esInlineConfig();
         } else {
             return testBuildConfig();
         }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,22 +48,21 @@ const baseConfig = {
     }
 } as Record<string, any>;
 
-function esInlineConfig() {
+function inlineConfig() {
     return mergeConfig(baseConfig, {
         build: {
             cssMinify: true,
             minify: true,
             sourcemap: true,
             lib: {
-                fileName: (format: string) =>
-                    `esInline/ramp.browser.${format}.js`,
+                fileName: (format: string) => `ramp.browser.${format}.js`,
                 formats: ['es', 'iife']
             },
             rollupOptions: {
                 output: {
                     assetFileNames: (assetInfo: any) => {
                         return assetInfo.name === 'style.css'
-                            ? 'esInline/ramp.css'
+                            ? 'ramp.css'
                             : assetInfo.name;
                     }
                 }
@@ -72,10 +71,10 @@ function esInlineConfig() {
     });
 }
 
-function esChunkConfig() {
+function esDynamicConfig() {
     return mergeConfig(baseConfig, {
         build: {
-            outDir: `${distName}/esChunked`,
+            outDir: `${distName}/esDynamic`,
             minify: true,
             sourcemap: true,
             cssMinify: true,
@@ -105,7 +104,7 @@ function npmBundleConfig() {
     const config = mergeConfig(baseConfig, {
         build: {
             lib: {
-                fileName: 'esInline/ramp.bundle.es',
+                fileName: 'ramp.bundle.es',
                 formats: ['es']
             },
             rollupOptions: {
@@ -156,10 +155,10 @@ export default defineConfig(viteConfig => {
     if (command === 'build') {
         if (mode === 'npm') {
             return npmBundleConfig();
-        } else if (mode === 'esChunk') {
-            return esChunkConfig();
-        } else if (mode === 'esInline') {
-            return esInlineConfig();
+        } else if (mode === 'esDynamic') {
+            return esDynamicConfig();
+        } else if (mode === 'inline') {
+            return inlineConfig();
         } else {
             return testBuildConfig();
         }


### PR DESCRIPTION
### Related Item(s)
#2389

### Changes
- [REFACTOR] Moved files from `dist/lib` to `dist` and created a new folder `esDynamic`
- [FIX] Removed `.prod` file versions, they are now all prod with sourcemaps for debugging.
- [FIX] Point cdn to serve from `esDynamic` by default

### Notes
`esDynamic` supports on demand asset loading, so libraries like `ag-grid` (not yet) and `fabric` (in PR) are not pulled down until the user needs them. It's similar to `assets` in the `demos` folder but it has static entry file names `ramp.js` and `ramp.css` (instead of `main-3dgfd78s87.js`) as well as sourcemaps.

Instead of both `ramp.browser.iife.js` and `ramp.browser.iife.prod.js` there's just `ramp.browser.iife.js` which is the prod version. Sourcemaps are now generated instead for debugging. Ditto for the inline es build.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Open any sample to see if it loads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2397)
<!-- Reviewable:end -->
