### PR TITLE
Retain focus after layer reorder

### DIFF
--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -138,6 +138,10 @@ class FocusContainerManager {
      * Sets tabindex to -1 for EVERY element under the container element
      */
     disableTabbing() {
+        // Skip disabling tabbing if any element inside the container currently has focus
+        if (this.element.contains(document.activeElement)) {
+            return;
+        }
         const tab_list = Array.prototype.filter.call(this.element.querySelectorAll(TABBABLE_TAGS), () => {
             return true;
         }) as HTMLElement[];

--- a/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/src/fixtures/layer-reorder/components/layer-component.vue
@@ -67,12 +67,14 @@
                         <reorder-button
                             :disabled="_isBoundary(element.componentIdx - 1)"
                             direction="up"
+                            :layerId="element.id"
                             class="px-7"
                             @click="onMoveLayerButton(element, 1)"
                         />
                         <reorder-button
                             :disabled="_isBoundary(element.componentIdx + 1)"
                             direction="down"
+                            :layerId="element.id"
                             class="px-7"
                             @click="onMoveLayerButton(element, -1)"
                         />
@@ -151,7 +153,7 @@ const watchers = ref<Array<() => void>>([]);
 const isAnimationEnabled = computed<boolean>(() => iApi.animate);
 
 /*
-General commentary on how this works. 
+General commentary on how this works.
 We only show stuff actually on the map, and not cosmetic. It's then ordered in the UI list top to bottom.
 The UI is build from a data model, layerModel.
 This model is reactive and gets recreated whenever
@@ -333,6 +335,9 @@ const onMoveLayerButton = (layerModel: LayerModel, direction: number): void => {
     // we want to do a "real" reorder to the global position that other layer
     // was occupying in the ramp map / layer store.
     const newRelativeIdx = currRelativeIdx - direction; // index of the "other" layer in fixture layersModel
+    if (newRelativeIdx < 0 || newRelativeIdx >= layersModel.value.length) {
+        return;
+    }
     const newGlobalIdx = layersModel.value[newRelativeIdx].orderIdx;
 
     // apply changes
@@ -344,6 +349,13 @@ const onMoveLayerButton = (layerModel: LayerModel, direction: number): void => {
             index: newGlobalIdx
         })!
     );
+
+    const directionStr = direction === 1 ? 'up' : 'down';
+    setTimeout(() => {
+        const selector = `button[data-layer-id="${layerModel.id}"][data-direction="${directionStr}"]`;
+        const btn = document.querySelector(selector) as HTMLElement | null;
+        btn?.focus();
+    }, 0);
 };
 
 /** ==================================== Helpers ==================================== **/

--- a/src/fixtures/layer-reorder/components/reorder-button.vue
+++ b/src/fixtures/layer-reorder/components/reorder-button.vue
@@ -1,25 +1,16 @@
 <template>
     <button
         type="button"
-        v-if="!disabled"
-        :class="`pb-10 text-gray-500 hover:text-black p-8 ${direction === 'up' ? 'rotate-180' : ''}`"
-        :content="t(`layer-reorder.move.${direction}`)"
-        v-tippy="{
-            placement: 'top-start',
-            aria: 'describedby'
-        }"
+        :data-layer-id="layerId"
+        :data-direction="direction"
+        :class="`
+            pb-10 p-8
+            ${direction === 'up' ? 'rotate-180' : ''}
+            ${disabled ? 'text-gray-300 cursor-not-allowed' : 'text-gray-500 hover:text-black'}
+        `"
         v-focus-item
-        :aria-label="t(`layer-reorder.move.${direction}`)"
-    >
-        <svg class="fill-current w-20 h-20" viewBox="0 0 23 21">
-            <path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z" />
-        </svg>
-    </button>
-    <button
-        type="button"
-        v-else
-        :class="`pb-10 text-gray-300 p-8 ${direction === 'up' ? 'rotate-180' : ''}`"
-        :disabled="disabled"
+        v-tippy="{ content: t(`layer-reorder.move.${direction}`), placement: 'top-start', aria: 'describedby' }"
+        :aria-disabled="disabled"
         :aria-label="t(`layer-reorder.move.${direction}`)"
     >
         <svg class="fill-current w-20 h-20" viewBox="0 0 23 21">
@@ -39,6 +30,10 @@ defineProps({
     },
     direction: {
         type: String,
+        required: true
+    },
+    layerId: {
+        type: [String, Number],
         required: true
     }
 });


### PR DESCRIPTION
### Related Item(s)
Issue #2606 

### Changes
- Ensure focus is preserved when reordering layers using keyboard controls. 

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any sample with multiple layers (e.g., enhanced sample 7).
2. Click on the reorder layers button. 
3. Use the keyboard to navigate to a layer’s up/down button and press enter to reorder.
4. Confirm that the focus stays on the control used after reordering.
