### PR TITLE
Prevent tooltips on dropdown menus from being appended to parent

### DIFF
--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -10,7 +10,6 @@
                 placement: tooltipPlacement,
                 theme: tooltipTheme,
                 animation: tooltipAnimation,
-                appendTo: 'parent',
                 trigger: 'manual'
             }"
             ref="dropdownTrigger"
@@ -113,7 +112,7 @@ onMounted(() => {
 
     dropdownTrigger.value!.addEventListener('mouseleave', blurDropdownTrigger);
 
-    // nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
+    // nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper.
     nextTick(() => {
         const overflowScrollModifier: Modifier<'overflowScroll', {}> = {
             name: 'overflowScroll',


### PR DESCRIPTION
### Related Item(s)
#2558 
#2519

### Changes
- Prevent the tooltips of dropdown menus from being appended to parent, and subsequently breaking the tab order

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

Try these steps in both Chrome and Firefox

1. Open enhanced sample 5
2. Open the legend
3. Tab to the 'toggle groups' dropdown menu
4. Press Enter to open it
5. Press Tab to enter the dropdown, the Shift+Tab to move focus to the 'reorder layers' button
6. Press Tab twice, and notice that focus correctly moves to the 'toggle visibility' dropdown trigger
7. Click on any layer in the legend to open its grid
8. Tab through the grid panel until you reach the vertical `...` menu
9. Press Enter to open it, and press Tab to move down the dropdown
10. Press Shift+Tab to move focus to the  'clear filters' button
11. Press Tab twice to move focus to the grid
12. Notice that focus correctly moves to the grid

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2561)
<!-- Reviewable:end -->
