### PR TITLE
Set identify mode to symbolic for layer swipe

### DIFF
--- a/demos/enhanced-scripts/012-layer-swipe.js
+++ b/demos/enhanced-scripts/012-layer-swipe.js
@@ -7,12 +7,14 @@ const runPreTest = (config, options, utils) => {
     const natureLayer = {
         id: 'Nature',
         layerType: 'esri-feature',
+        identifyMode: 'symbolic',
         url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/EcoAction/MapServer/6'
     };
 
     const waterLayer = {
         id: 'Water',
         layerType: 'esri-feature',
+        identifyMode: 'symbolic',
         url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/EcoAction/MapServer/8'
     };
 
@@ -44,6 +46,7 @@ const runPreTest = (config, options, utils) => {
         url: 'https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip&period__periode=Ann&offset=0&limit=150&province__province=on',
         xyInAttribs: true,
         colour: '#55ffff',
+        identifyMode: 'symbolic',
         fixtures: {
             details: {
                 template: 'WFSLayer-Custom'


### PR DESCRIPTION
### Related Item(s)
#2667 

### Changes
- Set `identifyMode` to 'symbolic' for layers that can be hidden/shown by the layer swipe feature

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 12 (layer swipe)
2. Find a specific feature and hide it using the layer swiper
3. Try to identify where the feature used to be
4. Notice that no feature is identified in the resulting details panel
5. Now use the layer swiper to reveal that feature
6. Identify that same feature
7. Notice that this feature shows up in the details panel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2719)
<!-- Reviewable:end -->
