### PR TITLE
Prevent error upon missing basemaps in config

### DIFF
--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -333,6 +333,9 @@
                             },
                             layers: [],
                             fixtures: {
+                                overviewmap: {
+                                    disabled: true
+                                },
                                 legend: {
                                     root: {
                                         children: []
@@ -599,6 +602,9 @@
                             },
                             layers: [],
                             fixtures: {
+                                overviewmap: {
+                                    disabled: true
+                                },
                                 legend: {
                                     root: {
                                         children: []

--- a/src/fixtures/overviewmap/api/overviewmap.ts
+++ b/src/fixtures/overviewmap/api/overviewmap.ts
@@ -13,7 +13,7 @@ export class OverviewmapAPI extends FixtureInstance {
         const overviewmapStore = useOverviewmapStore(this.$vApp.$pinia);
 
         overviewmapStore.basemaps = overviewmapConfig?.basemaps || {};
-        overviewmapStore.mapConfig.basemaps = overviewmapConfig ? Object.values(overviewmapConfig.basemaps) : [];
+        overviewmapStore.mapConfig.basemaps = Object.values(overviewmapStore.basemaps);
         overviewmapStore.startMinimized = overviewmapConfig?.startMinimized ?? true;
         overviewmapStore.expandFactor = overviewmapConfig?.expandFactor ?? 1.5;
         overviewmapStore.borderColour = overviewmapConfig?.borderColour ?? '#FF0000';


### PR DESCRIPTION
### Related Item(s)
#2570

### Changes
- Handle scenario where `overview` map is defined in the config, but doesn't contain any basemaps

### QA Testing

QA demo in future PR.

### Testing

Steps:
1. Open happy sample
2. Notice there are no errors in the console

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2601)
<!-- Reviewable:end -->
