### PR TITLE
Remove outer div of export component

### DIFF
--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -1,38 +1,36 @@
 <template>
-    <div ref="componentEl">
-        <panel-screen :panel="panel" :footer="true">
-            <template #header> {{ t('export.title') }} </template>
+    <panel-screen :panel="panel" :footer="true">
+        <template #header> {{ t('export.title') }} </template>
 
-            <template #content>
-                <div class="overflow-hidden border border-gray-200">
-                    <canvas class="export-canvas !w-[100%]"></canvas>
-                </div>
-            </template>
+        <template #content>
+            <div class="overflow-hidden border border-gray-200" ref="el">
+                <canvas class="export-canvas !w-[100%]"></canvas>
+            </div>
+        </template>
 
-            <template #footer>
-                <div class="flex">
-                    <button
-                        type="button"
-                        @click="fixture?.export()"
-                        class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-4 sm:px-16 mr-8 sm:mr-16"
-                        :aria-label="t('export.download')"
-                    >
-                        {{ t('export.download') }}
-                    </button>
+        <template #footer>
+            <div class="flex">
+                <button
+                    type="button"
+                    @click="fixture?.export()"
+                    class="bg-green-500 hover:bg-green-700 text-white font-bold py-8 px-4 sm:px-16 mr-8 sm:mr-16"
+                    :aria-label="t('export.download')"
+                >
+                    {{ t('export.download') }}
+                </button>
 
-                    <button type="button" @click="make()" class="py-8 px-4 sm:px-16" :aria-label="t('export.refresh')">
-                        {{ t('export.refresh') }}
-                    </button>
+                <button type="button" @click="make()" class="py-8 px-4 sm:px-16" :aria-label="t('export.refresh')">
+                    {{ t('export.refresh') }}
+                </button>
 
-                    <export-settings
-                        v-if="!hasCustomRenderer"
-                        :componentSelectedState="selectedComponents"
-                        class="ml-auto flex px-4 sm:px-8"
-                    ></export-settings>
-                </div>
-            </template>
-        </panel-screen>
-    </div>
+                <export-settings
+                    v-if="!hasCustomRenderer"
+                    :componentSelectedState="selectedComponents"
+                    class="ml-auto flex px-4 sm:px-8"
+                ></export-settings>
+            </div>
+        </template>
+    </panel-screen>
 </template>
 
 <script setup lang="ts">
@@ -62,7 +60,7 @@ const fixture = ref<ExportAPI>();
 const resizeObserver = ref<ResizeObserver | undefined>(undefined);
 const watchers = ref<Array<Function>>([]);
 
-const el = useTemplateRef('componentEl');
+const el = useTemplateRef('el');
 const componentSelectedState = computed(() => exportStore.componentSelectedState);
 const selectedComponents = computed<any>(() => {
     let state: any = {};
@@ -91,7 +89,6 @@ const make = debounce(300, () => {
     }
 
     const canvasElement = el.value!.querySelector('.export-canvas') as HTMLCanvasElement;
-
     fixture.value.make(canvasElement, el.value!.clientWidth);
 });
 

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -1,8 +1,6 @@
 <template>
     <panel-screen :panel="panel">
-        <template #header>
-            {{ t('legend.title') }}
-        </template>
+        <template #header> {{ t('legend.title') }} </template>
 
         <template #content>
             <legend-header />


### PR DESCRIPTION
### Related Item(s)
#2427

### Changes
- Removed the outer div from the export component, which was preventing its tooltip from being displayed

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any sample with an export panel
2. Open the export panel
3. Use tab to move focus over to the export panel
4. Observe that the appropriate tooltip now appears (`Export. Press enter or space to access the panel`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2446)
<!-- Reviewable:end -->
