### PR TITLE
Added a class for the keyboard instructions modal

### DIFF
--- a/src/components/keyboard-instructions.vue
+++ b/src/components/keyboard-instructions.vue
@@ -6,7 +6,7 @@
         @keydown="onKeydown"
     >
         <div
-            class="bg-white w-500 pointer-events-auto shadow-2xl p-20 flex flex-col"
+            class="bg-white w-500 pointer-events-auto shadow-2xl p-20 flex flex-col keyboard-instructions-modal-content"
             @click.stop.prevent
             tabindex="0"
             ref="firstEl"

--- a/src/components/shell.vue
+++ b/src/components/shell.vue
@@ -12,7 +12,7 @@
                     {{ t('keyboardInstructions.open') }}
                 </button>
             </div>
-            <keyboard-instructions-modal></keyboard-instructions-modal>
+            <keyboard-instructions-modal class="keyboard-instructions-modal"></keyboard-instructions-modal>
             <panel-stack
                 class="panel-stack sm:flex absolute inset-0 overflow-hidden sm:p-12 z-10 sm:pl-80 xs:pl-40 sm:pb-48 xs:pb-28 xs:pr-0 sm:pr-40"
             ></panel-stack>


### PR DESCRIPTION
### Related Item(s)
Issue #2683 

### Changes
- Added a class to the keyboard instructions modal and its content so external applications can more easily select and modify the modal

### Testing
1. Tab until you reach Open keyboard instructions
2. Press enter to open keyboard instructions
3. Inspect and verify that the popup has the class `keyboard-instructions-modal` and its content has the class `keyboard-instructions-modal-content`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2691)
<!-- Reviewable:end -->
