### PR TITLE
Layer Draw Warnings

### DIFF
--- a/docs/using-ramp4/layers/basic-properties.md
+++ b/docs/using-ramp4/layers/basic-properties.md
@@ -48,7 +48,7 @@ Generally speaking, this config option is useful when there is a small list of c
 
 *integer*, only applies to [map layers](./additional-layer-sections.md#layer-abilities)
 
-Defines a time limit, in milliseconds, for the expected time it would take for the layer to draw itself (i.e. the fetching and processing of data to render the layer in the current extent). If the limit is exceeded, a notification will be issued in the app. If missing, the map level configuration will be used. This defaults to 10000 (10 seconds). Setting to `0` will disable the notification.
+Defines a time limit, in milliseconds, for the expected time it would take for the layer to draw itself (i.e. the fetching and processing of data to render the layer in the current extent). If the limit is exceeded, a notification will be issued in the app. If missing, the map level configuration will be used. This defaults to 12000 (12 seconds). Setting to `0` will disable the notification.
 
 ```js
 {
@@ -60,7 +60,7 @@ Defines a time limit, in milliseconds, for the expected time it would take for t
 
 *integer*
 
-Defines a time limit, in milliseconds, for the expected time it would take for the layer load (i.e. establishing contact with a server, the fetching of metadata, the downloading of data for file or WFS type layers). If the limit is exceeded, a notification will be issued in the app. If missing, the map level configuration will be used. This defaults to 10000 (10 seconds). Setting to `0` will disable the notification.
+Defines a time limit, in milliseconds, for the expected time it would take for the layer load (i.e. establishing contact with a server, the fetching of metadata, the downloading of data for file or WFS type layers). If the limit is exceeded, a notification will be issued in the app. If missing, the map level configuration will be used. This defaults to 12000 (12 seconds). Setting to `0` will disable the notification.
 
 ```js
 {

--- a/schema.json
+++ b/schema.json
@@ -2926,12 +2926,12 @@
                     "properties": {
                         "expectedDrawTime": {
                             "type": "number",
-                            "default": 10000,
+                            "default": 12000,
                             "description": "The time span (in milliseconds) after which a 'slow-to-draw' notification is shown for any drawing layer. Zero will disable notifications. Values on individual layer configs will override."
                         },
                         "expectedLoadTime": {
                             "type": "number",
-                            "default": 10000,
+                            "default": 12000,
                             "description": "The time span (in milliseconds) after which a 'slow-to-load' notification is shown for any loading layer. Zero will disable notifications. Values on individual layer configs will override."
                         },
                         "maxLoadTime": {

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -537,19 +537,23 @@ export class CommonLayer extends LayerInstance {
      * @param type the type of timer to start (load or draw)
      */
     protected startTimer(type: TimerType): void {
-        this.stopTimer(type); // reset the timer if a timing is already in progress.
-        if (this.expectedTime[type] > 0) {
-            this.timers[type] = window.setTimeout(
-                () =>
-                    this.$iApi.notify.show(
-                        NotificationType.WARNING,
-                        // layer.longload or layer.longdraw
-                        this.$iApi.$i18n.t(`layer.long${type}`, {
-                            id: this.name || this.id
-                        })
-                    ),
-                this.expectedTime[type]
-            );
+        // don't show notifications on system layers.
+        // won't have any meaning to users, and these are typically graphic / local anyways.
+        if (!this.isSystem) {
+            this.stopTimer(type); // reset the timer if a timing is already in progress.
+            if (this.expectedTime[type] > 0) {
+                this.timers[type] = window.setTimeout(
+                    () =>
+                        this.$iApi.notify.show(
+                            NotificationType.WARNING,
+                            // layer.longload or layer.longdraw
+                            this.$iApi.$i18n.t(`layer.long${type}`, {
+                                id: this.name || this.id
+                            })
+                        ),
+                    this.expectedTime[type]
+                );
+            }
         }
     }
 

--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -153,7 +153,18 @@ export class MapLayer extends CommonLayer {
                 EsriWatch(
                     () => e.layerView.updating,
                     (newval: boolean) => {
-                        this.updateDrawState(newval ? DrawState.REFRESH : DrawState.UP_TO_DATE);
+                        // terminating layers can sometimes signal a view updating.
+                        // when changing languages, this can cause the "slow draw"
+                        // timer to start and never finish, resulting in notifications
+                        // after the map reloads in new langauge.
+                        if (
+                            !(
+                                this.initiationState === InitiationState.TERMINATED ||
+                                this.initiationState === InitiationState.TERMINATING
+                            )
+                        ) {
+                            this.updateDrawState(newval ? DrawState.REFRESH : DrawState.UP_TO_DATE);
+                        }
                     }
                 )
             );

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -60,8 +60,8 @@ export class MapAPI extends CommonMapAPI {
         // DEV NOTE these values get updated with any config overrides in createMap().
         //          But need to init values here on the chance layers start initializing prior to map
         //          getting "created". Affects overview map layers in particular.
-        draw: 10000,
-        load: 10000,
+        draw: 12000,
+        load: 12000,
         fail: 90000
     };
 
@@ -80,8 +80,8 @@ export class MapAPI extends CommonMapAPI {
         this.setMapMouseThrottle(config.mapMouseThrottle ?? 0);
         this.trackFirstBasemap = true; // we do this here (in this class) to prevent the overview map from tracking
 
-        this.layerDefaultTimes.draw = config.layerTimeDefault?.expectedDrawTime ?? 10000;
-        this.layerDefaultTimes.load = config.layerTimeDefault?.expectedLoadTime ?? 10000;
+        this.layerDefaultTimes.draw = config.layerTimeDefault?.expectedDrawTime ?? 12000;
+        this.layerDefaultTimes.load = config.layerTimeDefault?.expectedLoadTime ?? 12000;
 
         // using falsey || since a 0 would cause every layer to fail instantly
         this.layerDefaultTimes.fail = config.layerTimeDefault?.maxLoadTime || 90000;


### PR DESCRIPTION
### Related Item(s)

Enhances https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2663

### Changes
- Prevent terminating layers from seeing and timing draw state changes (this was causing false notifications on language change)
- Boost default layer warning times by 2 seconds
- Stop system layers from timing. Usually not applicable (local graphics), message doesn't hold much meaning to a user, and is easy fix for the overview map rectangle layer which was being very naughty.

### Notes

Additional commentary on linked issue.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 7 (Classic Main)
2. Watch if any slow load / draw warnings appear (could be valid, but pls note if you see it).
3. Change language to French.
4. Ensure that a bunch of big time lies in the form of Slow Draw warnings don't appear long after the layers have clearly drawn.
