### PR TITLE
Overview layer timeout race

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ramp-pcar",
-    "version": "4.11.0-beta",
+    "version": "4.10.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ramp-pcar",
-            "version": "4.11.0-beta",
+            "version": "4.10.1",
             "dependencies": {
                 "@ag-grid-community/locale": "~32.0.0",
                 "@arcgis/core": "4.31.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ramp-pcar",
-    "version": "4.11.0-beta",
+    "version": "4.10.1",
     "description": "RAMP4 - The Reusable Accessible Mapping Platform, is a Javascript based web mapping platform that provides a reusable, responsive and WCAG 2.1 AA compliant common viewer for the Government of Canada. ",
     "type": "module",
     "module": "./dist/bundler/ramp.bundle.es.js",

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -56,10 +56,12 @@ export class MapAPI extends CommonMapAPI {
      * Map wide defaults for layer times. Layers can override.
      */
     layerDefaultTimes: LayerTimes = {
-        // DEV NOTE these values get updated in createMap(). Using 0 here to avoid having defaults in two spots.
-        draw: 0,
-        load: 0,
-        fail: 0
+        // DEV NOTE these values get updated with any config overrides in createMap().
+        //          But need to init values here on the chance layers start initializing prior to map
+        //          getting "created". Affects overview map layers in particular.
+        draw: 10000,
+        load: 10000,
+        fail: 90000
     };
 
     /**


### PR DESCRIPTION
### Related Item(s)
#2541

### Changes
- Removes the "delayed setting" of layer timeout default values, mitigating lurking fast layers picking up a "fail after 0 seconds" state.
- Being cheeky and booping the version number too
 
### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Since this is a race condition, and "should be fixed", you kinda just need to try a bunch of times and watch for the bug.

General test:
1. Open any sample
2. Expand the overview map mini-window
3. Verify the red rectangle is present.

Ways that seemed to help trigger it prior to fix:

- Old James: Use a private browser
- Danbo: Use firefox. Open a sample, zoom the map, then open another sample (from sample dropdown picker). Would hit on second sample
- DJ Coulson:  do a non-cached refresh (CTRL + SHIFT + R on Chrome), it works. Then do a cached refresh (just CTRL+R, and dev tools closed), it fails

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2542)
<!-- Reviewable:end -->
