### PR TITLE
fix: remove tabindex from element in arcgis-swipe component that was duplicating our custom slider logic

### DIFF
--- a/src/fixtures/swipe/swipe.vue
+++ b/src/fixtures/swipe/swipe.vue
@@ -121,6 +121,24 @@ onMounted(async () => {
 
     await initializeSwipe();
 
+    // remove tabindex from element in arcgis-swipe component that was duplicating our custom slider logic
+    const observer = new MutationObserver((mutations, obs) => {
+        const swipeContainer = swipeComponent.value?.querySelector('.arcgis-swipe__container');
+        if (swipeContainer) {
+            swipeContainer.removeAttribute('tabindex');
+            obs.disconnect();
+        }
+    });
+
+    observer.observe(swipeComponent.value!, {
+        childList: true,
+        subtree: true,
+        attributes: false
+    });
+
+    // Fallback: stop observing after 5 seconds
+    setTimeout(() => observer.disconnect(), 5000);
+
     // Upon a basemap schema change, geo.map.esriView gets set to a new MapView, meaning that the one used by the
     // swipe component wouldn't exist. So, we must reinitialize the swipe component
     iApi.event.on(GlobalEvents.MAP_BASEMAPCHANGE, async (payload: BasemapChange) => {


### PR DESCRIPTION
### Related Item(s)
#2668

### Changes
- [FIX] remove tabindex from element in arcgis-swipe component that was duplicating our custom slider logic

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 12
2. Focus on the slider, move it with left/right arrow keys - all good
3. Press tab
4. Try moving the slider again with left/right arrow keys (before this fix an invisible slider would alter the map)
5. Notice nothing happens, bug-b-gone!
