### PR TITLE
Restrict modification of the default tab behavior for focus lists

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -106,11 +106,8 @@ onMounted(() => {
     });
 
     dropdownTrigger.value!.addEventListener('focus', focusDropdownTrigger);
-
     dropdownTrigger.value!.addEventListener('blur', blurDropdownTrigger);
-
     dropdownTrigger.value!.addEventListener('mouseover', focusDropdownTrigger);
-
     dropdownTrigger.value!.addEventListener('mouseleave', blurDropdownTrigger);
 
     // nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
@@ -174,11 +171,8 @@ onBeforeUnmount(() => {
     });
 
     dropdownTrigger.value!.removeEventListener('focus', focusDropdownTrigger);
-
     dropdownTrigger.value!.removeEventListener('blur', blurDropdownTrigger);
-
     dropdownTrigger.value!.removeEventListener('mouseover', focusDropdownTrigger);
-
     dropdownTrigger.value!.removeEventListener('mouseleave', blurDropdownTrigger);
 
     open.value = false;

--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -342,10 +342,15 @@ export class FocusListManager {
                 }
                 break;
             case KEYS.Tab:
-                // we only modify Tab behavior if the highlighted item isnt the list
-                if (this.highlightedItem !== this.element) {
-                    // prevent focus-items with tabbable children from being defocused right away
-                    if (this.highlightedItem.querySelectorAll(TABBABLE_TAGS).length === 0) {
+                const highlightedHasNoChildren = this.highlightedItem.querySelectorAll(TABBABLE_TAGS).length === 0;
+                const eventTargetIsFocusList = this.element.isEqualNode(event.target as HTMLElement);
+
+                // We only modify Tab behavior if the highlighted item isnt the list, and when the event's target is the focus list itself,
+                // as this implies that we are currently traversing focus items of the focus list, and thus we should modify the default behaviour
+                // upon clicking Tab
+                if (this.highlightedItem !== this.element && eventTargetIsFocusList) {
+                    // Prevent focus items with tabbable children from being defocused right away
+                    if (highlightedHasNoChildren) {
                         this.defocusItem(this.highlightedItem);
                     }
 


### PR DESCRIPTION
### Related Item(s)
#2539

### Changes
- When Tab is pressed within a focus list, the behavior of the corresponding event will only be modified when the focus list is the event target (and is not the currently highlighted element)
   - The focus list being the active element implies that we are currently traversing the focus items of that focus list, and are not currently focused on a child/descendent of a focus item
   

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any sample
2. Open the legend
3. Use keyboard to navigate to the 'More Options' button of a layer within the legend
4. Press Enter to open the options dropdown
5. Press Tab to navigate through the dropdown downwards
6. Press Shift+Tab, and observe that focus moves upwards in the dropdown, rather than moving to the focus list
7. Press Shift+Tab until focus reaches the 'More Options' button again
8. Press Shift+Tab and observe that focus moves to the layer's icon, rather than moving to the focus list
9. Test other focus lists within which the focus items have children/descendants (ex. Basemap, Notifications), and ensure that pressing Shift+Tab on those children/descendants doesn't move focus to the focus list
10. Ensure that the general behavior of the focus lists has not been messed up

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2559)
<!-- Reviewable:end -->
