### PR TITLE
Fix multiple WAVE issues

### DIFF
--- a/src/fixtures/basemap/item.vue
+++ b/src/fixtures/basemap/item.vue
@@ -14,7 +14,7 @@
                     :class="!basemap.hideThumbnail ? 'h-180' : 'h-30'"
                 >
                     <!-- text-only mode -->
-                    <img v-if="basemap.hideThumbnail" class="w-full h-30" />
+                    <div v-if="basemap.hideThumbnail" class="w-full h-30 hidden" />
                     <!-- Else if, use basemap thumbnail url -->
                     <img
                         v-else-if="basemap.thumbnailUrl"

--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -1,36 +1,38 @@
 <template>
-    <panel-screen :panel="panel" :footer="true">
-        <template #header> {{ t('export.title') }} </template>
+    <div ref="componentEl">
+        <panel-screen :panel="panel" :footer="true">
+            <template #header> {{ t('export.title') }} </template>
 
-        <template #content>
-            <div class="overflow-hidden border border-gray-200" ref="el">
-                <canvas class="export-canvas !w-[100%]"></canvas>
-            </div>
-        </template>
+            <template #content>
+                <div class="overflow-hidden border border-gray-200">
+                    <canvas class="export-canvas !w-[100%]"></canvas>
+                </div>
+            </template>
 
-        <template #footer>
-            <div class="flex">
-                <button
-                    type="button"
-                    @click="fixture?.export()"
-                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-4 sm:px-16 mr-8 sm:mr-16"
-                    :aria-label="t('export.download')"
-                >
-                    {{ t('export.download') }}
-                </button>
+            <template #footer>
+                <div class="flex">
+                    <button
+                        type="button"
+                        @click="fixture?.export()"
+                        class="bg-green-700 hover:bg-green-800 text-white font-bold py-8 px-4 sm:px-16 mr-8 sm:mr-16"
+                        :aria-label="t('export.download')"
+                    >
+                        {{ t('export.download') }}
+                    </button>
 
-                <button type="button" @click="make()" class="py-8 px-4 sm:px-16" :aria-label="t('export.refresh')">
-                    {{ t('export.refresh') }}
-                </button>
+                    <button type="button" @click="make()" class="py-8 px-4 sm:px-16" :aria-label="t('export.refresh')">
+                        {{ t('export.refresh') }}
+                    </button>
 
-                <export-settings
-                    v-if="!hasCustomRenderer"
-                    :componentSelectedState="selectedComponents"
-                    class="ml-auto flex px-4 sm:px-8"
-                ></export-settings>
-            </div>
-        </template>
-    </panel-screen>
+                    <export-settings
+                        v-if="!hasCustomRenderer"
+                        :componentSelectedState="selectedComponents"
+                        class="ml-auto flex px-4 sm:px-8"
+                    ></export-settings>
+                </div>
+            </template>
+        </panel-screen>
+    </div>
 </template>
 
 <script setup lang="ts">
@@ -60,7 +62,7 @@ const fixture = ref<ExportAPI>();
 const resizeObserver = ref<ResizeObserver | undefined>(undefined);
 const watchers = ref<Array<Function>>([]);
 
