### PR TITLE
Changed deferred promise from void to generic type

### DIFF
--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -888,8 +888,7 @@ const rInstance = createInstance(document.getElementById('app'), config, options
 //     rInstance.panel.pin('legend');
 // });
 
-rInstance.fixture.isLoaded('basemap').then(() => {
-    const bm = rInstance.fixture.get('basemap');
+rInstance.fixture.isLoaded('basemap').then(bm => {
     bm.persist = false;
 });
 

--- a/docs/api-guides/panels.md
+++ b/docs/api-guides/panels.md
@@ -427,7 +427,7 @@ i18n: {
 }
 ```
 * `updateHTML(panel: PanelInstance | string, html: { [key: string]: string | HTMLElement }, screenId?: string)` - Updates the content of a specific HTML-based screen of a panel, using HTML content 
-* `isRegistered(panelId: string | string[]): Promise<any>` - provides a promise that resolves when panels with the specified panel ID(s) have completed registration.
+* `isRegistered(panelId: string | string[]): Promise<PanelInstance | PanelInstance[]>` - provides a promise that resolves to the `PanelInstance` object (if `panelId` is a string) or the array of `PanelInstance` objects (if `panelId` is an array) when panel(s) with the specified panel ID(s) have completed registration.
 * `remove(value: string | PanelInstance): void` - removes the specified panel from the panel stack.
 * `get(value: string | PanelInstance): PanelInstance` - finds and returns the specified panel.
 * `open(value: string | PanelInstance | PanelInstancePath)` - opens the specified panel.

--- a/docs/using-ramp4/fixtures/custom-fixtures.md
+++ b/docs/using-ramp4/fixtures/custom-fixtures.md
@@ -7,8 +7,7 @@ This covers various ways to create fixtures.
 The fixture interface has one optional property: `persist`. This indicates whether the fixture should remain in the instance upon language change. Defaults to `true`. Note that if only one config is provided for all languages, the fixture will remain in the instance on language change, regardless of the value of the flag.
 Here is a code snippet that shows how to use this property:
 ```JS
-rInstance.fixture.isLoaded('basemap').then(() => {
-    const bm = rInstance.fixture.get('basemap');
+rInstance.fixture.isLoaded('basemap').then((bm) => {
     bm.persist = false;
 });
 rInstance.setLanguage('fr') // basemap fixture will be removed

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -196,17 +196,19 @@ export class FixtureAPI extends APIScope {
      * @param {(string | string[])} fixtureId the fixture ID(s) for which the promise is requested
      * @memberof FixtureAPI
      */
-    isLoaded(fixtureId: string | string[]): Promise<any> {
+    isLoaded<T extends string | string[]>(fixtureId: T): Promise<T extends string ? FixtureBase : FixtureBase[]> {
         const fixtureStore = useFixtureStore(this.$vApp.$pinia);
         // We first create loadPromises for fixtures that don't have one
-        const idsToCheck = Array.isArray(fixtureId) ? fixtureId : [fixtureId];
+        const idsToCheck: Array<string> = Array.isArray(fixtureId) ? fixtureId : [fixtureId];
         idsToCheck.forEach((id: string) => {
             if (fixtureStore.loadPromises[id] === undefined) {
                 fixtureStore.addLoadPromise(id);
             }
         });
         // Now, get all the promises and return
-        return Promise.all(fixtureStore.getLoadPromises(idsToCheck));
+        const proms = fixtureStore.getLoadPromises(idsToCheck);
+        // @ts-ignore I give up, TS is hopeless
+        return Array.isArray(fixtureId) ? Promise.all(proms) : proms[0];
     }
 
     /**

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -142,9 +142,11 @@ export class PanelAPI extends APIScope {
      * @param {(string | string[])} panelId the panel ID(s) for which the promise is requested
      * @memberof PanelAPI
      */
-    async isRegistered(panelId: string | string[]): Promise<void> {
+    async isRegistered<T extends string | string[]>(
+        panelId: T
+    ): Promise<T extends string ? PanelInstance : PanelInstance[]> {
         // We first need to create a registration promise for all panels that currently don't have one
-        const idsToCheck = Array.isArray(panelId) ? panelId : [panelId];
+        const idsToCheck: Array<string> = Array.isArray(panelId) ? panelId : [panelId];
         idsToCheck.forEach((id: string) => {
             if (this.panelStore.regPromises[id] === undefined) {
                 this.panelStore.addRegPromise(id);
@@ -152,9 +154,9 @@ export class PanelAPI extends APIScope {
         });
 
         // Wait for all promises
-        await Promise.all(this.panelStore.getRegPromises(idsToCheck));
-
-        // return nothing (stops a nonsense array from appearing in the result promise)
+        const proms = this.panelStore.getRegPromises(idsToCheck);
+        // @ts-ignore I give up, TS is hopeless
+        return Array.isArray(panelId) ? Promise.all(proms) : proms[0];
     }
 
     /**

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -549,7 +549,7 @@ const systemCols = ref<Set<string>>(new Set<string>());
 
 // manages fast incoming filter change events. Forces them to finish
 // in order to avoid race conditions
-const filterQueue = ref<Array<DefPromise>>([]);
+const filterQueue = ref<Array<DefPromise<void>>>([]);
 
 const onGridReady = (params: any) => {
     agGridApi.value = params.api;
@@ -1032,7 +1032,7 @@ const applyLayerFilters = async () => {
     // recent/accurate result. Would end up with the grid's store of "filtered oids" not
     // matching reality; would match the random order that calls resolved.
 
-    const thisFilterDef = new DefPromise();
+    const thisFilterDef = new DefPromise<void>();
     // we make a copy so any filters that come after do not change our local array.
     // this array does not contain thisFilterDef.
     const activeFilterPromises = filterQueue.value.slice().map(d => d.getPromise());

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -25,7 +25,7 @@ export class LegendItem extends APIScope {
     _children: Array<LegendItem> = []; // list of child legend items
     _parent?: LegendItem | undefined = undefined; // parent of legend item
 
-    _loadPromise: DefPromise; // deferred promise that resolves when legend item is loaded
+    _loadPromise: DefPromise<void>; // deferred promise that resolves when legend item is loaded
 
     _hidden: boolean; // indicates if item (and its children) should be hidden from the legend
     _expanded: boolean; // expanded state of item
@@ -52,7 +52,7 @@ export class LegendItem extends APIScope {
         this._parent = parent;
         this._children = [];
 
-        this._loadPromise = new DefPromise();
+        this._loadPromise = new DefPromise<void>();
 
         this._hidden = config.hidden ?? false;
         this._expanded = config.expanded ?? true;
@@ -359,7 +359,7 @@ export class LegendItem extends APIScope {
      */
     reload(): void {
         this._type = LegendType.Placeholder;
-        this._loadPromise = new DefPromise();
+        this._loadPromise = new DefPromise<void>();
     }
 
     /**

--- a/src/geo/api/utils/promise.ts
+++ b/src/geo/api/utils/promise.ts
@@ -15,10 +15,10 @@
 //
 // yes, yes, very bad and all -- show me a better solution and I'll consider it.
 
-export class DefPromise {
-    protected realPromise: Promise<void>;
+export class DefPromise<T> {
+    protected realPromise: Promise<T>;
 
-    resolveMe(): void {
+    resolveMe(v?: T): void {
         // i do nothing as i get overwritten;
     }
 
@@ -26,14 +26,16 @@ export class DefPromise {
         // i do nothing as i get overwritten;
     }
 
-    getPromise(): Promise<void> {
+    getPromise(): Promise<T> {
         return this.realPromise;
     }
 
     constructor() {
-        this.realPromise = new Promise((resolve, reject) => {
+        this.realPromise = new Promise<T>((resolve, reject) => {
             // we map the internal functions to our external methods, allowing outsiders to call them.
-            this.resolveMe = resolve;
+            this.resolveMe = (v?: T) => {
+                resolve(v!); // pretend v exists to shut TS
+            };
             this.rejectMe = reject;
         });
     }

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -43,7 +43,7 @@ export class CommonLayer extends LayerInstance {
 
     protected origRampConfig: RampLayerConfig;
 
-    protected loadDefProm: DefPromise; // a deferred promise that resolves when layer is fully ready and safe to use. for convenience of caller
+    protected loadDefProm: DefPromise<void>; // a deferred promise that resolves when layer is fully ready and safe to use. for convenience of caller
 
     /**
      * A boolean to track whether the promise is pending (false) or fulfilled/rejected (true)

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -134,7 +134,7 @@ export class FeatureLayer extends AttribLayer {
             return [];
         }
 
-        const dProm = new DefPromise();
+        const dProm = new DefPromise<void>();
 
         const result: IdentifyResult = reactive({
             items: [],

--- a/src/geo/layer/file-layer.ts
+++ b/src/geo/layer/file-layer.ts
@@ -216,7 +216,7 @@ export class FileLayer extends AttribLayer {
             return [];
         }
 
-        const dProm = new DefPromise();
+        const dProm = new DefPromise<void>();
 
         const result: IdentifyResult = reactive({
             items: [],

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -456,7 +456,7 @@ export class MapImageLayer extends MapLayer {
 
         // loop over active sublayers. call query on each and generate an IdentifyItem to track it
         return activeSublayers.map(sublayer => {
-            const dProm = new DefPromise();
+            const dProm = new DefPromise<void>();
             const qOpts: QueryFeaturesParams = {};
 
             const result: IdentifyResult = reactive({

--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -19,7 +19,7 @@ export class MapLayer extends CommonLayer {
     // used to manage debouncing when applying filter updates against a layer. Private! but needs to be seen by FCs.
     _lastFilterUpdate = '';
 
-    protected viewDefProm: DefPromise; // a deferred promise that resolves when a layer view has been created on the map. helps bridge the view handler with the layer load handler
+    protected viewDefProm: DefPromise<void>; // a deferred promise that resolves when a layer view has been created on the map. helps bridge the view handler with the layer load handler
 
     esriWatches: Array<__esri.WatchHandle>;
 

--- a/src/geo/layer/support/identify.ts
+++ b/src/geo/layer/support/identify.ts
@@ -85,7 +85,7 @@ export class ReactiveIdentifyFactory {
         // The method params also use the same secret reference, allowing the
         // layer to not fall under reactive().
 
-        const sneakyDeferred = new DefPromise();
+        const sneakyDeferred = new DefPromise<void>();
 
         const vanillaItem: IdentifyItem = {
             format: IdentifyResultFormat.ESRI,

--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -191,7 +191,7 @@ export class WmsLayer extends MapLayer {
 
         // TODO prolly need to flush out the config interfaces for this badboy
 
-        const dProm = new DefPromise();
+        const dProm = new DefPromise<void>();
 
         const result: IdentifyResult = reactive({
             items: [],

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -46,7 +46,7 @@ export class CommonMapAPI extends APIScope {
      * Internal deferred managing the view promise
      * @private
      */
-    protected _viewPromise: DefPromise;
+    protected _viewPromise: DefPromise<void>;
 
     /**
      * A promise that resolves when the map view has been created

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -440,7 +440,7 @@ export class MapAPI extends CommonMapAPI {
             const center = this.getExtent().center();
             const scale = this.getScale();
 
-            this._viewPromise = new DefPromise();
+            this._viewPromise = new DefPromise<void>();
             this.created = false;
             this.$iApi.event.emit(GlobalEvents.MAP_REFRESH_START);
             this.destroyMapView();

--- a/src/stores/fixture/fixture-store.ts
+++ b/src/stores/fixture/fixture-store.ts
@@ -5,9 +5,9 @@ import { markRaw, ref } from 'vue';
 
 export const useFixtureStore = defineStore('fixture', () => {
     const items = ref<{ [name: string]: FixtureBase }>({});
-    const loadPromises = ref<{ [name: string]: DefPromise }>({});
+    const loadPromises = ref<{ [name: string]: DefPromise<FixtureBase> }>({});
 
-    function getLoadPromises(fixtureIds: string[]): Promise<void>[] {
+    function getLoadPromises(fixtureIds: string[]): Promise<FixtureBase>[] {
         return fixtureIds.map(id => loadPromises.value[id].getPromise());
     }
 
@@ -15,14 +15,14 @@ export const useFixtureStore = defineStore('fixture', () => {
         items.value = { ...items.value, [value.id]: markRaw(value) };
         // since fixture has successfully loaded, resolve its associated load promise
         if (!(value.id in loadPromises.value)) {
-            const loadPromise = new DefPromise();
-            loadPromise.resolveMe();
+            const loadPromise = new DefPromise<FixtureBase>();
+            loadPromise.resolveMe(markRaw(value));
             loadPromises.value = {
                 ...loadPromises.value,
                 [value.id]: loadPromise
             };
         } else {
-            loadPromises.value[value.id].resolveMe();
+            loadPromises.value[value.id].resolveMe(markRaw(value));
         }
         // call the `added` life hook if available
         if (typeof value.added === 'function') {
@@ -44,7 +44,7 @@ export const useFixtureStore = defineStore('fixture', () => {
     function addLoadPromise(fixtureId: string) {
         loadPromises.value = {
             ...loadPromises.value,
-            [fixtureId]: new DefPromise()
+            [fixtureId]: new DefPromise<FixtureBase>()
         };
     }
 

--- a/src/stores/panel/panel-state.ts
+++ b/src/stores/panel/panel-state.ts
@@ -17,7 +17,7 @@ export interface PanelState {
      * @type {{ [name: string]: DefPromise }}
      * @memberof PanelState
      */
-    regPromises: { [name: string]: DefPromise };
+    regPromises: { [name: string]: DefPromise<PanelInstance> };
 
     /**
      * A list of all panels in the arrangement they would be put on screen.


### PR DESCRIPTION
### Related Item(s)
#2334

### Changes
- The `DefPromise` class now accepts any type, instead of being restricted to `void`.
- The `FixtureAPI.isLoaded(fixtureIds)` method now resolves to the array of fixtures requested, instead of being `void`. This prevents needing to fetch the fixture via `FixtureAPI.get(fixtureId)` after the promise has resolved.
- The `PanelAPI.isRegistered(panelIds)` method now resolves to the array of panels requested, instead of being `void`. This prevents needing to fetch the fixture via `PanelAPI.get(panelId)` after the promise has resolved.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
A general sanity test to ensure nothing broke would be good. Here is a console script you can use as well on your favourite sample:
```JS
debugInstance.fixture.isLoaded('grid').then((grid) => {
    console.log(grid);
});

debugInstance.panel.isRegistered(['legend', 'basemap', 'wizard']).then(([legend, basemap, wizard]) => {
    legend.open()
    basemap.open()
    wizard.open()
});

debugInstance.panel.isRegistered(['grouse']).then(([grouse]) => {
    console.log('muhahahaha') // this should never run (unless you added a panel with id of grouse)
});
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2434)
<!-- Reviewable:end -->
