### PR TITLE
use default details template if custom one is defined but not registered

### DIFF
--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -94,7 +94,7 @@
 import { useLayerStore } from '@/stores/layer';
 import { GeometryType, LayerType } from '@/geo/api';
 import { DetailsItemInstance, useDetailsStore, type DetailsFieldItem } from '../store';
-import { computed, ref, inject, onBeforeMount, onBeforeUnmount, watch } from 'vue';
+import { computed, inject, onBeforeMount, onBeforeUnmount, ref, resolveDynamicComponent, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import linkifyHtml from 'linkify-html';
 
@@ -246,8 +246,17 @@ const detailsTemplate = computed(() => {
 
     // If there is a custom template binding for this layer in the store, then
     // return its name.
-    if (layer && detailProperties.value[layer.id] && detailProperties.value[layer.id].template) {
-        return detailProperties.value[layer.id].template;
+    const templateVal = layer && detailProperties.value[layer.id] && detailProperties.value[layer.id].template;
+
+    if (templateVal) {
+        const customTemplateExists = typeof resolveDynamicComponent(templateVal) !== 'string';
+
+        // If the custom template exists, render it. Otherwise, fall through and use the default template.
+        if (customTemplateExists) {
+            return templateVal;
+        } else {
+            console.error(`Could not find custom details template named ${templateVal}. Was it registered correctly?`);
+        }
     }
 
     // If nothing is found, use a default template from config


### PR DESCRIPTION
### Related Item(s)
#2734 

### Changes
- If a layer has a custom details template defined in the config but the custom template is never registered, the details panel will now fall back to the default details template to prevent the app from freezing.


### Notes
- I wanted to display the 'template not found' alert in the notifications panel instead of a console.error, but calling `iApi.notify.show` was causing `detailsTemplate` to compute twice, resulting in two notifications getting pushed. If anyone knows a way to get around this, let me know!

- Don't merge this PR until I can re-add the runPostTest code in the sample script.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 6.
2. Open the data grid for the `Tasty Eats` layer.
3. Open the details panel for one of the points.
4. Notice that the default details template is now used for the points instead of displaying a blank panel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2736)
<!-- Reviewable:end -->
