### PR TITLE
System marker for layers

### DIFF
--- a/docs/api-guides/layers.md
+++ b/docs/api-guides/layers.md
@@ -329,6 +329,12 @@ Determine if the Layer is designated as `cosmetic`. This means the Layer appears
 myLayer.isCosmetic; // true
 ```
 
+Determine if the Layer is designated as `system`. This means the Layer is being used and managed by a RAMP functionality.
+
+```js
+myLayer.isSystem; // true
+```
+
 Get the visible scale ranges for the Layer or sublayer. A value of `0` on a range indicates there is no limit. Scales are fractions (i.e. a value of `2000` actually means 1/2000 scale), so `min` and `max` can be counterintuitive (large scale means the view is closer to real life size, so the viewport is closer to the ground level). Not supported by Data Layers.
 
 ```js

--- a/docs/using-ramp4/layer-overview.md
+++ b/docs/using-ramp4/layer-overview.md
@@ -36,6 +36,7 @@ Below is a list of the various properties that can be specified for a layer conf
 - [singleEntryCollapse](./layers/fancy-properties.md#singleentrycollapse)
 - [state](./layers/basic-properties.md#state)
 - [sublayers](./layers/fancy-properties.md#sublayers)
+- [system](./layers/basic-properties.md#system)
 - [tooltipArcade](./layers/fancy-properties.md#tooltiparcade)
 - [tooltipField](./layers/fancy-properties.md#tooltipfield)
 - [touchTolerance](./layers/fancy-properties.md#touchtolerance)

--- a/docs/using-ramp4/layers/basic-properties.md
+++ b/docs/using-ramp4/layers/basic-properties.md
@@ -152,3 +152,15 @@ Defines the desired state of the layer at load time.
     }
 }
 ```
+
+## system
+
+*boolean*
+
+Indicates if a layer is used / managed by a RAMP functionality. Some examples would be the layer that houses the North Pole marker, or feature highlighting. The value is informational, and does not change anything about the layer itself. In a typical scenario, a layer defined in a RAMP configuration will not need to set this. If missing, defaults to `false`. 
+
+```js
+{
+    system: true
+}
+```

--- a/schema.json
+++ b/schema.json
@@ -891,6 +891,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Indicates if this layer is a cosmetic supporting layer which will not be considered for general user interaction."
+                },
+                "system": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Indicates if this layer is used and managed by a RAMP functionality."
                 }
             },
             "required": ["id", "layerType", "url"],

--- a/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
@@ -52,6 +52,7 @@ export class FogHilightMode extends LiftHilightMode {
                 id: FOG_HILIGHT_LAYER_NAME,
                 layerType: LayerType.TILE,
                 cosmetic: true,
+                system: true,
                 // TODO: what if there's more than 1 URL provided?
                 // See https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/1352
                 url: mapConfig.layers[0].url

--- a/src/fixtures/hilight/api/hilight.ts
+++ b/src/fixtures/hilight/api/hilight.ts
@@ -53,6 +53,7 @@ export class HilightAPI extends FixtureInstance {
             id: HILIGHT_LAYER_NAME,
             layerType: LayerType.GRAPHIC,
             cosmetic: true,
+            system: true,
             url: ''
         });
 

--- a/src/fixtures/northarrow/northarrow.vue
+++ b/src/fixtures/northarrow/northarrow.vue
@@ -155,7 +155,8 @@ const updateNortharrow = async (newExtent: Extent) => {
                     id: POLE_MARKER_LAYER_ID,
                     layerType: LayerType.GRAPHIC,
                     url: '',
-                    cosmetic: true // mark this layer as a cosmetic layer
+                    cosmetic: true, // mark this layer as a cosmetic layer
+                    system: true
                 });
                 iApi.geo.map.addLayer(poleLayer);
 

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -762,6 +762,7 @@ export interface RampLayerConfig {
     catalogueUrl?: string;
     fixtures?: any; // layer-based fixture config
     cosmetic?: boolean;
+    system?: boolean;
     colour?: string;
     imageFormat?: string;
     initialFilteredQuery?: string;

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -108,6 +108,7 @@ export class CommonLayer extends LayerInstance {
         this.id = rampConfig.id || '';
         this.uid = this.$iApi.geo.shared.generateUUID();
         this.isCosmetic = false;
+        this.isSystem = rampConfig.system || false;
         this.isRemoved = false;
         this.isSublayer = false;
         this.supportsIdentify = false; // default state.

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -216,6 +216,11 @@ export class LayerInstance extends APIScope {
     isCosmetic: boolean;
 
     /**
+     * If the layer is being managed by a RAMP functionality
+     */
+    isSystem: boolean;
+
+    /**
      * If the layer was added by user interaction during the session
      */
     userAdded: boolean;
@@ -325,6 +330,7 @@ export class LayerInstance extends APIScope {
         this.isRemoved = false;
         this.isFile = false;
         this.isCosmetic = false;
+        this.isSystem = false;
         this.userAdded = false;
         this.identify = false; // will be updated later based on config/supportsIdentify value
         this.hovertips = false;

--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -16,6 +16,7 @@ export class MapImageSublayer extends AttribLayer {
         this.isSublayer = true;
         this.layerIdx = config.index;
         this.parentLayer = parent;
+        this.isSystem = parent.isSystem;
 
         // these two props will get flipped to raster during the server metadata checks if needed.
         // has to be set here to allow for initial/permanent filters to be set immediately.

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -21,7 +21,8 @@ export class OverviewMapAPI extends CommonMapAPI {
             id: 'RampOverviewGraphic',
             layerType: LayerType.GRAPHIC,
             url: '',
-            cosmetic: true
+            cosmetic: true,
+            system: true
         }) as GraphicLayer;
         this.overviewmapStore = useOverviewmapStore(this.$vApp.$pinia);
     }


### PR DESCRIPTION
### Related Item(s)

#2635

### Changes

- adds a layer property that makes it easy to spot layers that RAMP owns

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Open Enhanced Sample 1. Run this code in the console. Should see the ids for the hilighter and north arrow layers.

```js
debugInstance.geo.layer.allLayers().filter(l => l.isSystem).map(l => l.id).join(', ');
```