### PR TITLE
Fix tooltip angle bracket escaping and itemData typing

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -288,14 +288,14 @@ export class InstanceAPI {
             /**
              * Return the string with all special html chars replaced by their corresponding entities
              */
+            // Note: This function is duplicated in truncate.ts
             this.ui.escapeHtml = (content: string) => {
-                const specialChars = {
+                const specialChars: Record<string, string> = {
                     '<': '&lt;',
                     '>': '&gt;',
                     '"': '&quot;',
                     "'": '&#039;'
                 };
-                // @ts-expect-error TODO: explain why this is needed or remove
                 return content.replace(/[<>"']/g, m => specialChars[m]);
             };
 

--- a/src/directives/truncate/truncate.ts
+++ b/src/directives/truncate/truncate.ts
@@ -86,6 +86,23 @@ function onShow(instance: any) {
 }
 
 /**
+ * Escapes special HTML characters in a string to their corresponding HTML entities.
+ *
+ * @param content input string that may contain special characters
+ * @returns escaped string
+ */
+// Note: This function is duplicated in instance.ts
+const escapeHtml = (content: string) => {
+    const specialChars: Record<string, string> = {
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#039;'
+    };
+    return content.replace(/[<>"']/g, m => specialChars[m]);
+};
+
+/**
  * Applies hyperlinks to any URLs in the provided content.
  *
  * @param the text content
@@ -96,7 +113,9 @@ function linkifyContent(content: string | null): TippyContent {
         return '';
     }
 
-    let res = linkifyHtml(content, {
+    const escapedContent = escapeHtml(content);
+
+    let res = linkifyHtml(escapedContent, {
         target: '_blank',
         validate: {
             url: (value: string) => /^https?:\/\//.test(value) // only links that begin with a protocol will be hyperlinked

--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -55,7 +55,7 @@ const findAndDelete = (fields: FieldDefinition[], propertyType: 'type' | 'name',
  * - alias (display text for field. See aliases.name below)
  * - type (field data type)
  */
-const itemData = () => {
+const itemData = (): Record<string, { value: string; alias: string; type: string }> => {
     const clonePayload = Object.assign({}, props.identifyData.data);
 
     // Remove any fields of type geometry


### PR DESCRIPTION
### Related Item(s)
Issues #2658 and #2696

### Changes
- [FIX] Replaced the angle brackets (`<`, `>`) with their corresponding entities ([#2696](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2696))
- [FIX] Added explicit return type to `itemData` in `esri-default.vue` ([#2658](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2658))

### Notes

- The previous PR that addressed HTML special characters added the function `escapeHtml` in `truncate.ts` (which was later deleted). However for this issue, only angle brackets were causing rendering issues in tooltips, so I decided to only replace those characters, instead of restoring the full function. 

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

Wizard URL: 
```
https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/CESI/MapServer/26
```
1. Open any sample that has a wizard
2. Launch `+` wizard from legend panel, and add URL as `Feature Layer`
3. After layer loads, expand symbol stack in legend 
4. Mouse over text with angled brackets and confirm no text is cut off

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2733)
<!-- Reviewable:end -->
