### PR TITLE
Remove legal comments in minified esDynamic build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -86,7 +86,8 @@ function esDynamicConfig() {
                     }
                 }
             }
-        }
+        },
+        esbuild: { legalComments: 'none' }
     });
 }
 


### PR DESCRIPTION
### Related Item(s)
#2449 

### Changes
- [FIX] Remove legal comments from esDynamic build

### Notes

Removes about 70 kB from the initial load. 

Some comments remain since they are considered whitespace and vite doesn't want to remove them:

> Note the build.minify option does not minify whitespaces when using the 'es' format in lib mode, as it removes pure annotations and breaks tree-shaking.
See: https://vite.dev/config/build-options.html#build-minify

I haven't had luck with other tools like uglifyjs to remove comments post build, and that breaks sourcemaps. I'll continue looking around for solutions.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/index-esm.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2455)
<!-- Reviewable:end -->
