### PR TITLE
chore: refactor random id generation in the app and color picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -553,6 +553,16 @@
                 "node": ">= 6"
             }
         },
+        "node_modules/@cypress/request/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/@cypress/vite-dev-server": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/@cypress/vite-dev-server/-/vite-dev-server-2.2.2.tgz",
@@ -11164,16 +11174,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-        },
-        "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -795,6 +795,9 @@ function createApp(element: HTMLElement, iApi: InstanceAPI) {
     vueElement.config.globalProperties.$iApi = iApi;
     vueElement.config.globalProperties.$pinia = pinia;
 
+    // set the id prefix for the app for use in generating unique ids with `useId`
+    vueElement.config.idPrefix = `ramp-${element.id || iApi.geo.shared.generateUUID()}`;
+
     vueElement.provide('iApi', iApi);
 
     const app = vueElement.mount(element);

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -191,7 +191,7 @@
                                 @keydown.stop
                             />
                         </div>
-                        <label class="sr-only" :for="`${colourPickerId}-color-hex`">{{
+                        <label class="sr-only" :for="`${randomId}-color-hex`">{{
                             t('wizard.configure.colour.hex')
                         }}</label>
                         <label class="text-base font-bold" v-if="layerInfo?.configOptions.includes('colour')">{{
@@ -202,7 +202,7 @@
                             alpha-channel="hide"
                             :visible-formats="['hex']"
                             default-format="hex"
-                            :id="colourPickerId"
+                            :id="randomId + '-hue-slider'"
                             :color="colour"
                             @color-change="updateColour"
                         >
@@ -263,7 +263,8 @@ import {
     reactive,
     ref,
     type PropType,
-    useTemplateRef
+    useTemplateRef,
+    useId
 } from 'vue';
 
 import { ColorPicker } from 'vue-accessible-color-picker';
@@ -286,6 +287,7 @@ const wizardStore = useWizardStore();
 const { t } = useI18n();
 const iApi = inject('iApi') as InstanceAPI;
 const formElement = ref();
+const randomId = useId();
 
 const handlers = ref<Array<string>>([]);
 
@@ -300,7 +302,6 @@ const layerSource = computed(() => wizardStore.layerSource);
 const step = computed(() => wizardStore.currStep);
 
 const colour = ref();
-const colourPickerId = ref();
 const componentKey = ref(0);
 const disabled = ref(false);
 const thePanel = ref();
@@ -808,10 +809,6 @@ const generateColour = () => {
             Math.floor(Math.random() * 16777215)
                 .toString(16)
                 .padStart(6, '0');
-    // generate unique ID for colour picker to prevent multi-ramp collisions
-    do {
-        colourPickerId.value = Math.random().toString(36).substring(2, 9);
-    } while (document.getElementById(colourPickerId.value + '-hue-slider') !== null);
 };
 
 const updateColour = (eventData: any) => {


### PR DESCRIPTION
### Related Item(s)
#2510 

### Changes
- [REFACTOR] random id generation in the app and color picker

### Notes
Sets the vue application id prefix to the app element id if set, otherwise creates a unique id with the `uuid` library. [useId](https://vuejs.org/api/composition-api-helpers#useid) creates the final unique id for the component.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open https://milespetrov.github.io/ramp4-pcar4/2510-picker/demos/index-multi.html
2. Open the wizard in top left app, add a layer with colors (I used `shape.zip` for testing)
3. Inspect the color picker elements, see one with an id of `ramp-app1-1-0-hue-slider-hue-slider`
4. Repeat for other two apps
5. Notice each app has different ids (`ramp-app2-1-0-hue-slider-hue-slider`, `ramp-app3-1-0-hue-slider-hue-slider`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2603)
<!-- Reviewable:end -->
