### PR TITLE
Fix lint on column pin

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -736,9 +736,10 @@ const clearFilters = () => {
 
 const togglePinned = () => {
     pinned.value = !pinned.value;
+    const pinSetting = pinned.value ? 'left' : null;
 
-    let cols = columnApi.value.getAllDisplayedColumns();
-    columnApi.value.setColumnsPinned(cols.slice(1, 3), pinned.value ? 'left' : '');
+    const cols = columnApi.value.getAllDisplayedColumns();
+    columnApi.value.setColumnsPinned(cols.slice(1, 3), pinSetting);
 };
 
 const exportData = () => {


### PR DESCRIPTION
### Changes

- Attempts to fix the linting error that is making every PR "fail" the checks

### Notes

Seems `''` makes the type-matching angry for valid `ag-grid` pin settings. `null` appears to be the "off" setting it wants.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

1. Open Enhanced Sample 3 (Feature Layers)
2. Click the Legend to open a grid for one of the Layers
3. Horizontally scroll the grid to the right. Observe the Details and Zoomies column stays pinning & visible
4. Click the vertical `...` button in upper right of the grid. Uncheck the `Pin Columns` menu.
5. Details and Zoomies columns unpin and disappear from view.
6. Horizontally scroll the grid to the left. Verify columns still exist and are in correct spot (between row number and icon).
7. Do a zoomies for fun & integrity check
8. Horizontally scroll the grid to the right.
9. Click the vertical `...` button in upper right of the grid. Check the `Pin Columns` menu.
10. Details and Zoomies columns pin and appear on the left of the grid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2537)
<!-- Reviewable:end -->
