### PR TITLE
Restore respect to export CSS

### DIFF
--- a/src/components/panel-stack/panel-container.vue
+++ b/src/components/panel-stack/panel-container.vue
@@ -11,6 +11,7 @@
         <!-- only perform transition on screen components that are not loaded yet; if already loaded, switch right away -->
         <transition @before-leave="beforeLeave" @leave="leave" @enter="enter">
             <component
+                class="h-full"
                 :is="panel.route.screen"
                 v-bind="panel.route.props"
                 :panel="panel"


### PR DESCRIPTION
### Related Item(s)
#2407

### Changes
- [FIX] Fixed the export panel content overflowing its container

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps:
1. Open the export panel.
2. Attempt to make the vertical screen size smaller.
3. Ensure that everything looks respectful.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2408)
<!-- Reviewable:end -->
