### PR TITLE
Wizard Infinite Loop Fix

### DIFF
--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -834,7 +834,7 @@ const generateColour = () => {
     // generate unique ID for colour picker to prevent multi-ramp collisions
     do {
         colourPickerId.value = Math.random().toString(36).substring(2, 9);
-    } while (iApi.$vApp.$el.getElementById(colourPickerId.value + '-hue-slider') !== null);
+    } while (document.getElementById(colourPickerId.value + '-hue-slider') !== null);
 };
 
 const updateColour = (eventData: any) => {


### PR DESCRIPTION
### Related Item(s)

#2505

### Changes
- Backs out [change to wizard colour generator](https://github.com/ramp4-pcar4/ramp4-pcar4/commit/63ded3eae5996b91f87c8591409dc88e74bf6168#diff-80cd06412cb6dd214f2a76551c5df0c151c746436427918156b70d111b23652d) that was causing an infinite loop

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Wizard URL:

```
https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/Oilsands/MapServer/1
```

Steps:
1. Open the wizard via the `+` in the legend
2. Add above URL as a feature layer.
3. Ensure step 3 appears, and can finish the wizard. Layer appears on the map.