### PR TITLE
Remove tooltip on select components for Firefox users

### DIFF
--- a/src/fixtures/geosearch/top-filters.vue
+++ b/src/fixtures/geosearch/top-filters.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="rv-geosearch-top-filters sm:flex items-center w-full ml-8 mb-14" ref="el">
+    <div class="rv-geosearch-top-filters sm:flex items-center w-full ml-8 mb-14">
         <div class="w-fit inline-block sm:w-1/2 h-26 mb-8 sm:mb-0 pr-16 sm:pr-0">
             <select
                 class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
@@ -11,12 +11,6 @@
                     })
                 "
                 v-truncate
-                v-tippy="{
-                    content: t('select.items'),
-                    trigger: 'manual',
-                    placement: 'top-start'
-                }"
-                ref="selectProvince"
             >
                 <option value="" disabled hidden v-truncate>
                     {{ t('geosearch.filters.province') }}
@@ -37,12 +31,6 @@
                     })
                 "
                 v-truncate
-                v-tippy="{
-                    content: t('select.items'),
-                    trigger: 'manual',
-                    placement: 'top-start'
-                }"
-                ref="selectFilter"
             >
                 <option value="" disabled hidden>
                     {{ t('geosearch.filters.type') }}
@@ -74,7 +62,7 @@
 
 <script setup lang="ts">
 import type { InstanceAPI } from '@/api';
-import { computed, inject, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { computed, inject, onBeforeMount, onBeforeUnmount, ref, watch } from 'vue';
 import type { GeosearchAPI } from './api/geosearch';
 import { useGeosearchStore } from './store';
 import type { QueryParams } from './store';
@@ -83,9 +71,6 @@ import { useI18n } from 'vue-i18n';
 const { t } = useI18n();
 const iApi = inject<InstanceAPI>('iApi')!;
 const geosearchStore = useGeosearchStore();
-const el = ref<Element>();
-const selectProvince = ref<Element>();
-const selectFilter = ref<Element>();
 
 const provinces = ref<Array<any>>([]);
 const types = ref<Array<any>>([]);
@@ -131,48 +116,13 @@ const updateProvincesAndTypes = () => {
     });
 };
 
-const blurProvince = () => {
-    (selectProvince.value as any)._tippy.hide();
-};
-const blurFilter = () => {
-    (selectFilter.value as any)._tippy.hide();
-};
-const keyupProvince = (e: Event) => {
-    const evt = e as KeyboardEvent;
-    if (evt.key === 'Tab' && selectProvince.value?.matches(':focus') && navigator.userAgent.includes('Firefox')) {
-        (selectProvince.value as any)._tippy.show();
-    } else {
-        (selectProvince.value as any)._tippy.hide();
-    }
-};
-const keyupFilter = (e: Event) => {
-    const evt = e as KeyboardEvent;
-    if (evt.key === 'Tab' && selectFilter.value?.matches(':focus') && navigator.userAgent.includes('Firefox')) {
-        (selectFilter.value as any)._tippy.show();
-    } else {
-        (selectFilter.value as any)._tippy.hide();
-    }
-};
-
 onBeforeMount(() => {
     updateProvincesAndTypes();
     watchers.value.push(watch(language, updateProvincesAndTypes));
 });
 
-onMounted(() => {
-    selectProvince.value?.addEventListener('blur', blurProvince);
-    selectProvince.value?.addEventListener('keyup', keyupProvince);
-    selectFilter.value?.addEventListener('blur', blurFilter);
-    selectFilter.value?.addEventListener('keyup', keyupFilter);
-});
-
 onBeforeUnmount(() => {
     watchers.value.forEach(unwatch => unwatch());
-
-    selectProvince.value?.removeEventListener('blur', blurProvince);
-    selectProvince.value?.removeEventListener('keyup', keyupProvince);
-    selectFilter.value?.removeEventListener('blur', blurFilter);
-    selectFilter.value?.removeEventListener('keyup', keyupFilter);
 });
 </script>
 

--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -121,11 +121,6 @@
                         :value="modelValue"
                         @input="handleServiceSelection(size, $event)"
                         :aria-label="props.ariaLabel"
-                        v-tippy="{
-                            content: t('select.items'),
-                            trigger: 'manual',
-                            placement: 'top-start'
-                        }"
                         ref="selectInput"
                     >
                         <option class="p-6" v-for="option in options" :key="option.label" :value="option.value">
@@ -307,7 +302,6 @@ const watchers = reactive<Array<() => void>>([]);
 if (props.defaultOption && props.modelValue === '' && props.options.length) {
     // regex to guess closest default value for lat/long fields
     // eslint has beef with the following line for unknown reasons.
-
     let defaultValue = props.options[0].value;
     if (props.name === 'latField') {
         const latNames = new RegExp(/^(y|lat.*)$/i);
@@ -416,23 +410,7 @@ const addAriaLabel = () => {
     }
 };
 
-const blurEvent = () => {
-    (selectInput.value as any)._tippy.hide();
-};
-
-const keyupEvent = (e: Event) => {
-    const evt = e as KeyboardEvent;
-    if (evt.key === 'Tab' && selectInput.value?.matches(':focus') && navigator.userAgent.includes('Firefox')) {
-        (selectInput.value as any)._tippy.show();
-    } else {
-        (selectInput.value as any)._tippy.hide();
-    }
-};
-
 onMounted(() => {
-    selectInput.value?.addEventListener('blur', blurEvent);
-    selectInput.value?.addEventListener('keyup', keyupEvent);
-
     // only needed for wizard step 3, which takes longer to mount than the other steps
     if (props.step === 2 && props.step === props.activeStep) {
         emit('focusElement');
@@ -443,9 +421,6 @@ onBeforeUnmount(() => {
     // remove the resize observer
     resizeObserver.value!.disconnect();
     watchers.forEach(unwatch => unwatch());
-
-    selectInput.value?.removeEventListener('blur', blurEvent);
-    selectInput.value?.removeEventListener('keyup', keyupEvent);
 });
 </script>
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -56,4 +56,3 @@ layer.noexportmap,{name} was attempted to be added as a Map Image Layer but Map 
 caption.attributionDefaultText,Powered by ESRI,1,Propulsé par ESRI,0
 caption.attributionLogoAltText,ESRI logo,1,Logo ESRI,0
 caption.attributionLink,https://www.esri.com/,1,https://www.esri.com/fr-fr/home,1
-select.items, Use Arrow-up/down to select a value. Use Alt+Shift+Arrow-up/down to toggle the select menu,1,Utilisez Flèche haut/bas pour sélectionner une valeur. Utilisez Alt+Shift+Flèche haut/bas pour basculer le menu de sélection,0


### PR DESCRIPTION
### Related Item(s)
#2361

### Changes
- Remove tooltip on select components for Firefox users

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps :
#### Geosearch select components
1. Using Firefox, open any sample with geosearch
2. Open the geosearch panel
3. Click Tab until you reach the `Province` select menu
4. Observe that there is no tooltip on the select menu
5. Click Tab to reach the `Filter` select menu
6. Observe that there is no the tooltip on the select menu

#### Wizard select component
1. Using Firefox, open the legend, and then the wizard within it
2. Upload [happy.json](https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/public/file-layers/geojson.json)
3. Select GeoJSON as the format
4. Click Tab until you reach the `Primary Field` select menu
5. Observe that there is no tooltip on the select menu
6. Click Tab until you reach the `Tooltip Field` select menu
7. Observe that there is no tooltip on the select menu

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2555)
<!-- Reviewable:end -->
