### PR TITLE
delete the swipe message as it is not used anywhere

### DIFF
--- a/src/fixtures/swipe/index.ts
+++ b/src/fixtures/swipe/index.ts
@@ -5,7 +5,7 @@ class SwipeFixture extends FixtureInstance {
     async added(): Promise<void> {
         const { el, destroy } = this.mount(SwipeV, {
             app: this.$element,
-            props: { message: 'This is a swipe.', fixture: this }
+            props: { fixture: this }
         });
 
         if (el.childNodes[0]) this.$vApp.$el.appendChild(el.childNodes[0]);


### PR DESCRIPTION
### Related Item(s)
Issue #2656 

### Changes
- Removed the swipe message as it is not being used anywhere and wouldn't be used anywhere

### Testing
The difference is only in the code, should be no changes to functionality

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="50" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2689)
<!-- Reviewable:end -->
