### PR TITLE
Prevent image element from rendering when no logo in config

### DIFF
--- a/src/components/map/map-caption.vue
+++ b/src/components/map/map-caption.vue
@@ -6,7 +6,7 @@
 
         <notifications-caption-button class="sm:block display-none" />
 
-        <span class="relative top-2 sm:top-1 ml-4 sm:ml-0 shrink-0" v-if="!attribution?.logo!.disabled">
+        <span class="relative top-2 sm:top-1 ml-4 sm:ml-0 shrink-0" v-if="showLogo()">
             <a
                 class="pointer-events-auto cursor-pointer"
                 :href="attribution?.logo!.link"
@@ -159,6 +159,9 @@ onUpdated(() => {
         }
     });
 });
+
+const showLogo = () =>
+    attribution.value?.logo?.link && attribution.value?.logo?.value && !attribution.value?.logo?.disabled;
 
 const changeLang = (lang: string) => {
     if (iApi.$i18n.locale.value != lang) {


### PR DESCRIPTION
### Related Item(s)
#2514


### Changes
- Make more rigorous checks (regarding whether a logo exists in the config) before rendering the logo element

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open classic sample 14 
2. Enable the WAVE extension
3. Notice there are no WAVE errors
4. Open any sample that is meant to have a logo, and observe that the logo is rendered

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2548)
<!-- Reviewable:end -->
