### PR TITLE
Allow xml metadata to be treated as markdown

### DIFF
--- a/demos/starter-scripts/layer-metadata.js
+++ b/demos/starter-scripts/layer-metadata.js
@@ -90,8 +90,9 @@ let config = {
                     colour: '#4ef542',
                     nameField: 'name',
                     metadata: {
-                        url: 'https://open.canada.ca/data/en/dataset/be54680b-ea62-46f3-aaa9-7644ed970aef.xml',
-                        xmlType: 'DCAT'
+                        url: 'https://open.canada.ca/data/en/dataset/2dac78ba-8543-48a6-8f07-faeef56f9895.xml',
+                        xmlType: 'DCAT',
+                        treatXmlAsMarkdown: true
                     }
                 },
                 {

--- a/schema.json
+++ b/schema.json
@@ -1900,6 +1900,11 @@
                     "description": "What xslt to match to the metadata XML. HNAP and DCAT are currently supported.",
                     "enum": ["HNAP", "DCAT"],
                     "default": "HNAP"
+                },
+                "treatXmlAsMarkdown": {
+                    "type": "boolean",
+                    "description": "Whether to treat the text in the XML file as markdown",
+                    "default": false
                 }
             },
             "required": ["url"],

--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -236,7 +236,8 @@ const toggleMetadata = () => {
                 url: metaConfig.url,
                 catalogueUrl: catalogueUrl,
                 layer: props.legendItem!.layer,
-                xmlType: metaConfig.xmlType
+                xmlType: metaConfig.xmlType,
+                treatXmlAsMarkdown: metaConfig.treatXmlAsMarkdown
             });
         } else {
             console.warn('Layer does not have a metadata url defined');

--- a/src/fixtures/metadata/screen.vue
+++ b/src/fixtures/metadata/screen.vue
@@ -233,7 +233,12 @@ const applyXSLT = (xmlString: string, xslString: string, params: any[]) => {
                 url: (value: string) => /^https?:\/\//.test(value) // only links that begin with a protocol will be hyperlinked
             }
         };
-        output.firstChild.innerHTML = linkifyHtml(output.firstChild.innerHTML, options);
+
+        if (props.payload.treatXmlAsMarkdown) {
+            output.firstChild.innerHTML = marked.parse(output.firstChild.innerHTML);
+        } else {
+            output.firstChild.innerHTML = linkifyHtml(output.firstChild.innerHTML, options);
+        }
     }
     // ('-')7 IE retirement (╯°□°）╯︵ ┻━┻
 

--- a/src/fixtures/metadata/store/metadata-state.ts
+++ b/src/fixtures/metadata/store/metadata-state.ts
@@ -13,6 +13,7 @@ export interface MetadataPayload {
     catalogueUrl: string | undefined;
     layer: LayerInstance | undefined;
     xmlType: string;
+    treatXmlAsMarkdown: boolean;
 }
 
 export interface MetadataCache {


### PR DESCRIPTION
### Related Item(s)
#2681 

### Changes
- [FEATURE] Adds a flag `treatXmlAsMarkdown` to allow text in xml files to be parsed with `marked`


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=20

### Testing

Steps:
1. Open `index-samples` sample 20 (layers with metadata)
2. Open `DCAT` metadata, see nicely formatted text and no weird unparsed markdown
3. Open other metadata and see that it still shows up correctly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2682)
<!-- Reviewable:end -->
