### PR TITLE
Prevent aggressive linebreak on export timestamp

### DIFF
--- a/src/fixtures/export/api/export.ts
+++ b/src/fixtures/export/api/export.ts
@@ -232,7 +232,7 @@ export class ExportAPI extends FixtureInstance {
         if (selectedState.timestamp && exportTimestampFixture) {
             fbTimestamp = await exportTimestampFixture.make({
                 top: this.options.runningHeight + 40,
-                width: panelWidth
+                width: panelWidth * 1.5 // Magic number 1.5 prevents unnecessary linebreaks when there's still space
             });
 
             this.options.runningHeight +=


### PR DESCRIPTION
### Related Item(s)
#2309 

### Changes
- [FIX] Increases amount of export width available for the timestamp, so it doesn't break line when there's still plenty of space available.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to any sample with an export panel (e.g. Enhanced 01 "Happy").
2. Open the export panel.
3. Using the devtools emulator, reduce the width of the page, watching the timestamp at the bottom of the export canvas as you do. Notice the line breaking is much more conservative, only doing so when there isn't enough horizontal space.
