### PR TITLE
Restore WMS Spatial Ref check

### DIFF
--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -1,14 +1,5 @@
 import { CommonLayer, GlobalEvents, InstanceAPI } from '@/api/internal';
-import {
-    DefPromise,
-    DrawState,
-    Extent,
-    InitiationState,
-    LayerState,
-    LayerType,
-    ScaleSet,
-    SpatialReference
-} from '@/geo/api';
+import { DefPromise, DrawState, Extent, InitiationState, LayerState, ScaleSet, SpatialReference } from '@/geo/api';
 import type { DrawOrder, RampLayerConfig } from '@/geo/api';
 import { EsriWatch } from '@/geo/esri';
 import { markRaw } from 'vue';
@@ -266,21 +257,18 @@ export class MapLayer extends CommonLayer {
             this.identify = this.config.state?.identify ?? this.supportsIdentify;
         }
 
-        // See issue 2648 for why this IF exists
-        if (this.layerType !== LayerType.WMS) {
-            // layer base class doesnt have spatial ref, but we will assume all our layers do.
-            // consider adding fancy checks if its missing, and if so just promise.resolve .
-            // given the layer is dead without a success, we don't bother with any cancel-checking here.
-            const lookupPromise = this.$iApi.geo.proj.checkProj(this.getSR()).then(goodSR => {
-                if (goodSR) {
-                    return Promise.resolve();
-                } else {
-                    return Promise.reject();
-                }
-            });
+        // layer base class doesnt have spatial ref, but we will assume all our layers do.
+        // consider adding fancy checks if its missing, and if so just promise.resolve .
+        // given the layer is dead without a success, we don't bother with any cancel-checking here.
+        const lookupPromise = this.$iApi.geo.proj.checkProj(this.getSR()).then(goodSR => {
+            if (goodSR) {
+                return Promise.resolve();
+            } else {
+                return Promise.reject();
+            }
+        });
 
-            proms.push(lookupPromise);
-        }
+        proms.push(lookupPromise);
 
         return proms;
     }


### PR DESCRIPTION
### Related Item(s)

Un-does temp fix in https://github.com/ramp4-pcar4/ramp4-pcar4/pull/2649

### Changes

- Restores spatial reference validation on WMS layers

The currently un-merged PR to update the ESRI API will appear in the diff until someone green-buttons it.

File `map-layer.ts` is the only relevant change in this PR.

### Notes

Appears ESRI patched the issue in v4.33

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

1. Open Classic Sample 25
1. Ensure orange layer loads. Legend is not angry red.
1. Click on the orange, get an identify result.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2704)
<!-- Reviewable:end -->
