### PR TITLE
add aria-label to floating-button component

### DIFF
--- a/src/components/notification-center/floating-button.vue
+++ b/src/components/notification-center/floating-button.vue
@@ -4,6 +4,7 @@
         @click="iApi.panel.get('notifications').open()"
         class="pointer-events-auto items-center absolute left-8 bottom-36 p-6 block sm:display-none bg-black-75 rounded-full text-gray-400 hover:text-white"
         :content="t('notifications.title')"
+        :aria-label="t('notifications.title')"
         v-tippy
     >
         <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Anotifications -->


### PR DESCRIPTION
### Related Item(s)
#2511 

### Changes
- Adds an `aria-label` to the `floating-button` component.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open [sample 14](https://ryancoulsonca.github.io/ramp4-pcar4/fix-2511/demos/index-samples.html?sample=14).
2. Open the WAVE toolbar.
3. Notice that the `empty button` error is no longer appearing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2512)
<!-- Reviewable:end -->
