### PR TITLE
Prevent legend item from remounting on checkbox toggle

### DIFF
--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -142,8 +142,7 @@ export class FocusListManager {
         });
 
         document.addEventListener('click', function (event: MouseEvent) {
-            // @ts-expect-error TODO: explain why this is needed or remove
-            if (element.contains(event.target)) {
+            if (event.target && element.contains(event.target as Node)) {
                 focusManager.onClick(event);
             } else {
                 focusManager.defocusItem(focusManager.highlightedItem);

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :key="`${legendItem.uid}-${legendItem.visibility}`" v-if="!legendItem.hidden" ref="el">
+    <div :key="`${legendItem.uid}`" v-if="!legendItem.hidden" ref="el">
         <div class="relative">
             <div
                 class="flex items-center hover:bg-gray-200 default-focus-style !p-5"


### PR DESCRIPTION
### Related Item(s)
#2540

### Changes
- Prevents legend item from remounting on checkbox toggle, by removing the legend item's visibility status from its key
- Fix TS error in focus-list

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 7
2. Using your keyboard, navigate to a layer in the legend
3. Tab into it and press the Enter key to toggle the checkbox within it
4. Notice that focus remains on the checkbox, and that the respective focus item maintains its gray highlight
5. Press Tab to exit the legend, and use Shift+Tab to return to the legend panel
6. Tab to to the focus list, and notice that the focus item within which the checkbox was toggled has a blue highlight

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2569)
<!-- Reviewable:end -->
