### PR TITLE
Layer swipe demo

### DIFF
--- a/demos/enhanced-all.html
+++ b/demos/enhanced-all.html
@@ -48,6 +48,11 @@
                 09.
                 <a href="enhanced-samples.html?sample=9">Custom HTML panels</a>. Contains custom HTML panels
             </li>
+
+            <li>
+                11.
+                <a href="enhanced-samples.html?sample=11">Layer Swipe</a>. Contains demo of layer swipe feature
+            </li>
         </ul>
 
         <h2>Fancy Samples</h2>

--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -26,6 +26,7 @@
                 <option value="008-projection-party">08. Layers in Different Projections</option>
                 <option value="009-custom-panels">09. Custom HTML panels</option>
                 <option value="010-identify-priority">10. Identify Prioritization</option>
+                <option value="011-layer-swipe">11. Layer Swipe</option>
             </select>
             <nav class="linky-container">
                 <a class="linky" href="enhanced-all.html">Catalogue</a

--- a/demos/enhanced-scripts/009-custom-panels.js
+++ b/demos/enhanced-scripts/009-custom-panels.js
@@ -2,7 +2,8 @@
 Test 09: custom html panel
 - Loads Happy.json layer in the legend. Very basic.
 - Creates custom html panels
-- Tests the `persist` fixture property on the basemap and export fixtures, such that on a lang change (for which the configs of each lang are different), the fixtures will not persist
+- Tests the `persist` fixture property on the basemap and export fixtures, such that on a lang change 
+  (for which the configs of each lang are different), the fixtures will not persist
  */
 
 const runPreTest = (config, options, utils) => {

--- a/demos/enhanced-scripts/011-layer-swipe.js
+++ b/demos/enhanced-scripts/011-layer-swipe.js
@@ -1,0 +1,35 @@
+/*
+Test 11: Layer Swipe
+- 
+
+ */
+
+const runPreTest = (config, options, utils) => {
+    const natureLayer = {
+        id: 'Nature',
+        layerType: 'esri-feature',
+        url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/6'
+    };
+
+    const waterLayer = {
+        id: 'Water',
+        layerType: 'esri-feature',
+        url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/8'
+    };
+
+    // add layers (same across langs)
+    utils.addLayerLegend(natureLayer);
+    utils.addLayerLegend(waterLayer);
+
+    return { config, options };
+};
+
+const runPostTest = instance => {
+    // add export fixtures
+    instance.fixture.add('export');
+
+    // create a fixture for the layer slider
+    instance.fixture.add('swipe');
+};
+
+export { runPreTest, runPostTest };

--- a/demos/starter-scripts/simple-feature.js
+++ b/demos/starter-scripts/simple-feature.js
@@ -309,7 +309,4 @@ const rInstance = createInstance(document.getElementById('app'), config, options
 // add export fixtures
 rInstance.fixture.add('export');
 
-// load map if startRequired is true
-// rInstance.start();
-
 window.debugInstance = rInstance;

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -771,6 +771,8 @@ export class EventAPI extends APIScope {
                                 (tl as TileLayer).checkProj();
                             });
                     }
+                    const schemaChangeEvent = new CustomEvent('BasemapSchemaChange'); // used by swipe fixture
+                    window.dispatchEvent(schemaChangeEvent);
                 };
                 this.$iApi.event.on(GlobalEvents.MAP_BASEMAPCHANGE, zeHandler, handlerName);
                 break;

--- a/src/components/panel-stack/panel-stack.vue
+++ b/src/components/panel-stack/panel-stack.vue
@@ -1,5 +1,5 @@
 <template>
-    <transition-group @enter="enter" @leave="leave" name="panel-container" tag="div" ref="el">
+    <transition-group @enter="enter" @leave="leave" name="panel-container" tag="div" ref="el" class="panel-container">
         <!-- TODO: pass a corresponding fixture instance to the panel component as it can be useful -->
         <panel-container
             v-for="panel in visible(iApi!.screenSize)"
@@ -22,6 +22,9 @@ import { usePanelStore } from '@/stores/panel';
 const panelStore = usePanelStore();
 const iApi = inject<InstanceAPI>('iApi')!;
 const el = ref<ComponentPublicInstance>();
+const opacity = computed(() => {
+    return panelStore.opacity;
+});
 
 const mobileMode = computed(() => panelStore.mobileView);
 
