### PR TITLE
Use Local Geometry for Feature Layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "4.12.0-beta",
             "dependencies": {
                 "@ag-grid-community/locale": "~32.0.0",
-                "@arcgis/core": "4.32.9",
+                "@arcgis/core": "4.32.10",
                 "@popperjs/core": "^2.11.6",
                 "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect#v1.0.0",
                 "@terraformer/arcgis": "^2.1.2",
@@ -375,9 +375,9 @@
             }
         },
         "node_modules/@arcgis/core": {
-            "version": "4.32.9",
-            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.32.9.tgz",
-            "integrity": "sha512-w174cWsIkE6fsalkwFnqErO2saGB1lZcCYMC2yVCaaj50N7PM4brSNc5Myb7OWtDWsTNQPbkVSYW7d96iqNpHA==",
+            "version": "4.32.10",
+            "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.32.10.tgz",
+            "integrity": "sha512-dcYbISxjsrBUBmrIx1dlTV4ynrl1CrvqLcd2fYtFgc0WNTqx3V7lFNmpBbT9wu15wqaTUA8kVXmN9HCoUppA4w==",
             "license": "SEE LICENSE IN copyright.txt",
             "dependencies": {
                 "@esri/arcgis-html-sanitizer": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     },
     "dependencies": {
         "@ag-grid-community/locale": "~32.0.0",
-        "@arcgis/core": "4.32.9",
+        "@arcgis/core": "4.32.10",
         "@popperjs/core": "^2.11.6",
         "@ramp4-pcar4/vue3-treeselect": "github:ramp4-pcar4/vue3-treeselect#v1.0.0",
         "@terraformer/arcgis": "^2.1.2",

--- a/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
@@ -36,9 +36,8 @@ export class GlowHilightMode extends LiftHilightMode {
         const hilightLayer = this.$iApi.geo.layer.getLayer(HILIGHT_LAYER_NAME);
         if (hilightLayer && hilightLayer.esriLayer && hilightLayer.isLoaded && hilightLayer instanceof GraphicLayer) {
             const gs = graphics instanceof Array ? graphics : [graphics];
-            this.$iApi.geo.map.esriView?.whenLayerView(hilightLayer.esriLayer)?.then(function (layerView) {
-                layerView.highlight(gs.map(g => hilightLayer.getEsriGraphic(g.id)!));
-            });
+            await hilightLayer.viewPromise();
+            hilightLayer.esriView!.highlight(gs.map(g => hilightLayer.getEsriGraphic(g.id)!));
         }
     }
 

--- a/src/geo/layer/common-graphic-layer.ts
+++ b/src/geo/layer/common-graphic-layer.ts
@@ -19,6 +19,7 @@ export class CommonGraphicLayer extends MapLayer {
 
     protected _graphics: Array<Graphic> = [];
     declare esriLayer: EsriGraphicsLayer | undefined;
+    declare esriView: __esri.GraphicsLayerView | undefined;
 
     /**
      * Take a layer config from the RAMP application and derives a configuration for an ESRI layer

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -26,6 +26,7 @@ import { markRaw, reactive } from 'vue';
  */
 export class FeatureLayer extends AttribLayer {
     declare esriLayer: EsriFeatureLayer | undefined;
+    declare esriView: __esri.FeatureLayerView | undefined;
 
     tooltipField: string;
 

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -349,6 +349,16 @@ export class LayerInstance extends APIScope {
     }
 
     /**
+     * Provides a promise that resolves when the layer view has been created.
+     *
+     * @method viewPromise
+     * @returns {Promise} resolves when the layer view is created
+     */
+    viewPromise(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    /**
      * Indicates if the layer is in a state that is makes sense to interact with.
      * I.e. False if layer has not done it's initial load, or is in error state.
      * Acts as a handy shortcut to inspecting the layerState.

--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -2,6 +2,7 @@ import { CommonLayer, GlobalEvents, InstanceAPI } from '@/api/internal';
 import { DefPromise, DrawState, Extent, InitiationState, LayerState, ScaleSet, SpatialReference } from '@/geo/api';
 import type { DrawOrder, RampLayerConfig } from '@/geo/api';
 import { EsriWatch } from '@/geo/esri';
+import { markRaw } from 'vue';
 
 /**
  * A common layer class which is inherited by layer classes that implement map-based layers.
@@ -138,7 +139,7 @@ export class MapLayer extends CommonLayer {
         );
 
         this.esriLayer.on('layerview-create', (e: __esri.LayerLayerviewCreateEvent) => {
-            this.esriView = e.layerView;
+            this.esriView = markRaw(e.layerView);
             this.esriWatches.push(
                 EsriWatch(
                     () => e.layerView.updating,
@@ -270,6 +271,10 @@ export class MapLayer extends CommonLayer {
         proms.push(lookupPromise);
 
         return proms;
+    }
+
+    viewPromise(): Promise<void> {
+        return this.viewDefProm.getPromise();
     }
 
     // ----------- LAYER MANAGEMENT -----------


### PR DESCRIPTION
### Related Item(s)

https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2621

### Changes

- If a geometry is requested from a Feature Layer, now attempts to steal the geom lurking in the layer view before trying the server.
- Expose layer view promise in same way that other load and view promises work.
- Grab a late patch released by ESRI.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Layers to test: Anything Feature Layer. 
- Enhanced Test 7: Territories Poly, Basin Line
- Enhanced Test 3: Nature, Clean Water
- Via wizard: Oil Sands boundaries: [Feat layer few big polys](https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/Oilsands/MapServer/1), [Feat layer lots of small polys](https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/Oilsands/MapServer/2)

The two things that primarily use this function are zoomies and hilighting.

Good test one:
1. Open data grid on a feature layer. Don't do any identify clicking first.
2. Run the zoomies button (globe) on one of the rows.
3. Verify the map zoomed to the feature (you can do an identify now to validate it matches the row clicked).

Good test two: 
1. Zoom in (via mouse or navbar) on a polygon or a line.
2. Click it.
3. When it identifies, verify it is hilighted and the outline reasonably matches the current scale detail being drawn on the map.