### PR TITLE
Priority Identify

### DIFF
--- a/demos/enhanced-all.html
+++ b/demos/enhanced-all.html
@@ -87,6 +87,11 @@
                 <a href="enhanced-samples.html?sample=7">O.G. Main</a>. The first / default sample from the classic
                 samples.
             </li>
+            <li>
+                10.
+                <a href="enhanced-samples.html?sample=10">Identify Prioritization</a>. Has layers set up to test result
+                prioritization scenarios.
+            </li>
         </ul>
 
         <h2>Respect for Apps</h2>

--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -24,6 +24,7 @@
                 <option value="007-main-classic">07. Classic Main Sample</option>
                 <option value="008-projection-party">08. Layers in Different Projections</option>
                 <option value="009-custom-panels">09. Custom HTML panels</option>
+                <option value="010-identify-priority">10. Identify Prioritization</option>
             </select>
             <nav class="linky-container">
                 <a class="linky" href="enhanced-all.html">Catalogue</a

--- a/demos/enhanced-scripts/010-identify-priority.js
+++ b/demos/enhanced-scripts/010-identify-priority.js
@@ -1,0 +1,76 @@
+/*
+Test 10: Identify Priority
+- Adds layers with and without identify priorities
+- Layer polygons overlap to give a number of test cases
+*/
+
+const runPreTest = (config, options, utils) => {
+    // Add layers
+    const priority = {
+        id: 'priority',
+        nameField: 'thing_name',
+        name: 'High Priority',
+        layerType: 'file-geojson',
+        colour: '#40d91a',
+        state: { opacity: 0.7 },
+        url: '../file-layers/greedy-priority.json',
+        fixtures: {
+            details: {
+                priority: 0
+            }
+        }
+    };
+
+    const neutralA = {
+        id: 'neutralA',
+        nameField: 'thing_name',
+        name: 'Neutral Priority Purple',
+        layerType: 'file-geojson',
+        colour: '#752fd6',
+        state: { opacity: 0.7 },
+        url: '../file-layers/greedy-neutral-a.json',
+        fixtures: {
+            details: {
+                priority: 50
+            }
+        }
+    };
+
+    const neutralZ = {
+        id: 'neutralZ',
+        nameField: 'thing_name',
+        name: 'Neutral Priority Blue',
+        layerType: 'file-geojson',
+        colour: '#1e7cd4',
+        state: { opacity: 0.7 },
+        url: '../file-layers/greedy-neutral-z.json'
+    };
+
+    const low = {
+        id: 'low',
+        nameField: 'thing_name',
+        name: 'Low Priority',
+        layerType: 'file-geojson',
+        colour: '#db1241',
+        state: { opacity: 0.7 },
+        url: '../file-layers/greedy-low.json',
+        fixtures: {
+            details: {
+                priority: 100
+            }
+        }
+    };
+
+    utils.addLayerLegend(neutralA);
+    utils.addLayerLegend(priority);
+    utils.addLayerLegend(low);
+    utils.addLayerLegend(neutralZ);
+
+    return { config, options };
+};
+
+const runPostTest = (instance, utils) => {
+    // Nothing for this test
+};
+
+export { runPreTest, runPostTest };

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -76,7 +76,7 @@ export default {
                         items: [
                             { text: "Appbar", link: "/using-ramp4/fixtures/appbar" },
                             { text: "Data Grid", link: "/using-ramp4/fixtures/grid" },
-                            { text: "Details Custom Templating", link: "/using-ramp4/fixtures/details" },
+                            { text: "Details", link: "/using-ramp4/fixtures/details" },
                             { text: "Extent Guard", link: "/using-ramp4/fixtures/extentguard" },
                             { text: "Geosearch", link: "/using-ramp4/fixtures/geosearch" },
                             { text: "Layer Settings", link: "/using-ramp4/fixtures/layer-settings" },

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -22,7 +22,7 @@ The [Instantiation](introduction/instantiation.md) page provides examples of how
 - The [Layers Configuration](using-ramp4/layer-config.md) page is fairly complete.
 - Configuration for various fixtures
   - [Appbar](using-ramp4/fixtures/appbar.md#configuration)
-  - [Details Custom Templating](using-ramp4/fixtures/details.md#creating-a-custom-template)
+  - [Details](using-ramp4/fixtures/details.md)
   - [Geosearch](using-ramp4/fixtures/geosearch.md#configuration)
   - [Grid](using-ramp4/fixtures/grid.md#configuration)
   - [Layer Settings](using-ramp4/fixtures/layer-settings.md#configuration)

--- a/docs/using-ramp4/fixtures/details.md
+++ b/docs/using-ramp4/fixtures/details.md
@@ -9,9 +9,77 @@ The details fixture consists of three sections:
 2. The __Feature Info__ view displays information about a single result item. This screen will look different depending on the format of the information returned by the identify query. This is also the screen that can be customized using custom templates (see below). Scroll controls can move the view to other results in the layer. The "See List" button will switch to __List View__.
 3. The __List View__ contains a list of all results found for the selected layer. Clicking on an item in this list will bring you to the __Feature Info__ screen.
 
+## Details Configuration
+
+### Fixture Settings
+
+The fixture config supports a few global settings, such as a panel width and a [panel teleport target](../../api-guides/panels#teleporting-panels). 
+
+The default Vue template for each detail [format](https://ramp4-pcar4.github.io/ramp4-pcar4/main/docs/api-tech-docs/enums/geo_api_geo_defs.IdentifyResultFormat.html) type can be specified. New templates must be [registered on the instance](#creating-a-custom-template). If not provided, the out-of-box RAMP templates will be used.
+
+```js
+fixtures: {
+    details: {
+        panelWidth: 450,
+        templates: {
+            esri: 'MyCustomDefaultEsriTemplate',
+            html: 'MyCustomDefaultHtmlTemplate'
+        }
+    }
+}
+```
+### Layer Settings
+
+Since content can vary per layer, each layer config can provide details configurations under its own fixture configuration object.
+
+- `name` (string): will override the name field used on the default ESRI template. The field defined by the layer is used if not provided.
+- `template` (string): a [custom template ](#creating-a-custom-template) to use for this layer.
+- `priority` (integer): will influence if this layers result is first shown on a fresh identify. The value is 50 if not provided, lower numbers have higher priority.
+- `fields` (array of objects): can contain overriding settings for individual attributes on the default ESRI template. Object properties are
+  - `field` (string): matches the layer field name that this object is targeting.
+  - `alias` (string): specifies a different field name alias for the details display.
+  - `visible` (boolean): controls if field will show in the display. Defaults to `true`.
+
+```js
+layers: [
+    {
+        id: 'sample',
+        url: 'https://fake.ca/layer',
+        layerType: 'esri-feature',
+        fixtures: {
+            details: {
+                priority: 1,
+                name: 'fancy_field',
+                fields: [
+                    { field: 'secret_field', visible: false },
+                    { field: 'badly_worded_field', alias: 'A Nice Name' }
+                ]
+            }
+        }
+    }
+]
+```
+
+## Zoom Button Configuration
+
+It is possible to change the icon for the zoom button in the default ESRI details template by using the system variable `zoomIcon`. There are two built-in icons: `globe` and `magnify`. If you would like to customize the icon, the variable may be set to any emoji or SVG. Providing this value with a URL will not fetch the remote image.
+
+Note that if the grid fixture is added, the zoom icon will be modified there as well.
+
+Example usage which sets the zoom icon to the magnifying glass:
+```
+{
+    configs: {
+        en: {
+            system: { zoomIcon: 'magnify' }
+        }
+    }
+}
+```
+
 ## Creating a Custom Template
 
-If you don't want to use the provided templates for your layer results, you can create your own. The process is simple. All you need to do is create a Vue component and then add the layer-to-template binding to the RAMP configuration file.
+If you don't want to use the provided templates for your layer results, you can create your own. All you need to do is create a template Vue component on the RAMP instance, and then add the layer-to-template binding to the RAMP configuration file.
 
 The example below explains how to create a basic template for the details panel.
 
@@ -43,7 +111,7 @@ rInstance.$element.component('My_Custom_Component', {
 });
 ```
 
-__Note:__ it is important that you include the `identifyData` prop in the component since the details fixture will populate it with the results from the identify query. The `identifyData` prop is necessary in order to access the results.
+__Note:__ it is important that you include the `identifyData` prop in the component since the details fixture will populate it with the results from the identify query. The `identifyData` prop is necessary in order to access the results. The property will be an [IdentifyItem](https://ramp4-pcar4.github.io/ramp4-pcar4/main/docs/api-tech-docs/interfaces/geo_layer_support_identify.IdentifyItem.html).
 
 
 __2.__ Once the custom component has been created, you will want to add your layer to RAMP and set the new component as a custom template in the details fixture. You can do both of these in the configuration file:
@@ -69,18 +137,3 @@ const rInstance = RAMP.createInstance(document.getElementById("map"), {
 As shown in the config snippet above, template bindings should be placed under the layer's details fixture configuration. When the details panel first loads, it looks for any template bindings in here. Note that the `template` should match the name of the custom component that you registered on the host page.
 
 After completing these two steps, the custom component should now be displayed when requesting data from `My_New_Layer`.
-
-### Zoom Button Configuration
-It is possible to change the icon for the zoom button in the details fixture by using the system variable `zoomIcon`. There are two built-in icons: `globe` and `magnify`. If you would like to customize the icon, the variable may be set to any emoji or SVG. Providing this value with a URL will not fetch the remote image.
-
-Note that if the grid fixture is added, the zoom icon will be modified there as well.
-
-Example usage which sets the zoom icon to the magnifying glass:
-```
-{
-    configs: {
-        en: {
-            system: { zoomIcon: 'magnify' }
-        }
-    }
-}

--- a/public/file-layers/greedy-low.json
+++ b/public/file-layers/greedy-low.json
@@ -1,0 +1,59 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Low A"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-114.4773, 56.5179],
+                        [-117.9051, 58.4976],
+                        [-117.1392, 54.909],
+                        [-116.3476, 56.7763],
+                        [-114.4773, 56.5179]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Low B"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-70.5673, 53.275],
+                        [-67.1349, 55.5906],
+                        [-68.8867, 55.3423],
+                        [-69.8543, 56.343],
+                        [-70.5673, 53.275]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Low C"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-91.6323, 60.1583],
+                        [-90.4016, 59.2545],
+                        [-92.9447, 58.314],
+                        [-86.666, 59.1164],
+                        [-91.6323, 60.1583]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        }
+    ]
+}

--- a/public/file-layers/greedy-neutral-a.json
+++ b/public/file-layers/greedy-neutral-a.json
@@ -1,0 +1,60 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Neutral A"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-120.5716, 60.2146],
+                        [-117.3887, 55.7401],
+                        [-115.8041, 60.5226],
+                        [-117.9213, 59.1056],
+                        [-120.5716, 60.2146]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Neutral B"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-112.9986, 64.3221],
+                        [-110.734, 63.3241],
+                        [-113.281, 62.3336],
+                        [-105.467, 63.2976],
+                        [-112.9986, 64.3221]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Neutral C"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-98.4922, 57.7156],
+                        [-102.0193, 59.2165],
+                        [-101.3582, 58.2032],
+                        [-102.8259, 57.584],
+                        [-98.4922, 57.7156]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        }
+    ]
+}

--- a/public/file-layers/greedy-neutral-z.json
+++ b/public/file-layers/greedy-neutral-z.json
@@ -1,0 +1,59 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Neutral Z"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-108.0681, 61.8489],
+                        [-106.6706, 62.6356],
+                        [-104.5144, 61.7752],
+                        [-107.1097, 64.5575],
+                        [-108.0681, 61.8489]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Neutral Y"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-73.9964, 56.0791],
+                        [-72.8708, 54.5785],
+                        [-75.9588, 53.6417],
+                        [-67.947, 53.4447],
+                        [-73.9964, 56.0791]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Neutral X"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-99.5521, 57.7109],
+                        [-95.7057, 57.9372],
+                        [-96.8209, 58.5388],
+                        [-96.9113, 59.4291],
+                        [-99.5521, 57.7109]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        }
+    ]
+}

--- a/public/file-layers/greedy-priority.json
+++ b/public/file-layers/greedy-priority.json
@@ -1,0 +1,59 @@
+{
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Priority A"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-99.1177, 58.9126],
+                        [-100.9308, 55.7472],
+                        [-98.8637, 56.9477],
+                        [-96.6496, 56.1142],
+                        [-99.1177, 58.9126]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Priority B"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-89.353, 60.9638],
+                        [-87.6331, 58.0278],
+                        [-84.5366, 60.7483],
+                        [-87.1628, 59.857],
+                        [-89.353, 60.9638]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "thing_name": "Priority C"
+            },
+            "geometry": {
+                "coordinates": [
+                    [
+                        [-125.7696, 59.1173],
+                        [-122.1297, 58.1059],
+                        [-124.5975, 56.7919],
+                        [-115.4387, 58.4719],
+                        [-125.7696, 59.1173]
+                    ]
+                ],
+                "type": "Polygon"
+            }
+        }
+    ]
+}

