### PR TITLE
Await Layer API

### DIFF
--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -442,7 +442,7 @@ export class FixtureInstance extends APIScope implements FixtureBase {
                 let layerId: string = layer.id;
                 if (parent !== undefined) {
                     // generate suffixed layer id for sublayer entry
-                    layerId = `${parent.id}-${layer.index}`;
+                    layerId = this.$iApi.geo.layer.sublayerId(parent.id, layer.index);
                 }
                 fixtureConfigs[layerId] = layer.fixtures[this.id];
             }

--- a/src/fixtures/grid/api/grid.ts
+++ b/src/fixtures/grid/api/grid.ts
@@ -73,8 +73,9 @@ export class GridAPI extends FixtureInstance {
                 layers.forEach((layer: any) => {
                     if (layer.sublayers) {
                         layer.sublayers?.forEach((sl: number) => {
-                            layerIds.push(`${layer.layerId}-${sl}`);
-                            delete layerGridConfigs[`${layer.layerId}-${sl}`];
+                            const subId = this.$iApi.geo.layer.sublayerId(layer.layerId, sl);
+                            layerIds.push(subId);
+                            delete layerGridConfigs[subId];
                         });
                     } else {
                         layerIds.push(layer.layerId);

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -78,7 +78,7 @@ export class LegendAPI extends FixtureInstance {
             // create a wrapper legend object for single layer item
             // if the item is a sublayer, override the item id to the sublayers id
             if (itemConf.sublayerIndex !== undefined) {
-                itemConf.layerId = `${itemConf.layerId}-${itemConf.sublayerIndex}`;
+                itemConf.layerId = this.$iApi.geo.layer.sublayerId(itemConf.layerId, itemConf.sublayerIndex);
             }
             item = new LayerItem(this.$iApi, itemConf, parent) as unknown as LegendItem;
         }
@@ -352,7 +352,7 @@ export class LegendAPI extends FixtureInstance {
                         } else if (!node.isLayerRoot && !node.isLogicalLayer) {
                             // is not root, and is not logical layer (MIL sub groups)
                             // we remove the current layer item for the group, and instead turn it into a group
-                            layerItem = this.getLayerItem(`${layer.id}-${node.layerIdx}`);
+                            layerItem = this.getLayerItem(this.$iApi.geo.layer.sublayerId(layer.id, node.layerIdx));
                             if (layerItem) {
                                 const layerItemConf = layerItem.getConfig();
                                 delete layerItemConf.layerId;
@@ -386,7 +386,7 @@ export class LegendAPI extends FixtureInstance {
                 updateLayerItem(layer, true); // update the root layer item first
                 if (layer.supportsSublayers) {
                     layer.config.sublayers.forEach((sublayer: any) => {
-                        updateLayerItem(`${layer.id}-${sublayer.index}`, true); // hacky solution because sublayers arent created on error
+                        updateLayerItem(this.$iApi.geo.layer.sublayerId(layer.id, sublayer.index), true); // hacky solution because sublayers arent created on error
                     });
                 }
             });

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -202,7 +202,7 @@ export class MapImageLayer extends MapLayer {
                 if (!this._sublayers[sid]) {
                     this._sublayers[sid] = new MapImageSublayer(
                         {
-                            id: `${this.id}-${sid}`,
+                            id: this.$iApi.geo.layer.sublayerId(this.id, sid),
                             index: sid,
                             // TODO: Revisit once issue #961 is implemented.
                             // See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/1045#pullrequestreview-977116071


### PR DESCRIPTION
### Related Item(s)

#2562

### Changes

- adds the requested `awaitLayer` and `awaitSublayer` API calls
- adds a sublayer id maker method and uses that in the various RAMP locations

### Notes

I went with infinite promise if layer doesn't exist. This API is not used by RAMP internally. Would only happen if someone is writing special API code, and ideally they should know what they are doing and this doesn't happen. And if it does, a small code ping every 1.5 seconds with no server calls is a nothingburger.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Open Enhanced Happy and run this code in the console. It will ping when the new method sees the layer load.
You can change the delay time and ordering to test the different scenarios (e.g. more than 8 second delay, or register layer first, then do `awaitLayer`

```js
debugInstance.geo.layer.awaitLayer('Nature').then(l => console.log('TAADAA', l));

setTimeout(()=> {
  const nature = {
    id: 'Nature',
    layerType: 'esri-feature',
    url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/EcoAction/MapServer/6'
  };

  const layer = debugInstance.geo.layer.createLayer(nature);
  debugInstance.geo.map.addLayer(layer)
}, 4000);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2596)
<!-- Reviewable:end -->
