### PR TITLE
Version treeselect repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@ag-grid-community/locale": "~32.0.0",
                 "@arcgis/core": "4.29.10",
                 "@popperjs/core": "^2.11.6",
-                "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect",
+                "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect#v1.0.0",
                 "@vueform/toggle": "^2.1.3",
                 "ag-grid-community": "^27.3.0",
                 "ag-grid-vue3": "^27.3.0",
@@ -44,7 +44,7 @@
                 "vue-i18n": "^9.13.1",
                 "vue-slider-component": "^4.1.0-beta.7",
                 "vue-tippy": "^6.4.4",
-                "vuedraggable": "*"
+                "vuedraggable": "next"
             },
             "devDependencies": {
                 "@cypress/vite-dev-server": "^2.2.2",
@@ -1605,7 +1605,7 @@
         },
         "node_modules/@ramp4-pcar4/vue3-treeselect": {
             "version": "0.1.1",
-            "resolved": "git+ssh://git@github.com/ramp4-pcar4/vue3-treeselect.git#3dccc9e78dca3681289e7cff1cb94464c52443fa",
+            "resolved": "git+ssh://git@github.com/ramp4-pcar4/vue3-treeselect.git#7a77069eaeae2910f00eeb4960205d80c22f7856",
             "license": "MIT",
             "peerDependencies": {
                 "vue": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@ag-grid-community/locale": "~32.0.0",
         "@arcgis/core": "4.29.10",
         "@popperjs/core": "^2.11.6",
-        "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect",
+        "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect#v1.0.0",
         "@vueform/toggle": "^2.1.3",
         "ag-grid-community": "^27.3.0",
         "ag-grid-vue3": "^27.3.0",


### PR DESCRIPTION
### Related Item(s)
#2438

### Changes
- Versioned the treeselect repo. See https://github.com/ramp4-pcar4/vue3-treeselect/releases/tag/v1.0.0

### Notes
- The wording for the treeselect release can probably be improved, so let me know your thoughts/suggestions

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

#### Demo testing
Steps:
1. Open any sample with a wizard
2. Click on the `+` in the legend to open the wizard
3. Add the following as as a Map Image Layer: 
 ```
https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer
``` 
4. Click though the wizard to reach Step 3, where the tree picker appears
5. Type `natu` 
6. Click the Left arrow key, and observe that the cursor moves to the left on the first click
7.  Click the Right arrow key, and observe that the cursor moves to the right on the first click
8. Click the Home key, and observe that the cursor moves to the very beginning of the search term
9.  Click the End key, and observe that the cursor moves to the very end of the search term
10. Click the Down/Up arrow keys, and observe that the currently selected option is highlighted in gray


#### Local testing
1. Within `package.json` , add `#v1.0.0` to the end of `"@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect"`
2. Run `npm install`
3. Go to `package-lock.json`
4. Observe that the commit hash for the treeselect repo has switched from `3dccc9e78dca3681289e7cff1cb94464c52443fa` to `7a77069eaeae2910f00eeb4960205d80c22f7856`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2483)
<!-- Reviewable:end -->
