### PR TITLE
Fix empty button WAVE errors in grid

### DIFF
--- a/src/components/panel-stack/controls/expand.vue
+++ b/src/components/panel-stack/controls/expand.vue
@@ -10,6 +10,7 @@
                 animation: 'scale',
                 hideOnClick: false
             }"
+            :aria-label="t(`panels.controls.${active ? 'collapse' : 'expand'}`)"
         >
             <!-- EXPAND https://fonts.google.com/icons?selected=Material%20Icons%3Aexpand%3A -->
             <svg

--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -5,6 +5,7 @@ grid.splash.error,Error: Failed to load the layer's data.,1,Erreur : Échec du 
 grid.splash.loading,Loading data...,1,Chargement des données...,1
 grid.splash.building,Building table...,1,Création du tableau...,1
 grid.splash.cancel,Cancel,1,Annuler,1
+grid.search.clear,Clear search filter,1,Effacer le filtre de recherche,0
 grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,1
 grid.layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
 grid.label.pinColumns,Pin columns,1,Épingler les colonnes,1

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -95,6 +95,7 @@
                         <button
                             class="flex justify-center fill-current ml-6 cursor-pointer"
                             @click="resetQuickSearch()"
+                            :aria-label="t('grid.search.clear')"
                             v-else
                         >
                             <svg

--- a/src/fixtures/grid/templates/clear-filter.vue
+++ b/src/fixtures/grid/templates/clear-filter.vue
@@ -8,6 +8,7 @@
         :disabled="!params.stateManager.filtered"
         tabindex="-1"
         ref="el"
+        :aria-label="t('grid.filters.clear')"
     >
         <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/fixtures/grid/templates/details-button-renderer.vue
+++ b/src/fixtures/grid/templates/details-button-renderer.vue
@@ -7,6 +7,7 @@
         @click="openDetails"
         tabindex="-1"
         ref="el"
+        :aria-label="t('grid.cells.details')"
     >
         <svg class="m-auto" xmlns="http://www.w3.org/2000/svg" height="16" viewBox="0 0 24 24" width="16">
             <path d="M0 0h24v24H0z" fill="none" />

--- a/src/fixtures/grid/templates/zoom-button-renderer.vue
+++ b/src/fixtures/grid/templates/zoom-button-renderer.vue
@@ -8,6 +8,7 @@
         @click="zoomToFeature"
         tabindex="-1"
         ref="button"
+        :aria-label="t(`grid.cells.zoom${zoomStatus === 'none' ? '' : `.${zoomStatus}`}`)"
     >
         <div v-if="zoomStatus === 'zooming'" class="m-auto animate-spin spinner h-20 w-20"></div>
         <svg


### PR DESCRIPTION
### Related Item(s)
#2521

### Changes
- Added `aria-label`'s to the buttons in the grid that were causing 'empty button' WAVE errors

### Notes
- There are still some WAVE errors left in the grid, but I believe these are from `ag-grid`

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 8
2. Click on legend entry "Feature LatLon" to open datagrid
3. Click `Hide Columns` button in the upper right of the grid to open the list
4. Fire up the WAVE Toolbar
5. Observe that there are no more 'empty button' WAVE errors
6. You can also repeat this for the `More` button

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2552)
<!-- Reviewable:end -->
