### PR TITLE
Add new path input to fix main pr checks 

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -108,6 +108,7 @@ jobs:
                   ts-command: 'npm run ts:check'
                   lint-command: 'npm run lint:check'
                   format-command: 'npm run format:check'
+                  path: 'ramp'
 
             - name: Typescript badge
               if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
### Related Item(s)
#2549

### Changes
- [FIX] Fix failing status checks on main branch

### Notes
The main build checks out two branches into `ramp` and `demo-page` folders. Each step in the workflow starts at the root by default and we then change the cwd as needed. `path` lets status-checks know what the cwd should be if not root.

Actual code changes are already pushed: https://github.com/ramp4-pcar4/status-checks/commit/7e5c08fd32be131fb7be40e2665fcd2aca43c2e2

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

None needed. Though this won't run until merged so it might not actually work (like github yelling at me about path being a reserved word).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2560)
<!-- Reviewable:end -->
