### PR TITLE
Config and Reload events

### DIFF
--- a/docs/using-ramp4/default-setup.md
+++ b/docs/using-ramp4/default-setup.md
@@ -18,49 +18,50 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 
 | Event Name                                         | Payload                                                        | Event Announces                                  |
 | -------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------ |
-| APPBAR_BUTTON_CLICK<br>'appbar/click'                      | _id_: button component/panel id                                             | A button in the appbar was clicked
+| APPBAR_BUTTON_CLICK<br>'appbar/click'              | _id_: button component/panel id                                | A button in the appbar was clicked               |
 | COMPONENT<br>'ramp/component'                      | _id_: component id                                             | A vue component registered                       |
-| CONFIG_CHANGE<br>'config/change'                   | RampConfig object                                              | The config was changed                           |
+| CONFIG_CHANGE<br>'config/change'                   | RampConfig object                                              | The active config was changed                    |
 | FILTER_CHANGE<br>'filter/change'                   | FilterEventParam object                                        | A filter has changed                             |
 | FIXTURE_ADDED<br>'fixture/added'                   | FixtureInstance object                                         | A fixture has been added                         |
 | FIXTURE_REMOVED<br>'fixture/removed'               | FixtureInstance object                                         | A fixture has been removed                       |
 | LANG_CHANGE<br>'lang/change'                       | _oldLang_: old language, _newLang_: new language               | The language was changed                         |
-| LAYER_DRAWSTATECHANGE<br>'layer/drawstatechange'   | _state_: new value, _layer_: LayerInstance object                | The layer draw state changed                     |
-| LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, _layer_: LayerInstance object      | The layer layer state changed |
-| LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange' | _state_: new value, _layer_: LayerInstance object, _userCancel_: boolean                | The layer load state changed |                     |
-| LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, _layer_: LayerInstance object              | The layer opacity changed                        |
-| LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was registered with the instance                   |
+| LAYER_DRAWSTATECHANGE<br>'layer/drawstatechange'   | _state_: new value, _layer_: LayerInstance object              | The layer draw state changed                     |
+| LAYER_INITIATIONSTATECHANGE<br>'layer/initiationStatechange' | _state_: new value, _layer_: LayerInstance object    | The layer layer state changed                    |
+| LAYER_LAYERSTATECHANGE<br>'layer/layerstatechange' | _state_: new value, _layer_: LayerInstance object, _userCancel_: boolean   | The layer load state changed         |
+| LAYER_OPACITYCHANGE<br>'layer/opacitychange'       | _opacity_: new value, _layer_: LayerInstance object            | The layer opacity changed                        |
+| LAYER_REGISTERED<br>'layer/registered'             | LayerInstance object                                           | The layer was registered with the instance       |
 | LAYER_RELOAD_END<br>'layer/reloadend'              | LayerInstance object                                           | The layer finished reloading                     |
 | LAYER_RELOAD_START<br>'layer/reloadstart'          | LayerInstance object                                           | The layer started reloading                      |
 | LAYER_REMOVE<br>'layer/remove'                     | LayerInstance object                                           | The layer was removed from the map               |
-| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _layer_: LayerInstance object           | The layer visibility changed                     |
-| MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | _basemapId_: string, _schemaChanged_: boolean                      | The basemap was changed                          |
+| LAYER_VISIBILITYCHANGE<br>'layer/visibilitychange' | _visibility_: new value, _layer_: LayerInstance object         | The layer visibility changed                     |
+| MAP_BASEMAPCHANGE<br>'map/basemapchanged'          | _basemapId_: string, _schemaChanged_: boolean                  | The basemap was changed                          |
 | MAP_BLUR<br>'map/blur'                             | KeyboardEvent object                                           | The map lost focus                               |
 | MAP_CLICK<br>'map/click'                           | MapClick object                                                | The map was clicked                              |
 | MAP_CREATED<br>'map/created'                       | none                                                           | The map was created                              |
 | MAP_DESTROYED<br>'map/destroyed'                   | none                                                           | The map was destroyed                            |
 | MAP_DOUBLECLICK<br>'map/doubleclick'               | MapClick object                                                | The map was double clicked                       |
 | MAP_EXTENTCHANGE<br>'map/extentchanged'            | RAMP Extent object                                             | The map extent changed                           |
-| MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                                |
+| MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                             |
 | MAP_GRAPHICHIT<br>'map/graphichit'                 | _layer_: LayerInstance object, _graphicHit_: object, _attributes_: object, _icon_: string, _screenPoint_: object            | A graphic was found where the mouse/crosshair is |
 | MAP_IDENTIFY<br>'map/identify'                     | MapIdentifyResult object                                       | A map identify was requested                     |
 | MAP_KEYDOWN<br>'map/keydown'                       | KeyboardEvent object                                           | A key was pressed                                |
 | MAP_KEYUP<br>'map/keyup'                           | KeyboardEvent object                                           | A key was released                               |
 | MAP_MOUSEDOWN<br>'map/mousedown'                   | PointerEvent object                                            | A mouse button was depressed
-| MAP_MOUSELEAVE<br>'map/mouseleave'             |     PointerEvent object                                            | The mouse left the map                    |
+| MAP_MOUSELEAVE<br>'map/mouseleave'                 | PointerEvent object                                            | The mouse left the map                           |
 | MAP_MOUSEMOVE<br>'map/mousemove'                   | MapMove object                                                 | The mouse moved over the map                     |
 | MAP_MOUSEMOVE_END<br>'map/mousemoveend'            | MapMove object                                                 | The mouse started moving over the map            |
 | MAP_MOUSEMOVE_START<br>'map/mousemovestart'        | MapMove object                                                 | The mouse stopped moving over the map            |
 | MAP_REFRESH_END<br>'map/refreshend'                | none                                                           | The map view started refreshing                  |
 | MAP_REFRESH_START<br>'map/refreshstart'            | none                                                           | The map view finished refreshing                 |
-| MAP_REORDER<br>'map/reorder'                       | _newIndex_: z-index, _layer_: LayerInstance object               | A layer was reordered |
+| MAP_REORDER<br>'map/reorder'                       | _newIndex_: z-index, _layer_: LayerInstance object             | A layer was reordered |
 | MAP_RESIZED<br>'map/resized'                       | _height_: new height, _width_: new width                       | The map view changed size                        |
-| MAP_SCALECHANGE<br>'map/scalechanged'              | scale (denominator) number                                      | The map scale changed                            |
+| MAP_SCALECHANGE<br>'map/scalechanged'              | scale (denominator) number                                     | The map scale changed                            |
 | MAP_START<br>'map/start'                           | none                                                           | The map startup was requested                    |
 | PANEL_CLOSED<br>'panel/closed'                     | PanelInstance object                                           | A panel was closed                               |
-| PANEL_MINIMIZED<br>'panel/closed'                  | PanelInstance object                                           | A panel was minimized                             |
+| PANEL_MINIMIZED<br>'panel/closed'                  | PanelInstance object                                           | A panel was minimized                            |
 | PANEL_OPENED<br>'panel/opened'                     | PanelInstance object                                           | A panel was opened                               |
-| RAMP_MOBILEVIEW_CHANGE<br>'ramp/mobile'            | mobileMode boolean                                            | The screen changes to/from mobile resolution     |
+| RAMP_MOBILEVIEW_CHANGE<br>'ramp/mobileviewchange'  | mobileMode boolean                                             | The screen changes to/from mobile resolution     |
+| RAMP_RELOAD<br>'ramp/reload'                       | none                                                           | The instance was explicitly reloaded             |
 | USER_LAYER_ADDED<br>'user/layeradded'              | LayerInstance object                                           | A layer was added during the session             |
 
 ### Core Fixture Events