-const el = useTemplateRef('el');
+const el = useTemplateRef('componentEl');
 const componentSelectedState = computed(() => exportStore.componentSelectedState);
 const selectedComponents = computed<any>(() => {
     let state: any = {};
@@ -89,6 +91,7 @@ const make = debounce(300, () => {
     }
 
     const canvasElement = el.value!.querySelector('.export-canvas') as HTMLCanvasElement;
+
     fixture.value.make(canvasElement, el.value!.clientWidth);
 });
 

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -28,7 +28,7 @@
                 role="button"
                 :aria-label="t('legend.layer.controls.metadata')"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="setting-svg" viewBox="0 0 23 21">
                     <path
                         d="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"
                     />
@@ -46,7 +46,7 @@
                 role="button"
                 :aria-label="t('legend.layer.controls.settings')"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="setting-svg" viewBox="0 0 23 21">
                     <g>
                         <path
                             d="M 3,17L 3,19L 9,19L 9,17L 3,17 Z M 3,5L 3,7L 13,7L 13,5L 3,5 Z M 13,21L 13,19L 21,19L 21,17L 13,17L 13,15L 11,15L 11,21L 13,21 Z M 7,9L 7,11L 3,11L 3,13L 7,13L 7,15L 9,15L 9,9L 7,9 Z M 21,13L 21,11L 11,11L 11,13L 21,13 Z M 15,9L 17,9L 17,7L 21,7L 21,5L 17,5L 17,3L 15,3L 15,9 Z "
@@ -66,7 +66,7 @@
                 role="button"
                 :aria-label="t('legend.layer.controls.datatable')"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="setting-svg" viewBox="0 0 23 21">
                     <path
                         d="M 4.00002,3L 20,3C 21.1046,3 22,3.89543 22,5L 22,20C 22,21.1046 21.1046,22 20,22L 4.00001,22C 2.89544,22 2.00001,21.1046 2.00001,20L 2.00002,5C 2.00002,3.89543 2.89545,3 4.00002,3 Z M 4.00002,7L 4.00001,10L 8,10L 8,7.00001L 4.00002,7 Z M 10,7.00001L 9.99999,10L 14,10L 14,7.00001L 10,7.00001 Z M 20,10L 20,7L 16,7.00001L 16,10L 20,10 Z M 4.00002,12L 4.00002,15L 8,15L 8,12L 4.00002,12 Z M 4.00001,20L 8,20L 8,17L 4.00002,17L 4.00001,20 Z M 9.99999,12L 9.99999,15L 14,15L 14,12L 9.99999,12 Z M 9.99999,20L 14,20L 14,17L 9.99999,17L 9.99999,20 Z M 20,20L 20,17L 16,17L 16,20L 20,20 Z M 20,12L 16,12L 16,15L 20,15L 20,12 Z "
                     />
@@ -84,7 +84,7 @@
                 role="button"
                 :aria-label="t('legend.layer.controls.symbology')"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="setting-svg" viewBox="0 0 23 21">
                     <path
                         d="M11.99 18.54l-7.37-5.73L3 14.07l9 7 9-7-1.63-1.27-7.38 5.74zM12 16l7.36-5.73L21 9l-9-7-9 7 1.63 1.27L12 16z"
                     />
@@ -102,7 +102,7 @@
                 role="button"
                 :aria-label="t('legend.layer.controls.boundaryzoom')"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                <svg class="setting-svg" viewBox="0 0 24 24">
                     <path
                         d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
                     />
@@ -122,7 +122,7 @@
                 role="button"
                 :aria-label="t('legend.layer.controls.remove')"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 23 21">
+                <svg class="setting-svg" viewBox="0 0 23 21">
                     <path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"></path>
                 </svg>
                 {{ t('legend.layer.controls.remove') }}
@@ -149,7 +149,7 @@
                 role="button"
                 :aria-label="t('legend.layer.controls.reload')"
             >
-                <svg class="inline-block fill-current w-18 h-18 mr-10" viewBox="0 0 24 24">
+                <svg class="setting-svg" viewBox="0 0 24 24">
                     <path
                         d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
                     ></path>
@@ -301,6 +301,14 @@ const getFixtureExists = (fixtureName: string): boolean => {
 
 <style lang="scss" scoped>
 .disabled {
-    @apply text-gray-400 cursor-default;
+    @apply text-neutral-500 cursor-default;
+}
+.setting-svg {
+    margin-bottom: 5px;
+    display: inline-block;
+    fill: currentColor;
+    width: 18px;
+    height: 18px;
+    margin-right: 10px;
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
Issues:
#2437 
#2429 
#2428 

### Changes
- [FIX] Fix WAVE issues in export download button, disabled legend menu items, and basemap items without images
- [FIX] Align legend item settings icons so they aren't slightly below where they should be

### Notes

Settings before aligning and WAVE fixing:
<img width="285" alt="image" src="https://github.com/user-attachments/assets/6ec49b23-68c3-4f56-9567-9ddc8afed6a6">

Settings after aligning and WAVE fixing:
<img width="275" alt="image" src="https://github.com/user-attachments/assets/2f6db816-7507-4abe-988c-835cc40ba22c">


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

**Export download button**
1. Open the export panel, then open the WAVE tool.
2. There should no longer be a WAVE contrast error on the green download button.

**Disabled legend menu item**
1. On the first enhanced sample (happy), open the options menu for the first legend item, then open the WAVE tool.
2. There should no longer be a WAVE contrast error on the disabled settings option.
3. Also notice the icons are much better aligned with their corresponding text (before, each icon was slightly offset below the text).

**Basemap items without images**
1. On the first enhanced sample (happy), open the basemap selector and scroll down to the item without an image.
2. Open the WAVE tool.
3. There should no longer be a WAVE error on this item for not having alt text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2442)
<!-- Reviewable:end -->
