### PR TITLE
Update old metadata XSLT and add new one for DCAT

### DIFF
--- a/demos/index-samples.html
+++ b/demos/index-samples.html
@@ -35,7 +35,7 @@
                 <option value="r2-config-upgraded">17. RAMP 2 config upgraded</option>
                 <option value="error-layers">18. Layers in error state</option>
                 <option value="disabled-options">19. Layers with disabled options</option>
-                <option value="layer-metadata">20. Layer with metadata</option>
+                <option value="layer-metadata">20. Layers with metadata</option>
                 <option value="section-item">21. Section Items</option>
                 <option value="info-section">22. Info Sections</option>
                 <option value="legname">23. Legend Name Hunt</option>

--- a/demos/starter-scripts/layer-metadata.js
+++ b/demos/starter-scripts/layer-metadata.js
@@ -75,11 +75,34 @@ let config = {
             layers: [
                 {
                     id: 'ecogeo-nature',
-                    name: 'Nature',
+                    name: 'Nature - Markdown metadata',
                     layerType: 'esri-feature',
                     url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/EcoAction/MapServer/6',
                     metadata: {
                         url: 'https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/main/public/help/en.md'
+                    }
+                },
+                {
+                    id: 'Happy',
+                    name: 'Happy - DCAT metadata',
+                    layerType: 'file-geojson',
+                    url: '../file-layers/geojson.json',
+                    colour: '#4ef542',
+                    nameField: 'name',
+                    metadata: {
+                        url: 'https://open.canada.ca/data/en/dataset/be54680b-ea62-46f3-aaa9-7644ed970aef.xml',
+                        xmlType: 'DCAT'
+                    }
+                },
+                {
+                    id: 'Happy2',
+                    name: 'Happy - HNAP metadata',
+                    layerType: 'file-geojson',
+                    url: '../file-layers/geojson.json',
+                    colour: '#fe3742',
+                    nameField: 'name',
+                    metadata: {
+                        url: '../sample-metadata/csw.xml'
                     }
                 }
             ],
@@ -89,6 +112,12 @@ let config = {
                         children: [
                             {
                                 layerId: 'ecogeo-nature'
+                            },
+                            {
+                                layerId: 'Happy'
+                            },
+                            {
+                                layerId: 'Happy2'
                             }
                         ]
                     }

--- a/public/sample-metadata/csw.xml
+++ b/public/sample-metadata/csw.xml
@@ -1,0 +1,959 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csw:GetRecordByIdResponse xmlns:csw="http://www.opengis.net/cat/csw/2.0.2">
+  <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gfc="http://www.isotc211.org/2005/gfc" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gss="http://www.isotc211.org/2005/gss" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.isotc211.org/2005/gmd" xmlns:geonet="http://www.fao.org/geonetwork" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/gmd/gmd.xsd http://www.isotc211.org/2005/srv http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/srv/srv.xsd http://www.geconnections.org/nap/napMetadataTools/napXsd/napm http://nap.geogratis.gc.ca/metadata/tools/schemas/metadata/can-cgsb-171.100-2009-a/napm/napm.xsd">
+    <gmd:fileIdentifier>
+      <gco:CharacterString>9e1507cd-f25c-4c64-995b-6563bf9d65bd</gco:CharacterString>
+    </gmd:fileIdentifier>
+    <gmd:language>
+      <gco:CharacterString>eng; CAN</gco:CharacterString>
+    </gmd:language>
+    <gmd:characterSet>
+      <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+    </gmd:characterSet>
+    <gmd:hierarchyLevel>
+      <gmd:MD_ScopeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_108" codeListValue="RI_622">dataset; jeuDonnées</gmd:MD_ScopeCode>
+    </gmd:hierarchyLevel>
+    <gmd:contact>
+      <gmd:CI_ResponsibleParty>
+        <gmd:individualName gco:nilReason="missing">
+          <gco:CharacterString />
+        </gmd:individualName>
+        <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+          <gco:CharacterString>Government of Canada; Natural Resources Canada; Surveyor General Branch</gco:CharacterString>
+          <gmd:PT_FreeText>
+            <gmd:textGroup>
+              <gmd:LocalisedCharacterString locale="#fra">Gouvernement du Canada; Ressources naturelles Canada; Direction de l'arpenteur général</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+          </gmd:PT_FreeText>
+        </gmd:organisationName>
+        <gmd:positionName gco:nilReason="missing">
+          <gco:CharacterString />
+        </gmd:positionName>
+        <gmd:contactInfo>
+          <gmd:CI_Contact>
+            <gmd:phone>
+              <gmd:CI_Telephone>
+                <gmd:voice xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                  <gco:CharacterString />
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra" />
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:voice>
+                <gmd:facsimile gco:nilReason="missing">
+                  <gco:CharacterString />
+                </gmd:facsimile>
+              </gmd:CI_Telephone>
+            </gmd:phone>
+            <gmd:address>
+              <gmd:CI_Address>
+                <gmd:deliveryPoint xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>physical; 588; Booth Street</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">physique; 588; rue Booth</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:deliveryPoint>
+                <gmd:city>
+                  <gco:CharacterString>Ottawa</gco:CharacterString>
+                </gmd:city>
+                <gmd:administrativeArea xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Ontario</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Ontario</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:administrativeArea>
+                <gmd:postalCode>
+                  <gco:CharacterString>K1A 0Y7</gco:CharacterString>
+                </gmd:postalCode>
+                <gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Canada</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Canada</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:country>
+                <gmd:electronicMailAddress xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>nrcan.clss-satc.rncan@canada.ca</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">nrcan.clss-satc.rncan@canada.ca</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:electronicMailAddress>
+              </gmd:CI_Address>
+            </gmd:address>
+            <gmd:onlineResource>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage gco:nilReason="missing">
+                  <gmd:URL />
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>http</gco:CharacterString>
+                </gmd:protocol>
+              </gmd:CI_OnlineResource>
+            </gmd:onlineResource>
+            <gmd:hoursOfService xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+              <gco:CharacterString />
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#fra" />
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:hoursOfService>
+          </gmd:CI_Contact>
+        </gmd:contactInfo>
+        <gmd:role>
+          <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90" codeListValue="RI_414">pointOfContact; contact</gmd:CI_RoleCode>
+        </gmd:role>
+      </gmd:CI_ResponsibleParty>
+    </gmd:contact>
+    <gmd:dateStamp>
+      <gco:DateTime>2022-07-20T19:37:09</gco:DateTime>
+    </gmd:dateStamp>
+    <gmd:metadataStandardName xsi:type="gmd:PT_FreeText_PropertyType">
+      <gco:CharacterString>North American Profile of ISO 19115:2003 - Geographic information - Metadata</gco:CharacterString>
+      <gmd:PT_FreeText>
+        <gmd:textGroup>
+          <gmd:LocalisedCharacterString locale="#fra">Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées</gmd:LocalisedCharacterString>
+        </gmd:textGroup>
+      </gmd:PT_FreeText>
+    </gmd:metadataStandardName>
+    <gmd:metadataStandardVersion>
+      <gco:CharacterString>CAN/CGSB-171.100-2009</gco:CharacterString>
+    </gmd:metadataStandardVersion>
+    <gmd:dataSetURI gco:nilReason="missing">
+      <gco:CharacterString />
+    </gmd:dataSetURI>
+    <gmd:locale>
+      <gmd:PT_Locale id="fra">
+        <gmd:languageCode>
+          <gmd:LanguageCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_116" codeListValue="fra">French; Français</gmd:LanguageCode>
+        </gmd:languageCode>
+        <gmd:country>
+          <gmd:Country codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_117" codeListValue="CAN">Canada; Canada</gmd:Country>
+        </gmd:country>
+        <gmd:characterEncoding>
+          <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="RI_458">utf8; utf8</gmd:MD_CharacterSetCode>
+        </gmd:characterEncoding>
+      </gmd:PT_Locale>
+    </gmd:locale>
+    <gmd:referenceSystemInfo>
+      <gmd:MD_ReferenceSystem>
+        <gmd:referenceSystemIdentifier>
+          <gmd:RS_Identifier>
+            <gmd:code>
+              <gco:CharacterString>EPSG:3979</gco:CharacterString>
+            </gmd:code>
+            <gmd:codeSpace gco:nilReason="missing">
+              <gco:CharacterString />
+            </gmd:codeSpace>
+            <gmd:version gco:nilReason="missing">
+              <gco:CharacterString />
+            </gmd:version>
+          </gmd:RS_Identifier>
+        </gmd:referenceSystemIdentifier>
+      </gmd:MD_ReferenceSystem>
+    </gmd:referenceSystemInfo>
+    <gmd:identificationInfo>
+      <gmd:MD_DataIdentification>
+        <gmd:citation>
+          <gmd:CI_Citation>
+            <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>National Parks and National Park Reserves of Canada Legislative Boundaries</gco:CharacterString>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#fra">Limites législatives des parcs nationaux et des réserves à vocation de parc national du Canada</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:title>
+            <gmd:date>
+              <gmd:CI_Date>
+                <gmd:date>
+                  <gco:Date>2016-02-03</gco:Date>
+                </gmd:date>
+                <gmd:dateType>
+                  <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
+                </gmd:dateType>
+              </gmd:CI_Date>
+            </gmd:date>
+            <gmd:date>
+              <gmd:CI_Date>
+                <gmd:date>
+                  <gco:Date>2016-02-03</gco:Date>
+                </gmd:date>
+                <gmd:dateType>
+                  <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                </gmd:dateType>
+              </gmd:CI_Date>
+            </gmd:date>
+            <gmd:identifier>
+              <gmd:MD_Identifier>
+                <gmd:code />
+              </gmd:MD_Identifier>
+            </gmd:identifier>
+            <gmd:citedResponsibleParty>
+              <gmd:CI_ResponsibleParty>
+                <gmd:individualName gco:nilReason="missing">
+                  <gco:CharacterString />
+                </gmd:individualName>
+                <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Government of Canada; Natural Resources Canada; Surveyor General Branch</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Gouvernement du Canada; Ressources naturelles Canada; Direction de l'arpenteur général</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:organisationName>
+                <gmd:positionName gco:nilReason="missing">
+                  <gco:CharacterString />
+                </gmd:positionName>
+                <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                    <gmd:phone>
+                      <gmd:CI_Telephone>
+                        <gmd:voice xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>voice; 1 (343) 2926642</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">voix; 1 (343) 2926642</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:voice>
+                        <gmd:facsimile gco:nilReason="missing">
+                          <gco:CharacterString />
+                        </gmd:facsimile>
+                      </gmd:CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                      <gmd:CI_Address>
+                        <gmd:deliveryPoint xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>physical; 588; Booth Street</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">physique; 588; rue Booth</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:deliveryPoint>
+                        <gmd:city>
+                          <gco:CharacterString>Ottawa</gco:CharacterString>
+                        </gmd:city>
+                        <gmd:administrativeArea xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>Ontario</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">Ontario</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:administrativeArea>
+                        <gmd:postalCode>
+                          <gco:CharacterString>K1A 0Y7</gco:CharacterString>
+                        </gmd:postalCode>
+                        <gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>Canada</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">Canada</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:country>
+                        <gmd:electronicMailAddress xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>nrcan.clss-satc.rncan@canada.ca</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">nrcan.clss-satc.rncan@canada.ca</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:electronicMailAddress>
+                      </gmd:CI_Address>
+                    </gmd:address>
+                    <gmd:onlineResource>
+                      <gmd:CI_OnlineResource>
+                        <gmd:linkage gco:nilReason="missing">
+                          <gmd:URL />
+                        </gmd:linkage>
+                        <gmd:protocol>
+                          <gco:CharacterString>http</gco:CharacterString>
+                        </gmd:protocol>
+                      </gmd:CI_OnlineResource>
+                    </gmd:onlineResource>
+                    <gmd:hoursOfService xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                      <gco:CharacterString />
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#fra" />
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gmd:hoursOfService>
+                  </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90" codeListValue="RI_418">author; auteur</gmd:CI_RoleCode>
+                </gmd:role>
+              </gmd:CI_ResponsibleParty>
+            </gmd:citedResponsibleParty>
+          </gmd:CI_Citation>
+        </gmd:citation>
+        <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+          <gco:CharacterString>The National Parks and National Park Reserves of Canada Legislative Boundaries web service includes the following lands:  1) National Parks of Canada as defined in Schedule 1 of the Canada National Parks Act, 2) National Park Reserves of Canada as defined in Schedule 2 of the Canada National Parks Act, 3) Rouge National Urban Park as defined in the Rouge National Urban Park Act and 4) Saguenay–St. Lawrence Marine Park as defined in the Saguenay-St. Lawrence Marine Park Act.
+
+The Data available for download is the former National Framework Canada Lands Administrative Boundaries Level 1 product. There are some attribute differences between the data available for download and the web service; however both contain the same underlying data. Please refer to the Supporting Documents for additional information on the National Framework Canada Lands Administrative Boundaries Level 1 dataset. Work is under way to align these two data products.  As well, the Comprehensive Claims Settlement Areas have been removed from this dataset, but can be obtained from the Post-1975 Treaties (Modern Treaties) dataset produced by Indigenous and Northern Affairs Canada.</gco:CharacterString>
+          <gmd:PT_FreeText>
+            <gmd:textGroup>
+              <gmd:LocalisedCharacterString locale="#fra">Le service web des limites législatives des parcs nationaux et des réserves à vocation de parc national du Canada inclut les terres suivantes: 1) les parcs nationaux du Canada tels que définis dans l'annexe 1 de la Loi sur les parcs nationaux du Canada, 2) les réserves à vocation de parc national du Canada telles que définies dans l'annexe 2 de la Loi sur les parcs nationaux du Canada, 3) le Parc urbain national de la Rouge tel que défini dans la Loi sur le parc urbain national de la Rouge et 4) le Parc marin du Saguenay — Saint-Laurent tel que défini dans la Loi sur le parc marin du Saguenay — Saint-Laurent.
+
+Les données disponibles pour fins de téléchargement est l'ancien produit Cadre national - Limites administratives des terres du Canada niveau 1. Il y a des différences entre les attributs des données disponibles pour fins de téléchargement et le service Web; cependant les deux contiennent les mêmes données sous-jacentes. Veuillez consulter les documents à l'appui pour obtenir de plus amples renseignements sur le jeu de données Cadre national - Limites administratives des terres du Canada niveau 1. Des travaux sont en cours pour harmoniser ces deux produits. De plus, les aires de revendication territoriale ont été retirés de ce jeu de données.  Toutefois, celles-ci peuvent être obtenus du jeu de données sur les Traités post-1975 (traités modernes) produit par Affaires autochtones et du Nord Canada.</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+          </gmd:PT_FreeText>
+        </gmd:abstract>
+        <gmd:status>
+          <gmd:MD_ProgressCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_106" codeListValue="RI_596">onGoing; enContinue</gmd:MD_ProgressCode>
+        </gmd:status>
+        <gmd:resourceMaintenance>
+          <gmd:MD_MaintenanceInformation>
+            <gmd:maintenanceAndUpdateFrequency>
+              <gmd:MD_MaintenanceFrequencyCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_102" codeListValue="RI_536">monthly; mensuel</gmd:MD_MaintenanceFrequencyCode>
+            </gmd:maintenanceAndUpdateFrequency>
+          </gmd:MD_MaintenanceInformation>
+        </gmd:resourceMaintenance>
+        <gmd:graphicOverview>
+          <gmd:MD_BrowseGraphic>
+            <gmd:fileName gco:nilReason="missing">
+              <gco:CharacterString />
+            </gmd:fileName>
+          </gmd:MD_BrowseGraphic>
+        </gmd:graphicOverview>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Canada Lands</gco:CharacterString>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#fra">Terres du Canada</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
+            </gmd:type>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:descriptiveKeywords>
+          <gmd:MD_Keywords>
+            <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>National parks</gco:CharacterString>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#fra">Parc national</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:keyword>
+            <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Boundaries</gco:CharacterString>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#fra">Frontière</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:keyword>
+            <gmd:type>
+              <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="RI_528">theme; thème</gmd:MD_KeywordTypeCode>
+            </gmd:type>
+            <gmd:thesaurusName>
+              <gmd:CI_Citation>
+                <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Government of Canada Core Subject Thesaurus</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Thésaurus des sujets de base du gouvernement du Canada</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:title>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2004</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_366">creation; création</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:date>
+                  <gmd:CI_Date>
+                    <gmd:date>
+                      <gco:Date>2016-07-04</gco:Date>
+                    </gmd:date>
+                    <gmd:dateType>
+                      <gmd:CI_DateTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_87" codeListValue="RI_367">publication; publication</gmd:CI_DateTypeCode>
+                    </gmd:dateType>
+                  </gmd:CI_Date>
+                </gmd:date>
+                <gmd:citedResponsibleParty>
+                  <gmd:CI_ResponsibleParty>
+                    <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                      <gco:CharacterString>Government of Canada; Library and Archives Canada</gco:CharacterString>
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#fra">Gouvernement du Canada; Bibliothèque et Archives Canada</gmd:LocalisedCharacterString>
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gmd:organisationName>
+                    <gmd:role>
+                      <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90" codeListValue="RI_409">custodian; conservateur</gmd:CI_RoleCode>
+                    </gmd:role>
+                  </gmd:CI_ResponsibleParty>
+                </gmd:citedResponsibleParty>
+              </gmd:CI_Citation>
+            </gmd:thesaurusName>
+          </gmd:MD_Keywords>
+        </gmd:descriptiveKeywords>
+        <gmd:resourceConstraints>
+          <gmd:MD_LegalConstraints>
+            <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
+              <gco:CharacterString>Open Government Licence - Canada (http://open.canada.ca/en/open-government-licence-canada)</gco:CharacterString>
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#fra">Licence du gouvernement ouvert - Canada (http://ouvert.canada.ca/fr/licence-du-gouvernement-ouvert-canada)</gmd:LocalisedCharacterString>
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:useLimitation>
+            <gmd:accessConstraints>
+              <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+            </gmd:accessConstraints>
+            <gmd:useConstraints>
+              <gmd:MD_RestrictionCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_107" codeListValue="RI_606">license; licence</gmd:MD_RestrictionCode>
+            </gmd:useConstraints>
+            <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+              <gco:CharacterString />
+              <gmd:PT_FreeText>
+                <gmd:textGroup>
+                  <gmd:LocalisedCharacterString locale="#fra" />
+                </gmd:textGroup>
+              </gmd:PT_FreeText>
+            </gmd:otherConstraints>
+          </gmd:MD_LegalConstraints>
+        </gmd:resourceConstraints>
+        <gmd:spatialRepresentationType>
+          <gmd:MD_SpatialRepresentationTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_109" codeListValue="RI_635">vector; vecteur</gmd:MD_SpatialRepresentationTypeCode>
+        </gmd:spatialRepresentationType>
+        <gmd:language>
+          <gco:CharacterString>eng; CAN</gco:CharacterString>
+        </gmd:language>
+        <gmd:language>
+          <gco:CharacterString>fra; CAN</gco:CharacterString>
+        </gmd:language>
+        <gmd:characterSet>
+          <gmd:MD_CharacterSetCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_95" codeListValue="" />
+        </gmd:characterSet>
+        <gmd:topicCategory>
+          <gmd:MD_TopicCategoryCode>boundaries</gmd:MD_TopicCategoryCode>
+        </gmd:topicCategory>
+        <gmd:environmentDescription gco:nilReason="missing">
+          <gco:CharacterString />
+        </gmd:environmentDescription>
+        <gmd:extent>
+          <gmd:EX_Extent>
+            <gmd:temporalElement>
+              <gmd:EX_TemporalExtent>
+                <gmd:extent>
+                  <gml:TimePeriod gml:id="d194907e569">
+                    <gml:beginPosition>2004-04-02</gml:beginPosition>
+                    <gml:endPosition />
+                  </gml:TimePeriod>
+                </gmd:extent>
+              </gmd:EX_TemporalExtent>
+            </gmd:temporalElement>
+          </gmd:EX_Extent>
+        </gmd:extent>
+        <gmd:extent>
+          <gmd:EX_Extent>
+            <gmd:geographicElement>
+              <gmd:EX_GeographicBoundingBox>
+                <gmd:westBoundLongitude>
+                  <gco:Decimal>-141.003</gco:Decimal>
+                </gmd:westBoundLongitude>
+                <gmd:eastBoundLongitude>
+                  <gco:Decimal>-52.6174</gco:Decimal>
+                </gmd:eastBoundLongitude>
+                <gmd:southBoundLatitude>
+                  <gco:Decimal>41.6755</gco:Decimal>
+                </gmd:southBoundLatitude>
+                <gmd:northBoundLatitude>
+                  <gco:Decimal>83.1139</gco:Decimal>
+                </gmd:northBoundLatitude>
+              </gmd:EX_GeographicBoundingBox>
+            </gmd:geographicElement>
+          </gmd:EX_Extent>
+        </gmd:extent>
+        <gmd:supplementalInformation gco:nilReason="missing">
+          <gco:CharacterString />
+        </gmd:supplementalInformation>
+      </gmd:MD_DataIdentification>
+    </gmd:identificationInfo>
+    <gmd:distributionInfo>
+      <gmd:MD_Distribution>
+        <gmd:distributionFormat>
+          <gmd:MD_Format>
+            <gmd:name>
+              <gco:CharacterString>WMS</gco:CharacterString>
+            </gmd:name>
+            <gmd:version>
+              <gco:CharacterString>1.3.0</gco:CharacterString>
+            </gmd:version>
+          </gmd:MD_Format>
+        </gmd:distributionFormat>
+        <gmd:distributionFormat>
+          <gmd:MD_Format>
+            <gmd:name>
+              <gco:CharacterString>ESRI REST</gco:CharacterString>
+            </gmd:name>
+            <gmd:version>
+              <gco:CharacterString>10.3.1</gco:CharacterString>
+            </gmd:version>
+          </gmd:MD_Format>
+        </gmd:distributionFormat>
+        <gmd:distributor>
+          <gmd:MD_Distributor>
+            <gmd:distributorContact>
+              <gmd:CI_ResponsibleParty>
+                <gmd:individualName gco:nilReason="missing">
+                  <gco:CharacterString />
+                </gmd:individualName>
+                <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Government of Canada; Natural Resources Canada; Surveyor General Branch</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Gouvernement du Canada; Ressources naturelles Canada; Direction de l'arpenteur général</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:organisationName>
+                <gmd:positionName gco:nilReason="missing">
+                  <gco:CharacterString />
+                </gmd:positionName>
+                <gmd:contactInfo>
+                  <gmd:CI_Contact>
+                    <gmd:phone>
+                      <gmd:CI_Telephone>
+                        <gmd:voice xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                          <gco:CharacterString />
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra" />
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:voice>
+                        <gmd:facsimile gco:nilReason="missing">
+                          <gco:CharacterString />
+                        </gmd:facsimile>
+                      </gmd:CI_Telephone>
+                    </gmd:phone>
+                    <gmd:address>
+                      <gmd:CI_Address>
+                        <gmd:deliveryPoint xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                          <gco:CharacterString />
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra" />
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:deliveryPoint>
+                        <gmd:city gco:nilReason="missing">
+                          <gco:CharacterString />
+                        </gmd:city>
+                        <gmd:administrativeArea xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>Ontario</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">Ontario</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:administrativeArea>
+                        <gmd:postalCode gco:nilReason="missing">
+                          <gco:CharacterString />
+                        </gmd:postalCode>
+                        <gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>Canada</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">Canada</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:country>
+                        <gmd:electronicMailAddress xsi:type="gmd:PT_FreeText_PropertyType">
+                          <gco:CharacterString>nrcan.clss-satc.rncan@canada.ca</gco:CharacterString>
+                          <gmd:PT_FreeText>
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString locale="#fra">nrcan.clss-satc.rncan@canada.ca</gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </gmd:PT_FreeText>
+                        </gmd:electronicMailAddress>
+                      </gmd:CI_Address>
+                    </gmd:address>
+                    <gmd:onlineResource>
+                      <gmd:CI_OnlineResource>
+                        <gmd:linkage gco:nilReason="missing">
+                          <gmd:URL />
+                        </gmd:linkage>
+                        <gmd:protocol>
+                          <gco:CharacterString>http</gco:CharacterString>
+                        </gmd:protocol>
+                      </gmd:CI_OnlineResource>
+                    </gmd:onlineResource>
+                    <gmd:hoursOfService xsi:type="gmd:PT_FreeText_PropertyType" gco:nilReason="missing">
+                      <gco:CharacterString />
+                      <gmd:PT_FreeText>
+                        <gmd:textGroup>
+                          <gmd:LocalisedCharacterString locale="#fra" />
+                        </gmd:textGroup>
+                      </gmd:PT_FreeText>
+                    </gmd:hoursOfService>
+                  </gmd:CI_Contact>
+                </gmd:contactInfo>
+                <gmd:role>
+                  <gmd:CI_RoleCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_90" codeListValue="RI_412">distributor; distributeur</gmd:CI_RoleCode>
+                </gmd:role>
+              </gmd:CI_ResponsibleParty>
+            </gmd:distributorContact>
+          </gmd:MD_Distributor>
+        </gmd:distributor>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine xlink:role="urn:xml:lang:eng-CAN">
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://proxyinternet.nrcan-rncan.gc.ca/arcgis/services/CLSS-SATC/CLSS_Administrative_Boundaries/MapServer/WMSServer?request=GetCapabilities&amp;service=WMS&amp;version=1.3.0&amp;layers=0&amp;legend_format=image%2Fpng&amp;feature_info_type=text%2Fhtml</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>OGC:WMS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>National Parks and National Park Reserves of Canada Legislative Boundaries</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Limites législatives des parcs nationaux et des réserves à vocation de parc national du Canada</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Web Service;WMS;eng</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Service Web;WMS;eng</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine xlink:role="urn:xml:lang:fra-CAN">
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://proxyinternet.nrcan-rncan.gc.ca/arcgis/services/CLSS-SATC/SATC_Limites_administratives/MapServer/WMSServer?request=GetCapabilities&amp;service=WMS&amp;version=1.3.0&amp;layers=0&amp;legend_format=image%2Fpng&amp;feature_info_type=text%2Fhtml</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>OGC:WMS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>National Parks and National Park Reserves of Canada Legislative Boundaries</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Limites législatives des parcs nationaux et des réserves à vocation de parc national du Canada</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Web Service;WMS;fra</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Service Web;WMS;fra</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine xlink:role="urn:xml:lang:eng-CAN">
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://proxyinternet.nrcan-rncan.gc.ca/arcgis/rest/services/CLSS-SATC/CLSS_Administrative_Boundaries/MapServer/1</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>ESRI REST: Map Service</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>National Parks and National Park Reserves of Canada Legislative Boundaries</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Limites législatives des parcs nationaux et des réserves à vocation de parc national du Canada</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Web Service;ESRI REST;eng</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Service Web;ESRI REST;eng</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine xlink:role="urn:xml:lang:fra-CAN">
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://proxyinternet.nrcan-rncan.gc.ca/arcgis/rest/services/CLSS-SATC/SATC_Limites_administratives/MapServer/1</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>ESRI REST: Map Service</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>National Parks and National Park Reserves of Canada Legislative Boundaries</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Limites législatives des parcs nationaux et des réserves à vocation de parc national du Canada</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Web Service;ESRI REST;fra</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Service Web;ESRI REST;fra</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://clss.nrcan-rncan.gc.ca/mb-nc/en/index.html</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>HTTPS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Canada Lands Survey System - CLSS Map Browser (English)</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Système d'arpentage des terres du Canada - Navigateur cartographique du SATC (anglais)</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Application;Web App;eng</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Application;Web App;eng</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://clss.nrcan-rncan.gc.ca/mb-nc/fr/index.html</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>HTTPS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Canada Lands Survey System - CLSS Map Browser (French)</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Système d'arpentage des terres du Canada - Navigateur cartographique du SATC (français)</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Application;Web App;fra</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Application;Web App;fra</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://clss.nrcan-rncan.gc.ca/data-donnees/nplb_llpn/</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>HTTPS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Download SHP (English) file through FTP</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Téléchargez le fichier SHP (anglais) via FTP</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Dataset;SHP;eng</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Données;SHP;eng</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://clss.nrcan-rncan.gc.ca/data-donnees/nplb_llpn/CLAB_FeatureCatalogue_ISO19110_eng.pdf</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>HTTPS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Download CLAB, Feature Catalogue through FTP</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Téléchargez CLAB, Feature Catalogue via FTP</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Supporting Document;PDF;eng</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Document de soutien;PDF;eng</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://clss.nrcan-rncan.gc.ca/data-donnees/nplb_llpn/CLAB_FeatureCatalogue_ISO19110.xml</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>HTTPS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Download CLAB, Feature Catalogue through FTP</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Téléchargez CLAB, Feature Catalogue via FTP</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Supporting Document;XML;eng</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Document de soutien;XML;eng</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://clss.nrcan-rncan.gc.ca/data-donnees/nplb_llpn/LATC_CatalogueEntit%C3%A9s_ISO19110_fra.pdf</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>HTTPS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Download LATC, Catalogue d'entités through FTP</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Téléchargez LATC, Catalogue d'entités via FTP</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Supporting Document;PDF;fra</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Document de soutien;PDF;fra</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+        <gmd:transferOptions>
+          <gmd:MD_DigitalTransferOptions>
+            <gmd:onLine>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>https://clss.nrcan-rncan.gc.ca/data-donnees/nplb_llpn/LATC_CatalogueEntit%C3%A9s_ISO19110.xml</gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gco:CharacterString>HTTPS</gco:CharacterString>
+                </gmd:protocol>
+                <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Download LATC, Catalogue d'entités through FTP</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Téléchargez LATC, Catalogue d'entités via FTP</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:name>
+                <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                  <gco:CharacterString>Supporting Document;XML;fra</gco:CharacterString>
+                  <gmd:PT_FreeText>
+                    <gmd:textGroup>
+                      <gmd:LocalisedCharacterString locale="#fra">Document de soutien;XML;fra</gmd:LocalisedCharacterString>
+                    </gmd:textGroup>
+                  </gmd:PT_FreeText>
+                </gmd:description>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </gmd:MD_DigitalTransferOptions>
+        </gmd:transferOptions>
+      </gmd:MD_Distribution>
+    </gmd:distributionInfo>
+  </gmd:MD_Metadata>
+</csw:GetRecordByIdResponse>
+

--- a/schema.json
+++ b/schema.json
@@ -1894,6 +1894,12 @@
                 "name": {
                     "type": "string",
                     "description": "Name to be displayed as the header of the metadata panel."
+                },
+                "xmlType": {
+                    "type": "enum",
+                    "description": "What xslt to match to the metadata XML. HNAP and DCAT are currently supported.",
+                    "enum": ["HNAP", "DCAT"],
+                    "default": "HNAP"
                 }
             },
             "required": ["url"],

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -235,7 +235,8 @@ const toggleMetadata = () => {
                 layerName: name,
                 url: metaConfig.url,
                 catalogueUrl: catalogueUrl,
-                layer: props.legendItem!.layer
+                layer: props.legendItem!.layer,
+                xmlType: metaConfig.xmlType
             });
         } else {
             console.warn('Layer does not have a metadata url defined');

--- a/src/fixtures/metadata/files/xstyle_dcat_en.xsl
+++ b/src/fixtures/metadata/files/xstyle_dcat_en.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:locn="http://www.w3.org/ns/locn#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+  <xsl:param name="catalogue_url" />
+  <xsl:decimal-format NaN=""/>
+
+  <xsl:template match="/">
+
+    <div class="metadata-view">
+
+      <xsl:if test="//dct:description[@xml:lang='en']/text() != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Abstract}}</h5>
+        <p>
+          <xsl:value-of select="//dct:description[@xml:lang='en']/text()" />
+        </p>
+      </xsl:if>
+
+      <xsl:comment>
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Scope}}</h5>
+        <p>{{metadata.xslt.hereBeScope}}</p>
+      </xsl:comment>
+
+      <!-- xsl:if test="//gml:TimePeriod//* != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.timePeriod}}</h5>
+        <p>
+          <xsl:value-of select="//gml:TimePeriod//gml:beginPosition" />
+          <xsl:if test="//gml:TimePeriod//gml:beginPosition/text() != '' and //gml:TimePeriod//gml:endPosition/text() != ''">
+            -
+          </xsl:if>
+          <xsl:value-of select="//gml:TimePeriod//gml:endPosition" />
+        </p>
+      </xsl:if -->
+
+      <!-- xsl:comment>
+        <xsl:if test="//gmd:supplementalInformation/gco:CharacterString/text() != ''">
+          <h5 class="text-xl font-bold mb-3">{{metadata.xslt.supplementalData}}</h5>
+          <p>
+            <xsl:value-of select="//gmd:supplementalInformation/gco:CharacterString/text()" />
+          </p>
+        </xsl:if>
+      </xsl:comment -->
+
+      <xsl:if test="//dct:publisher//foaf:Organization/* != '' 
+              or //dcat:contactPoint//vcard:hasEmail != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.contactInfo}}</h5>
+        <p>
+          <xsl:value-of select="//dct:publisher//foaf:name[@xml:lang='en']/text()" />
+        </p>
+        <p>
+          <a href="mailto:{substring-after(//dcat:contactPoint//vcard:hasEmail/@rdf:resource, 'mailto:')}">
+            <xsl:value-of select="substring-after(//dcat:contactPoint//vcard:hasEmail/@rdf:resource, 'mailto:')" />
+          </a>
+        </p>
+      </xsl:if>
+
+      <xsl:if test="$catalogue_url != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.cataloguePage}}</h5>
+        <p>
+          <a href="{$catalogue_url}"
+             rel="external" target="_blank" class="ui-link">
+            {{metadata.xslt.metadata}}
+          </a>
+        </p>
+      </xsl:if>
+    </div>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/fixtures/metadata/files/xstyle_dcat_fr.xsl
+++ b/src/fixtures/metadata/files/xstyle_dcat_fr.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:locn="http://www.w3.org/ns/locn#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+  <xsl:param name="catalogue_url" />
+  <xsl:decimal-format NaN=""/>
+
+  <xsl:template match="/">
+
+    <div class="metadata-view">
+
+      <xsl:if test="//dct:description[@xml:lang='fr']/text() != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Abstract}}</h5>
+        <p>
+          <xsl:value-of select="//dct:description[@xml:lang='fr']/text()" />
+        </p>
+      </xsl:if>
+
+      <xsl:comment>
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.Scope}}</h5>
+        <p>{{metadata.xslt.hereBeScope}}</p>
+      </xsl:comment>
+
+      <!-- xsl:if test="//gml:TimePeriod//* != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.timePeriod}}</h5>
+        <p>
+          <xsl:value-of select="//gml:TimePeriod//gml:beginPosition" />
+          <xsl:if test="//gml:TimePeriod//gml:beginPosition/text() != '' and //gml:TimePeriod//gml:endPosition/text() != ''">
+            -
+          </xsl:if>
+          <xsl:value-of select="//gml:TimePeriod//gml:endPosition" />
+        </p>
+      </xsl:if -->
+
+      <!-- xsl:comment>
+        <xsl:if test="//gmd:supplementalInformation/gco:CharacterString/text() != ''">
+          <h5 class="text-xl font-bold mb-3">{{metadata.xslt.supplementalData}}</h5>
+          <p>
+            <xsl:value-of select="//gmd:supplementalInformation/gco:CharacterString/text()" />
+          </p>
+        </xsl:if>
+      </xsl:comment -->
+
+      <xsl:if test="//dct:publisher//foaf:Organization/* != '' 
+              or //dcat:contactPoint//vcard:hasEmail != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.contactInfo}}</h5>
+        <p>
+          <xsl:value-of select="//dct:publisher//foaf:name[@xml:lang='fr']/text()" />
+        </p>
+        <p>
+          <a href="mailto:{substring-after(//dcat:contactPoint//vcard:hasEmail/@rdf:resource, 'mailto:')}">
+            <xsl:value-of select="substring-after(//dcat:contactPoint//vcard:hasEmail/@rdf:resource, 'mailto:')" />
+          </a>
+        </p>
+      </xsl:if>
+
+      <xsl:if test="$catalogue_url != ''">
+        <h5 class="text-xl font-bold mb-3">{{metadata.xslt.cataloguePage}}</h5>
+        <p>
+          <a href="{$catalogue_url}"
+             rel="external" target="_blank" class="ui-link">
+            {{metadata.xslt.metadata}}
+          </a>
+        </p>
+      </xsl:if>
+    </div>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/fixtures/metadata/files/xstyle_default_en.xsl
+++ b/src/fixtures/metadata/files/xstyle_default_en.xsl
@@ -50,30 +50,30 @@
         </xsl:if>
       </xsl:comment>
 
