### PR TITLE
Prevent empty fixture array from loading in default fixtures

### DIFF
--- a/demos/starter-scripts/mapnav.js
+++ b/demos/starter-scripts/mapnav.js
@@ -3,6 +3,7 @@ import { createInstance, geo } from '@/main';
 window.debugInstance = null;
 
 let config = {
+    startingFixtures: [],
     configs: {
         en: {
             map: {

--- a/docs/introduction/instantiation.md
+++ b/docs/introduction/instantiation.md
@@ -39,7 +39,7 @@ This object can optionally include a `startingFixtures` list which is a set of f
 
 The following options are supported when creating an instance.
 
-`loadDefaultFixtures` will instruct RAMP to use the default set of fixtures, providing an "out-of-the-box" experience and requiring minimal setup. The default value is `true`, setting it to `false` means the instantiator must manage their own fixture setup. See the [defaults page](../using-ramp4/default-setup.md) and the [fixtures page](../using-ramp4/fixtures/custom-fixtures.md) for additional details. If `startingFixtures` is specified in the the `config` object above and is non-empty, this option will be ignored and the specified fixtures will be loaded instead.
+`loadDefaultFixtures` will instruct RAMP to use the default set of fixtures, providing an "out-of-the-box" experience and requiring minimal setup. The default value is `true`, setting it to `false` means the instantiator must manage their own fixture setup. See the [defaults page](../using-ramp4/default-setup.md) and the [fixtures page](../using-ramp4/fixtures/custom-fixtures.md) for additional details. If `startingFixtures` is specified in the the `config` object above, this option will be ignored and the specified fixtures will be loaded instead.
 
 `loadDefaultEvents` is related to `loadDefaultFixtures`, and will apply the default event handlers to link all the default fixtures to each-other and the RAMP core. The default value is `true`, setting it to `false` means the instantiator must wire up their own preferred event handlers.  See the [defaults page](../using-ramp4/default-setup.md) and the [events page](../api-guides/events.md) for additional details.
 

--- a/src/api/fixture.ts
+++ b/src/api/fixture.ts
@@ -224,7 +224,7 @@ export class FixtureAPI extends APIScope {
      * @memberof FixtureAPI
      */
     addDefaultFixtures(fixtureNames?: Array<string>): Promise<Array<FixtureBase>> {
-        if (!Array.isArray(fixtureNames) || fixtureNames.length === 0) {
+        if (!Array.isArray(fixtureNames)) {
             fixtureNames = [
                 'appbar',
                 'basemap',


### PR DESCRIPTION
### Related Item(s)
#2572

### Changes
- Prevent the default fixtures from loading in when the `startingFixtures` array is empty

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Load in classic sample 14
2. Notice that none of the default fixtures have loaded in

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2632)
<!-- Reviewable:end -->
