### PR TITLE
Added support for custom Geosearch sources, and an enhanced demo

### DIFF
--- a/demos/enhanced-all.html
+++ b/demos/enhanced-all.html
@@ -56,6 +56,10 @@
                 13.
                 <a href="enhanced-samples.html?sample=13">Drawing Tools</a>. Contains demo of drawing tools
             </li>
+            <li>
+                14.
+                <a href="enhanced-samples.html?sample=14">Custom Geosearch</a>. Demo of custom geosearch types
+            </li>
         </ul>
 
         <h2>Fancy Samples</h2>

--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -29,6 +29,7 @@
                 <option value="011-clusterer">11. Point Clusterer</option>
                 <option value="012-layer-swipe">12. Layer Swipe</option>
                 <option value="013-drawing-tools">13. Drawing Tools</option>
+                <option value="014-geosearch-sources">14. Custom Geosearch Sources</option>
             </select>
             <nav class="linky-container">
                 <a class="linky" href="enhanced-all.html">Catalogue</a
@@ -337,6 +338,9 @@
                             },
                             layers: [],
                             fixtures: {
+                                geosearch:{
+                                    customSources: []
+                                },
                                 legend: {
                                     root: {
                                         children: []
@@ -603,6 +607,9 @@
                             },
                             layers: [],
                             fixtures: {
+                                geosearch:{
+                                    customSources: []
+                                },
                                 legend: {
                                     root: {
                                         children: []
@@ -646,6 +653,15 @@
                 // test script common utils.
                 // update the header comment in `a-sample.js` script when new methods are added.
                 const utils = {
+                    //adds custom geosearch source(s)
+                    addGeosearchSource: (source, lang) => {
+                        const langConfig = config.configs[lang];
+                                if (Array.isArray(source)) {
+                                    langConfig.fixtures.geosearch.customSources.push(...source);
+                                } else {
+                                    langConfig.fixtures.geosearch.customSources.push(source);
+                                }
+                        },
                     // adds a layer to both languages
                     addLayer: layerConfig => {
                         langConfigs.forEach(lang => {

--- a/demos/enhanced-scripts/014-geosearch-sources.js
+++ b/demos/enhanced-scripts/014-geosearch-sources.js
@@ -1,0 +1,88 @@
+const runPreTest = (config, options, utils) => {
+    const customSourcesEN = [
+        {
+            code: 'FAC',
+            catName: 'Facility',
+            data: [
+                {
+                    name: 'Facility A',
+                    bbox: [-79.9036837, 43.5663634, -79.598067, 43.8551317],
+                    location: { province: { code: 35, abbr: 'ON', name: 'Ontario' } },
+                    order: 0
+                },
+                {
+                    name: 'Facility B',
+                    bbox: [-73.6534994, 45.440039299999995, -73.65749939999999, 45.4440393],
+                    location: { province: { code: 24, abbr: 'QC', name: 'Quebec' } },
+                    order: 1
+                }
+            ]
+        },
+        {
+            code: 'PARK',
+            catName: 'Park',
+            data: [
+                {
+                    name: 'Park 1',
+                    bbox: [-66.078333, 45.257222, -66.038333, 45.297222],
+                    location: { province: { code: 35, abbr: 'ON', name: 'Ontario' } },
+                    order: 0
+                },
+                {
+                    name: 'Park 2',
+                    bbox: [-115.6074265, 58.0734097, -111.0120161, 60.6959884],
+                    location: { province: { code: 24, abbr: 'BC', name: 'British Columbia' } },
+                    order: 1
+                }
+            ]
+        }
+    ];
+
+    const customSourcesFR = [
+        {
+            code: 'INS',
+            catName: 'Installation',
+            data: [
+                {
+                    name: 'Installation A',
+                    bbox: [-79.9036837, 43.5663634, -79.598067, 43.8551317],
+                    location: { province: { code: 35, abbr: 'ON', name: 'Ontario' } },
+                    order: 0
+                },
+                {
+                    name: 'Installation B',
+                    bbox: [-73.6534994, 45.440039299999995, -73.65749939999999, 45.4440393],
+                    location: { province: { code: 24, abbr: 'QC', name: 'Quebec' } },
+                    order: 1
+                }
+            ]
+        },
+        {
+            code: 'PARC',
+            catName: 'Parc',
+            data: [
+                {
+                    name: 'Parc 1',
+                    bbox: [-66.078333, 45.257222, -66.038333, 45.29722],
+                    location: { province: { code: 35, abbr: 'ON', name: 'Ontario' } },
+                    order: 0
+                },
+                {
+                    name: 'Parc 2',
+                    bbox: [-115.6074265, 58.0734097, -111.0120161, 60.6959884],
+                    location: { province: { code: 24, abbr: 'BC', name: 'British Columbia' } },
+                    order: 1
+                }
+            ]
+        }
+    ];
+    utils.addGeosearchSource(customSourcesEN, 'en');
+    utils.addGeosearchSource(customSourcesFR, 'fr');
+    return { config, options };
+};
+
+const runPostTest = () => {
+    // Not used in this test
+};
+
+export { runPreTest, runPostTest };

--- a/schema.json
+++ b/schema.json
@@ -359,6 +359,29 @@
                             "description": "Whether to return only official names for the geographic names. Default is false which will return both official names and formerly official names."
                         }
                     }
+                },
+                "customSources": {
+                    "type": "array",
+                    "description": "List of custom search sources to include in geosearch",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "code": {
+                                "type": "string",
+                                "description": "Unique code identifier for the type"
+                            },
+                            "catName": {
+                                "type": "string",
+                                "description": "Category name for the type (shown in UI)"
+                            },
+                            "data": {
+                                "type": "array",
+                                "description": "Array of data for each item of the type"
+                            }
+                        },
+                        "required": ["code", "catName", "data"]
+                    },
+                    "default": []
                 }
             },
             "unevaluatedProperties": false

--- a/src/fixtures/geosearch/index.ts
+++ b/src/fixtures/geosearch/index.ts
@@ -11,8 +11,8 @@ class GeosearchFixture extends GeosearchAPI {
     async added() {
         // console.log(`[fixture] ${this.id} added`);
 
-        const geosearchStore = useGeosearchStore(this.$vApp.$pinia);
-        geosearchStore.initService(this.$iApi.language, this.config);
+        // const geosearchStore = useGeosearchStore(this.$vApp.$pinia);
+        // geosearchStore.initService(this.$iApi.language, this.config);
 
         this.$iApi.component('geosearch-nav-button', GeosearchNavButtonV);
 


### PR DESCRIPTION
Added ability for users to add their own custom sources for Geosearch. I created an enhanced demo script to test this feature.

### Changes
- Users can implement their own custom Geosearch sources to extend the type list with new types with its own locations
- Sources can be added separately to English or French configuration

### Notes
- Note that these are not real or accurate locations, the values and names are just random/taken from an existing location
 
### Testing

Steps:
1. Navigate to enhanced sample 14
2. Open the Geosearch panel
3. In the types list, test the new custom types: `Facility` and `Park` (If language switched to French, it would be` Installation` and `Parc`)
