### PR TITLE
Identify Highlight Reactivity Fix

### DIFF
--- a/demos/starter-scripts/cam.js
+++ b/demos/starter-scripts/cam.js
@@ -11,6 +11,7 @@ let config = {
         'geosearch',
         'grid',
         'help',
+        'hilight',
         'layer-reorder',
         'legend',
         'mapnav',

--- a/schema.json
+++ b/schema.json
@@ -2514,15 +2514,7 @@
                             "$ref": "#/$defs/panelWidth"
                         },
                         "panelTeleport": {
-                            "type": "object",
-                            "properties": {
-                                "details-layers": {
-                                    "$ref": "#/$defs/panelTeleport"
-                                },
-                                "details-items": {
-                                    "$ref": "#/$defs/panelTeleport"
-                                }
-                            }
+                            "$ref": "#/$defs/panelTeleport"
                         }
                     },
                     "required": ["templates"]

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -20,6 +20,7 @@ import { useAppbarStore } from '@/fixtures/appbar/store';
 import { useGridStore } from '@/fixtures/grid/store';
 import { LayerState, LayerType } from '@/geo/api';
 import type {
+    BasemapChange,
     IdentifyResultFormat,
     MapClick,
     MapMove,
@@ -832,13 +833,15 @@ export class EventAPI extends APIScope {
 
             case DefEH.MAP_BASEMAP_CHECKS_TILE_PROJ:
                 // check for any tile layer projection mismatches when the basemap changes
-                zeHandler = () => {
-                    this.$iApi.geo.layer
-                        .allLayers()
-                        .filter(l => l.layerType === LayerType.TILE)
-                        .forEach(tl => {
-                            (tl as TileLayer).checkProj();
-                        });
+                zeHandler = (payload: BasemapChange) => {
+                    if (payload.schemaChanged) {
+                        this.$iApi.geo.layer
+                            .allLayers()
+                            .filter(l => l.layerType === LayerType.TILE)
+                            .forEach(tl => {
+                                (tl as TileLayer).checkProj();
+                            });
+                    }
                 };
                 this.$iApi.event.on(
                     GlobalEvents.MAP_BASEMAPCHANGE,

--- a/src/fixtures/details/api/details.ts
+++ b/src/fixtures/details/api/details.ts
@@ -31,7 +31,7 @@ export class DetailsAPI extends FixtureInstance {
         // Save the provided identify result in the store.
         this.detailsStore.payload = payload;
 
-        const panel = this.$iApi.panel.get('details-panel');
+        const panel = this.$iApi.panel.get('details');
         // Indicate this request for the details panel comes from clicking on the map
         this.detailsStore.origin = 'identify';
         panel.button.tooltip = 'details.layers.title.identifyOrigin';
@@ -46,10 +46,10 @@ export class DetailsAPI extends FixtureInstance {
         });
 
         // Open the details panel.
-        const detailsPanel = this.$iApi.panel.get('details-panel');
+        const detailsPanel = this.$iApi.panel.get('details');
         if (!detailsPanel.isOpen) {
             this.$iApi.panel.open({
-                id: 'details-panel'
+                id: 'details'
             });
         }
     }
@@ -78,7 +78,7 @@ export class DetailsAPI extends FixtureInstance {
         },
         open: boolean | undefined
     ): void {
-        const panel = this.$iApi.panel.get('details-panel');
+        const panel = this.$iApi.panel.get('details');
 
         if (open === false) {
             // close panel and run away. allows a close without providing featureData
@@ -155,8 +155,8 @@ export class DetailsAPI extends FixtureInstance {
             this.detailsStore.defaultTemplates = config.templates;
         }
 
-        this.handlePanelWidths(['details-panel']);
-        this.handlePanelTeleports(['details-panel']);
+        this.handlePanelWidths(['details']);
+        this.handlePanelTeleports(['details']);
 
         // get all layer fixture configs
         const layerDetailsConfigs: any = this.getLayerFixtureConfigs();

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -10,7 +10,7 @@ class DetailsFixture extends DetailsAPI {
     async added() {
         this.$iApi.panel.register(
             {
-                'details-panel': {
+                details: {
                     screens: {
                         'details-screen': markRaw(DetailsScreenV)
                     },
@@ -41,11 +41,11 @@ class DetailsFixture extends DetailsAPI {
             // console.log(`[fixture] ${this.id} removed`);
             unwatch();
 
-            this.$iApi.panel.remove('details-panel');
+            this.$iApi.panel.remove('details');
 
             if (this.$iApi.fixture.exists('appbar')) {
                 const appbarStore = useAppbarStore(this.$vApp.$pinia);
-                appbarStore.removeButton('details-panel');
+                appbarStore.removeButton('details');
             }
 
             const detailsStore = useDetailsStore(this.$vApp.$pinia);

--- a/src/fixtures/extentguard/index.ts
+++ b/src/fixtures/extentguard/index.ts
@@ -1,4 +1,5 @@
 import { Extent } from '@/geo/api';
+import type { BasemapChange } from '@/geo/api';
 import { ExtentguardAPI } from './api/extentguard';
 import { type ExtentguardConfig, useExtentguardStore } from './store';
 import { GlobalEvents } from '@/api';
@@ -98,7 +99,7 @@ class ExtentguardFixture extends ExtentguardAPI {
         // watch for basemap schema changes
         this.schemaEH = this.$iApi.event.on(
             GlobalEvents.MAP_BASEMAPCHANGE,
-            (payload: { basemapId: string; schemaChanged: boolean }) => {
+            (payload: BasemapChange) => {
                 if (payload.schemaChanged) {
                     // make sure new schema wants the fixture active
                     this.checkActive();

--- a/src/fixtures/overviewmap/overviewmap.vue
+++ b/src/fixtures/overviewmap/overviewmap.vue
@@ -68,7 +68,7 @@ import {
     ref
 } from 'vue';
 
-import type { Extent, RampBasemapConfig } from '@/geo/api';
+import type { BasemapChange, Extent, RampBasemapConfig } from '@/geo/api';
 import { GlobalEvents, InstanceAPI, OverviewMapAPI } from '@/api/internal';
 import { useOverviewmapStore } from './store';
 import { debounce } from 'throttle-debounce';
@@ -143,10 +143,7 @@ onMounted(() => {
         handlers.push(
             iApi.event.on(
                 GlobalEvents.MAP_BASEMAPCHANGE,
-                async (payload: {
-                    basemapId: string;
-                    schemaChanged: boolean;
-                }) => {
+                async (payload: BasemapChange) => {
                     if (!payload.schemaChanged && overviewMap.created) {
                         if (
                             activeBasemap.value &&

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -311,6 +311,9 @@ export const enum IdentifyResultFormat {
 // way they should be exposed from the main app as well (like, exported? in one of those .d.ts files?)?
 // same question probably applies to a number of other interfaces here.
 
+/**
+ * Event payload for a Map Click
+ */
 export interface MapClick {
     mapPoint: Point;
     screenX: number;
@@ -320,11 +323,29 @@ export interface MapClick {
     clickTime: number;
 }
 
+/**
+ * Event payload for a Map Move
+ */
 export interface MapMove {
     screenX: number;
     screenY: number;
     button: number;
     moveTime: number;
+}
+
+/**
+ * Event payload for a Basemap Change
+ */
+export interface BasemapChange {
+    /**
+     * New basemap id
+     */
+    basemapId: string;
+
+    /**
+     * True if new basemap caused the map schema to change
+     */
+    schemaChanged: boolean;
 }
 
 export interface LayerTimes {


### PR DESCRIPTION
### Related Item(s)

#2412

### Changes
- Restores original "active detail item" watcher in details panel
- Adds manual management of highlights for details list view
- Turns on hilighter in CAM sample
- Added a missing `.value` thing on a reactive boolean test. As is, it was always true since it just checked if the reactive object existed.
- Improves some code around Basemap Change events that should have only been running on schema change.
- Changes identify panel id to align with all other fixture panels. Cleans up lurking lies in the schema for identify teleport.

### Notes

I tried very hard to make the "list" view highlight refresh reactive as well, but there was just too much conflict & double triggering. The "active item" variable remains in play when in list view, and clicking the first item in the list view would not update the active item.  Same scenario trying to react to the "list bounds index" variables. Thrown into that is there was already manual updates to highlight when doing certain things.  So now its detail view === reactive update, list view === manual update.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Use the various Enhanced Samples (both single layer and multi layer), as well as Classic Sample 23 (CAM, has enough results to get the list paginator showing). Try the various behaviors listed below, try to observe respectful highlighting.
Sometimes its helpful to identify a cluster, then zoom in a bit (without re-identifying) so you can clearly see the highlights jumping around the map.

General

- Click single feature
- Click cluster of features
- Click somewhere that gives results for more than one layer
- Click a few identifies in a series.

In item detail view

- Click the forward / back paginator arrows to change the individual result
- Click the `Show List` button to flip to list view
- Close the panel

In list view

- Paginate. Observe the set of highlights updating (first draw on full pages may be slow).
- Click a list item to switch to its detail view
- Click the first list item to switch to its detail view (important since that item is secretly the active item)
- Close the panel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2414)
<!-- Reviewable:end -->
