### PR TITLE
Reload button tooltip now shows correctly

### DIFF
--- a/src/fixtures/legend/components/legend-options.vue
+++ b/src/fixtures/legend/components/legend-options.vue
@@ -132,10 +132,9 @@
             <a
                 href="javascript:;"
                 class="flex leading-snug items-center text-left w-auto"
-                :class="{
-                    disabled: !reloadableLayer
-                }"
-                :content="!reloadableLayer ? t('legend.layer.controls.reloadDisabled') : ''"
+                :key="+reloadableLayer"
+                :class="{ disabled: !reloadableLayer }"
+                :content="reloadableLayer ? null : t('legend.layer.controls.reloadDisabled')"
                 @mouseover.stop="hover($event.currentTarget!)"
                 @mouseout="
                     //@ts-expect-error TODO: explain why this is needed or remove


### PR DESCRIPTION
### Related Item(s)
Issue #2609 

### Changes
- The layer is not reloadable tooltip now only shows when the layer is actually not reloadable, instead of always showing on the first load

### Notes
- the problem had something to do with reloadableLayer boolean starting off as false and when the layer fully loads it becomes true; the button tooltip did not update correctly with that
- It was interesting because in `:content="!reloadableLayer ? t('legend.layer.controls.reloadDisabled') : ''"` If `''` had any characters like `'hello'` it would work correctly

### Testing

Steps:
1. Go to any sample with reloadable layers
2. Reload button does not say layer is not reloadable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2692)
<!-- Reviewable:end -->
