### PR TITLE
npm pub patch, ver unbump

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -25,6 +25,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   path: ramp
+                  registry-url: 'https://registry.npmjs.org'
 
             - uses: actions/setup-node@v4
               with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp-pcar",
-    "version": "4.9.1",
+    "version": "4.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-pcar",
-            "version": "4.9.1",
+            "version": "4.9.0",
             "dependencies": {
                 "@ag-grid-community/locale": "~32.0.0",
                 "@arcgis/core": "4.29.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ramp-pcar",
-    "version": "4.9.1",
+    "version": "4.9.0",
     "description": "RAMP4 - The Reusable Accessible Mapping Platform, is a Javascript based web mapping platform that provides a reusable, responsive and WCAG 2.1 AA compliant common viewer for the Government of Canada. ",
     "type": "module",
     "module": "./dist/ramp.bundle.es.js",


### PR DESCRIPTION
### Changes
- Script fix to allow tag to publish to NPM
- Version unbump back to `4.9.0`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2441)
<!-- Reviewable:end -->
