### PR TITLE
Change some docsite urls to avoid unwanted string substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ During build, the `public` folder contents are placed into the `dist` folder.
 When you push changes to your forked repo, a demo preview is automatically generated. The demo preview will update each time you push changes. Note that demos are deleted daily whenever the source branch or tag is deleted from your forked repo.
 
 ### Accessing Your Demo Previews:
-- **Branch or Tag Preview**: Visit `https://{{github-username}}.github.io/ramp4-pcar4/{{branch-or-tag-name}}` to see a live preview of the branch or tag you've pushed.
-- **List of All Demos**: View all your demo previews by navigating to `https://github.com/{{github-username}}/ramp4-pcar4/tree/demo-page`.
+- **Branch or Tag Preview**: Visit `https://YOUR-GITHUB-USERNAME.github.io/ramp4-pcar4/BRANCH-OR-TAG-NAME` to see a live preview of the branch or tag you've pushed.
+- **List of All Demos**: View all your demo previews by navigating to `https://github.com/YOUR-GITHUB-USERNAME/ramp4-pcar4/tree/demo-page`.
 
 ### Enabling Demos for Your Forked Repo:
 To enable demo previews on your forked repository, update the following settings:

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -3,8 +3,8 @@
 When you push changes to your forked repo, a demo preview is automatically generated. The demo preview will update each time you push changes. Note that demos are deleted daily whenever the source branch or tag is deleted from your forked repo.
 
 ### Accessing Your Demo Previews:
-- **Branch or Tag Preview**: Visit `https://{{github-username}}.github.io/ramp4-pcar4/{{branch-or-tag-name}}` to see a live preview of the branch or tag you've pushed.
-- **List of All Demos**: View all your demo previews by navigating to `https://github.com/{{github-username}}/ramp4-pcar4/tree/demo-page`.
+- **Branch or Tag Preview**: Visit `https://YOUR-GITHUB-USERNAME.github.io/ramp4-pcar4/BRANCH-OR-TAG-NAME` to see a live preview of the branch or tag you've pushed.
+- **List of All Demos**: View all your demo previews by navigating to `https://github.com/YOUR-GITHUB-USERNAME/ramp4-pcar4/tree/demo-page`.
 
 ### Enabling Demos for Your Forked Repo:
 To enable demo previews on your forked repository, update the following settings:


### PR DESCRIPTION
### Related Item(s)
#2506 

### Changes

- [FIX] Change some docsite urls to avoid unwanted string substitution

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open **https://milespetrov.github.io/ramp4-pcar4/2506-docsite-url/docs/introduction/setup.html#accessing-your-demo-previews**
2. Notice the urls are now `https://YOUR-GITHUB-USERNAME.github.io/ramp4-pcar4/BRANCH-OR-TAG-NAME` and `https://github.com/YOUR-GITHUB-USERNAME/ramp4-pcar4/tree/demo-page`.

Note: The doc site reader must replace `YOUR-GITHUB-USERNAME` and `BRANCH-OR-TAG-NAME` since the urls vary based on account names and branch/tag names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2508)
<!-- Reviewable:end -->
