### PR TITLE
Fix accented characters sorting in provinces/types lists

### DIFF
--- a/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/src/fixtures/geosearch/store/geosearch-store.ts
@@ -70,7 +70,12 @@ export const useGeosearchStore = defineStore('geosearch', () => {
      *
      * @return {Promise<Array>} a promise that resolves to a list of all provinces in the form
      */
-    const getProvinces = computed<Promise<Array<IProvinceInfo>>>(() => GSservice.value.fetchProvinces());
+    const getProvinces = computed<Promise<Array<IProvinceInfo>>>(() =>
+        GSservice.value.fetchProvinces().then(provs => {
+            provs.sort((provA, provB) => provA.name.localeCompare(provB.name, undefined, { sensitivity: 'case' }));
+            return provs;
+        })
+    );
 
     /**
      * Fetches the list of all possible types in a geoName query. Returned type objects contain the following properties:
@@ -84,7 +89,9 @@ export const useGeosearchStore = defineStore('geosearch', () => {
         () =>
             new Promise(resolve => {
                 GSservice.value.fetchTypes().then((types: Array<any>) => {
-                    types.sort((typeA: any, typeB: any) => (typeA.name > typeB.name ? 1 : -1));
+                    types.sort((typeA: any, typeB: any) =>
+                        typeA.name.localeCompare(typeB.name, undefined, { sensitivity: 'case' })
+                    );
                     resolve(types);
                 });
             })


### PR DESCRIPTION
### Related Item(s)
Issue #2654 

### Changes
- [FEATURE] Ensure that sorting in province and type lists handles accented characters

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open the default sample. 
2. Put RAMP into French.
3. Open Geolocation Search.
4. Click on the Province or Type combos.
5. Confirm that words with accented characters (e.g., échelle, île) are sorted alongside unaccented words correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2670)
<!-- Reviewable:end -->
