### PR TITLE
Change names of lambert base maps

### DIFF
--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -193,7 +193,7 @@
                                 tileSchemas: [
                                     {
                                         id: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
-                                        name: 'Lambert Maps',
+                                        name: 'Canada Lambert Maps',
                                         extentSetId: 'EXT_NRCAN_Lambert_3978',
                                         lodSetId: 'LOD_NRCAN_Lambert_3978',
                                         thumbnailTileUrls: [
@@ -223,7 +223,7 @@
                                 basemaps: [
                                     {
                                         id: 'baseNrCan',
-                                        name: 'Canada Base Map - Transportation (CBMT)',
+                                        name: 'Topographic Basemap',
                                         description:
                                             'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
                                         altText:
@@ -240,7 +240,7 @@
                                     },
                                     {
                                         id: 'baseSimple',
-                                        name: 'Canada Base Map - Simple',
+                                        name: 'Simple Basemap',
                                         description: 'Canada Base Map - Simple',
                                         altText: 'Canada base map - Simple',
                                         layers: [
@@ -255,7 +255,7 @@
                                     },
                                     {
                                         id: 'baseCBME_CBCE_HS_RO_3978',
-                                        name: 'Canada Base Map - Elevation (CBME)',
+                                        name: 'Elevation (CBME) Basemap',
                                         description:
                                             'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
                                         altText:
@@ -272,7 +272,7 @@
                                     },
                                     {
                                         id: 'baseCBMT_CBCT_GEOM_3978',
-                                        name: 'Canada Base Map - Transportation (CBMT)',
+                                        name: 'Transportation (CBMT) Basemap',
                                         description:
                                             ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
                                         altText:


### PR DESCRIPTION
### Related Item(s)
#2253

### Changes
- Changed title of Lambert group from 'Lambert Maps' To 'Canada Lambert Maps'
- Removed 'Canada base map - ' from the titles of the Lambert base maps
- Changed the name of the labelled 'Transportation (CBMT)' Lambert base map to 'Topographic Basemap'

### Notes
- The changes I made were only in the `en` config of `enhanced-samples.html`. Once we have finalized the basemap names, I can include them in the other configs as well

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open the happy sample
2. Open the basemap panel
3. Observe the name/title changes listed above
