### PR TITLE
QA - appropriately disable layer settings controls

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -290,9 +290,19 @@ let config = {
                     url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=1000&province__province=on',
                     xyInAttribs: true,
                     colour: '#55ffff',
+                    controls: ['visibility', 'opacity', 'settings'],
+                    state: {
+                        opacity: 0.8,
+                        visibility: false,
+                        identify: true
+                    },
                     fixtures: {
                         details: {
                             template: 'WFSLayer-Custom'
+                        },
+                        settings: {
+                            controls: ['opacity', 'identify'],
+                            disabledControls: ['visibility']
                         }
                     },
                     fieldMetadata: {
@@ -309,12 +319,33 @@ let config = {
                 },
                 {
                     id: 'TerritoriesPoly',
+                    controls: ['visibility', 'settings'],
+                    disabledControls: ['identify'],
+                    state: {
+                        opacity: 0.4,
+                        visibility: true,
+                        identify: false
+                    },
+                    fixtures: {
+                        settings: {}
+                    },
                     layerType: 'esri-feature',
                     url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/SupportData/MapServer/3',
                     permanentFilteredQuery: `Name = 'Nunavut' OR Name = 'Northwest Territories' OR Name = 'Yukon Territory'`
                 },
                 {
                     id: 'BasinLine',
+                    controls: ['identify', 'opacity', 'settings'],
+                    state: {
+                        opacity: 0,
+                        visibility: true,
+                        identify: true
+                    },
+                    fixtures: {
+                        settings: {
+                            controls: ['visibility']
+                        }
+                    },
                     layerType: 'esri-feature',
                     url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/CESI/MapServer/2',
                     permanentFilteredQuery: `OBJECTID > 80`

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -34,12 +34,12 @@ export class FixtureAPI extends APIScope {
 
     /**
      * Returns whether a given fixture exists.
-     * 
+     *
      * @param {string} id the fixture ID to be checked
      * @returns {boolean} whether the fixture identified by 'id' exists
      * @memberof FixtureAPI
      */
-    exists(id: string) : boolean {
+    exists(id: string): boolean {
         return id in useFixtureStore(this.$vApp.$pinia).items;
     }
 

--- a/src/fixtures/settings/screen.vue
+++ b/src/fixtures/settings/screen.vue
@@ -78,7 +78,10 @@
                         @toggled="updateIdentify"
                         :config="{
                             value: identifyModel,
-                            disabled: !controlAvailable(LayerControl.Identify)
+                            disabled: !(
+                                controlAvailable(LayerControl.Identify) &&
+                                props.layer.supportsIdentify
+                            )
                         }"
                         :ariaLabel="t('settings.label.identify')"
                     ></settings-component>
@@ -169,6 +172,19 @@ watchers.push(
 );
 
 onMounted(() => {
+    // testing code
+    console.log('layer');
+    console.log(props.layer);
+    console.log(`value of supportsIdentify: ${props.layer.supportsIdentify}`);
+    console.log(
+        `identify control available? ${controlAvailable(LayerControl.Identify)}`
+    );
+    console.log(
+        `opacity control available? ${controlAvailable(LayerControl.Opacity)}`
+    );
+    console.log(
+        `visibility control avalable? ${controlAvailable(LayerControl.Visibility)}`
+    );
     loadLayerProperties();
 
     handlers.push(
@@ -232,12 +248,12 @@ const controlAvailable = (control: LayerControl): boolean => {
         props.layer.id
     );
 
-    // check disabled controls, then controls
-    return settingsConfig?.disabledControls?.includes(control)
-        ? false
-        : settingsConfig?.controls
-          ? settingsConfig?.controls?.includes(control)
-          : true;
+    // if a settings fixture config exists for the bounded layer, use it to determine the control's availability.
+    // Otherwise, use the controls/disabledControls configuration from the bound layer
+    return settingsConfig &&
+        (settingsConfig.controls || settingsConfig.disabledControls)
+        ? iApi.geo.shared.controlAvailable(control, settingsConfig)
+        : props.layer.controlAvailable(control);
 };
 
 /**

--- a/src/geo/api/utils/shared-utils.ts
+++ b/src/geo/api/utils/shared-utils.ts
@@ -1,4 +1,4 @@
-import type { ArcGisServerUrl, UrlQueryMap } from '@/geo/api';
+import type { ArcGisServerUrl, UrlQueryMap, LayerControl } from '@/geo/api';
 import deepmerge from 'deepmerge';
 
 export class SharedUtilsAPI {
@@ -128,6 +128,27 @@ export class SharedUtilsAPI {
         }
 
         return result;
+    }
+    /**
+     * Determines whether the provided control is enabled for the bound layer, based on the config provided
+     * @param control the control we want to determine the availability of
+     * @param config an object containing information regarding enabled/disabled controls for the bound layer
+     * @returns whether the control is available
+     */
+    controlAvailable(
+        control: LayerControl,
+        config:
+            | {
+                  controls?: Array<string>;
+                  disabledControls?: Array<string>;
+              }
+            | undefined
+    ): boolean {
+        return config?.disabledControls?.includes(control)
+            ? false
+            : config?.controls
+              ? config?.controls?.includes(control)
+              : true;
     }
 }
 

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -786,10 +786,6 @@ export class LayerInstance extends APIScope {
               }
             | undefined = this.$iApi.geo.layer.getLayerControls(this.id);
 
-        // check disabled controls first
-        if (controls?.disabledControls?.includes(control)) {
-            return false;
-        }
-        return controls?.controls.includes(control) ?? false;
+        return this.$iApi.geo.shared.controlAvailable(control, controls);
     }
 }


### PR DESCRIPTION
### Related Item(s)
#2263
QA PR of #2369

### Changes
- Correctly disable controls in layer settings based on controls array, as well as the `supportsIdentify` prop wrt the identify control

### QA Testing
Please test using the demo links in the first comment.

### Testing
Steps:
1. Open classic sample 1 
2. Click F12 to open the console
3. Click the 'more settings' button of the `WFSLayer` layer to open its settings panel
4. Observe that the visibility toggle is disabled. This corresponds with the fact that `visibility` is in the `disabledControls` array of the settings config
5. Go back to the legend and click the 'more settings' button of the `TerritoriesPoly` layer to open its settings panel
6. Observe that the identify toggle is disabled. This corresponds with the fact that the settings config exists but the `disabledControls` and `controls` arrays are not defined, and `identify` is in the `disabledControls` array for this layer. Also observe that the opacity slider is disabled, because the `controls` array does not contain `opacity` for this layer
7. Go back to the legend and click the 'more settings' button of the `BasinLine` layer to open its settings panel
8. Observe that the identify toggle and the opacity slider is disabled. This corresponds with the fact that only the `controls`  array is defined in the settings config, and it only contains `visibility`
9. Paste the following script into the console to create a new layer: 
```
const coulson = {
  "name": "Sand Pond National Wildlife Area",
  "controls": ['visibility', 'settings'],
  "disabledControls": ['opacity'],
  "nameField": "NAME_E",  
  "permanentFilteredQuery": "Zone_ID=730011100",
  "fixtures": {
    "settings" : {
         "disabledControls": []
     },  
    "grid": {        
      "columns": [
        {
          "field": "NAME_E"
        }
      ]
    },   
  },
  "id": "1",
  "url": "https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CWS_SCF/CPCAD/MapServer/0",  
  "layerType": "esri-feature"
}

const lay = debugInstance.geo.layer.createLayer(coulson);
debugInstance.geo.map.addLayer(lay).then(()=> { 
  debugInstance.event.emit('user/layeradded', lay);
});
```
10. Open the 'more settings' button of this new layer
11. Observe that all three controls of the settings fixture (`visibility`, `opacity` and `identify`) are all enabled. This is because the setting config is defined, the `disabledControls` array is empty and the `controls` array is not defined

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2399)
<!-- Reviewable:end -->
