### PR TITLE
fix: unwatch event handlers when details panel is closed

### DIFF
--- a/src/fixtures/details/components/result-list.vue
+++ b/src/fixtures/details/components/result-list.vue
@@ -393,6 +393,10 @@ const clickShowList = () => {
  */
 const detailsClosed = () => {
     detailsFixture.value.removeDetailsHilight();
+    // unwatch when the panel is closed, not when unmounted because a minimized
+    // panel will be unmounted but still needs to have watchers active.
+    watchers.value.forEach(unwatch => unwatch());
+    handlers.value.forEach(handler => iApi.event.off(handler));
 
     // (JR) commenting this out. if user turns off toggle, it shouldnt reset back to on when screen closes.
     // detailsStore.hilightToggle = true;
@@ -545,10 +549,6 @@ onBeforeMount(() => {
 });
 
 onBeforeUnmount(() => {
-    // clean up hooks into various events.
-    watchers.value.forEach(unwatch => unwatch());
-    handlers.value.forEach(handler => iApi.event.off(handler));
-
     el.value?.removeEventListener('blur', blurEvent);
     el.value?.removeEventListener('keyup', keyupEvent);
 });


### PR DESCRIPTION
### Related Item(s)
#2524

### Changes
- [FIX] move unwatch event handlers to when details panel is closed

### Notes

This issue happens whenever the details panel is hidden for lack of screen space on mobile and desktop. The details panel is unmounted when hidden but we want to keep the watchers active so the highlight is removed on layer delete. Instead they unwatch on panel close.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 10 on mobile
2. Remove other layers (not green)
3. Minimize legend if needed
4. Click green arrow in Alberta/BC
5. Open the legend from the side panel
6. Remove green layer
7. Rejoice at an empty map

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2585)
<!-- Reviewable:end -->
