### PR TITLE
Reduce initial download size

### DIFF
--- a/src/fixtures/basemap/index.ts
+++ b/src/fixtures/basemap/index.ts
@@ -1,5 +1,4 @@
 import { markRaw } from 'vue';
-import BasemapScreenV from './screen.vue';
 import { FixtureInstance } from '@/api';
 import BasemapNavButtonV from './nav-button.vue';
 import messages from './lang/lang.csv?raw';
@@ -16,7 +15,7 @@ class BasemapFixture extends FixtureInstance {
             {
                 id: 'basemap',
                 config: {
-                    screens: { 'basemap-component': markRaw(BasemapScreenV) },
+                    screens: { 'basemap-component': () => markRaw(import('./screen.vue')) },
                     button: {
                         tooltip: 'basemap.title',
                         icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M20.5 3l-.16.03L15 5.1 9 3 3.36 4.9c-.21.07-.36.25-.36.48V20.5c0 .28.22.5.5.5l.16-.03L9 18.9l6 2.1 5.64-1.9c.21-.07.36-.25.36-.48V3.5c0-.28-.22-.5-.5-.5zM15 19l-6-2.11V5l6 2.11V19z"/><path d="M0 0h24v24H0z" fill="none" /></svg>'

--- a/src/fixtures/details/index.ts
+++ b/src/fixtures/details/index.ts
@@ -1,6 +1,5 @@
 import { DetailsAPI } from './api/details';
 import { type DetailsConfig, useDetailsStore } from './store';
-import DetailsScreenV from './details-screen.vue';
 import messages from './lang/lang.csv?raw';
 
 import { markRaw } from 'vue';
@@ -12,7 +11,7 @@ class DetailsFixture extends DetailsAPI {
             {
                 details: {
                     screens: {
-                        'details-screen': markRaw(DetailsScreenV)
+                        'details-screen': () => markRaw(import('./details-screen.vue'))
                     },
                     style: {
                         width: '425px'

--- a/src/fixtures/geosearch/index.ts
+++ b/src/fixtures/geosearch/index.ts
@@ -1,5 +1,4 @@
 import { markRaw } from 'vue';
-import GeosearchScreenV from './screen.vue';
 import { GeosearchAPI } from './api/geosearch';
 import GeosearchNavButtonV from './nav-button.vue';
 
@@ -22,7 +21,7 @@ class GeosearchFixture extends GeosearchAPI {
                 id: 'geosearch',
                 config: {
                     screens: {
-                        'geosearch-component': markRaw(GeosearchScreenV)
+                        'geosearch-component': () => markRaw(import('./screen.vue'))
                     },
                     button: {
                         tooltip: 'geosearch.title',

--- a/src/fixtures/help/index.ts
+++ b/src/fixtures/help/index.ts
@@ -1,6 +1,5 @@
 import { markRaw } from 'vue';
 import { HelpAPI } from './api/help';
-import HelpScreenV from './screen.vue';
 import HelpNavButtonV from './nav-button.vue';
 
 import messages from './lang/lang.csv?raw';
@@ -17,7 +16,7 @@ class HelpFixture extends HelpAPI {
             {
                 help: {
                     screens: {
-                        'help-screen': markRaw(HelpScreenV)
+                        'help-screen': () => markRaw(import('./screen.vue'))
                     },
                     style: {
                         'flex-grow': '1',

--- a/src/fixtures/layer-reorder/index.ts
+++ b/src/fixtures/layer-reorder/index.ts
@@ -1,5 +1,4 @@
 import { markRaw } from 'vue';
-import LayerReorderScreenV from './screen.vue';
 import messages from './lang/lang.csv?raw';
 import { LayerReorderAPI } from './api/layer-reorder';
 import { useAppbarStore } from '../appbar/store';
@@ -12,7 +11,7 @@ class LayerReorderFixture extends LayerReorderAPI {
             {
                 'layer-reorder': {
                     screens: {
-                        'layer-reorder-screen': markRaw(LayerReorderScreenV)
+                        'layer-reorder-screen': () => markRaw(import('./screen.vue'))
                     },
                     style: {
                         width: '350px'

--- a/src/fixtures/legend/index.ts
+++ b/src/fixtures/legend/index.ts
@@ -1,7 +1,6 @@
 import { markRaw } from 'vue';
 import { LegendAPI } from './api/legend';
 import LegendNavButtonV from './nav-button.vue';
-import LegendScreenV from './screen.vue';
 
 import messages from './lang/lang.csv?raw';
 import { useAppbarStore } from '../appbar/store';
@@ -18,7 +17,7 @@ class LegendFixture extends LegendAPI {
             {
                 legend: {
                     screens: {
-                        'legend-screen': markRaw(LegendScreenV)
+                        'legend-screen': () => markRaw(import('./screen.vue'))
                     },
                     style: {
                         width: '350px'

--- a/src/fixtures/metadata/index.ts
+++ b/src/fixtures/metadata/index.ts
@@ -1,6 +1,5 @@
 import { markRaw } from 'vue';
 import { MetadataAPI } from './api/metadata';
-import MetadataScreenV from './screen.vue';
 
 import messages from './lang/lang.csv?raw';
 import { useAppbarStore } from '../appbar/store';
@@ -12,7 +11,7 @@ class MetadataFixture extends MetadataAPI {
             {
                 metadata: {
                     screens: {
-                        'metadata-screen-content': markRaw(MetadataScreenV)
+                        'metadata-screen-content': () => markRaw(import('./screen.vue'))
                     },
                     style: {
                         width: '350px'

--- a/src/fixtures/settings/index.ts
+++ b/src/fixtures/settings/index.ts
@@ -1,6 +1,5 @@
 import { markRaw } from 'vue';
 import { SettingsAPI } from './api/settings';
-import SettingsScreenV from './screen.vue';
 import messages from './lang/lang.csv?raw';
 import { useAppbarStore } from '../appbar/store';
 
@@ -12,7 +11,7 @@ class SettingsFixture extends SettingsAPI {
             {
                 settings: {
                     screens: {
-                        'settings-screen-content': markRaw(SettingsScreenV)
+                        'settings-screen-content': () => markRaw(import('./screen.vue'))
                     },
                     style: {
                         width: '350px'

--- a/src/fixtures/wizard/index.ts
+++ b/src/fixtures/wizard/index.ts
@@ -1,6 +1,5 @@
 import { markRaw } from 'vue';
 import { WizardAPI } from './api/wizard';
-import WizardScreenV from './screen.vue';
 import { LayerSource } from './store/layer-source';
 import messages from './lang/lang.csv?raw';
 import { useWizardStore } from './store';
@@ -13,7 +12,7 @@ class WizardFixture extends WizardAPI {
             {
                 wizard: {
                     screens: {
-                        'wizard-screen': markRaw(WizardScreenV)
+                        'wizard-screen': () => markRaw(import('./screen.vue'))
                     },
                     button: {
                         tooltip: 'wizard.title',

--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -9,7 +9,7 @@ import EsriBasemap from '@arcgis/core/Basemap';
 import EsriColour from '@arcgis/core/Color';
 import EsriConfig from '@arcgis/core/config';
 import EsriExtent from '@arcgis/core/geometry/Extent';
-import EsriGeometry from '@arcgis/core/geometry/Geometry';
+import type EsriGeometry from '@arcgis/core/geometry/Geometry';
 import EsriMultipoint from '@arcgis/core/geometry/Multipoint';
 import EsriPoint from '@arcgis/core/geometry/Point';
 import EsriPolygon from '@arcgis/core/geometry/Polygon';
@@ -25,16 +25,16 @@ import EsriOpenStreetMapLayer from '@arcgis/core/layers/OpenStreetMapLayer';
 import EsriTileLayer from '@arcgis/core/layers/TileLayer';
 import EsriWMSLayer from '@arcgis/core/layers/WMSLayer';
 import EsriField from '@arcgis/core/layers/support/Field';
-import EsriLOD from '@arcgis/core/layers/support/LOD';
-import EsriWMSSublayer from '@arcgis/core/layers/support/WMSSublayer';
+import type EsriLOD from '@arcgis/core/layers/support/LOD';
+import type EsriWMSSublayer from '@arcgis/core/layers/support/WMSSublayer';
 import EsriMap from '@arcgis/core/Map';
-import EsriClassBreaksRenderer from '@arcgis/core/renderers/ClassBreaksRenderer';
-import EsriRenderer from '@arcgis/core/renderers/Renderer';
+import type EsriClassBreaksRenderer from '@arcgis/core/renderers/ClassBreaksRenderer';
+import type EsriRenderer from '@arcgis/core/renderers/Renderer';
 import EsriSimpleRenderer from '@arcgis/core/renderers/SimpleRenderer';
-import EsriUniqueValueRenderer from '@arcgis/core/renderers/UniqueValueRenderer';
-import EsriClassBreakInfo from '@arcgis/core/renderers/support/ClassBreakInfo';
+import type EsriUniqueValueRenderer from '@arcgis/core/renderers/UniqueValueRenderer';
+import type EsriClassBreakInfo from '@arcgis/core/renderers/support/ClassBreakInfo';
 import { fromJSON as EsriRendererFromJson } from '@arcgis/core/renderers/support/jsonUtils';
-import EsriUniqueValueInfo from '@arcgis/core/renderers/support/UniqueValueInfo';
+import type EsriUniqueValueInfo from '@arcgis/core/renderers/support/UniqueValueInfo';
 import EsriRequest from '@arcgis/core/request';
 import { executeForIds as EsriQueryByIds } from '@arcgis/core/rest/query';
 import EsriQuery from '@arcgis/core/rest/support/Query';
@@ -42,7 +42,7 @@ import EsriPictureMarkerSymbol from '@arcgis/core/symbols/PictureMarkerSymbol';
 import EsriSimpleFillSymbol from '@arcgis/core/symbols/SimpleFillSymbol';
 import EsriSimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import EsriSimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
-import EsriSymbol from '@arcgis/core/symbols/Symbol';
+import type EsriSymbol from '@arcgis/core/symbols/Symbol';
 import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jsonUtils';
 import EsriFeatureFilter from '@arcgis/core/layers/support/FeatureFilter';
 import EsriMapView from '@arcgis/core/views/MapView';
@@ -51,8 +51,8 @@ import EsriColorBackground from '@arcgis/core/webmap/background/ColorBackground'
 // sorted by name
 export {
     EsriBasemap,
-    EsriClassBreakInfo,
-    EsriClassBreaksRenderer,
+    type EsriClassBreakInfo,
+    type EsriClassBreaksRenderer,
     EsriColour,
     EsriColorBackground,
     EsriConfig,
@@ -60,12 +60,12 @@ export {
     EsriFeatureFilter,
     EsriFeatureLayer,
     EsriField,
-    EsriGeometry,
+    type EsriGeometry,
     EsriGeometryFromJson,
     EsriGraphic,
     EsriGraphicsLayer,
     EsriImageryLayer,
-    EsriLOD,
+    type EsriLOD,
     EsriMap,
     EsriMapImageLayer,
     EsriMapView,
@@ -77,7 +77,7 @@ export {
     EsriPolyline,
     EsriQuery,
     EsriQueryByIds,
-    EsriRenderer,
+    type EsriRenderer,
     EsriRendererFromJson,
     EsriRequest,
     EsriSimpleFillSymbol,
@@ -85,11 +85,11 @@ export {
     EsriSimpleMarkerSymbol,
     EsriSimpleRenderer,
     EsriSpatialReference,
-    EsriSymbol,
+    type EsriSymbol,
     EsriSymbolFromJson,
     EsriTileLayer,
-    EsriUniqueValueInfo,
-    EsriUniqueValueRenderer,
+    type EsriUniqueValueInfo,
+    type EsriUniqueValueRenderer,
     EsriWMSLayer,
-    EsriWMSSublayer
+    type EsriWMSSublayer
 };

--- a/src/geo/layer/support/ogc-utils.ts
+++ b/src/geo/layer/support/ogc-utils.ts
@@ -5,7 +5,6 @@ import yxList from './reversedAxis.json';
 import { EsriRequest } from '@/geo/esri';
 import axios from 'redaxios';
 import to from 'await-to-js';
-import { XMLParser } from 'fast-xml-parser';
 
 type WFSResponse = {
     data: { numberMatched: number; features: any[] };
@@ -257,27 +256,29 @@ export class OgcUtils extends APIScope {
             return formats;
         };
 
-        return gcPromise.then((xmlNode: any): any => {
-            // Not sure if this check is still needed here.
-            if (!xmlNode) {
-                return [];
-            }
-            const xmlData: string = new XMLSerializer().serializeToString(xmlNode);
-            const options: Object = {
-                ignoreAttributes: false // check for tag attributes
-            };
-            const jsonObj: any = new XMLParser(options).parse(xmlData);
-            // We get an XML with a <ServiceExceptionReport> tag back when something goes wrong with the request.
-            // Might be able to get rid of this now that we are appending missing parameters to the URL.
-            if ('ServiceExceptionReport' in jsonObj) {
-                console.error(jsonObj.ServiceExceptionReport.ServiceException);
-                return [];
-            }
-            const capability: any = jsonObj.WMS_Capabilities.Capability;
-            return {
-                layers: getLayers(capability),
-                queryTypes: getQueryTypes(capability.Request.GetFeatureInfo)
-            };
+        return import('fast-xml-parser').then(({ XMLParser }) => {
+            return gcPromise.then((xmlNode: any): any => {
+                // Not sure if this check is still needed here.
+                if (!xmlNode) {
+                    return [];
+                }
+                const xmlData: string = new XMLSerializer().serializeToString(xmlNode);
+                const options: Object = {
+                    ignoreAttributes: false // check for tag attributes
+                };
+                const jsonObj: any = new XMLParser(options).parse(xmlData);
+                // We get an XML with a <ServiceExceptionReport> tag back when something goes wrong with the request.
+                // Might be able to get rid of this now that we are appending missing parameters to the URL.
+                if ('ServiceExceptionReport' in jsonObj) {
+                    console.error(jsonObj.ServiceExceptionReport.ServiceException);
+                    return [];
+                }
+                const capability: any = jsonObj.WMS_Capabilities.Capability;
+                return {
+                    layers: getLayers(capability),
+                    queryTypes: getQueryTypes(capability.Request.GetFeatureInfo)
+                };
+            });
         });
     }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,8 +16,7 @@ const baseConfig = {
     base: './',
     resolve: {
         alias: {
-            '@': resolve(__dirname, 'src'),
-            vue: 'vue/dist/vue.esm-bundler.js'
+            '@': resolve(__dirname, 'src')
         }
     },
     build: {


### PR DESCRIPTION
### Changes
- [REFACTOR] Fixtures and select external libraries are now dynamically loaded

### Notes
These changes reduce the initial download size of `esDynamic` by 391 kB (g-zip). Some libraries are now dynamically loaded when needed. Size reductions for:

vue 		109kb
vuedraggable 	62kb
shpjs 		76kb
JSZip 		28kb
fast-xml-parser 17kb
flatgeobuf 	80kb

**Vue has been switched to runtime only**, let me know if client side (string) template compilation is needed. Our custom fixtures seem to use the render function and this continues to be supported.

`esri.ts` was updated so type only imports are marked as such, to appease the compiler warnings. 


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

General sanity testing for export, basemaps, geosearch, help, import wizard, legend etc

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2489)
<!-- Reviewable:end -->
