### PR TITLE
Remove outer div from export, Make scrollable content tabbable

### DIFF
--- a/src/fixtures/export/screen.vue
+++ b/src/fixtures/export/screen.vue
@@ -1,38 +1,36 @@
 <template>
-    <div ref="componentEl">
-        <panel-screen :panel="panel" :footer="true">
-            <template #header> {{ t('export.title') }} </template>
+    <panel-screen :panel="panel" :footer="true">
+        <template #header> {{ t('export.title') }} </template>
 
-            <template #content>
-                <div class="overflow-hidden border border-gray-200">
-                    <canvas class="export-canvas !w-[100%]"></canvas>
-                </div>
-            </template>
+        <template #content>
+            <div class="overflow-hidden border border-gray-200" ref="componentEl">
+                <canvas class="export-canvas !w-[100%]"></canvas>
+            </div>
+        </template>
 
-            <template #footer>
-                <div class="flex">
-                    <button
-                        type="button"
-                        @click="fixture?.export()"
-                        class="bg-green-700 hover:bg-green-800 text-white font-bold py-8 px-4 sm:px-16 mr-8 sm:mr-16"
-                        :aria-label="t('export.download')"
-                    >
-                        {{ t('export.download') }}
-                    </button>
+        <template #footer>
+            <div class="flex">
+                <button
+                    type="button"
+                    @click="fixture?.export()"
+                    class="bg-green-700 hover:bg-green-800 text-white font-bold py-8 px-4 sm:px-16 mr-8 sm:mr-16"
+                    :aria-label="t('export.download')"
+                >
+                    {{ t('export.download') }}
+                </button>
 
-                    <button type="button" @click="make()" class="py-8 px-4 sm:px-16" :aria-label="t('export.refresh')">
-                        {{ t('export.refresh') }}
-                    </button>
+                <button type="button" @click="make()" class="py-8 px-4 sm:px-16" :aria-label="t('export.refresh')">
+                    {{ t('export.refresh') }}
+                </button>
 
-                    <export-settings
-                        v-if="!hasCustomRenderer"
-                        :componentSelectedState="selectedComponents"
-                        class="ml-auto flex px-4 sm:px-8"
-                    ></export-settings>
-                </div>
-            </template>
-        </panel-screen>
-    </div>
+                <export-settings
+                    v-if="!hasCustomRenderer"
+                    :componentSelectedState="selectedComponents"
+                    class="ml-auto flex px-4 sm:px-8"
+                ></export-settings>
+            </div>
+        </template>
+    </panel-screen>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
### Related Item(s)
#2454
#2427

### Changes
- Removed the outer div from the export component, which was preventing its tooltip from being displayed (changes from #2446 must have been undone somewhere)
- Make panel's content section tabbable when it becomes scrollable

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps (#2427):
1. Open any sample with an export panel
2. Open the export panel
3. Use tab to move focus over to the export panel
4. Observe that the appropriate tooltip now appears (`Export. Press enter or space to access the panel`)

Steps (#2454):
1. Open any sample with an export and basemap panel
2. Open the export panel (while in full screen)
3. Use keyboard to navigate through the export panel
4. Observe that the content section is not tabbable
5. Decrease the width of your screen, so that the content section of the export panel has a vertical scrollbar
6. Use keyboard to navigate through the export panel again
7. Observe that the content section is now tabbable.
8. Close the export panel and open the basemap panel (while in full screen)
9. Use keyboard to navigate through the basemap panel
10. Observe that the content section is tabbable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2474)
<!-- Reviewable:end -->
