### PR TITLE
Fix long names in details getting two tooltips

### DIFF
--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -22,10 +22,9 @@
                 v-if="data.loaded"
                 class="pl-3 text-left flex-grow itemName"
                 :content="itemName"
-                v-tippy="{ placement: 'right', allowHTML: true }"
                 v-html="makeHtmlLink(itemName)"
                 v-truncate="{
-                    options: { placement: 'right-end' }
+                    options: { placement: 'right' }
                 }"
                 :tabindex="inList ? -1 : 0"
             ></span>


### PR DESCRIPTION
### Related Item(s)
#2416 

### Changes
- [FIX] Fixed long names in the details panel getting two tooltips. Now, only long names will get a tooltip, whereas names that fit get nothing. Based on slack chat this approach is ok for accessibility.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
1. Open the details panel on your favourite sample.
2. Ensure that one tooltip is shown for long names.
3. Ensure that no tooltips are shown for short names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2423)
<!-- Reviewable:end -->
