### PR TITLE
Apply focus to root legend item upon pressing reload

### DIFF
--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -141,6 +141,15 @@ export class FocusListManager {
             focusManager.onTouchstart();
         });
 
+        // Focuses a legend item after it's reload button is clicked. See issue 2605.
+        element.addEventListener('refocusLegendItem', e => {
+            const evt = e as CustomEvent;
+            const focusItem = evt.detail.focusItem;
+            focusManager.element.focus();
+            focusManager.focusItem(focusItem);
+            this.highlightedItem = focusItem;
+        });
+
         document.addEventListener('click', function (event: MouseEvent) {
             if (event.target && element.contains(event.target as Node)) {
                 focusManager.onClick(event);

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -440,7 +440,6 @@ export class LegendAPI extends FixtureInstance {
      */
     reloadLayerItem(layer: LayerInstance | string): boolean {
         const affectedBlocks = this.getLayerBoundItems(layer);
-
         affectedBlocks.forEach(block => block.reload());
 
         return affectedBlocks.length > 0;

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -56,6 +56,7 @@
                     aria: 'describedby'
                 }"
                 truncate-trigger
+                ref="legendFocusItem"
             >
                 <!-- smiley face. very important that we migrate this -->
                 <div class="flex p-5 mr-[13px]" v-if="legendItem.type !== LegendType.Item">
@@ -243,6 +244,7 @@
                         invisible: legendItem.type === LegendType.Placeholder
                     }"
                     :legendItem="legendItem"
+                    @focus-item="() => $emit('focusItem', legendFocusItem as HTMLElement)"
                 />
 
                 <!-- Button only appears for loading or errored LayerItems -->
@@ -479,7 +481,12 @@
         </div>
         <!-- Display children of the group -->
         <div class="legend-group border-l-2 ml-4 pl-4" v-if="legendItem.expanded">
-            <item v-for="item in legendItem.children" :legendItem="item" :key="item.uid" />
+            <item
+                v-for="item in legendItem.children"
+                :legendItem="item"
+                :key="item.uid"
+                @focus-item="(focusItem: HTMLElement) => $emit('focusItem', focusItem)"
+            />
         </div>
     </div>
 </template>
@@ -492,7 +499,7 @@ import { useLayerStore } from '@/stores/layer';
 import to from 'await-to-js';
 import { marked } from 'marked';
 import type { PropType } from 'vue';
-import { toRaw, computed, inject, ref, watch } from 'vue';
+import { computed, inject, ref, toRaw, useTemplateRef, watch } from 'vue';
 import { LayerItem } from '../store/layer-item';
 import { LegendControl, LegendType } from '../store/legend-item';
 import { InfoType, SectionItem } from '../store/section-item';
@@ -531,6 +538,7 @@ const layerConfigs = computed(() => layerStore.layerConfigs);
 const symbologyStack = ref<Array<LegendSymbology>>([]); // ref instead of reactive to maintain reactivity after promise
 const symbologyStackLoaded = ref<boolean>(false);
 const hovered = ref(false);
+const legendFocusItem = useTemplateRef('legendFocusItem');
 
 /**
  * Get the type of layer

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -7,6 +7,7 @@
             tooltipPlacement="left"
             tooltipPlacementAlt="left"
             ref="dropdown"
+            :key="legendOptionKey"
         >
             <template #header>
                 <div class="flex p-4 justify-center items-center">
@@ -145,7 +146,7 @@
                     trigger: 'manual focus',
                     aria: 'describedby'
                 }"
-                @click="reloadLayer"
+                @click="e => reloadLayer(e as PointerEvent)"
                 role="button"
                 :aria-label="t('legend.layer.controls.reload')"
             >
@@ -174,6 +175,8 @@ const dropdown = ref();
 const hovered = ref(false);
 const panelStore = usePanelStore();
 const mobileMode = ref(panelStore.mobileView);
+const emit = defineEmits(['focusItem']);
+const legendOptionKey = ref(0);
 
 const props = defineProps({
     legendItem: LayerItem
@@ -260,11 +263,19 @@ const removeLayer = () => {
 
 /**
  * Reloads a layer on the map.
+ *
+ * @param {PointerEvent} e the PointerEvent corresponding to the reload button being clicked/pressed
  */
-const reloadLayer = () => {
+const reloadLayer = (e: PointerEvent) => {
     if (reloadableLayer.value) {
-        toRaw(props.legendItem!.layer!).reload();
-        dropdown.value.open = false;
+        toRaw(props.legendItem!.layer!)
+            .reload()
+            .then(() => {
+                legendOptionKey.value += 1;
+                if (e.pointerType !== 'mouse') {
+                    emit('focusItem');
+                }
+            });
     }
 };
 

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -15,7 +15,12 @@
                 }"
                 ref="el"
             >
-                <legend-item v-for="item in children" :legendItem="item" :key="item.uid" />
+                <legend-item
+                    v-for="item in children"
+                    :legendItem="item"
+                    :key="item.uid"
+                    @focus-item="(focusItem: HTMLElement, legendItem: LegendItem) => applyFocusToItem(focusItem)"
+                />
             </div>
         </template>
     </panel-screen>
@@ -48,15 +53,18 @@ const keyupEvent = (e: Event) => {
     }
 };
 
+const applyFocusToItem = (focusItem: HTMLElement) => {
+    const focusItemEvent = new CustomEvent('refocusLegendItem', { detail: { focusItem } });
+    el.value?.dispatchEvent(focusItemEvent);
+};
+
 onMounted(() => {
     el.value?.addEventListener('blur', blurEvent);
-
     el.value?.addEventListener('keyup', keyupEvent);
 });
 
 onBeforeUnmount(() => {
     el.value?.removeEventListener('blur', blurEvent);
-
     el.value?.removeEventListener('keyup', keyupEvent);
 });
 


### PR DESCRIPTION
### Related Item(s)
#2605

### Changes
- Upon reloading a layer in the legend, focus will return to the root legend item, and the legend options dropdown will be closed

### Notes
- Putting focus onto the legend item once the reloading process is complete (i.e when the legend item's `_type` is set to "item" again) become problematic for layers that take very long to reload (ex. `WFSLayer`).
- If the user tabs away after the reload, focus would be forcefully moved back to the legend item
- This is also why returning focus to the reload button can cause issues, since the legend options dropdown rerenders once the `_type` of the legend item gets set to "item"

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 7
2. Tab to a layer in the legend
3. Open the legend options dropdown
4. Press the reload button
5. Notice that focus returns to the legend item, and the dropdown remains closed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2622)
<!-- Reviewable:end -->
