### PR TITLE
ESRI Chunk Load

### DIFF
--- a/docs/using-ramp4/layers/fancy-properties.md
+++ b/docs/using-ramp4/layers/fancy-properties.md
@@ -246,8 +246,6 @@ This differs from the `initialFilteredQuery`, in that the filter is locked for t
 
 File based layers will still download everything up-front, but will respect the filter afterwards. Same with WFS, but a WFS can apply a similar filter in its URL if the server will respect the parameter.
 
-To align a legend symbol stack with a particular permanent filter, see the `symbologyStack` option of the [legend configuration](/using-ramp4/fixtures/legend.md#layer-item-1).
-
 ```js
 {
     permanentFilteredQuery: "resto_type = 'Hamburger'"

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -201,32 +201,32 @@ export class InstanceAPI {
                     clearInterval(mapDivWatcher);
 
                     // create the map
-                    this.geo.map.createMap(langConfig.map, mapViewElement as HTMLDivElement);
+                    this.geo.map.createMap(langConfig.map, mapViewElement as HTMLDivElement).then(() => {
+                        // Hide hovertip on map creation
+                        //@ts-ignore
+                        mapViewElement._tippy.hide(0);
+                        //@ts-ignore
+                        maptipStore.setMaptipInstance(mapViewElement._tippy);
 
-                    // Hide hovertip on map creation
-                    //@ts-ignore
-                    mapViewElement._tippy.hide(0);
-                    //@ts-ignore
-                    maptipStore.setMaptipInstance(mapViewElement._tippy);
-
-                    if (langConfig.layers && langConfig.layers.length > 0) {
-                        // Add all the config layers to the instance, in order.
-                        // Config layers always get "added first", so we provide order positions here for the map layers.
-                        // Enhanced positioning logic is now handled by map.addLayer()
-                        let mapOrderPos = 0;
-                        langConfig.layers.forEach(layerConfig => {
-                            const layer = this.geo.layer.createLayer(layerConfig);
-                            this.geo.map
-                                .addLayer(layer, mapOrderPos)
-                                // just to silence console about unhandled rejections.
-                                .catch(() => {});
-                            if (layer.mapLayer) {
-                                // we only increment for map layers. Data layers get added but do not live in the map stack.
-                                // so no ++. We pass the param to map.addLayer above out of lazyness. It gets ignored for data layers.
-                                mapOrderPos++;
-                            }
-                        });
-                    }
+                        if (langConfig.layers && langConfig.layers.length > 0) {
+                            // Add all the config layers to the instance, in order.
+                            // Config layers always get "added first", so we provide order positions here for the map layers.
+                            // Enhanced positioning logic is now handled by map.addLayer()
+                            let mapOrderPos = 0;
+                            langConfig.layers.forEach(layerConfig => {
+                                const layer = this.geo.layer.createLayer(layerConfig);
+                                this.geo.map
+                                    .addLayer(layer, mapOrderPos)
+                                    // just to silence console about unhandled rejections.
+                                    .catch(() => {});
+                                if (layer.mapLayer) {
+                                    // we only increment for map layers. Data layers get added but do not live in the map stack.
+                                    // so no ++. We pass the param to map.addLayer above out of lazyness. It gets ignored for data layers.
+                                    mapOrderPos++;
+                                }
+                            });
+                        }
+                    });
                 }
             }, 100);
 

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -599,7 +599,10 @@ export interface GeoJsonOptions {
 }
 
 export interface LoadLayerMetadataOptions {
-    customRenderer?: EsriRenderer; // renderer in ESRI API format
+    /**
+     * renderer in ESRI JS API format
+     */
+    customRenderer?: EsriRenderer;
 }
 
 export interface CsvOptions {

--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -5,7 +5,7 @@
 // we should consider an alternate approach (some exceptions might arise).
 
 // sorted by library path
-import EsriBasemap from '@arcgis/core/Basemap';
+import type EsriBasemap from '@arcgis/core/Basemap';
 import EsriColour from '@arcgis/core/Color';
 import EsriConfig from '@arcgis/core/config';
 import EsriExtent from '@arcgis/core/geometry/Extent';
@@ -17,79 +17,168 @@ import EsriPolyline from '@arcgis/core/geometry/Polyline';
 import EsriSpatialReference from '@arcgis/core/geometry/SpatialReference';
 import { fromJSON as EsriGeometryFromJson } from '@arcgis/core/geometry/support/jsonUtils';
 import EsriGraphic from '@arcgis/core/Graphic';
-import EsriFeatureLayer from '@arcgis/core/layers/FeatureLayer';
-import EsriGraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
-import EsriImageryLayer from '@arcgis/core/layers/ImageryLayer';
-import EsriMapImageLayer from '@arcgis/core/layers/MapImageLayer';
-import EsriOpenStreetMapLayer from '@arcgis/core/layers/OpenStreetMapLayer';
-import EsriTileLayer from '@arcgis/core/layers/TileLayer';
-import EsriWMSLayer from '@arcgis/core/layers/WMSLayer';
-import EsriField from '@arcgis/core/layers/support/Field';
+import type EsriFeatureLayer from '@arcgis/core/layers/FeatureLayer';
+import type EsriGraphicsLayer from '@arcgis/core/layers/GraphicsLayer';
+import type EsriImageryLayer from '@arcgis/core/layers/ImageryLayer';
+import type EsriMapImageLayer from '@arcgis/core/layers/MapImageLayer';
+import type EsriOpenStreetMapLayer from '@arcgis/core/layers/OpenStreetMapLayer';
+import type EsriTileLayer from '@arcgis/core/layers/TileLayer';
+import type EsriWMSLayer from '@arcgis/core/layers/WMSLayer';
+import type EsriField from '@arcgis/core/layers/support/Field';
 import type EsriLOD from '@arcgis/core/layers/support/LOD';
 import type EsriWMSSublayer from '@arcgis/core/layers/support/WMSSublayer';
-import EsriMap from '@arcgis/core/Map';
+import type EsriMap from '@arcgis/core/Map';
 import type EsriClassBreaksRenderer from '@arcgis/core/renderers/ClassBreaksRenderer';
 import type EsriRenderer from '@arcgis/core/renderers/Renderer';
-import EsriSimpleRenderer from '@arcgis/core/renderers/SimpleRenderer';
+import type EsriSimpleRenderer from '@arcgis/core/renderers/SimpleRenderer';
 import type EsriUniqueValueRenderer from '@arcgis/core/renderers/UniqueValueRenderer';
 import type EsriClassBreakInfo from '@arcgis/core/renderers/support/ClassBreakInfo';
-import { fromJSON as EsriRendererFromJson } from '@arcgis/core/renderers/support/jsonUtils';
 import type EsriUniqueValueInfo from '@arcgis/core/renderers/support/UniqueValueInfo';
 import EsriRequest from '@arcgis/core/request';
-import { executeForIds as EsriQueryByIds } from '@arcgis/core/rest/query';
-import EsriQuery from '@arcgis/core/rest/support/Query';
+import type EsriQuery from '@arcgis/core/rest/support/Query';
 import EsriPictureMarkerSymbol from '@arcgis/core/symbols/PictureMarkerSymbol';
 import EsriSimpleFillSymbol from '@arcgis/core/symbols/SimpleFillSymbol';
 import EsriSimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import EsriSimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
 import type EsriSymbol from '@arcgis/core/symbols/Symbol';
 import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jsonUtils';
-import EsriFeatureFilter from '@arcgis/core/layers/support/FeatureFilter';
-import EsriMapView from '@arcgis/core/views/MapView';
-import EsriColorBackground from '@arcgis/core/webmap/background/ColorBackground';
+import type EsriFeatureFilter from '@arcgis/core/layers/support/FeatureFilter';
+import type EsriMapView from '@arcgis/core/views/MapView';
+import type EsriColorBackground from '@arcgis/core/webmap/background/ColorBackground';
+
+// NOTE we need to have explicit strings in the `await import()` calls, as that's
+//      how Vite knows how to optimize the chunks.
+//      So lots of boilerplate here instead of nice `genericLoad(libPath: string)` gettup.
+
+class EsriAPI {
+    // --- Maps ---
+
+    static async Basemap(prams: __esri.BasemapProperties): Promise<EsriBasemap> {
+        const lib = await import('@arcgis/core/Basemap');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async Map(prams: __esri.MapProperties): Promise<EsriMap> {
+        const lib = await import('@arcgis/core/Map');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async MapView(prams: __esri.MapViewProperties): Promise<EsriMapView> {
+        const lib = await import('@arcgis/core/views/MapView');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    // --- Layers ---
+
+    static async FeatureLayer(prams: __esri.FeatureLayerProperties): Promise<EsriFeatureLayer> {
+        const lib = await import('@arcgis/core/layers/FeatureLayer');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async GraphicsLayer(prams: __esri.GraphicsLayerProperties): Promise<EsriGraphicsLayer> {
+        const lib = await import('@arcgis/core/layers/GraphicsLayer');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async ImageryLayer(prams: __esri.ImageryLayerProperties): Promise<EsriImageryLayer> {
+        const lib = await import('@arcgis/core/layers/ImageryLayer');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async MapImageLayer(prams: __esri.MapImageLayerProperties): Promise<EsriMapImageLayer> {
+        const lib = await import('@arcgis/core/layers/MapImageLayer');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async OpenStreetMapLayer(prams: __esri.OpenStreetMapLayerProperties): Promise<EsriOpenStreetMapLayer> {
+        const lib = await import('@arcgis/core/layers/OpenStreetMapLayer');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async TileLayer(prams: __esri.TileLayerProperties): Promise<EsriTileLayer> {
+        const lib = await import('@arcgis/core/layers/TileLayer');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async WMSLayer(prams: __esri.WMSLayerProperties): Promise<EsriWMSLayer> {
+        const lib = await import('@arcgis/core/layers/WMSLayer');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    // --- Utils ---
+
+    static async ColorBackground(prams: __esri.ColorBackgroundProperties): Promise<EsriColorBackground> {
+        const lib = await import('@arcgis/core/webmap/background/ColorBackground');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async FeatureFilter(prams: __esri.FeatureFilterProperties): Promise<EsriFeatureFilter> {
+        const lib = await import('@arcgis/core/layers/support/FeatureFilter');
+        return Reflect.construct(lib.default, [prams]);
+    }
+
+    static async FieldFromJson(json: any): Promise<EsriField> {
+        const lib = await import('@arcgis/core/layers/support/Field');
+        return lib.default.fromJSON(json);
+    }
+
+    static async Query(): Promise<EsriQuery> {
+        const lib = await import('@arcgis/core/rest/support/Query');
+        return Reflect.construct(lib.default, []);
+    }
+
+    static async QueryByIds(url: string, query: EsriQuery, options?: __esri.RequestOptions): Promise<Array<number>> {
+        const { executeForIds } = await import('@arcgis/core/rest/query');
+        return executeForIds(url, query, options);
+    }
+
+    static async RendererFromJson(json: any): Promise<EsriRenderer> {
+        const { fromJSON } = await import('@arcgis/core/renderers/support/jsonUtils');
+        return fromJSON(json);
+    }
+}
 
 // sorted by name
 export {
-    EsriBasemap,
+    EsriAPI,
+    type EsriBasemap,
     type EsriClassBreakInfo,
     type EsriClassBreaksRenderer,
     EsriColour,
-    EsriColorBackground,
+    type EsriColorBackground,
     EsriConfig,
     EsriExtent,
-    EsriFeatureFilter,
-    EsriFeatureLayer,
-    EsriField,
+    type EsriFeatureFilter,
+    type EsriFeatureLayer,
+    type EsriField,
     type EsriGeometry,
     EsriGeometryFromJson,
     EsriGraphic,
-    EsriGraphicsLayer,
-    EsriImageryLayer,
+    type EsriGraphicsLayer,
+    type EsriImageryLayer,
     type EsriLOD,
-    EsriMap,
-    EsriMapImageLayer,
-    EsriMapView,
+    type EsriMap,
+    type EsriMapImageLayer,
+    type EsriMapView,
     EsriMultipoint,
-    EsriOpenStreetMapLayer,
+    type EsriOpenStreetMapLayer,
     EsriPictureMarkerSymbol,
     EsriPoint,
     EsriPolygon,
     EsriPolyline,
-    EsriQuery,
-    EsriQueryByIds,
+    type EsriQuery,
     type EsriRenderer,
-    EsriRendererFromJson,
     EsriRequest,
     EsriSimpleFillSymbol,
     EsriSimpleLineSymbol,
     EsriSimpleMarkerSymbol,
-    EsriSimpleRenderer,
+    type EsriSimpleRenderer,
     EsriSpatialReference,
     type EsriSymbol,
     EsriSymbolFromJson,
-    EsriTileLayer,
+    type EsriTileLayer,
     type EsriUniqueValueInfo,
     type EsriUniqueValueRenderer,
-    EsriWMSLayer,
+    type EsriWMSLayer,
     type EsriWMSSublayer
 };

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -114,6 +114,14 @@ export class AttribLayer extends MapLayer {
         this.extent = this.extent ?? sData.extent;
         this._serverVisibility = sData.defaultVisibility;
 
+        /* See https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#title
+               In particular, if the service has several layers, then the title of each layer will be the concatenation
+               of the service name and the layer name.
+               For consistency with map image sublayers, we set the layer's name to only the service name below. */
+        if (!this.origRampConfig.name) {
+            this.name = sData.name ?? this.id;
+        }
+
         // stuff for Feature vs Raster
         if (this.dataFormat === DataFormat.ESRI_FEATURE) {
             this.supportsFeatures = true;
@@ -163,14 +171,6 @@ export class AttribLayer extends MapLayer {
                 permanentFilter: this.getSqlFilter(CoreFilter.PERMANENT)
             };
             this.attribs.attLoader = new ArcServerAttributeLoader(this.$iApi, loadData);
-
-            /* See https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-FeatureLayer.html#title
-               In particular, if the service has several layers, then the title of each layer will be the concatenation
-               of the service name and the layer name.
-               For consistency with map image sublayers, we set the layer's name to only the service name below. */
-            if (!this.origRampConfig.name) {
-                this.name = sData.name ?? this.id;
-            }
         } else {
             // raster layer
             this.supportsFeatures = false;

--- a/src/geo/layer/graphic-layer.ts
+++ b/src/geo/layer/graphic-layer.ts
@@ -1,7 +1,7 @@
 import { CommonGraphicLayer, InstanceAPI } from '@/api/internal';
 import { DrawState, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
-import { EsriGraphicsLayer } from '@/geo/esri';
+import { EsriAPI } from '@/geo/esri';
 import { markRaw } from 'vue';
 
 // NOTE this class is fairly meh, but gives a vanilla implementation of the common graphic layer base.
@@ -18,7 +18,7 @@ export class GraphicLayer extends CommonGraphicLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        this.esriLayer = markRaw(new EsriGraphicsLayer(this.makeEsriLayerConfig(this.origRampConfig)));
+        this.esriLayer = markRaw(await EsriAPI.GraphicsLayer(this.makeEsriLayerConfig(this.origRampConfig)));
         await super.onInitiate();
     }
 

--- a/src/geo/layer/imagery-layer.ts
+++ b/src/geo/layer/imagery-layer.ts
@@ -1,7 +1,8 @@
 import { InstanceAPI, MapLayer } from '@/api/internal';
 import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
-import { EsriImageryLayer } from '@/geo/esri';
+import type { EsriImageryLayer } from '@/geo/esri';
+import { EsriAPI } from '@/geo/esri';
 import { markRaw } from 'vue';
 
 /**
@@ -19,7 +20,7 @@ export class ImageryLayer extends MapLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        this.esriLayer = markRaw(new EsriImageryLayer(this.makeEsriLayerConfig(this.origRampConfig)));
+        this.esriLayer = markRaw(await EsriAPI.ImageryLayer(this.makeEsriLayerConfig(this.origRampConfig)));
         await super.onInitiate();
     }
 

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -34,7 +34,8 @@ import {
     LayerType,
     SpatialReference
 } from '@/geo/api';
-import { EsriField, EsriRendererFromJson, EsriRequest } from '@/geo/esri';
+import { EsriAPI, EsriRequest } from '@/geo/esri';
+import type { EsriField } from '@/geo/esri';
 import { useLayerStore } from '@/stores/layer';
 import to from 'await-to-js';
 
@@ -382,7 +383,9 @@ export class LayerAPI extends APIScope {
 
             if (Array.isArray(sData.fields)) {
                 // parse fields to our format
-                const esriFields: Array<EsriField> = sData.fields.map((f: any) => EsriField.fromJSON(f));
+                const esriFields: Array<EsriField> = await Promise.all(
+                    sData.fields.map((f: any) => EsriAPI.FieldFromJson(f))
+                );
                 md.fields = esriFields.map(f => {
                     return {
                         name: f.name,
@@ -422,7 +425,7 @@ export class LayerAPI extends APIScope {
                     md.geometryType = this.$iApi.geo.geom.serverGeomTypeToRampGeomType(sData.geometryType);
 
                     if (sData.drawingInfo?.renderer) {
-                        md.renderer = EsriRendererFromJson(sData.drawingInfo.renderer);
+                        md.renderer = await EsriAPI.RendererFromJson(sData.drawingInfo.renderer);
                     }
 
                     if (sData.sourceSpatialReference) {

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -30,7 +30,8 @@ import type {
     RampLayerMapImageSublayerConfig
 } from '@/geo/api';
 
-import { EsriMapImageLayer, EsriRendererFromJson } from '@/geo/esri';
+import { EsriAPI } from '@/geo/esri';
+import type { EsriMapImageLayer } from '@/geo/esri';
 import { markRaw, reactive } from 'vue';
 
 // Formerly known as DynamicLayer
@@ -57,7 +58,7 @@ export class MapImageLayer extends MapLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        this.esriLayer = markRaw(new EsriMapImageLayer(this.makeEsriLayerConfig(this.origRampConfig)));
+        this.esriLayer = markRaw(await EsriAPI.MapImageLayer(this.makeEsriLayerConfig(this.origRampConfig)));
 
         await super.onInitiate();
     }
@@ -299,7 +300,7 @@ export class MapImageLayer extends MapLayer {
             // generate the RAMP wrapper on the layer.
             const hasCustRed = miSL.esriSubLayer && config?.customRenderer?.type;
             if (hasCustRed) {
-                miSL.esriSubLayer!.renderer = EsriRendererFromJson(config.customRenderer);
+                miSL.esriSubLayer!.renderer = await EsriAPI.RendererFromJson(config.customRenderer);
             }
 
             await miSL.loadLayerMetadata(hasCustRed ? { customRenderer: miSL.esriSubLayer?.renderer } : {});

--- a/src/geo/layer/osm-tile-layer.ts
+++ b/src/geo/layer/osm-tile-layer.ts
@@ -3,7 +3,8 @@ import { DataFormat, LayerFormat, LayerType } from '@/geo/api';
 
 import type { LegendSymbology, RampLayerConfig } from '@/geo/api';
 
-import { EsriOpenStreetMapLayer } from '@/geo/esri';
+import { EsriAPI } from '@/geo/esri';
+import type { EsriOpenStreetMapLayer } from '@/geo/esri';
 import { markRaw } from 'vue';
 
 /**
@@ -22,7 +23,7 @@ export class OsmTileLayer extends MapLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        this.esriLayer = markRaw(new EsriOpenStreetMapLayer(this.makeEsriLayerConfig(this.origRampConfig)));
+        this.esriLayer = markRaw(await EsriAPI.OpenStreetMapLayer(this.makeEsriLayerConfig(this.origRampConfig)));
         await super.onInitiate();
     }
 

--- a/src/geo/layer/support/file-utils.ts
+++ b/src/geo/layer/support/file-utils.ts
@@ -5,7 +5,7 @@ import { csv2geojson, dsv } from 'csv2geojson';
 import axios from 'redaxios';
 import type { CrsMeta } from 'flatgeobuf';
 
-import { EsriSimpleRenderer } from '@/geo/esri';
+import { EsriAPI } from '@/geo/esri';
 import { Colour, FieldType, LayerType, SpatialReference } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 
@@ -431,7 +431,7 @@ export class FileUtils extends APIScope {
         // Note: while this appears to always give the layer a simple renderer,
         // if a customRenderer is on the config, it will get applied to the esri
         // layer during FileLayer.onLoadActions()
-        configPackage.renderer = EsriSimpleRenderer.fromJSON(defRender.renderer);
+        configPackage.renderer = await EsriAPI.RendererFromJson(defRender.renderer);
 
         // add all the fields to config.Package
         configPackage.fields = (configPackage.fields || []).concat(

--- a/src/geo/layer/tile-layer.ts
+++ b/src/geo/layer/tile-layer.ts
@@ -1,7 +1,8 @@
 import { InstanceAPI, MapLayer, NotificationType } from '@/api/internal';
 import { DataFormat, LayerFormat, LayerState, LayerType } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
-import { EsriTileLayer } from '@/geo/esri';
+import { EsriAPI } from '@/geo/esri';
+import type { EsriTileLayer } from '@/geo/esri';
 import { markRaw } from 'vue';
 
 /**
@@ -20,7 +21,7 @@ export class TileLayer extends MapLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        this.esriLayer = markRaw(new EsriTileLayer(this.makeEsriLayerConfig(this.origRampConfig)));
+        this.esriLayer = markRaw(await EsriAPI.TileLayer(this.makeEsriLayerConfig(this.origRampConfig)));
         await super.onInitiate();
     }
 

--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -19,8 +19,8 @@ import type {
     Point
 } from '@/geo/api';
 
-import { EsriRequest, EsriWMSLayer } from '@/geo/esri';
-import type { EsriWMSSublayer } from '@/geo/esri';
+import { EsriAPI, EsriRequest } from '@/geo/esri';
+import type { EsriWMSLayer, EsriWMSSublayer } from '@/geo/esri';
 
 import { markRaw, reactive } from 'vue';
 
@@ -48,7 +48,7 @@ export class WmsLayer extends MapLayer {
     }
 
     protected async onInitiate(): Promise<void> {
-        this.esriLayer = markRaw(new EsriWMSLayer(this.makeEsriLayerConfig(this.origRampConfig)));
+        this.esriLayer = markRaw(await EsriAPI.WMSLayer(this.makeEsriLayerConfig(this.origRampConfig)));
         await super.onInitiate();
     }
 

--- a/src/geo/utils/query.ts
+++ b/src/geo/utils/query.ts
@@ -3,7 +3,7 @@ import { BaseGeometry, Extent, GeometryType, Graphic, NoGeometry, Point, Spatial
 
 import type { QueryFeaturesArcServerParams, QueryFeaturesParams } from '@/geo/api';
 
-import { EsriQuery, EsriQueryByIds } from '@/geo/esri';
+import { EsriAPI } from '@/geo/esri';
 
 // this exists here instead of our main definitions file because it uses `FileLayer` type.
 // the layer inherits from APIScope, causing circular references in the public folder
@@ -31,7 +31,7 @@ export class QueryAPI extends APIScope {
 
         // create and set the esri query parameters
 
-        const query = new EsriQuery();
+        const query = await EsriAPI.Query();
         query.returnGeometry = false;
 
         if (options.filterSql) {
@@ -55,7 +55,7 @@ export class QueryAPI extends APIScope {
             query.spatialRelationship = 'intersects';
         }
 
-        const oids = await EsriQueryByIds(options.url, query);
+        const oids = await EsriAPI.QueryByIds(options.url, query);
         return Array.isArray(oids) ? oids : [];
     }
 
@@ -66,7 +66,7 @@ export class QueryAPI extends APIScope {
      * @returns resolves with array of graphic result objects.
      */
     async geoJsonQuery(options: QueryFeaturesFileParams): Promise<Array<Graphic>> {
-        const query = new EsriQuery();
+        const query = await EsriAPI.Query();
         query.returnGeometry = !!options.includeGeometry;
         query.outFields = ['*']; // TODO look into using the options value. test it well, as the .where gets wonky with outfields
 


### PR DESCRIPTION
### Related Item(s)

#2155 (should relatively conclude the RAMP side of this issue. Storyilnes / Respect bundler still a target for enhancements).

### Changes

- Wires up on-demand chunk loading for most ESRI libraries when using the `esDynamic` build, or importing from `npm` combined with having a respectful bundler.
- ESRI Geometry and Symbology classes remain pre-bundled, as introducing async on all of them would not have been worth the tradeoff.
- Improved error handling of poorly configured basemaps.
- Found and squashed small bug around loading server name from MIL Raster children.
- Removed an incorrect piece of doc in `permanentFilteredQuery` section.

### Notes

The main starter chunk dropped from 2.7 mb to 1.3 mb :rocket:.

**Breaking Changes:**

The following Map API calls now return a Promise that resolves with the original synchronous value. This affects both the primary map (`MapAPI`) and the overview map (`OverviewMapAPI`).
- `createMap()`
- `reloadMap()`
- `findBasemap()`
- `setBasemap()`
- `recoverBasemap()`

The class constructor for `Basemap` will no longer initialize the internal ESRI basemap class. Use the new static method `Basemap.create(config)`, which returns a Promise that resolves in the initialized basemap.

Typical sites will not be impacted by these API changes. Using `createInstance()` works as it always has. But any fancy page code or custom fixtures directly hitting these endpoints will need to adjust.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

General integrity tests:

- General map and layer loading
- Changing basemaps (with and without map schema change)
- Language change (use an Enhanced sample to ensure its not a singular config and true map reload)
- Classic Sample 33 - basemap failover (will take 10 seconds or so but basemap should appear)
- Classic Sample 44 - delayed map load

Developer network activity test:

1. Open Enhanced Sample 1
1. Mash `F12`, open `Network` tab, clear all the activity
1. Paste the below script in the console. You should see something named `@arcgis_core_layers_MapImageLayer.js` get downloaded, since this is the first MIL on this sample.

```js
const inputConfig = {
    id: 'EcoGeo',
    layerType: 'esri-map-image',
    url: 'https://section917.canadacentral.cloudapp.azure.com/arcgis/rest/services/TestData/EcoAction/MapServer/',
    sublayers: [{ index: 6 }, { index: 8 }]
};
const lay = debugInstance.geo.layer.createLayer(inputConfig);
debugInstance.geo.map.addLayer(lay).then(()=> { 
  debugInstance.event.emit('user/layeradded', lay);
});
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2529)
<!-- Reviewable:end -->
