### PR TITLE
Make language change dropdown visible

### DIFF
--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -84,7 +84,7 @@
             </button>
 
             <dropdown-menu
-                class="flex-shrink-0 pointer-events-auto focus:outline-none px-4 mr-4 relative top-2 overflow-hidden"
+                class="flex-shrink-0 pointer-events-auto focus:outline-none px-4 mr-4 relative top-2"
                 position="top-end"
                 v-if="!langtoggle?.disabled"
                 :tooltip="t('map.changeLanguage')"


### PR DESCRIPTION
### Related Item(s)
#2471

### Changes
- Remove the `overflow-hidden` styling from the language change dropdown, which was preventing it from opening

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any sample
2. Click on the `Change Language` button in the bottom right
3. Observe that the dropdown now opens

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2472)
<!-- Reviewable:end -->
