### PR TITLE
Add tooltip to basemap selection

### DIFF
--- a/src/fixtures/basemap/screen.vue
+++ b/src/fixtures/basemap/screen.vue
@@ -5,24 +5,35 @@
         </template>
 
         <template #content>
-            <div class="h-600 overflow-y-auto">
-                <div class="mx-5" v-for="(tileSchema, idx) in tileSchemas" :key="tileSchema.id">
-                    <!-- use mt-5 if it's the first basemap title schema, use mt-36 otherwise -->
-                    <div :class="(idx === 0 ? 'mt-5' : 'mt-36') + ' flex mb-5'">
-                        <h3 class="font-bold text-xl" v-truncate>
-                            {{ tileSchema.name }}
-                        </h3>
-                    </div>
+            <div
+                v-focus-list
+                :content="t('panels.controls.items')"
+                v-tippy="{
+                    trigger: 'manual',
+                    placement: 'top-end',
+                    maxWidth: 190
+                }"
+                ref="el"
+            >
+                <div class="h-600 overflow-y-auto">
+                    <div class="mx-5" v-for="(tileSchema, idx) in tileSchemas" :key="tileSchema.id">
+                        <!-- use mt-5 if it's the first basemap title schema, use mt-36 otherwise -->
+                        <div :class="(idx === 0 ? 'mt-5' : 'mt-36') + ' flex mb-5'">
+                            <h3 class="font-bold text-xl" v-truncate>
+                                {{ tileSchema.name }}
+                            </h3>
+                        </div>
 
-                    <ul class="border-t border-b border-gray-600" v-focus-list v-if="basemaps.length > 0">
-                        <li v-for="basemap in filterBasemaps(tileSchema.id)" :key="basemap.id">
-                            <basemap-item
-                                :basemap="basemap"
-                                :tileSchema="tileSchema"
-                                class="block relative overflow-hidden"
-                            ></basemap-item>
-                        </li>
-                    </ul>
+                        <ul class="border-t border-b border-gray-600" v-if="basemaps.length > 0">
+                            <li v-for="basemap in filterBasemaps(tileSchema.id)" :key="basemap.id">
+                                <basemap-item
+                                    :basemap="basemap"
+                                    :tileSchema="tileSchema"
+                                    class="block relative overflow-hidden"
+                                ></basemap-item>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </template>
@@ -30,7 +41,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, onBeforeUnmount, ref, useTemplateRef } from 'vue';
 import type { PropType } from 'vue';
 
 import BasemapItem from './item.vue';
@@ -47,13 +58,30 @@ defineProps({
     }
 });
 
+const el = useTemplateRef('el');
 const tileSchemas = ref<Array<RampTileSchemaConfig>>([]);
 const basemaps = ref<Array<RampBasemapConfig>>([]);
+const keyupEvent = (e: Event) => {
+    const evt = e as KeyboardEvent;
+    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+        (el.value as any)._tippy.show();
+    }
+};
+const blurEvent = () => {
+    (el.value as any)._tippy.hide();
+};
 
 onMounted(() => {
     const mapConfig = configStore.config.map as RampMapConfig;
     tileSchemas.value = mapConfig.tileSchemas;
     basemaps.value = mapConfig.basemaps;
+    el.value?.addEventListener('blur', blurEvent);
+    el.value?.addEventListener('keyup', keyupEvent);
+});
+
+onBeforeUnmount(() => {
+    el.value?.removeEventListener('blur', blurEvent);
+    el.value?.removeEventListener('keyup', keyupEvent);
 });
 
 // filter out all the basemaps that match the current schema


### PR DESCRIPTION
### Related Item(s)
#2453 

### Changes
- [FIX] Adds a tooltip for keyboard users when selecting basemaps

### Notes
A few important things to note:
1. Instead of having a focus list for each tileSchema it is one big list that you can freely traverse. This was out of laziness to keep the tippy logic simple, otherwise there'll be arrays of lists to track.
2. Focus manager (I think) has a bug where focus lands on the outter most panel content `div` when you don't end up entering the panel. `div` elements should not be focusable unless they have a `tabindex` which this does not. Peeking in the focus manager code doesn't make it seem like it would target div's. A mystery.

I'm ok if this pr is scrapped, maybe someone has better focus skills. 

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 1
4. Open the basemap panel
5. Press `tab` to focus on the basemap panel, press `enter`, then tab until you see the basemap selection tooltip

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2469)
<!-- Reviewable:end -->
