### PR TITLE
Make Enter key work for first two data column headers

### DIFF
--- a/src/fixtures/grid/accessibility.ts
+++ b/src/fixtures/grid/accessibility.ts
@@ -63,14 +63,14 @@ export class GridAccessibilityManager {
     }
 
     /**
-     * Set up the listeners for the grid
+     * Set up the listeners for the grid.
      */
     private initAccessibilityListeners() {
         const headerCells = Array.prototype.slice.call(
             this.headerRows[0].querySelectorAll('.ag-header-cell')
         ) as HTMLElement[];
         headerCells.forEach((cell, index) => {
-            if (index < 3) {
+            if (index < 1) {
                 return;
             }
             const buttons = Array.prototype.slice.call(cell.querySelectorAll('button')) as HTMLElement[];
@@ -94,14 +94,14 @@ export class GridAccessibilityManager {
     }
 
     /**
-     * Remove all accessibility listeners from the grid
+     * Remove all accessibility listeners from the grid.
      */
     removeAccessibilityListeners() {
         const headerCells = Array.prototype.slice.call(
             this.headerRows[0].querySelectorAll('.ag-header-cell')
         ) as HTMLElement[];
         headerCells.forEach((cell, index) => {
-            if (index < 3) {
+            if (index < 1) {
                 return;
             }
             const buttons = Array.prototype.slice.call(cell.querySelectorAll('button')) as HTMLElement[];


### PR DESCRIPTION
### Related Item(s)
#2516

### Changes
- Make clicking the Enter key enter the column headers for the first two data columns

### Notes
- Not exactly sure what the root cause of the issue is

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 5
2. Open the grid for any layer
3. Use keyboard to navigate into the grid
4. Use arrow keys to focus on the first data columns header
5. Press Enter, and observe that focus enters the header
6. Move focus to the next column header and repeat. 
7. Observe that focus also enters this header

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2551)
<!-- Reviewable:end -->
