### PR TITLE
Fix console error when export has no canvas

### DIFF
--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -86,7 +86,7 @@ const hasCustomRenderer = computed(() => {
 });
 
 const make = debounce(300, () => {
-    if (!fixture.value) {
+    if (!fixture.value || !el.value) {
         return;
     }
 


### PR DESCRIPTION
### Related Item(s)
#2439

### Changes
- [FIX] Prevent console error when export canvas is missing (not persisted)

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to classic sample 1
2. Open the export
3. Open the console and flip the app into French mode
4. Witness no console error
