### PR TITLE
Add blue highlight to "More" appbar button when focused

### DIFF
--- a/src/fixtures/appbar/more-button.vue
+++ b/src/fixtures/appbar/more-button.vue
@@ -192,4 +192,12 @@ defineExpose({
 .dropdown {
     @apply left-full bottom-0;
 }
+
+button {
+    outline: none !important;
+
+    &.focused {
+        @apply bg-blue-900 text-white;
+    }
+}
 </style>


### PR DESCRIPTION
### Related Item(s)
#2443

### Changes
- Added blue highlight to the "More" button upon keyboard and mouse focus

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 1
2. Open the layer's grid
3. Open the details panel for one of the grid entries
4. Reduce the screen height until the "More" button is visible
5. Use your keyboard to reach the "More" button
6. Observe that the "More" button is highlighted blue
7. Move keyboard focus away from the "More" button, and observe that the blue highlight disappears 
8. Click on the "More" button, and observe the blue highlight again
