### PR TITLE
Prevent permanent highlight on MIL items

### DIFF
--- a/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/src/fixtures/layer-reorder/components/layer-component.vue
@@ -18,7 +18,7 @@
                     :class="`
                         mt-4
                         relative
-                        ${element.isExpanded ? 'bg-gray-200' : ''}
+                        ${element.isExpanded ? 'hover:bg-gray-200' : ''}
                         border-2
                         border-gray-300
                         default-focus-style
@@ -78,9 +78,9 @@
                         />
                     </div>
 
-                    <!-- display children of the parent layer -->
+                    <!-- display children of the parent layer. -->
                     <div
-                        class="items-center bg-gray-200 p-5 pl-30 default-focus-style cursor-pointer"
+                        class="items-center p-5 pl-30 default-focus-style cursor-pointer"
                         v-if="element.isExpanded && element.sublayers.length > 0"
                         v-focus-list
                     >


### PR DESCRIPTION
### Related Item(s)
#2385

### Changes
- Prevent MIL items from being permanently highlighted in layer reorder panel

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to Enhanced Sample 7 (Classic)
2. Open the reorder panel via icon in appbar or legend header
3. Expand the CESI block in reorder panel via the + icon
4. Observe that the CESI block is not permanently highlighted gray anymore
5. Hover over the CESI block as well as its child block with your mouse, and observe that they are only highlighted gray upon hover

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2445)
<!-- Reviewable:end -->