--- a/schema.json
+++ b/schema.json
@@ -229,7 +229,12 @@
             "properties": {
                 "name": {
                     "type": "string",
-                    "description": "Display name of the identified layer"
+                    "description": "Display name field of the identified layer. Only applies to layers that support attributes and do not have an overriding template. The field defined by the layer is used if not provided."
+                },
+                "priority": {
+                    "type": "number",
+                    "description": "Specifies a priority ranking for the layer result being initially selected. Smaller number has higher priority.",
+                    "default": 50
                 },
                 "template": {
                     "type": "string",
@@ -237,7 +242,7 @@
                 },
                 "fields": {
                     "type": "array",
-                    "description": "An array to specify how the layer data fields are defined. Only applies to attribute layers that do not have an overriding template.",
+                    "description": "An array to specify alternate display settings for layer fields. Only applies to layers that support attributes and do not have an overriding template.",
                     "items": {
                         "$ref": "#/$defs/detailsField"
                     }

--- a/src/fixtures/details/details-screen.vue
+++ b/src/fixtures/details/details-screen.vue
@@ -90,7 +90,7 @@ const changeLayerSelection = (uid: string) => {
 const findLayerResult = (uid: string): IdentifyResult | undefined => layerResults.value.find(item => item.uid === uid);
 
 /**
- * Load identify result items after all item's load promise has resolved
+ * Intake a new identify result set, initiate auto-open logic.
  */
 const loadPayloadItems = (newPayload: Array<IdentifyResult>): void => {
     // NOTE: the incoming payload array needs to be made reactive at the source,
@@ -172,38 +172,75 @@ const autoOpen = (newPayload: Array<IdentifyResult>): void => {
 /**
  * Will watch all the result items. First layer to resolve with a valid result will become
  * the active layer in the details view.
+ *
+ * @param newPayload the identify result payload we're watching
+ * @param priorityStack helper param for priority recursion. Is omitted on initial call
  */
-const autoOpenAny = (newPayload: Array<IdentifyResult>): void => {
-    const loadingResults = newPayload.map(item =>
-        item.loading.then(() => (item.items.length > 0 ? Promise.resolve(item) : Promise.reject()))
-    );
+const autoOpenAny = (newPayload: Array<IdentifyResult>, priorityStack?: Array<[number, Array<string>]>): void => {
+    /**
+     * Array of [priority, [layerIds]], sorted by highest to lowest priority value (low number goes first)
+     */
+    let priStack: Array<[number, Array<string>]>;
+    if (priorityStack) {
+        // recursive call, use previously generated stack
+        priStack = priorityStack;
+    } else {
+        const layerDetailsConfigs = detailsStore.properties;
+
+        // list of [priority, layerId]
+        const layerPriorities = newPayload.map((idRes): [number, string] => [
+            (layerDetailsConfigs[idRes.layerId]?.priority as number) ?? 50,
+            idRes.layerId
+        ]);
+        // create set of distinct priority values
+        const setMagic = new Set(layerPriorities.map(lp => lp[0]));
+        priStack = [];
+        // group layer ids by priority value
+        setMagic.forEach(uniquePriority => {
+            const matchingLayerIds = layerPriorities.filter(lp => lp[0] === uniquePriority).map(lp => lp[1]);
+            priStack.push([uniquePriority, matchingLayerIds]);
+        });
+        // sort by priority value in descending order
+        priStack.sort((a, b) => b[0] - a[0]);
+    }
+
+    if (priStack.length === 0) {
+        // handles case of no identifiable layers (either from initial conditions, or all priorities have been popped).
+        // Stop & exit.
+        detailsStore.activeGreedy = 0;
+        noResults.value = true;
+        return;
+    }
+
+    // watch the priority layers
+    const currentPriorites = priStack[priStack.length - 1][1];
+    const loadingResults = newPayload
+        .filter(payloadIR => currentPriorites.includes(payloadIR.layerId))
+        .map(payloadIR =>
+            payloadIR.loading.then(() => (payloadIR.items.length > 0 ? Promise.resolve(payloadIR) : Promise.reject()))
+        );
     const lastTime = newPayload.length === 0 ? 0 : newPayload[0].requestTime;
 
     // wait on any layer promise to resolve first with new identify results
     Promise.any(loadingResults)
-        .then(res => {
+        .then(winningResult => {
             // new identify request came in while loading old results, exit greedy algo
-            if (res.requestTime !== activeGreedy.value) {
+            if (winningResult.requestTime !== activeGreedy.value) {
                 return;
             }
 
-            // open results item screen and turn off greedy loading and abort flags
-            const winningResult = findLayerResult(res.uid);
+            // open results item screen and turn off greedy loading
             detailsStore.activeGreedy = 0;
-            if (winningResult) {
-                selectedLayer.value = winningResult.uid;
-                noResults.value = false;
-            }
+            selectedLayer.value = winningResult.uid;
+            noResults.value = false;
         })
         .catch(() => {
-            // new identify request came in while loading old results, exit greedy algo
-            if (lastTime !== activeGreedy.value) {
-                return;
+            if (lastTime === activeGreedy.value) {
+                // this process is still the active greedy result.
+                // try next priority bucket. recursive call will also handle the no-result empty array case
+                priStack.pop();
+                autoOpenAny(newPayload, priStack);
             }
-
-            // no promise resolved, clicked on empty map point with no identify results.
-            detailsStore.activeGreedy = 0;
-            noResults.value = true;
         });
 };
 

--- a/src/fixtures/details/details-screen.vue
+++ b/src/fixtures/details/details-screen.vue
@@ -57,9 +57,15 @@ const handlers = ref<Array<string>>([]);
 const watchers = ref<Array<Function>>([]);
 const layerResults = ref<Array<IdentifyResult>>([]);
 const noResults = ref<boolean>(false);
-const selectedLayer = ref<string>('');
-const userSelectedLayer = ref<boolean>(false);
 
+/**
+ * UID of the layer "selected" into the detail/list section. Empty string when panel is freshly opened.
+ */
+const selectedLayer = ref<string>('');
+
+/**
+ * Contains the timestamp of the most recent payload. 0 if we are not watching for a greedy open
+ */
 const activeGreedy = computed<number>(() => detailsStore.activeGreedy);
 const payload = computed<IdentifyResult[]>(() => detailsStore.payload);
 const detailProperties = computed<{ [id: string]: DetailsItemInstance }>(() => detailsStore.properties);
@@ -70,10 +76,18 @@ defineProps({
     }
 });
 
+/**
+ * Handles user picking a new layer from the "symbol stack" list
+ */
 const changeLayerSelection = (uid: string) => {
     selectedLayer.value = uid;
-    userSelectedLayer.value = true;
 };
+
+/**
+ * Finds the result object for a layer uid, or undefined if no result exists
+ * @param uid logical layer uid
+ */
+const findLayerResult = (uid: string): IdentifyResult | undefined => layerResults.value.find(item => item.uid === uid);
 
 /**
  * Load identify result items after all item's load promise has resolved
@@ -98,17 +112,15 @@ const loadPayloadItems = (newPayload: Array<IdentifyResult>): void => {
     // Would like to revist, as this current solution is unintuitive,
     // nobody writing a new layer type is going to have a clue they need
     // to wrap their identify outputs in reactive() due to disrespectful code.
+
     // if no payload, just return
     if (newPayload === undefined) {
         return;
     }
 
-    // track last identify request timestamp and add to payload items. If details items panel does not exist, no new results,
-    // app is in mobile mode, or if there is not enough space available to open the detail items panel,
-    // then disable the greedy identify.
-    const greedyMode = newPayload.length === 0 ? 0 : newPayload[0].requestTime;
-    detailsStore.activeGreedy = greedyMode;
-    detailsStore.slowLoadingFlag = false;
+    // track last identify request timestamp and add to payload items. If no new results,
+    // disable the greedy identify.
+    detailsStore.activeGreedy = newPayload.length === 0 ? 0 : newPayload[0].requestTime;
 
     layerResults.value = newPayload;
 
@@ -116,79 +128,70 @@ const loadPayloadItems = (newPayload: Array<IdentifyResult>): void => {
 };
 
 /**
- * Multiple greedy approach to auto-open identify item panel explained as follows:
- * A new array of promises (loadingResults) is created that resolves for each item when it is done loading and contains non-empty results count, and is rejected otherwise.
- * Case 1 - if no identify panels are open or only the identify summary panel is open:
- *              wait for any of the promises to resolve and open the item screen for the first that does, track this layer ID (also tracked if item screen opened manually)
- *              if no promises resolve, user clicked on empty map point with no data so reset last layer ID to none and close items screen
- * Case 2 - if item panel is already open for a layer:
- *              this layer takes priority so wait for it to resolve first, if there are new results refresh the panel to update
- *              otherwise if there are no results for this previously open layer, follow the same steps as for case 1
+ * Auto-selects which layer to show in the detail section when a new payload of identify results arrive.
+ *
+ * 1. If a layer is already the active layer in the details view, we wait for it to report its findings.
+ *    If it has a result, it remains the active layer.
+ * 2. If no active layer (freshly opened panel or old active layer was deleted), or the active layer had
+ *    no results in 1., we then watch identify results for all candidate layers. First layer to report
+ *    a hit becomes the active layer.
  */
 const autoOpen = (newPayload: Array<IdentifyResult>): void => {
-    // if the item panel is already open for a layer, wait on that layer to resolve first
-    if (userSelectedLayer.value) {
-        const lastIdx = layerResults.value.findIndex((item: IdentifyResult) => item.uid === selectedLayer.value);
+    // if the detail panel is already showing details of a specific layer,
+    // wait on that layer to resolve first
+    if (selectedLayer.value) {
+        const selectedResult = findLayerResult(selectedLayer.value);
 
-        if (lastIdx !== -1) {
-            const lastIdentify = layerResults.value[lastIdx];
-            // wait on last opened layer to see if it resolves with new results
-            lastIdentify.loading.then(() => {
+        if (selectedResult) {
+            // wait on the currently selected layer to see if it resolves with new results
+            selectedResult.loading.then(() => {
                 // new identify request came in while loading old results, exit greedy algo
-                if (lastIdentify.requestTime !== activeGreedy.value) {
+                if (selectedResult.requestTime !== activeGreedy.value) {
                     return;
                 }
 
-                // update items screen with new results for that layer and turn off greedy loading and abort flags
-                if (lastIdentify.items.length > 0) {
+                if (selectedResult.items.length > 0) {
+                    // got a hit. update items screen with new results and turn off greedy loading
                     detailsStore.activeGreedy = 0;
-                    userSelectedLayer.value = false;
                     noResults.value = false;
                 } else {
-                    // otherwise proceed as normal in case 1
+                    // current layer has no hits, fall back to examining all.
                     autoOpenAny(newPayload);
                 }
             });
         } else {
-            // if last opened layer no longer exists proceed with case 1
+            // last opened layer no longer exists, proceed examine all layers
             autoOpenAny(newPayload);
         }
     } else {
-        // if no identify item panel was open or no last layer is tracked, proceed with case 1
+        // panel was freshly opened. show first layer with results
         autoOpenAny(newPayload);
     }
-
-    // after a set time period, if greedy mode is still running for current identify request turn on loading flag
-    setTimeout(() => {
-        if (activeGreedy.value !== 0 && newPayload[0].requestTime === activeGreedy.value) {
-            detailsStore.slowLoadingFlag = true;
-        }
-    }, 500);
 };
 
 /**
- * Helper function for greedy auto-open function, implementation for case 1.
+ * Will watch all the result items. First layer to resolve with a valid result will become
+ * the active layer in the details view.
  */
 const autoOpenAny = (newPayload: Array<IdentifyResult>): void => {
-    const loadingResults = newPayload.map((item: IdentifyResult) =>
+    const loadingResults = newPayload.map(item =>
         item.loading.then(() => (item.items.length > 0 ? Promise.resolve(item) : Promise.reject()))
     );
     const lastTime = newPayload.length === 0 ? 0 : newPayload[0].requestTime;
 
     // wait on any layer promise to resolve first with new identify results
-    // @ts-ignore
     Promise.any(loadingResults)
-        .then((res: IdentifyResult) => {
+        .then(res => {
             // new identify request came in while loading old results, exit greedy algo
             if (res.requestTime !== activeGreedy.value) {
                 return;
             }
 
             // open results item screen and turn off greedy loading and abort flags
-            const idx = layerResults.value.find((item: IdentifyResult) => item.uid === res.uid);
+            const winningResult = findLayerResult(res.uid);
             detailsStore.activeGreedy = 0;
-            if (idx !== undefined) {
-                selectedLayer.value = idx.uid;
+            if (winningResult) {
+                selectedLayer.value = winningResult.uid;
                 noResults.value = false;
             }
         })
@@ -220,15 +223,6 @@ onBeforeMount(() => {
                 immediate: true
             }
         )
-    );
-
-    watchers.value.push(
-        watch(activeGreedy, (newGreedy: Number) => {
-            // watch to turn off greedy loading flag if greedy mode is turned off
-            if (newGreedy === 0) {
-                detailsStore.slowLoadingFlag = false;
-            }
-        })
     );
 });
 

--- a/src/fixtures/details/store/details-state.ts
+++ b/src/fixtures/details/store/details-state.ts
@@ -73,6 +73,14 @@ export interface DetailsConfigItem {
      * @memberof DetailsConfigItem
      */
     fields?: DetailsFieldItem[];
+
+    /**
+     * Specifies result priority for auto-open. Lower number is higher priority.
+     *
+     * @type {number}
+     * @memberof DetailsConfigItem
+     */
+    priority: number;
 }
 
 export class DetailsItemInstance implements DetailsConfigItem {
@@ -82,14 +90,22 @@ export class DetailsItemInstance implements DetailsConfigItem {
 
     template: string;
 
+    priority: number;
+
     fields?: DetailsFieldItem[];
 
     componentId?: string;
 
     constructor(value: string | DetailsConfigItem) {
         const params = {
-            ...(typeof value === 'string' ? { id: value, template: '', name: '' } : value)
+            ...(typeof value === 'string' ? { id: value, template: '', name: '', priority: 50 } : value)
         };
-        ({ template: this.template, id: this.id, name: this.name, fields: this.fields } = params);
+        ({
+            template: this.template,
+            id: this.id,
+            name: this.name,
+            fields: this.fields,
+            priority: this.priority
+        } = params);
     }
 }

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -25,11 +25,6 @@ export const useDetailsStore = defineStore('details', () => {
     const currentFeatureId = ref<string>();
 
     /**
-     * Indicates whether greedy mode is still loading for current identify request after 500ms delay.
-     */
-    const slowLoadingFlag = ref<boolean>(false);
-
-    /**
      * Indicates whether greedy mode is off (0), or currently running for the last request timestamp.
      */
     const activeGreedy = ref<number>(0);
@@ -67,7 +62,6 @@ export const useDetailsStore = defineStore('details', () => {
         properties,
         defaultTemplates,
         currentFeatureId,
-        slowLoadingFlag,
         activeGreedy,
         lastHilight,
         hilightToggle,


### PR DESCRIPTION
### Related Item(s)

Donethankses #2458

### Changes
- Adds identify prioritization to greedy algo and fixture config.
- Cleans up some obsolete stuff in the greedy algo that was only needed for the two-panel identify of old.
- More complete doc for details fixture configuration.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 10.
2. Do lots of clicking to verify the following rules are being followed.

- Rules if identify panel is closed when map is clicked:
  - Layer that has a hit, and is in the highest priority bucket of hits, has it's details shown.
  - Layers in same priority bucket will tie-break based on first to return. In this sample, they're both fast so will be random.
- Rules if identify panel is open when map is clicked:
  - Layer that was selected prior to click will stay active if it has a result
  - If the selected layer didn't have a result, then the same rules apply as if the panel had been closed. Highest priority hit will display.
  - If no hits were found at all, the panel will keep the "selected layer" in memory and will apply that to the next click (unless panel gets closed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2459)
<!-- Reviewable:end -->
