### PR TITLE
Fix app freezing on trying to overflow custom appbar button

### DIFF
--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -347,13 +347,22 @@ let config = {
                     items: [
                         [
                             'diligord-p1',
+                            'iklob-p1',
+                            'mouruge-p1',
                             {
                                 id: 'gazebo'
-                            },
-                            'iklob-p1',
-                            'mouruge-p1'
+                            }
                         ],
-                        ['snowman', 'legend', 'geosearch', 'basemap']
+                        [
+                            'snowman',
+                            'legend',
+                            'geosearch',
+                            'basemap',
+                            {
+                                id: 'appbar-link',
+                                componentId: 'appbar-link-1'
+                            }
+                        ]
                     ]
                 },
                 mapnav: { items: ['fullscreen', 'help', 'home', 'basemap'] },
@@ -398,6 +407,20 @@ rInstance.$element.component('WFSLayer-Custom', {
             <img src="https://i.imgur.com/WtY0tdC.gif" />
         </div>
     `
+});
+
+rInstance.$element.component(`appbar-link-1`, {
+    template: `<appbar-button :onClickFunction="onClick" tooltip="Custom button">
+        <div class="default fill-current w-24 h-24 ml-8 sm:ml-20">
+            <svg data-slot="icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path clip-rule="evenodd" fill-rule="evenodd" d="M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z"></path>
+            </svg>
+        </div></appbar-button>`,
+    methods: {
+        onClick() {
+            window.open('https://www.google.ca', '_blank').focus();
+        }
+    }
 });
 
 rInstance.$element.component('Water-Quantity-Template', {

--- a/src/fixtures/appbar/appbar.vue
+++ b/src/fixtures/appbar/appbar.vue
@@ -27,13 +27,13 @@
                     :class="`identifier-${item}-${index2}`"
                 ></default-button>
                 <component
-                    v-else-if="overflowFlags[`${item}-${index2}`] !== true"
+                    v-else-if="overflowFlags[`${item.id}-${index2}`] !== true"
                     :is="item.componentId"
-                    :key="`${item}-${index2}-custom`"
+                    :key="`${item.id}-${index2}-custom`"
                     :options="item.options"
                     class="appbar-item h-48"
-                    :id="item.id"
-                    :class="`identifier-${item}-${index2}`"
+                    :buttonId="item.id"
+                    :class="`identifier-${item.id}-${index2}`"
                 ></component>
             </template>
             <divider
@@ -72,13 +72,13 @@
                             overflow
                         ></default-button>
                         <component
-                            v-else-if="overflowFlags[`${item}-${index2}`]"
-                            :is="item!.componentId"
-                            :key="`${item}-${index2}-custom`"
+                            v-else-if="overflowFlags[`${item.id}-${index2}`]"
+                            :is="item.componentId"
+                            :key="`${item.id}-${index2}-custom`"
                             :options="item.options"
-                            :id="item.id"
+                            :buttonId="item.id"
                             class="appbar-item h-48"
-                            :class="`identifier-${item}-${index2}`"
+                            :class="`identifier-${item.id}-${index2}`"
                         ></component>
                     </template>
                     <divider

--- a/src/fixtures/appbar/button.vue
+++ b/src/fixtures/appbar/button.vue
@@ -34,7 +34,7 @@ const props = defineProps({
         type: Function,
         required: true
     },
-    id: {
+    buttonId: {
         type: String,
         required: true
     },
@@ -44,7 +44,7 @@ const props = defineProps({
     }
 });
 
-const onClick = () => iApi?.event.emit(GlobalEvents.APPBAR_BUTTON_CLICK, props.id);
+const onClick = () => iApi?.event.emit(GlobalEvents.APPBAR_BUTTON_CLICK, props.buttonId);
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
### Related Item(s)
#2646 

### Changes
- [FIX] Uses `item.id` instead of `item` in class name and overflow flag for custom appbar buttons
- [REFACTOR] Renamed `id` to `buttonId` for custom button prop to allow for actual `id` on buttons if needed

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=2

### Testing

Steps:
1. Open sample 2 in the old sample page (QA: your link above already opens it)
2. Resize window vertically until the `link` icon button runs out of room and enters the `...` overflow
3. The app should still be responsive

### Additional notes

I can change what sample the extra button is in. I put it in sample 2 because it has the "fake" custom buttons (they're still buttons for panels but not core).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2647)
<!-- Reviewable:end -->
