### PR TITLE
Fix WAVE errors in ag-grid

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -567,6 +567,19 @@ const systemCols = ref<Set<string>>(new Set<string>());
 // in order to avoid race conditions
 const filterQueue = ref<Array<DefPromise<void>>>([]);
 
+const addAriaLabels = () => {
+    const checkboxInputs = iApi.$vApp.$el.querySelectorAll(
+        '.ag-input-field-input.ag-checkbox-input'
+    ) as NodeListOf<Element>;
+
+    checkboxInputs.forEach((input, index) => {
+        const allColumns = columnApi.value.getAllDisplayedColumns();
+        const column = allColumns[index].getColDef();
+
+        input.setAttribute('aria-label', column.headerName ?? t('grid.label.specialColumn'));
+    });
+};
+
 const onGridReady = (params: any) => {
     agGridApi.value = params.api;
     columnApi.value = params.columnApi;
@@ -581,18 +594,6 @@ const onGridReady = (params: any) => {
     if (rowData.value.length > 0) {
         columnApi.value.autoSizeAllColumns();
     }
-
-    const addAriaLabels = () => {
-        const checkboxInputs = iApi.$vApp.$el.querySelectorAll(
-            '.ag-input-field-input.ag-checkbox-input'
-        ) as NodeListOf<Element>;
-        checkboxInputs.forEach((input, index) => {
-            const allColumns = columnApi.value.getAllDisplayedColumns();
-            const column = allColumns[index].getColDef();
-
-            input.setAttribute('aria-label', column.headerName ?? t('grid.label.specialColumn'));
-        });
-    };
 
     // Initial load
     addAriaLabels();
@@ -664,6 +665,8 @@ const gridRendered = () => {
         agGridApi.value as GridApi,
         columnApi.value as ColumnApi
     );
+
+    addAriaLabels();
 };
 
 // Updates the global search value.
@@ -1675,7 +1678,10 @@ onBeforeMount(() => {
         tabToNextCell: tabToNextCellHandler,
         // tab vertically instead of horizontally
         tabToNextHeader: tabToNextHeaderHandler,
-        onModelUpdated: debounce(300, () => columnApi.value.autoSizeAllColumns())
+        onModelUpdated: debounce(300, () => {
+            columnApi.value.autoSizeAllColumns();
+            addAriaLabels();
+        })
     };
 
     setUpColumns();


### PR DESCRIPTION
### Related Item(s)
#2565

### Changes
- Called `addAriaLabels()` after any call to `autoSizeAllColumns()`

### Notes
- It seems like `autoSizeAllColumns()` removes the aria-labels from the checkboxes

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open the grid
2. Open the WAVE extension, and notice that there are no WAVE errors
3. Close WAVE, filter some columns and open WAVE again
4. Notice there are still no WAVE errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2602)
<!-- Reviewable:end -->