-      <xsl:if test="//gmd:pointOfContact//gmd:individualName/* != '' 
-              or //gmd:pointOfContact//gmd:organisationName/gco:CharacterString/text() != ''
-              or //gmd:pointOfContact//gmd:positionName/gco:CharacterString/text() != ''
-              or //gmd:pointOfContact//gmd:electronicMailAddress/* != ''
-              or //gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
+      <xsl:if test="//gmd:citedResponsibleParty//gmd:individualName/* != '' 
+              or //gmd:citedResponsibleParty//gmd:organisationName/gco:CharacterString/text() != ''
+              or //gmd:citedResponsibleParty//gmd:positionName/gco:CharacterString/text() != ''
+              or //gmd:citedResponsibleParty//gmd:electronicMailAddress/* != ''
+              or //gmd:citedResponsibleParty//gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
         <h5 class="text-xl font-bold mb-3">{{metadata.xslt.contactInfo}}</h5>
         <p>
-          <xsl:value-of select="//gmd:pointOfContact//gmd:individualName" />
+          <xsl:value-of select="//gmd:citedResponsibleParty//gmd:individualName" />
         </p>
         <p>
-          <xsl:value-of select="//gmd:pointOfContact//gmd:organisationName/gco:CharacterString/text()" />
+          <xsl:value-of select="//gmd:citedResponsibleParty//gmd:organisationName/gco:CharacterString/text()" />
         </p>
         <p>
