### PR TITLE
Layerid on Identify Result

### DIFF
--- a/docs/api-guides/layers.md
+++ b/docs/api-guides/layers.md
@@ -430,9 +430,10 @@ Options parameter object, with descriptions following:
 
 The result object of `runIdentify()` is on the fancy side, as there are a few levels identify acts upon. The topmost array of results has an entry for each logical layer involved, including:
 
-- The `uid` of the logical layer
-- A request timestamp (`requestTime`)
-- An array of individual hits (`items`) for the logical layer
+- The `uid` of the logical layer.
+- The `layerId` (i.e. the `id` property value) of the logical layer.
+- A request timestamp (`requestTime`).
+- An array of individual hits (`items`) for the logical layer.
 - A loaded flag (`loaded`) to indicate if `items` has been populated.
 - A promise (`loading`) that resolves when `items` has been populated.
 - A flag to indicate if the identify request failed (`errored`).
@@ -453,6 +454,7 @@ The objects in the `items` array manage each result. To limit lots of potential 
 [
     {
         uid,
+        layerId,
         loaded,
         loading,
         errored,

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -1,9 +1,4 @@
-import {
-    AttribLayer,
-    FixtureInstance,
-    LayerInstance,
-    ReactiveIdentifyFactory
-} from '@/api';
+import { FixtureInstance, LayerInstance, ReactiveIdentifyFactory } from '@/api';
 import type { IdentifyItem, IdentifyResult } from '@/api';
 import type { Graphic, IdentifyResultFormat } from '@/geo/api';
 import { DetailsItemInstance, useDetailsStore } from '../store';
@@ -65,9 +60,10 @@ export class DetailsAPI extends FixtureInstance {
      * If panel open and incoming data is what is currently shown, panel closes.
      * The `open` parameter can override the behavior.
      * featureData payload (can be empty if forcing closed)
-     * - uid    : uid string of the layer hosting the feature
-     * - format : structure of the data. IdentifyResultFormat value.
-     * - data   : source information for the feature. Analogous to the data property of an IdentifyItem
+     * - uid     : uid string of the layer hosting the feature
+     * - format  : structure of the data. IdentifyResultFormat value.
+     * - data    : source information for the feature. Analogous to the data property of an IdentifyItem
+     * - layerId : optional layerId string of the layer hosting the feature. Will be looked up if not provided
      *
      * @param {{data: any, uid: string, format: IdentifyResultFormat}} featureData
      * @param {boolean | undefined} open can force the panel to open (true) or close (false) regardless of current panel state
@@ -77,6 +73,7 @@ export class DetailsAPI extends FixtureInstance {
         featureData: {
             data: any;
             uid: string;
+            layerId?: string;
             format: IdentifyResultFormat;
         },
         open: boolean | undefined
@@ -132,6 +129,7 @@ export class DetailsAPI extends FixtureInstance {
                 )
             ],
             uid: featureData.uid,
+            layerId: featureData.layerId || layer?.id || 'error-not-found',
             loading: Promise.resolve(),
             loaded: true,
             errored: false,

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -130,13 +130,15 @@ export class FeatureLayer extends AttribLayer {
                 this.tooltipField =
                     this.origRampConfig.tooltipField || this.nameField;
 
-            this.$iApi.geo.attributes.applyFieldMetadata(
-                this,
-                this.origRampConfig.fieldMetadata
-            );
-            this.attribs.attLoader.updateFieldList(this.fieldList);
-            this.attribs.attLoader.updateFieldsToTrim(this.getFieldsToTrim());
-        }
+                this.$iApi.geo.attributes.applyFieldMetadata(
+                    this,
+                    this.origRampConfig.fieldMetadata
+                );
+                this.attribs.attLoader.updateFieldList(this.fieldList);
+                this.attribs.attLoader.updateFieldsToTrim(
+                    this.getFieldsToTrim()
+                );
+            }
         });
 
         const pFC = this.$iApi.geo.layer
@@ -178,6 +180,7 @@ export class FeatureLayer extends AttribLayer {
             loaded: false,
             errored: false,
             uid: this.uid,
+            layerId: this.id,
             requestTime: Date.now()
         });
 

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -262,6 +262,7 @@ export class FileLayer extends AttribLayer {
             loaded: false,
             errored: false,
             uid: this.uid,
+            layerId: this.id,
             requestTime: Date.now()
         });
 

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -523,6 +523,7 @@ export class MapImageLayer extends MapLayer {
                 loaded: false,
                 errored: false,
                 uid: sublayer.uid,
+                layerId: sublayer.id,
                 requestTime: Date.now()
             });
 

--- a/src/geo/layer/support/identify.ts
+++ b/src/geo/layer/support/identify.ts
@@ -134,6 +134,11 @@ export interface IdentifyResult {
     uid: string;
 
     /**
+     * Layer Id of the logical layer the result came from
+     */
+    layerId: string;
+
+    /**
      * Indicates if the list of results have been identified.
      * This means items is populated. Each item will need to have details loaded as needed.
      */

--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -211,6 +211,7 @@ export class WmsLayer extends MapLayer {
             loaded: false,
             errored: false,
             uid: this.uid,
+            layerId: this.id,
             requestTime: Date.now()
         });
 


### PR DESCRIPTION
### Related Item(s)
#2402

### Changes
- Adds the layer id to the identify result object

### Notes

Nothing in the RAMP core uses this new property. It's only added to make things nicer for external code listening to identify events.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Console script

```js
debugInstance.event.on('map/identify', identifyResult => {
    console.group('Identify id results');
    identifyResult.results.forEach(layerResults => console.log(layerResults.layerId))
    console.groupEnd();
});
```

Steps:
1. Open a sample with some identifiable layers. Enhanced Sample 7 is a good one.
2. Mash `F12` and paste the above script into the console. Run it.
3. Click on the map to run an identify.
4. Look at the console output. Should see the layer ids being displayed after each click. Should not see empty strings or error strings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2405)
<!-- Reviewable:end -->