@@ -94,7 +95,6 @@ Along with the default fixtures, there are default event handlers that are appli
 
 Updates the map attribution in the map-caption by retrieving it from the current basemap config
 
-- `ramp_config_change_updates_map_attribs` when a configuration file changes (e.g. new language)
 - `ramp_map_basemap_updates_map_attribs` when the basemap changes
 - `ramp_map_created_updates_map_attribs` when the map is created
 

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -13,8 +13,7 @@ import type { WizardAPI } from '@/fixtures/wizard/api/wizard';
 import { useAppbarStore } from '@/fixtures/appbar/store';
 import { useGridStore } from '@/fixtures/grid/store';
 import { LayerState, LayerType } from '@/geo/api';
-import type { BasemapChange, IdentifyResultFormat, MapClick, MapMove, RampBasemapConfig, ScreenPoint } from '@/geo/api';
-import type { RampConfig } from '@/types';
+import type { BasemapChange, IdentifyResultFormat, MapClick, MapMove, ScreenPoint } from '@/geo/api';
 import { debounce, throttle } from 'throttle-debounce';
 import { useMapCaptionStore } from '@/stores/map-caption';
 import { useConfigStore } from '@/stores/config';
@@ -310,6 +309,12 @@ export enum GlobalEvents {
     RAMP_MOBILEVIEW_CHANGE = 'ramp/mobileviewchange',
 
     /**
+     * Fires when the instance has been explicitly reloaded / restarted
+     * Payload: none
+     */
+    RAMP_RELOAD = 'ramp/reload',
+
+    /**
      * Fires when a request is issued to toggle (open/close) the Layer Reorder panel.
      * Payload: none
      */
@@ -338,7 +343,6 @@ export enum GlobalEvents {
 // IMPORTANT: These values are part of the public API, best to never edit them unless no other alternative,
 //            as it will be a breaking change to API usage.
 enum DefEH {
-    CONFIG_CHANGE_UPDATES_MAP_ATTRIBS = 'ramp_config_change_updates_map_attribs',
     LAYER_ERROR_UPDATES_LEGEND = 'ramp_layer_error_updates_legend',
     LAYER_REGISTER_BINDS_LEGEND = 'ramp_layer_register_binds_legend',
     LAYER_RELOAD_END_BINDS_LEGEND = 'ramp_layer_reload_end_binds_legend',
@@ -630,19 +634,6 @@ export class EventAPI extends APIScope {
     private defaultHandlerFactory(handlerName: string): string {
         let zeHandler: (payload?: any) => void;
         switch (handlerName) {
-            case DefEH.CONFIG_CHANGE_UPDATES_MAP_ATTRIBS:
-                // update any basemap attribution in the map caption when the config changes (likely language switch)
-                zeHandler = (payload: RampConfig) => {
-                    const currentBasemapConfig: RampBasemapConfig | undefined = payload.map.basemaps.find(
-                        bms => bms.id === this.$iApi.geo.map.getCurrentBasemapId()
-                    );
-
-                    this.$iApi.geo.map.caption.updateAttribution(currentBasemapConfig?.attribution);
-                };
-
-                this.$iApi.event.on(GlobalEvents.CONFIG_CHANGE, zeHandler, handlerName);
-                break;
-
             case DefEH.LAYER_ERROR_UPDATES_LEGEND:
                 // when a layer errors, have the standard legend update in accordance to the layer
                 zeHandler = (payload: { state: string; layer: LayerInstance }) => {

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -166,30 +166,17 @@ export class InstanceAPI {
         const panelStore = usePanelStore(this.$vApp.$pinia);
         const maptipStore = useMaptipStore(this.$vApp.$pinia);
         if (configs?.configs !== undefined) {
-            const langConfigs: {
-                [key: string]: RampConfig;
-            } = configs.configs;
+            // update the config set in the store, ensuring every language is mapped to something
+            const allLangs = Object.keys(this.$i18n.messages.value);
+            configStore.registerAllConfigs(configs, allLangs);
 
-            const langConfig = langConfigs[this.$i18n.locale.value] ?? langConfigs[Object.keys(langConfigs)[0]];
-            configStore.newConfig(langConfig);
-
-            // register first config for all available languages and then overwrite configs per language as needed
-            configStore.registerConfig({
-                config: langConfig,
-                configLangs: Object.keys(langConfigs),
-                allLangs: Object.keys(this.$i18n.messages.value)
-            });
-
-            for (const lang in langConfigs) {
-                configStore.registerConfig({
-                    config: langConfigs[lang],
-                    configLangs: [lang]
-                });
-            }
+            // set the current languages' config as the active config
+            const activeConfig = configStore.registeredConfigs[configStore.registeredLangs[this.$i18n.locale.value]];
+            configStore.newConfig(activeConfig);
 
             // set the initial basemap
-            configStore.activeBasemapConfig = langConfig.map.basemaps.find(
-                bm => bm.id === langConfig.map.initialBasemapId
+            configStore.activeBasemapConfig = activeConfig.map.basemaps.find(
+                bm => bm.id === activeConfig.map.initialBasemapId
             );
 
             // need to wait for the map container div to appear
@@ -202,19 +189,19 @@ export class InstanceAPI {
                     clearInterval(mapDivWatcher);
 
                     // create the map
-                    this.geo.map.createMap(langConfig.map, mapViewElement as HTMLDivElement).then(() => {
+                    this.geo.map.createMap(activeConfig.map, mapViewElement as HTMLDivElement).then(() => {
                         // Hide hovertip on map creation
                         //@ts-expect-error TODO: explain why this is needed or remove
                         mapViewElement._tippy.hide(0);
                         //@ts-expect-error TODO: explain why this is needed or remove
                         maptipStore.setMaptipInstance(mapViewElement._tippy);
 
-                        if (langConfig.layers && langConfig.layers.length > 0) {
+                        if (activeConfig.layers && activeConfig.layers.length > 0) {
                             // Add all the config layers to the instance, in order.
                             // Config layers always get "added first", so we provide order positions here for the map layers.
                             // Enhanced positioning logic is now handled by map.addLayer()
                             let mapOrderPos = 0;
-                            langConfig.layers.forEach(layerConfig => {
+                            activeConfig.layers.forEach(layerConfig => {
                                 const layer = this.geo.layer.createLayer(layerConfig);
                                 this.geo.map
                                     .addLayer(layer, mapOrderPos)
@@ -231,17 +218,17 @@ export class InstanceAPI {
                 }
             }, 100);
 
-            if (langConfig.panels) {
+            if (activeConfig.panels) {
                 // open and pin appropiate panels on startup
                 // TODO: Note that certain panels like grid, settings, etc. need to get data for a specific layer.
                 // Because different fixtures get this data in different ways (some use LayerInstance, some uid, some custom config),
                 // there is no way to open the panel with layer data loaded without writing specific code for specific fixtures.
                 // Once layer usage throughout RAMP is normalized, add an extra nugget in the config called options or something so that the panel
                 // can load layer data as well.
-                if (langConfig.panels.open && langConfig.panels.open.length > 0) {
-                    const panelIds = langConfig.panels.open.map(p => p.id);
+                if (activeConfig.panels.open && activeConfig.panels.open.length > 0) {
+                    const panelIds = activeConfig.panels.open.map(p => p.id);
                     this.panel.isRegistered(panelIds).then(() => {
-                        langConfig.panels?.open?.forEach(panel => {
+                        activeConfig.panels?.open?.forEach(panel => {
                             this.panel.open({
                                 id: panel.id,
                                 screen: panel.screen
@@ -254,29 +241,29 @@ export class InstanceAPI {
                 }
 
                 // enable/disable reorder controls
-                panelStore.reorderable = langConfig.panels.reorderable ?? true;
+                panelStore.reorderable = activeConfig.panels.reorderable ?? true;
             }
 
             // disable animations if needed
-            if (!langConfig.system?.animate && this.$element._container && this.$element._container.children[0]) {
+            if (!activeConfig.system?.animate && this.$element._container && this.$element._container.children[0]) {
                 this.$element._container.children[0].classList.remove('animation-enabled');
             }
 
             // process system configurations
-            if (langConfig.system?.proxyUrl) {
-                this.geo.proxy = langConfig.system.proxyUrl;
+            if (activeConfig.system?.proxyUrl) {
+                this.geo.proxy = activeConfig.system.proxyUrl;
             }
-            if (langConfig.system?.exposeOid) {
-                this.ui.exposeOids = langConfig.system.exposeOid;
+            if (activeConfig.system?.exposeOid) {
+                this.ui.exposeOids = activeConfig.system.exposeOid;
             }
-            if (langConfig.system?.exposeMeasurements != undefined) {
-                this.ui.exposeMeasurements = langConfig.system.exposeMeasurements;
+            if (activeConfig.system?.exposeMeasurements != undefined) {
+                this.ui.exposeMeasurements = activeConfig.system.exposeMeasurements;
             }
-            if (langConfig.system?.scrollToInstance) {
-                this.ui.scrollToInstance = langConfig.system?.scrollToInstance;
+            if (activeConfig.system?.scrollToInstance) {
+                this.ui.scrollToInstance = activeConfig.system?.scrollToInstance;
             }
-            if (langConfig.system?.suppressNumberLocalization) {
-                this.ui.suppressNumberLocalization = langConfig.system?.suppressNumberLocalization;
+            if (activeConfig.system?.suppressNumberLocalization) {
+                this.ui.suppressNumberLocalization = activeConfig.system?.suppressNumberLocalization;
             }
 
             // set up key to SVG bindings for zoom icons
@@ -286,7 +273,7 @@ export class InstanceAPI {
             };
 
             // Set up custom zoom icon for the map and details panel. If not specified in the config, 'globe' is the default.
-            const zoomKey: string = langConfig.system?.zoomIcon || 'globe';
+            const zoomKey: string = activeConfig.system?.zoomIcon || 'globe';
             const zoomIcon: string = zoomSvgs[zoomKey] || zoomKey;
 
             this.ui.getZoomIcon = () => {
@@ -351,12 +338,13 @@ export class InstanceAPI {
     }
 
     /**
-     * Reloads Vue R4MP instance with a new config
+     * Encapsulates the steps required to reload the instance. Utility to be called
+     * by other orchestrator methods.
      *
      * @param {RampConfigs} configs language-keyed R4MP config
      * @param {RampOptions} options startup options for this R4MP instance
      */
-    reload(configs?: RampConfigs, options?: RampOptions): void {
+    private reloadWorker(configs?: RampConfigs, options?: RampOptions): void {
         const instanceStore = useInstanceStore(this.$vApp.$pinia);
         const notificationStore = useNotificationStore(this.$vApp.$pinia);
         const configStore = useConfigStore(this.$vApp.$pinia);
@@ -364,10 +352,9 @@ export class InstanceAPI {
         const layerStore = useLayerStore(this.$vApp.$pinia);
         const gridStore = useGridStore(this.$vApp.$pinia);
 
-        // if a user provides their own config, we pretend that RAMP is initializing for the first time
-        const first = !!configs;
+        const newConfigProvided = !!configs;
 
-        if (first) {
+        if (newConfigProvided) {
             // remove all fixtures
             // get list of all fixture ids currently added
             const addedFixtures: Array<string> = Object.keys(fixtureStore.items);
@@ -406,8 +393,8 @@ export class InstanceAPI {
             this._eventsOn = false;
         }
 
-        // if configs is not provided, use the current configs
-        if (configs === undefined) {
+        if (!newConfigProvided) {
+            // if configs is not provided, use the current configs (e.g. language change, basic reload).
             // Need to clone this config to trigger config watch handlers
             configs = JSON.parse(
                 JSON.stringify({
@@ -424,7 +411,25 @@ export class InstanceAPI {
         this.geo.map.maptip.clear();
 
         // re-initalize ramp
-        this.initialize(first, configs, options);
+        // if a user provides their own config, we pretend that RAMP is initializing for the first time
+        this.initialize(newConfigProvided, configs, options);
+
+        if (newConfigProvided) {
+            // raise event that the configuration changed.
+            // call this last, as we need initialize() to register the new config first
+            this.event.emit(GlobalEvents.CONFIG_CHANGE, this.getConfig());
+        }
+    }
+
+    /**
+     * Reloads Vue R4MP instance, with the option of providing a new config
+     *
+     * @param {RampConfigs} configs language-keyed R4MP config. if missing, the existing configs will be used
+     * @param {RampOptions} options startup options for this R4MP instance
+     */
+    reload(configs?: RampConfigs, options?: RampOptions): void {
+        this.reloadWorker(configs, options);
+        this.event.emit(GlobalEvents.RAMP_RELOAD);
     }
 
     /**
@@ -484,7 +489,7 @@ export class InstanceAPI {
      *
      * @memberof InstanceAPI
      */
-    getConfig() {
+    getConfig(): RampConfig {
         // clone it to avoid mutations to store config
         const configStore = useConfigStore(this.$vApp.$pinia);
         return JSON.parse(JSON.stringify(configStore.getActiveConfig(this.language)));
@@ -588,7 +593,7 @@ export class InstanceAPI {
         }
         const configStore = useConfigStore(this.$vApp.$pinia);
         const notificationStore = useNotificationStore(this.$vApp.$pinia);
-        const langs = configStore.registeredLangs;
+        const underlyingConfigLang = configStore.registeredLangs;
 
         // If monoconfig, clear all notifications (notification language isn't changed on lang change)
         if (Object.keys(configStore.registeredConfigs).length === 1) {
@@ -601,9 +606,15 @@ export class InstanceAPI {
         const activeConfig = this.getConfig();
 
         // reload the map and emit event if configs are different
-        if (langs[old] !== langs[language]) {
+        if (underlyingConfigLang[old] !== underlyingConfigLang[language]) {
+            // reload, but in sneaky fashion. this is a lang change, not a forced reload.
+            // calling the worker avoids the reload event getting yeet'd
+            this.reloadWorker();
+
+            // We are changing "active" configs, and the configs are actually different.
+            // The reloader will not throw this event since we're using the existing config sets.
+            // So throw the config event here. Do it after .reload() to match the timing of an API-triggered reload
             this.event.emit(GlobalEvents.CONFIG_CHANGE, activeConfig);
-            this.reload();
         }
 
         this.event.emit(GlobalEvents.LANG_CHANGE, {

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -628,8 +628,8 @@ const onGridReady = (params: any) => {
         })
     );
     handlers.value.push(
-        iApi.event.on(GlobalEvents.CONFIG_CHANGE, () => {
-            // Refresh the grid when the config changes (the language might have changed)
+        iApi.event.on(GlobalEvents.LANG_CHANGE, () => {
+            // Refresh the grid when the language changes
             agGridApi.value.redrawRows({
                 force: true
             } as any);

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -33,6 +33,11 @@ export class CommonMapAPI extends APIScope {
     created = false;
 
     /**
+     * Identifies the map. Primarily used for debugging.
+     */
+    name: string;
+
+    /**
      * Tracks if we are watching for the first basemap to load.
      * @private
      */
@@ -89,7 +94,7 @@ export class CommonMapAPI extends APIScope {
      */
     protected pointZoomScale: number;
 
-    protected constructor(iApi: InstanceAPI) {
+    protected constructor(iApi: InstanceAPI, name: string = '') {
         super(iApi);
 
         this.esriMap = undefined;
@@ -97,10 +102,12 @@ export class CommonMapAPI extends APIScope {
         this._viewPromise = new DefPromise();
         this.handlers = [];
         this.pointZoomScale = 50000;
+        this.name = name;
     }
 
     protected noMapErr(): void {
-        console.error('Attempted to manipulate the map before calling createMap()');
+        console.error(`Attempted to manipulate the ${this.name} map before calling createMap()`);
+        console.trace();
     }
 
     protected abstractError(): void {

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -16,7 +16,7 @@ export class OverviewMapAPI extends CommonMapAPI {
      * @param {InstanceAPI} iApi the RAMP instance
      */
     constructor(iApi: InstanceAPI) {
-        super(iApi);
+        super(iApi, 'overview');
         this.overviewGraphicLayer = this.$iApi.geo.layer.createLayer({
             id: 'RampOverviewGraphic',
             layerType: LayerType.GRAPHIC,

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -69,7 +69,7 @@ export class MapAPI extends CommonMapAPI {
      * @param {InstanceAPI} iApi the RAMP instance
      */
     constructor(iApi: InstanceAPI) {
-        super(iApi);
+        super(iApi, 'main');
         this.maptip = new MaptipAPI(iApi);
         this.caption = new MapCaptionAPI(iApi);
         this.mapMouseThrottle = 0; // default to 0 (no throttle)

--- a/src/stores/config/config-store.ts
+++ b/src/stores/config/config-store.ts
@@ -1,5 +1,5 @@
 import type { RampBasemapConfig } from '@/geo/api';
-import type { RampConfig } from '@/types';
+import type { RampConfig, RampConfigs } from '@/types';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { useLayerStore } from '../layer';
@@ -18,7 +18,16 @@ export const useConfigStore = defineStore('config', () => {
     });
     const startingFixtures = ref<string[]>([]);
     const activeBasemapConfig = ref<RampBasemapConfig>();
+
+    /**
+     * Maps a language to the config defined for that language.
+     */
     const registeredConfigs = ref<{ [key: string]: RampConfig }>({});
+
+    /**
+     * Maps an actual language to the language of the config bound to it.
+     * E.g. Separate config: {en:'en', fr:'fr'} ; Mono config keyed to en: {en:'en', fr:'en'}
+     */
     const registeredLangs = ref<{ [key: string]: string }>({});
 
     function getActiveConfig(lang: string): RampConfig {
@@ -38,36 +47,59 @@ export const useConfigStore = defineStore('config', () => {
         }
     }
 
-    function registerConfig(configInfo: any): void {
-        // configLangs are languages with a given config, whereas allLangs include languages without their own config
-        const configLangs = configInfo.configLangs;
-        const config = configInfo.config;
-        const allLangs = configInfo.allLangs;
-        if (configLangs !== undefined && configLangs.length > 0) {
-            // register config for specified languages
-            configLangs.forEach((lang: string) => {
-                registeredConfigs.value[lang] = config;
+    /**
+     * Will register a language-specific config to a language code
+     *
+     * @param {RampConfig} config a config object tailored for a language
+     * @param {string} lang the language key to register this config under
+     */
+    function registerConfig(config: RampConfig, lang: string): void {
+        registeredConfigs.value[lang] = config;
+        // add correspondence between language and config
+        registeredLangs.value[lang] = lang;
+    }
+
+    /**
+     * Will register a full set of configs, and ensure every supported language is mapped to a config
+     *
+     * @param {RampConfigs} allConfigs full configuration object containing all language-specific configs for the instance
+     * @param {Array<string>} allLangs every language code the instance can support
+     */
+    function registerAllConfigs(allConfigs: RampConfigs, allLangs: Array<string>): void {
+        const providedConfigs = allConfigs.configs;
+        const providedLangs = Object.keys(providedConfigs);
+
+        if (providedLangs.length) {
+            // This defaulting is fine for classic en/fr ramp. Either all langs have definitions, or only one def exists.
+            // If we ever get into > 2 langs, the defaulting will be a bit random.
+            // E.g. support en/fr/es , provide configs for fr & es. en will get defaulted to whatever key shows up
+            //      first in Object.keys. Which maybe changes every run, or is some arbitrary order (alpha? first insertion?).
+            // Worry about it if we start supporting huge tracts of langs.
+            const defaultLang = providedLangs[0];
+
+            // make sure every supported language has a config assigned to it
+            allLangs.forEach(realLang => {
+                // link to real config if one exists for this lang. Otherwise link to the default lang
+                const linkedLang = providedLangs.includes(realLang) ? realLang : defaultLang;
+
+                registeredConfigs.value[realLang] = providedConfigs[linkedLang];
                 // add correspondence between language and config
-                registeredLangs.value[lang] = lang;
+                registeredLangs.value[realLang] = linkedLang;
             });
-        }
-        if (allLangs !== undefined && allLangs.length > 0) {
-            // register config for all available languages
-            allLangs.forEach((lang: string) => {
-                // initially each language corresponds to first config by default
-                registeredLangs.value[lang] = Object.keys(registeredConfigs.value)[0];
-            });
+        } else {
+            console.error('Nothingburger config set was registered', allConfigs);
         }
     }
 
     return {
-        config,
-        startingFixtures,
         activeBasemapConfig,
+        config,
         registeredConfigs,
         registeredLangs,
+        startingFixtures,
         getActiveConfig,
         newConfig,
+        registerAllConfigs,
         registerConfig
     };
 });


### PR DESCRIPTION
### Related Item(s)

https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2637

### Changes

- New Instance Reload event.
- Make events fire when I want them to.
- Refactored config store registration stuff to be more precise, less swiss-army-knife.
- Removed obsolete default event handler for updating map caption on config change. Map reload already covers this.
- Doc updates.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Open Enhanced Sample 1. Let it load. Then paste this script in the console and run it.

It will do four tests and write the tests & live event reactions.

If you want to observe the site as the test runs, the things to watch are:

- Map flickering: it did a reload (reload request or lang change to new config)
- Language in lower right: what lang mode we are in
- Title of the legend (`Legend` vs `Légende`): tells what lang RAMP is binding to
- Map caption (in english or french): tells what config is being used.
  - Note in the final test, we switch to english but have a mono-french config, so seeing "Legend" + EN but French map caption is correct


```js
debugInstance.event.on('ramp/reload', ()=> console.log('🍅 Instance Reload pinged'));
debugInstance.event.on('lang/change', ()=> console.log('🍅 Language Change pinged'));
debugInstance.event.on('config/configchanged', ()=> console.log('🍅 Config Change pinged'));

const sleep = async (millsecs)=> {
    return new Promise(resolve => {
        setTimeout(() => {
            resolve();
        }, millsecs);
    });
};

const holdYourHorses = async () => {
    await sleep(7000);
    console.log('Next test in 5 seconds');
    console.log('----------------------');
    await sleep(5000);
}

const funtimes = async () => {

    console.log('About to change lang on dual-config.\nLang will become French, map reloads\nShould see Lang Change and Config Change');
    debugInstance.setLanguage('fr');

    await holdYourHorses();
    
    console.log('About to force a vanilla reload.\nLang stays French, map reloads\nShould see Instance Reload');
    debugInstance.reload()
    
    await holdYourHorses();
    
    console.log('About to force a reload with a mono-config [just french].\nLang stays French, map reloads\nShould see Instance Reload and Config Change');
    const fakeConfig = { configs: { fr: debugInstance.getConfig() } };
    debugInstance.reload(fakeConfig);

    await holdYourHorses();
    
    console.log('About to change lang on mono-config.\nLang changes to EN, but config remains French. No reload\nShould see Lang Change');
    debugInstance.setLanguage('en');

    await sleep(5000);
    console.log('Donethanks');

}

funtimes();
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2638)
<!-- Reviewable:end -->
