### PR TITLE
fix: linting only targets the src folder

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,6 +8,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.head.sha }}
 
             - uses: actions/setup-node@v4
               with:

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
         "ts:check": "vue-tsc --noEmit -p ./tsconfig.app.json",
         "ts:copy": "npx --yes cpx \"src/*.d.ts\" \"dist/bundler/src\"",
         "ts-docs:generate": "npx typedoc --skipErrorChecking",
-        "lint": "eslint . --fix",
-        "lint:check": "eslint . --format json > results.json",
+        "lint": "eslint src/ --fix",
+        "lint:check": "eslint src/ --format json > results.json",
         "format": "prettier --write src/",
         "format:check": "prettier . -c",
         "vite-docs:generate": "npx vitepress build docs"

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -22,6 +22,7 @@ import {
 } from '@/geo/api';
 import type {
     IdentifyParameters,
+    LoadLayerMetadataOptions,
     Point,
     QueryFeaturesParams,
     RampLayerConfig,
@@ -302,16 +303,14 @@ export class MapImageLayer extends MapLayer {
             // setting custom renderer here (if one is provided)
             // this code applies esri renderer. loadLayerMetadata will
             // generate the RAMP wrapper on the layer.
-            const hasCustRed = miSL.esriSubLayer && config?.customRenderer?.type;
-            if (hasCustRed) {
-                miSL.esriSubLayer!.renderer = await EsriAPI.RendererFromJson(config.customRenderer);
+            const llmOptions: LoadLayerMetadataOptions = {};
+            if (miSL.esriSubLayer && config?.customRenderer?.type) {
+                const esriCustomRenderer = await EsriAPI.RendererFromJson(config.customRenderer);
+                miSL.esriSubLayer.renderer = esriCustomRenderer;
+                llmOptions.customRenderer = esriCustomRenderer;
             }
 
-            await miSL.loadLayerMetadata(
-                hasCustRed && miSL.esriSubLayer && miSL.esriSubLayer.renderer
-                    ? { customRenderer: miSL.esriSubLayer.renderer }
-                    : {}
-            );
+            await miSL.loadLayerMetadata(llmOptions);
 
             if (startTime < this.lastCancel) {
                 // cancelled, kickout.

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -307,7 +307,11 @@ export class MapImageLayer extends MapLayer {
                 miSL.esriSubLayer!.renderer = await EsriAPI.RendererFromJson(config.customRenderer);
             }
 
-            await miSL.loadLayerMetadata(hasCustRed ? { customRenderer: miSL.esriSubLayer?.renderer! } : {});
+            await miSL.loadLayerMetadata(
+                hasCustRed && miSL.esriSubLayer && miSL.esriSubLayer.renderer
+                    ? { customRenderer: miSL.esriSubLayer.renderer }
+                    : {}
+            );
 
             if (startTime < this.lastCancel) {
                 // cancelled, kickout.


### PR DESCRIPTION
### Related Item(s)
#2623 

### Changes
- [FIX] linting only targets the src folder

### Notes

A lot of linting errors on the `vite-docs` and `ts-docs` folders. It should only be targeting files in `src`.

Also fixed one lint error that made its way in.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

General sanity testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2630)
<!-- Reviewable:end -->
