### PR TITLE
Simplify vanilla HTML panel API

### DIFF
--- a/demos/enhanced-scripts/009-custom-panels.js
+++ b/demos/enhanced-scripts/009-custom-panels.js
@@ -51,14 +51,9 @@ const runPostTest = instance => {
         },
         id: 'panel3',
         alertName: 'new.title',
-        style: undefined,
-        options: {
-            i18n: {
-                messages: {
-                    en: { 'new.title': 'English' },
-                    fr: { 'new.title': 'French' }
-                }
-            }
+        i18nMap: {
+            en: { 'new.title': 'English' },
+            fr: { 'new.title': 'French' }
         }
     };
 

--- a/docs/api-guides/panels.md
+++ b/docs/api-guides/panels.md
@@ -303,32 +303,29 @@ frenchContent.appendChild(frenchText);
 ```
 
 ### Step 2: Register your panel
-Before your panel is ready to use, you need to register it via the `registerHTML` method in the [Panel API](#the-panel-api). Shown below is the way you would register the panel for either of the panel screen
-template creation methods in step 1.
+Before your panel is ready for use, you need to register it via the `registerHTML` method in the [Panel API](#the-panel-api). Shown below is the way you would register the panel for either of the panel screen template creation methods in step 1.
+
+Note that, for `i18nMap`, the keys of this object should be language strings, and the values should be objects of keys that map to strings of the respective language. The keys within the objects for each language are what should be used for the `alertName`, as well as any other content within the panel. Currently the only language strings supported are 'en' and 'fr'.
 
 ```JS
 const htmlContent = {en: englishContent, fr: frenchContent};
 const panelId = 'panel1';
-const alertName = 'panelName' // should be a key within each lang object of  `panelOptions.i18n.messages` below
+const alertName = 'panelName';
+const i18nMap = { 
+    en: {'panelName': "My panel"},
+    fr: {'panelName': "Mon panneau"}
+};
 const panelStyle = {
     'background-color': 'red'
 }; 
-const panelOptions = {
-            i18n: {
-                messages: {
-                    en: {'panelName': "My panel"},
-                    fr: {'panelName': "Mon panneau"}
-                }
-            }
-        };
 
 const htmlPanel = {
     content: htmlContent,
     id: panelId,
-    alertName: alertName, 
+    alertName, 
+    i18nMap,
     style: panelStyle, 
-    options: panelOptions
-}
+};
 const myCustomPanel = myRAMPInstance.panel.registerHTML(htmlPanel);
 ```
 
@@ -416,14 +413,12 @@ The API provides the following methods:
 
     Additionally, the `PanelRegistrationOptions` object has one optional property of `i18n`, where you should include the localized strings for the panel. For more details on localization, please see the [localization documentation](../using-ramp4/config-language.md)
 * `isRegistered(panelId: string | string[]): Promise<void>` - provides a promise that resolves when panels with the specified panel ID(s) have completed registration.
-* `registerHTML(htmlPanel: HTMLPanelInstance)` - Registers a new panel containing a screen of HTML content and returns the PanelInstance. Note: `htmlPanel.options` should be structured as follows:
+* `registerHTML(htmlPanel: HTMLPanelInstance)` - Registers a new panel containing a screen of HTML content and returns the PanelInstance. Note: `htmlPanel.i18nMap` should be structured as follows:
 ```
