### PR TITLE
Implement better notification handling on lang switch

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -579,7 +579,13 @@ export class InstanceAPI {
             return;
         }
         const configStore = useConfigStore(this.$vApp.$pinia);
+        const notificationStore = useNotificationStore(this.$vApp.$pinia);
         const langs = configStore.registeredLangs;
+
+        // If monoconfig, clear all notifications (notification language isn't changed on lang change)
+        if (Object.keys(configStore.registeredConfigs).length === 1) {
+            notificationStore.clearAll();
+        }
 
         const old = this.$i18n.locale.value;
         this.$i18n.locale.value = language;


### PR DESCRIPTION
### Related Item(s)
#2432 

### Changes
- [FIX] Implements better logic for notifications on language switch, to ensure proper translations are shown.
  - If the RAMP instance is a monoconfig, the notifications will be cleared on language switch.
  - If the RAMP instance is a multi-config, there is no change to behaviour: notifications get refreshed along with everything else, so they're shown in the correct language already. 

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to a multi-config sample (e.g. classic sample 1). 
2. Use the bottom-right dropdown to switch languages, and check for notifications. Notice that they are shown in the correct language.
3. Go to a monoconfig sample (e.g. classic sample 33 - delayed start).
4. Ensure there are a few notifications (should be in the current language). Then switch languages - notifications should be cleared.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2487)
<!-- Reviewable:end -->
