### PR TITLE
Add back support for client side string template compilation

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,8 @@ const baseConfig = {
     base: './',
     resolve: {
         alias: {
-            '@': resolve(__dirname, 'src')
+            '@': resolve(__dirname, 'src'),
+            vue: 'vue/dist/vue.esm-bundler.js'
         }
     },
     build: {


### PR DESCRIPTION
### Related Item(s)
#2535 

### Changes
- [FIX] Add back support for client side string template compilation

### Notes

I think it's fine to add back, I just nuked it for size savings and didn't think it was used at all. Oddly when I did another comparison between main and my branch (sample 7) the difference was only 11 kB. Not sure where I got the original 109 kB 

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to [enhanced samples 7](https://milespetrov.github.io/ramp4-pcar4/2535-runtime/demos/enhanced-samples.html?sample=7)
2. Click on one of the teal circle points in Ontario (the "WFS Layer")
3. Enjoy seeing Rick in the details panel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2536)
<!-- Reviewable:end -->
