### PR TITLE
Linked Issue Verb Freedom

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,9 +3,6 @@
 ### Related Item(s)
 *#Item 1*, *#Item 2*
 
-*Do not put any of the following words before the issue number*
-*close ; closes ; closed ; fix ; fixes ; fixed ; resolve ; resolves ; resolved*
-
 ### Changes
 - [FEATURE] *Describe feature...*
 - [FIX] *Describe fix...*


### PR DESCRIPTION
### Changes
- Updates the PR template to relax some rules

### Notes

Github just added a [new respectful setting](https://github.blog/changelog/2025-04-23-users-can-now-choose-whether-merging-linked-pull-requests-automatically-closes-the-issue/) to stop linked issues from auto-closing when a PR gets merged.

I've turned off that behaviour in the repo, so we can now use lovely words like `closes` in front of our issues links in the PRs

### QA Testing

None

### Testing

None. Trust the diff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2639)
<!-- Reviewable:end -->