@@ -107,5 +110,10 @@ declare class ResizeObserver {
 // https://vuejs.org/v2/guide/transitions.html#List-Move-Transitions
 .panel-container-move {
     transition: 0.3s transform cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.panel-container {
+    transition: opacity 0.2s ease-out;
+    opacity: v-bind(opacity) !important;
 }
 </style>

--- a/src/fixtures/swipe/index.ts
+++ b/src/fixtures/swipe/index.ts
@@ -1,0 +1,49 @@
+import { EsriAPI } from '@/geo/esri';
+import SwipeV from './swipe.vue'; // import on-map component
+import { FixtureInstance } from '@/api';
+
+class SwipeFixture extends FixtureInstance {
+    async added(): Promise<void> {
+        const { el, destroy } = this.mount(SwipeV, {
+            app: this.$element,
+            props: { message: 'This is a swipe.', fixture: this }
+        });
+
+        this.$vApp.$el.appendChild(el.childNodes[0]);
+
+        const leadingLayers = await EsriAPI.Collection();
+        const trailingLayers = await EsriAPI.Collection();
+        await this.$iApi.geo.map.viewPromise;
+        let view = this.$iApi.geo.map.esriView;
+        const natureLayer = this.$iApi.geo.layer.getLayer('Nature')?.esriLayer;
+        const waterLayer = this.$iApi.geo.layer.getLayer('Water')?.esriLayer;
+
+        leadingLayers.add(natureLayer);
+        trailingLayers.add(waterLayer);
+        let swipe = await EsriAPI.Swipe({ view, leadingLayers, trailingLayers, position: 50 });
+        //view?.ui.add(swipe);
+
+        const layerSliderId = '#layerSlider' + this.$element._uid; // uses ID of VueApp object to ensure uniqueness
+        const slider = this.$vApp.$el.querySelector(layerSliderId) as HTMLInputElement;
+        slider?.addEventListener('MoveInput', e => {
+            const evt = e as CustomEvent;
+            swipe.position = (evt.detail / this.$iApi?.$rootEl.clientWidth) * 100;
+        });
+
+        // Upon a basemap schema change, geo.map.esriView gets set to a new MapView, meaning that the one used by the
+        // swipe component wouldn't exist. So, we must reinitialize the swipe component
+        window.addEventListener('BasemapSchemaChange', async () => {
+            swipe.destroy();
+            view = this.$iApi.geo.map.esriView;
+            swipe = await EsriAPI.Swipe({ view, leadingLayers, trailingLayers, position: 50 });
+        });
+
+        this.removed = (): void => {
+            this.$vApp.$el.removeChild(el.childNodes[0]);
+            swipe.destroy();
+            destroy();
+        };
+    }
+}
+
+export default SwipeFixture;

--- a/src/fixtures/swipe/swipe.vue
+++ b/src/fixtures/swipe/swipe.vue
@@ -1,0 +1,153 @@
+<template>
+    <div class="swipe-container">
+        <div id="verticalLine" :style="{ left: linePosition, height: lineHeight, bottom: lineBottom }"></div>
+        <input
+            v-model="sliderPosition"
+            :id="'layerSlider' + iApi?.$element._uid"
+            class="layerSliderElement"
+            type="range"
+            ref="slider"
+            min="0"
+            aria-valuemin="0"
+            aria-valuemax="90"
+            :aria-valuenow="sliderPosition"
+            :aria-label="$t('map.layerSwipe.label')"
+            max="90"
+            step="0.5"
+            :content="$t('map.layerSwipe.drag')"
+            v-tippy="{ followCursor: true }"
+        />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { FixtureInstance } from '@/api';
+import { computed, inject, onBeforeMount, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue';
+import { usePanelStore } from '@/stores/panel';
+import type { InstanceAPI } from '@/api';
+
+const iApi = inject<InstanceAPI>('iApi');
+
+const panelStore = usePanelStore();
+const slider = useTemplateRef('slider');
+const sliderPosition = ref<number>(45);
+const clientHeight = ref<number>(0);
+const refreshCounter = ref(0);
+
+const linePosition = computed(() => {
+    const thumbWidth = 30 + refreshCounter.value - refreshCounter.value;
+    const sliderWidth = slider.value?.clientWidth ?? 0;
+    const inputToPercentage = +sliderPosition.value / 90; // Percentage of slider that slider thumb has surpassed
+    const sliderOffset = (sliderWidth - thumbWidth) * inputToPercentage; // Number of pixels in slider that slider thumb has surpassed
+    const pos = (slider.value?.getBoundingClientRect().x ?? 0) + sliderOffset + (thumbWidth - 4) / 2;
+
+    const event = new CustomEvent('MoveInput', { detail: pos });
+    slider.value?.dispatchEvent(event);
+
+    return `${pos}px`;
+});
+
+const lineHeight = computed(() => {
+    return `${clientHeight.value}px`;
+});
+
+const lineBottom = computed(() => {
+    return `${-65 * (clientHeight.value / 1270)}px`;
+});
+
+defineProps({
+    fixture: {
+        type: FixtureInstance,
+        required: true
+    },
+    message: String
+});
+
+onBeforeMount(() => {
+    clientHeight.value = iApi?.$rootEl?.clientHeight ?? 1200;
+});
+
+onMounted(() => {
+    window.addEventListener('resize', () => {
+        clientHeight.value = iApi?.$rootEl?.clientHeight ?? clientHeight.value;
+        refreshCounter.value++; // used to force update on window resize
+        setTimeout(() => {
+            refreshCounter.value++; // window minimizing/maximizing requires a second, delayed update
+        }, 50);
+    });
+    slider.value?.addEventListener('focus', () => panelStore.setOpacity(0.1));
+    slider.value?.addEventListener('blur', () => panelStore.setOpacity(1));
+    slider.value?.addEventListener('mouseover', () => panelStore.setOpacity(0.1));
+    slider.value?.addEventListener('mouseleave', () => panelStore.setOpacity(1));
+    setTimeout(() => {
+        refreshCounter.value++; // window minimizing/maximizing requires a second, delayed update
+    }, 50);
+});
+
+onBeforeUnmount(() => {
+    window.removeEventListener('resize', () => {
+        clientHeight.value = iApi?.$rootEl?.clientHeight ?? clientHeight.value;
+        refreshCounter.value++; // used to force update on window resize
+        setTimeout(() => {
+            refreshCounter.value++; // window minimizing/maximizing requires a second, delayed update
+        }, 50);
+    });
+    slider.value?.removeEventListener('focus', () => panelStore.setOpacity(0.1));
+    slider.value?.removeEventListener('blur', () => panelStore.setOpacity(1));
+    slider.value?.removeEventListener('mouseover', () => panelStore.setOpacity(0.1));
+    slider.value?.removeEventListener('mouseleave', () => panelStore.setOpacity(1));
+});
+</script>
+
+<style lang="scss" scoped>
+.swipe-container {
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
+    bottom: 5%;
+    padding-top: 20px;
+    padding-bottom: 20px;
+    background: linear-gradient(to right, rgba(0, 0, 0, 0) 5%, #4caf50 5%, #4caf50 95%, rgba(0, 0, 0, 0) 95%);
+    z-index: 0;
+}
+
+.layerSliderElement {
+    height: 5px;
+    width: 90%;
+    -webkit-appearance: none;
+    appearance: none;
+    //background: inherit;
+}
+
+.layerSliderElement:hover {
+    opacity: 1;
+}
+
+.layerSliderElement::-webkit-slider-thumb {
+    width: 30px;
+    height: 25px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: black;
+    cursor: col-resize;
+}
+
+.layerSliderElement::-moz-range-thumb {
+    width: 30px;
+    height: 25px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: black;
+    cursor: col-resize;
+}
+
+#verticalLine {
+    display: flex;
+    align-items: center;
+    position: absolute;
+    padding-right: 5px;
+    z-index: -15;
+    background: linear-gradient(#000, #000) no-repeat center/4px 100%;
+}
+</style>

--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -8,6 +8,7 @@
 import type EsriBasemap from '@arcgis/core/Basemap';
 import EsriColour from '@arcgis/core/Color';
 import EsriConfig from '@arcgis/core/config';
+import type EsriCollection from '@arcgis/core/core/Collection';
 import EsriExtent from '@arcgis/core/geometry/Extent';
 import type EsriGeometry from '@arcgis/core/geometry/Geometry';
 import EsriMultipoint from '@arcgis/core/geometry/Multipoint';
@@ -45,6 +46,7 @@ import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jso
 import type EsriFeatureFilter from '@arcgis/core/layers/support/FeatureFilter';
 import type EsriMapView from '@arcgis/core/views/MapView';
 import type EsriColorBackground from '@arcgis/core/webmap/background/ColorBackground';
+import type EsriSwipe from '@arcgis/core/widgets/Swipe.js';
 
 // NOTE we need to have explicit strings in the `await import()` calls, as that's
 //      how Vite knows how to optimize the chunks.
@@ -136,6 +138,18 @@ class EsriAPI {
         const { fromJSON } = await import('@arcgis/core/renderers/support/jsonUtils');
         return fromJSON(json);
     }
+
+    // --- Components ---
+
+    static async Swipe(prams: __esri.SwipeProperties): Promise<EsriSwipe> {
+        const lib = await import('@arcgis/core/widgets/Swipe.js');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async Collection(): Promise<EsriCollection> {
+        const lib = await import('@arcgis/core/core/Collection');
+        return Reflect.construct(lib.default, []);
+    }
 }
 
 // sorted by name
@@ -144,6 +158,7 @@ export {
     type EsriBasemap,
     type EsriClassBreakInfo,
     type EsriClassBreaksRenderer,
+    type EsriCollection,
     EsriColour,
     type EsriColorBackground,
     EsriConfig,
@@ -174,6 +189,7 @@ export {
     EsriSimpleMarkerSymbol,
     type EsriSimpleRenderer,
     EsriSpatialReference,
+    type EsriSwipe,
     type EsriSymbol,
     EsriSymbolFromJson,
     type EsriTileLayer,

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -24,6 +24,8 @@ map.language.en,English,1,English,1
 map.language.fr,Français,1,Français,1
 map.language.curr,current,1,actuel,1
 map.export,export map,1,exporter la carte,1
+map.layerSwipe.drag,Drag and slide to move,1,Faites glisser et glissez pour déplacer,0
+map.layerSwipe.label,Layer swipe,1,Glissement de calque,0
 notifications.open,Open Notifications Panel,1,Ouvrir la fenêtre des notifications,1
 notifications.title,Notifications,1,Notifications,1
 notifications.empty,No new notifications.,1,Aucune nouvelle notification.,1

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -18,6 +18,7 @@ export interface PanelStore {
     orderedItems: Ref<[]>;
     teleported: Ref<[]>;
     visible: Ref<[]>;
+    opacity: Ref<number>;
     getRemainingWidth: ComputedRef<number>;
     getVisible: (screenSize: string) => PanelConfig[];
     getRegPromises: (panelIds: string[]) => Promise<PanelInstance>[];
@@ -25,6 +26,7 @@ export interface PanelStore {
     closePanel: (panel: PanelInstance) => void;
     movePanel: (panel: PanelInstance, direction: PanelDirection) => void;
     removePanel: (panel: PanelInstance) => void;
+    setOpacity: (value: number) => void;
     setStackWidth: (value: number) => void;
     setMobileView: (value: boolean) => void;
     updateVisible: () => void;
@@ -48,6 +50,7 @@ export const usePanelStore = defineStore('panel', () => {
     const orderedItems = ref<PanelInstance[]>([]);
     const teleported = ref<PanelInstance[]>([]);
     const visible = ref<PanelInstance[]>([]);
+    const opacity = ref<number>(1);
 
     /**
      * Returns `remainingWidth` from the state. Displays how much space is left for panels to be displayed on the map.
@@ -106,6 +109,10 @@ export const usePanelStore = defineStore('panel', () => {
     function removePanel(panel: PanelInstance): void {
         remove(panel);
         updateVisible();
+    }
+
+    function setOpacity(value: number): void {
+        opacity.value = value;
     }
 
     /**
@@ -302,6 +309,7 @@ export const usePanelStore = defineStore('panel', () => {
         pinned,
         priority,
         visible,
+        opacity,
         stackWidth,
         remWidth,
         mobileView,
@@ -314,6 +322,7 @@ export const usePanelStore = defineStore('panel', () => {
         closePanel,
         movePanel,
         removePanel,
+        setOpacity,
         setStackWidth,
         setMobileView,
         updateVisible,


### PR DESCRIPTION
### Related Item(s)
#2308

### Changes
- Created a fixture that allows for layers to be swiped
- Included map peek upon focusing on the range input (from https://github.com/ramp4-pcar4/ramp4-pcar4/pull/1922)

### Notes
- I tried adding ESRI's layer swipe UI component onto the `MapView` but it would only appear under it, so I decided to create a new fixture to control to layer swiping
- I also tried recreating ESRI's layer swipe UI component (something like [this](https://www.arcgis.com/apps/instant/media/index.html?appid=a428f2b2d60146d8b3c01a356cb7e644)), but it wasn't very convenient to use, so I decided to implement something similar to a time slider. Let me know if you would also like to see a demo of that previous attempt

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 11
2. Play around with the layer swipe feature

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2497)
<!-- Reviewable:end -->
