### PR TITLE
refactor: simplify VSCode extensions recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,3 @@
 {
-    "recommendations": [
-        "esbenp.prettier-vscode",
-        "bradlc.vscode-tailwindcss",
-        "austenc.tailwind-docs",
-        "gruntfuggly.todo-tree",
-        "Vue.volar",
-        "dbaeumer.vscode-eslint",
-        "EditorConfig.EditorConfig"
-    ]
+    "recommendations": ["esbenp.prettier-vscode", "bradlc.vscode-tailwindcss", "vue.volar", "dbaeumer.vscode-eslint"]
 }


### PR DESCRIPTION
### Related Item(s)
#2628

### Changes
- [CLEANUP] Removed unnecessary and unused VS Code extensions from `.vscode/extensions.json`.

### Notes
- Removed `EditorConfig.EditorConfig` as it was never used for organizing the repo structure.
- Kept `vue.Volar` since it is the [officially recommended extension](https://vuejs.org/guide/scaling-up/tooling.html#ide-support) for Vue projects, despite the confusing naming in the VS Marketplace.
- Removed `austenc.tailwind-docs` since its functionality is redundant; inline Tailwind annotation is already handled by `bradlc.vscode-tailwindcss`.
- Removed `gruntfuggly.todo-tree` as it provides minimal value (just lists TODOs).

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

None needed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2650)
<!-- Reviewable:end -->
