### PR TITLE
fix: improve build date display format in about ramp dropdown

### DIFF
--- a/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/src/components/about-ramp/about-ramp-dropdown.vue
@@ -56,7 +56,8 @@
                         </div>
                         <div>
                             <span class="text-sm cursor-text">
-                                {{ buildDate }}
+                                <span class="font-bold">{{ buildDate[0] }}</span>
+                                <span class="ml-5">{{ buildDate[1] }}</span>
                             </span>
                         </div>
                         <div class="mt-5">
@@ -124,12 +125,12 @@ const versionHash = computed<string>(() => {
 /**
  * Get RAMP build date
  */
-const buildDate = computed<string>(() => {
+const buildDate = computed(() => {
     const timestamp = new Date(version.timestamp);
-    if (isNaN(timestamp as any)) {
+    if (isNaN(timestamp.getTime())) {
         // this appears to be broken in dev serve mode (but not always).
         // likely the vite `git log -1 --format=%cd` command isnt working in that context
-        return 'dev mode, no date';
+        return ['dev mode', 'no date'];
     } else {
         const padZero = (num: number): string => {
             if (num < 10) {
@@ -138,20 +139,20 @@ const buildDate = computed<string>(() => {
                 return num.toString();
             }
         };
-        return `${timestamp.getFullYear()}-${
-            timestamp.getMonth() + 1
-        }-${timestamp.getDate()} ${timestamp.getHours()}:${padZero(
-            timestamp.getMinutes()
-        )}:${padZero(timestamp.getSeconds())}`;
+        return [
+            `${timestamp.getFullYear()}-${timestamp.getMonth() + 1}-${timestamp.getDate()}`,
+            `${timestamp.getHours()}:${padZero(timestamp.getMinutes())}:${padZero(timestamp.getSeconds())}`
+        ];
     }
 });
 </script>
 
 <style lang="scss" scoped>
 .about-ramp-dropdown {
-    @apply p-0 #{!important};
+    padding: 0 !important;
+
     &:hover {
-        @apply bg-white #{!important};
+        background-color: #fff !important;
     }
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
#2624 

### Changes
- [FIX] improve build date display format in about ramp dropdown

### Notes
Date is now bolded and there is additional space between date and time. Fixed a scss grouse in the editor.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any sample
2. Open the about ramp popup in bottom left corner
3. See the changes to date and time
