### PR TITLE
Fix basemap info tooltip issues, Fix various other tooltip issues

### DIFF
--- a/src/components/notification-center/notification-list.vue
+++ b/src/components/notification-center/notification-list.vue
@@ -5,7 +5,7 @@
             v-if="notificationStack.length > 0"
             v-focus-list
             :content="t('panels.controls.items')"
-            v-tippy="{ trigger: 'manual', placement: 'top-start' }"
+            v-tippy="{ trigger: 'manual', placement: 'top-start', touch: false }"
             ref="el"
         >
             <template v-for="(notification, index) in notificationStack" :key="notification.message + index">

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -4,6 +4,7 @@
         :content="`<div style='word-break: break-word;'>${t(panel.alertName) + '. ' + t('panels.access')}</div>`"
         v-tippy="{
             trigger: 'manual',
+            touch: false,
             onShow: checkMode,
             allowHTML: true,
             maxWidth: panel.style['flex-basis'] ?? 350,

--- a/src/fixtures/appbar/appbar.vue
+++ b/src/fixtures/appbar/appbar.vue
@@ -5,6 +5,7 @@
         :content="t('panels.controls.items')"
         v-tippy="{
             trigger: 'manual',
+            touch: false,
             placement: 'top-end',
             popperOptions: {
                 placement: 'top',

--- a/src/fixtures/basemap/screen.vue
+++ b/src/fixtures/basemap/screen.vue
@@ -11,6 +11,7 @@
                 v-tippy="{
                     trigger: 'manual',
                     placement: 'top-end',
+                    touch: false,
                     maxWidth: 190
                 }"
                 ref="el"

--- a/src/fixtures/details/components/result-list.vue
+++ b/src/fixtures/details/components/result-list.vue
@@ -97,7 +97,8 @@
                     :content="t('details.layers.results.list.tooltip')"
                     v-tippy="{
                         trigger: 'manual',
-                        placement: 'top-start'
+                        placement: 'top-start',
+                        touch: false
                     }"
                     ref="el"
                 >

--- a/src/fixtures/details/components/symbology-list.vue
+++ b/src/fixtures/details/components/symbology-list.vue
@@ -10,7 +10,8 @@
         :content="t('details.layers.results.list.tooltip')"
         v-tippy="{
             trigger: 'manual',
-            placement: 'top-start'
+            placement: 'top-start',
+            touch: false
         }"
         ref="el"
     >

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -10,6 +10,7 @@
                 v-tippy="{
                     trigger: 'manual',
                     placement: 'top-end',
+                    touch: false,
                     maxWidth: 190
                 }"
                 ref="el"

--- a/src/fixtures/mapnav/mapnav.vue
+++ b/src/fixtures/mapnav/mapnav.vue
@@ -7,6 +7,7 @@
             v-tippy="{
                 trigger: 'manual',
                 placement: 'top-end',
+                touch: false,
                 maxWidth: 190
             }"
             ref="el"


### PR DESCRIPTION
### Related Item(s)
#2520

### Changes
- Fix basemap info tooltip
- Prevent tooltips intended for keyboard users from being shown to mobile users 

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps (Basemap info):
1. Open the Basemap panel
2. With your keyboard, enter the Basemap panel and put focus on the info icon of a basemap. Observe the tooltip appear. Exit focus from it and observe the tooltip disappear
3. Hover over the info icon of a basemap, and observe the tooltip appear. Move the mouse away and observe the tooltip disappear
4. On a mobile device (or in mobile mode), touch the info icon. Observe that the tooltip appears. Touch the icon again (or any part of the screen), and observe the tooltip disappear

Steps (other tooltip issues)
1. Go to enhanced sample 7
2. On a mobile device, open any panel and touch+hold some area in the panel. Observe that the tooltip at the top of the panel doesn't appear anymore
3. Touch an area of the map with lots of features to trigger identify
4. Within the details panel, touch+hold the symbology list, and observe that its tooltip doesn't appear anymore
5. Within the details panel, open the list view and touch+hold the list. Observe that its tooltip doesn't appear anymore
6. Switch languages quickly to get some notifications
7. Open the notifications list and touch+hold it. Observe that its tooltip doesn't appear anymore
8. Touch+hold the appbar, and observe that its tooltip doesn't appear anymore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2527)
<!-- Reviewable:end -->
