### PR TITLE
fix: add outline to draw tools when focused and fix outlines showing one side as a lighter blue

### DIFF
--- a/src/fixtures/draw/draw-nav-section.vue
+++ b/src/fixtures/draw/draw-nav-section.vue
@@ -10,6 +10,7 @@
                 'active-tool': drawStore.activeTool === tool.type
             }"
             :style="{ marginBottom: index !== filteredDrawingTools.length - 1 ? '0px' : '0' }"
+            :showOutline="showOutline"
         >
             <component :is="tool.icon" class="fill-current w-32 h-20"></component>
         </mapnav-button>
@@ -22,7 +23,13 @@ import type { ActiveToolList } from './store';
 import { useI18n } from 'vue-i18n';
 import { markRaw, defineAsyncComponent, computed, inject } from 'vue';
 import { InstanceAPI } from '@/api/internal';
-import DividerNav from '@/fixtures/mapnav/buttons/divider-nav.vue';
+
+defineProps({
+    showOutline: {
+        type: Boolean,
+        default: false
+    }
+});
 
 const iApi = inject('iApi') as InstanceAPI;
 const { t } = useI18n();

--- a/src/fixtures/mapnav/button.vue
+++ b/src/fixtures/mapnav/button.vue
@@ -3,7 +3,11 @@
         <button
             type="button"
             class="w-full h-full default-focus-style"
-            :class="[showOutline ? 'focus:outline focus:outline-2 focus:outline-blue-400' : 'focus:outline-none']"
+            :class="[
+                showOutline
+                    ? 'focus:outline focus:outline-2 focus:outline-blue-400 focus:absolute focus:z-50'
+                    : 'focus:outline-none'
+            ]"
             @click="onClickFunction()"
             v-focus-item
             :content="tooltip"

--- a/src/fixtures/mapnav/mapnav.vue
+++ b/src/fixtures/mapnav/mapnav.vue
@@ -69,9 +69,9 @@
             }"
         >
             <div v-if="isDrawFixtureLoaded">
-                <draw-nav-section></draw-nav-section>
+                <draw-nav-section showOutline></draw-nav-section>
             </div>
-            <template v-for="(button, index) in visible" :key="button.id + 'button'">
+            <template v-for="button in visible" :key="button.id + 'button'">
                 <component
                     :is="button.id + '-nav-button'"
                     class="mapnav-section bg-white-75 hover:bg-white"


### PR DESCRIPTION
## Related Item(s)
#2687 

### Changes
- [FIX] add outline to draw tools when focused and fix outlines showing one side as a lighter blue

### Notes
Also fixed a minor issue where an outline vertex could display as a lighter blue due to a neighbor vertex having a higher display priority.
<img width="287" height="347" alt="Screenshot 2025-07-23 131635" src="https://github.com/user-attachments/assets/ee8af9f6-d469-4d9a-ae22-a961870ec568" />

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to enhanced sample 13. Drawing tools.
2. Vertically shrink the window so the mapnav shrinks
3. Open the submenu with the left arrow button
4. Use the keyboard to tab to the draw tool buttons inside the submenu
5. Rejoice at the blue-ness

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2708)
<!-- Reviewable:end -->