-i18n: { 
-    messages: {
-        lang1: {key1: lang1-value1, key2: lang1-value2, ...}, 
-        lang2: {key1: lang2-value1, key2: lang2-value2, ...},
-        ...
-    }
+{
+    lang1: {key1: lang1-value1, key2: lang1-value2, ...}, 
+    lang2: {key1: lang2-value1, key2: lang2-value2, ...},
+    ...
 }
 ```
 * `updateHTML(panel: PanelInstance | string, html: { [key: string]: string | HTMLElement }, screenId?: string)` - Updates the content of a specific HTML-based screen of a panel, using HTML content 

--- a/src/api/panel.ts
+++ b/src/api/panel.ts
@@ -1,5 +1,5 @@
 import { APIScope, GlobalEvents, isHTMLScreen, PanelInstance } from './internal';
-import type { PanelConfigStyle, PanelDirection } from '@/stores/panel';
+import type { HTMLScreen, PanelConfigStyle, PanelDirection } from '@/stores/panel';
 import { usePanelStore } from '@/stores/panel';
 import type { HTMLPanelInstance } from '@/stores/panel';
 import type { PanelConfig, PanelConfigRoute } from '@/stores/panel';
@@ -18,7 +18,7 @@ export class PanelAPI extends APIScope {
      * @param {string} [screenId] id of the screen to be updated. If not provided, it will update the first screen in the panel
      * @memberof PanelAPI
      */
-    updateHTML(panel: PanelInstance | string, html: { [key: string]: string | HTMLElement }, screenId?: string): void {
+    updateHTML(panel: PanelInstance | string, html: HTMLScreen | { [key: string]: string }, screenId?: string): void {
         // An html-based panel should have only one screen
         const panelInstance = this.get(panel);
 
@@ -36,13 +36,14 @@ export class PanelAPI extends APIScope {
     /**
      * Helper for `registerHTML()`. Creates and returns the `PanelConfigSet` required to register the HTML panel
      *
-     * @param {HTMLPanelInstance} htmlPanel a `HTMLPanelInstance` object, excluding its `options` (if it exists), corresponding
-     * to the new html panel
+     * @param {HTMLPanelInstance} htmlPanel a `HTMLPanelInstance` object, excluding its `i18nMap` (if it exists),
+     * corresponding to the new html panel
      * @returns {PanelConfigSet} The `PanelConfigSet` corresponding to the panel that is to be created
      * @memberof PanelAPI
      */
-    private registerHTMLConfig(htmlPanel: Omit<HTMLPanelInstance, 'options'>): PanelConfigSet {
+    private registerHTMLConfig(htmlPanel: Omit<HTMLPanelInstance, 'i18nMap'>): PanelConfigSet {
         for (const lang in htmlPanel.content) {
+            // After this, htmlPanel.content will be of type HTMLScreen
             if (typeof htmlPanel.content[lang] === 'string') {
                 const newHtml = document.createElement('div');
                 newHtml.innerHTML = htmlPanel.content[lang];
@@ -71,11 +72,17 @@ export class PanelAPI extends APIScope {
     registerHTML(htmlPanel: HTMLPanelInstance): PanelInstance {
         const existingPanel = this.get(htmlPanel.id);
         if (existingPanel) {
-            console.error('panel already exist');
+            console.error('Panel already exist');
             return existingPanel;
         }
         const panelConfig = this.registerHTMLConfig(htmlPanel);
-        const panel: PanelInstance = this.register(panelConfig, htmlPanel.options) as unknown as PanelInstance;
+        const panelOptions = {
+            i18n: {
+                messages: htmlPanel.i18nMap
+            }
+        } as PanelRegistrationOptions;
+
+        const panel: PanelInstance = this.register(panelConfig, panelOptions) as unknown as PanelInstance;
 
         return panel;
     }

--- a/src/stores/panel/panel-state.ts
+++ b/src/stores/panel/panel-state.ts
@@ -1,6 +1,6 @@
 import type { Component, ComponentOptions, ComponentPublicInstance } from 'vue';
 
-import type { PanelInstance, PanelRegistrationOptions } from '@/api';
+import type { PanelInstance } from '@/api';
 import type { DefPromise } from '@/geo/api';
 
 export interface PanelState {
@@ -114,13 +114,13 @@ export type HTMLScreen = {
 
 export type HTMLPanelInstance = {
     /**
-     * keyed language object containing HTML content for each language, represented as an HTMLElement
+     * Keyed language object containing HTML content for each language, represented as an HTMLElement
      * object or a string.
      *
-     * @type {{ [key: string]: string | HTMLElement }}
+     * @type { HTMLScreen | { [key: string]: string }}
      * @memberof HTMLPanelInstance
      */
-    content: HTMLScreen;
+    content: HTMLScreen | { [key: string]: string };
 
     /**
      * id of the panel
@@ -139,20 +139,20 @@ export type HTMLPanelInstance = {
     alertName: string;
 
     /**
+     * A set of language keys to be utilized by the panel
+     *
+     * @type { [lang: string]: { [key: string]: string } }
+     * @memberof HTMLPanelInstance
+     */
+    i18nMap?: { [lang: string]: { [key: string]: string } };
+
+    /**
      * The style object to apply to the panel. If none provided, the default panel styling will be used.
      *
      * @type {PanelConfigStyle}
      * @memberof HTMLPanelInstance
      */
     style?: PanelConfigStyle;
-
-    /**
-     * a set of options that will apply to the panel
-     *
-     * @type {PanelRegistrationOptions}
-     * @memberof HTMLPanelInstance
-     */
-    options?: PanelRegistrationOptions;
 };
 
 /**


### PR DESCRIPTION
### Related Item(s)
#2563

### Changes
- Simplify vanilla panel API by replacing the `options` prop with `languageKey` 
- Fix type of `HTMLPanelInstance`, by expanding type of the `content` prop to allow an object whose values are strings
- Adjusted panel docs

### Notes
- Feel free to suggest additional ways the API can be simplified

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 9
2. Ensure that custom panel loads in fine, and that it responds appropriately to lang changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2576)
<!-- Reviewable:end -->
