### PR TITLE
GeoJson WKT Support

### DIFF
--- a/demos/enhanced-scripts/008-projection-party.js
+++ b/demos/enhanced-scripts/008-projection-party.js
@@ -20,12 +20,22 @@ const runPreTest = (config, options, utils) => {
     };
 
     const yarmouth = {
-        id: 'gjFancy',
-        name: 'GeoJson Great Lakes Albers',
+        id: 'gjFancyCRS',
+        name: 'GeoJson CRS Great Lakes Albers',
         layerType: 'file-geojson',
         url: '../file-layers/yarmouth.json',
         caching: true,
         colour: '#FF8C00',
+        nameField: 'name'
+    };
+
+    const duffers = {
+        id: 'gjFancyWKT',
+        name: 'GeoJson WKT Great Lakes Albers',
+        layerType: 'file-geojson',
+        url: '../file-layers/duffers.json',
+        caching: true,
+        colour: '#008CAA',
         nameField: 'name'
     };
 
@@ -56,6 +66,7 @@ const runPreTest = (config, options, utils) => {
     utils.addLayerLegend(lambertFL);
     utils.addLayerLegend(happy);
     utils.addLayerLegend(yarmouth);
+    utils.addLayerLegend(duffers);
 
     return { config, options };
 };

--- a/public/file-layers/duffers.json
+++ b/public/file-layers/duffers.json
@@ -1,0 +1,22 @@
+{
+  "type": "FeatureCollection",
+  "crs": {
+    "type": "name",
+    "properties": {
+      "name": "PROJCS[\"NAD83 / Great Lakes Albers\",GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\",SPHEROID[\"GRS 1980\",6378137,298.257222101],TOWGS84[0,0,0,0,0,0,0]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4269\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"latitude_of_center\",45.568977],PARAMETER[\"longitude_of_center\",-84.455955],PARAMETER[\"standard_parallel_1\",42.122774],PARAMETER[\"standard_parallel_2\",49.01518],PARAMETER[\"false_easting\",1000000],PARAMETER[\"false_northing\",1000000],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH],AUTHORITY[\"EPSG\",\"3174\"]]"
+    }
+  },
+  "features": [
+    {
+      "type": "Feature",
+      "properties": { "name": "4905 Duffers" },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1400729.1329429878,
+          813466.9383310359
+        ]
+      }
+    }
+  ]
+}

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -545,13 +545,43 @@ export interface UrlQueryMap {
     [name: string]: string;
 }
 
+/**
+ * Options for converting GeoJson to EsriJson
+ */
 export interface GeoJsonOptions {
+    /**
+     * Will use this layerid on the EsriJson
+     */
     layerId?: string;
+
+    /**
+     * Will use this colour in the basic default symbol
+     */
     colour?: string;
+
+    /**
+     * Any layer fieldMetadata configuration to apply
+     */
     fieldMetadata?: RampLayerFieldMetadataConfig;
-    sourceProjection?: string;
-    targetSR?: string | number | SpatialReference | Record<any, unknown>;
+
+    /**
+     * Projection of incoming GeoJson. If missing, will use geojson crs, LatLong if no crs.
+     */
+    sourceProjection?: string | number | SpatialReference;
+
+    /**
+     * Spatial Reference of output Esri Json geometry
+     */
+    targetSR?: string | number | SpatialReference;
+
+    /**
+     * Latitude field name if exists in the GeoJson. Typically from a CSV conversion. Ensures field gets encoded as a number.
+     */
     latField?: string;
+
+    /**
+     * Longitude field name if exists in the GeoJson. Typically from a CSV conversion. Ensures field gets encoded as a number.
+     */
     lonField?: string;
 }
 

--- a/src/geo/api/graphic/geometry/spatial-reference.ts
+++ b/src/geo/api/graphic/geometry/spatial-reference.ts
@@ -117,12 +117,20 @@ export class SpatialReference {
         }
     }
 
+    /**
+     * Parse the typical RAMP formats for spatial references into an RAMP SpatialReference object
+     * @param {SpatialReference | string | number} sr can be RAMP SpatialReference, WKID integer, WKT string, or ESPG:#### string
+     * @returns {SpatialReference} Spatial Reference object
+     */
     static parseSR(sr?: SrDef): SpatialReference {
         if (!sr) {
             // default to lat long if no SR is provided
             return SpatialReference.latLongSR();
         } else if (sr instanceof SpatialReference) {
             return sr.clone();
+        } else if (typeof sr === 'string' && sr.startsWith('EPSG:')) {
+            // convert epsg code to wkid
+            return new SpatialReference(parseInt(sr.substring(5).trim()));
         } else {
             // cheating typescript. this will pass a string wkt or number wkid
             return new SpatialReference(<any>sr);
@@ -162,7 +170,7 @@ export class SpatialReference {
     /**
      * Convert a GeoJSON styled co-ord reference to an EPSG styled string
      * @param {GeoJson.CoordinateReferenceSystem} crs GeoJSON crs object
-     * @returns {string} EPSG projection string, either EPSG code or wkt
+     * @returns {string} A proj4 friendly projection, in the form EPSG:#### or a WKT
      */
     static parseGeoJsonCrs(
         crs: GeoJson.CoordinateReferenceSystem | undefined

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -109,14 +109,10 @@ export class FileLayer extends AttribLayer {
         const opts: GeoJsonOptions = {
             layerId: this.origRampConfig.id || '',
             targetSR: this.$iApi.geo.map.getSR(),
-            ...(this.origRampConfig.latField && {
-                latField: this.origRampConfig.latField
-            }),
-            ...(this.origRampConfig.longField && {
-                lonField: this.origRampConfig.longField
-            }),
             colour: this.origRampConfig.colour,
-            fieldMetadata: this.origRampConfig.fieldMetadata
+            fieldMetadata: this.origRampConfig.fieldMetadata,
+            latField: this.origRampConfig.latField || '',
+            lonField: this.origRampConfig.longField || ''
         };
 
         this.esriJson = await this.$iApi.geo.layer.files.geoJsonToEsriJson(


### PR DESCRIPTION
### Related Item(s)

#2410

### Changes
- Makes GeoJSON with WTK projection definition work
- Adds better support across Spatial Reference & Projection utils for all our supported projection formats (`SpatialReference`, WTK string, EPSG string, WKID integer).
- Fixed a lurking bug in our use of ESRI SR constructor
- Cleaned up missing / fibbing JS Docs

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 8 - Projection Party
2. Vanilla GeoJSON: Verify Happy is in the usual location in Northern Ontario.
3. CRS Code GeoJSON: Verify the point in the GeoJson CRS layer is in Yarmouth, Nova Scotia
4. WKT GeoJSON: Verify the point in the GeoJson WKT layer is at the Dufferin ECCC office.
