### PR TITLE
Add functionality to trigger full map reload

### DIFF
--- a/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/src/components/about-ramp/about-ramp-dropdown.vue
@@ -23,6 +23,23 @@
         <template v-slot:default="scope">
             <div class="about-ramp-dropdown pointer-events-auto bg-white rounded w-256 h-50">
                 <div>
+                    <button
+                        class="absolute left-5 top-5 text-gray-500 hover:text-black focus:text-black p-8"
+                        @click="reloadRamp"
+                        :aria-label="t('ramp.reload')"
+                        :content="t('ramp.reload')"
+                        v-tippy="{
+                            placement: 'bottom-start',
+                            theme: 'ramp4',
+                            animation: 'scale'
+                        }"
+                    >
+                        <svg class="fill-current w-16 h-16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                            <path
+                                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+                            ></path>
+                        </svg>
+                    </button>
                     <h4 class="pb-8 border-b border-gray-600 mb-10">
                         {{ t('ramp.about') }}
                     </h4>
@@ -68,11 +85,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, inject } from 'vue';
 import { version } from '@/main';
 import { useI18n } from 'vue-i18n';
+import type { InstanceAPI } from '@/api';
 
 const { t } = useI18n();
+const iApi = inject<InstanceAPI>('iApi')!;
 
 defineProps({
     position: {
@@ -80,6 +99,13 @@ defineProps({
         default: 'top-start'
     }
 });
+
+/**
+ * Reload the entire RAMP config
+ */
+const reloadRamp = () => {
+    iApi.reload();
+};
 
 /**
  * Get RAMP's version string

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -6,6 +6,7 @@ lang-fr,anglais,1,français,1
 lang-native,English,1,Français,1
 ramp.about.open,Open About RAMP,1,Ouvrir À propos de PCAR,1
 ramp.about,About RAMP,1,À propos de PCAR,1
+ramp.reload,Reload RAMP,1,Recharger PCAR,0
 keyboardInstructions.title,Keyboard Instructions,1,Instructions clavier,1
 keyboardInstructions.open,Open keyboard instructions,1,Instructions clavier ouvert,1
 keyboardInstructions.app,"Use 'Tab' to navigate between sections of the application.",1,"Utilisez la touche Tab pour vous déplacer entre les sections de l'application.",1


### PR DESCRIPTION
### Related Item(s)
For #2583 

### Changes
- This PR adds the ability to reload the entire ramp config through the "About RAMP" box

### Notes
![image](https://github.com/user-attachments/assets/967b9c33-e46f-4372-83d0-c501fe4aa4b9)



### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to any sample and click the "About RAMP" icon at the bottom right
2. Click the reload icon at the top left of the box, clicking it should reload the entire RAMP instance

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2594)
<!-- Reviewable:end -->