-          <xsl:value-of select="//gmd:pointOfContact//gmd:positionName/gco:CharacterString/text()" />
+          <xsl:value-of select="//gmd:citedResponsibleParty//gmd:positionName/gco:CharacterString/text()" />
         </p>
         <p>
-          <a href="mailto:{//gmd:pointOfContact//gmd:electronicMailAddress/gco:CharacterString/text()}?Subject={//gmd:identificationInfo//gmd:title/gco:CharacterString/text()}">
-            <xsl:value-of select="//gmd:pointOfContact//gmd:electronicMailAddress" />
+          <a href="mailto:{//gmd:citedResponsibleParty//gmd:electronicMailAddress/gco:CharacterString/text()}?Subject={//gmd:identificationInfo//gmd:title/gco:CharacterString/text()}">
+            <xsl:value-of select="//gmd:citedResponsibleParty//gmd:electronicMailAddress" />
           </a>
         </p>
         <p>
           <xsl:variable name="roleCode" >
-            <xsl:value-of select="concat(substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue,1,1),
-                        substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue, 2))" />
+            <xsl:value-of select="concat(substring(//gmd:citedResponsibleParty//gmd:role/gmd:CI_RoleCode/@codeListValue,1,1),
+                        substring(//gmd:citedResponsibleParty//gmd:role/gmd:CI_RoleCode/@codeListValue, 2))" />
           </xsl:variable>
 
           <xsl:choose>

--- a/src/fixtures/metadata/files/xstyle_default_fr.xsl
+++ b/src/fixtures/metadata/files/xstyle_default_fr.xsl
@@ -50,30 +50,30 @@
         </xsl:if>
       </xsl:comment>
 
-      <xsl:if test="//gmd:pointOfContact//gmd:individualName/* != '' 
-              or //gmd:pointOfContact//gmd:organisationName//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''
-              or //gmd:pointOfContact//gmd:positionName//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''
-              or //gmd:pointOfContact//gmd:electronicMailAddress/* != ''
-              or //gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
+      <xsl:if test="//gmd:citedResponsibleParty//gmd:individualName/* != '' 
+              or //gmd:citedResponsibleParty//gmd:organisationName//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''
+              or //gmd:citedResponsibleParty//gmd:positionName//gmd:LocalisedCharacterString[@locale='#fra']/text() != ''
+              or //gmd:citedResponsibleParty//gmd:electronicMailAddress/* != ''
+              or //gmd:citedResponsibleParty//gmd:role/gmd:CI_RoleCode/@codeListValue != ''">
         <h5 class="text-xl font-bold mb-3">{{metadata.xslt.contactInfo}}</h5>
         <p>
-          <xsl:value-of select="//gmd:pointOfContact//gmd:individualName" />
+          <xsl:value-of select="//gmd:citedResponsibleParty//gmd:individualName" />
         </p>
         <p>
-          <xsl:value-of select="//gmd:pointOfContact//gmd:organisationName//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
+          <xsl:value-of select="//gmd:citedResponsibleParty//gmd:organisationName//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
         </p>
         <p>
-          <xsl:value-of select="//gmd:pointOfContact//gmd:positionName//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
+          <xsl:value-of select="//gmd:citedResponsibleParty//gmd:positionName//gmd:LocalisedCharacterString[@locale='#fra']/text()" />
         </p>
         <p>
-          <a href="mailto:{//gmd:pointOfContact//gmd:electronicMailAddress//gmd:LocalisedCharacterString[@locale='#fra']/text()}?Subject={//gmd:identificationInfo//gmd:title//gmd:LocalisedCharacterString[@locale='#fra']/text()}">
-            <xsl:value-of select="//gmd:pointOfContact//gmd:electronicMailAddress" />
+          <a href="mailto:{//gmd:citedResponsibleParty//gmd:electronicMailAddress//gmd:LocalisedCharacterString[@locale='#fra']/text()}?Subject={//gmd:identificationInfo//gmd:title//gmd:LocalisedCharacterString[@locale='#fra']/text()}">
+            <xsl:value-of select="//gmd:citedResponsibleParty//gmd:electronicMailAddress" />
           </a>
         </p>
         <p>
           <xsl:variable name="roleCode" >
-            <xsl:value-of select="concat(substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue,1,1),
-                        substring(//gmd:pointOfContact//gmd:role/gmd:CI_RoleCode/@codeListValue, 2))" />
+            <xsl:value-of select="concat(substring(//gmd:citedResponsibleParty//gmd:role/gmd:CI_RoleCode/@codeListValue,1,1),
+                        substring(//gmd:citedResponsibleParty//gmd:role/gmd:CI_RoleCode/@codeListValue, 2))" />
           </xsl:variable>
 
           <xsl:choose>

--- a/src/fixtures/metadata/store/metadata-state.ts
+++ b/src/fixtures/metadata/store/metadata-state.ts
@@ -12,6 +12,7 @@ export interface MetadataPayload {
     url: string;
     catalogueUrl: string | undefined;
     layer: LayerInstance | undefined;
+    xmlType: string;
 }
 
 export interface MetadataCache {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2661

### Changes
- [FEATURE] Add XSLT for DCAT XML format and config property to choose XML type
- [FIX] Update HNAP XSLT to match current XML format
- [FEATURE] `linkify`s XML metadata
- [FIX] Fix metadata status never being `loading`

### Notes
*Additional comments about the changes in this PR, including screenshots/gifs*

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=20

### Testing

Steps:
1. Open sample 20 on `index-samples` (QA link above goes there automatically.
2. Look at various formats of metadata
3. All 3 should load in their info and look reasonable.
4. Repeat the above in french for the two `Happy` layers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2662)
<!-- Reviewable:end -->
