### PR TITLE
Fix focus issues with wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "vue-i18n": "^9.13.1",
                 "vue-slider-component": "^4.1.0-beta.7",
                 "vue-tippy": "^6.4.4",
-                "vuedraggable": "*"
+                "vuedraggable": "next"
             },
             "devDependencies": {
                 "@cypress/vite-dev-server": "^2.2.2",

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -73,6 +73,7 @@ const panelStore = usePanelStore();
 const appbarStore = useAppbarStore();
 const iApi = inject<InstanceAPI>('iApi');
 const el = ref<HTMLElement>();
+defineExpose({ el });
 
 const props = defineProps({
     // prop indicating if the `header` slot should be rendered


### PR DESCRIPTION
### Related Item(s)
#1973 
#2104

### Changes
- Prevent the `focusout` event from propagating to the `FocusStateManager` when moving between wizard steps
- Manually enable tabbing on elements within the wizard panel when moving between wizard steps
- Set focus on the appropriate input elements of each wizard step when moving between them 
- Add grey background upon keyboard/mouse focus on the file upload input within wizard step 1

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any sample with a wizard (ex. enhanced sample 1)
2. Open the wizard
3. Use keyboard to navigate to wizard panel
4. Upload a layer and move to the next step
5. Observe that keyboard focus is on the select element of wizard step 2
6. Choose the appropriate file format and move to the next step
7. Observe that keyboard focus is on the text input element of wizard step 3
8. Tab to the `Cancel` button and press Enter
9. Observe that keyboard focus is back on the select element of wizard step 2
10. Tab to the `Cancel` button and press Enter again
11. Observe that keyboard focus is on the URL input element of wizard step 1
12. Upload the layer and choose the appropriate file format again to get to wizard step 3
13. Tab to the `Continue` button and press Enter
14. Observe that keyboard focus is on the URL input element of wizard step 1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2470)
<!-- Reviewable:end -->
