### PR TITLE
Updating typescript definition with missing fields.

### DIFF
--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -760,7 +760,7 @@ export interface RampLayerConfig {
     longField?: string; // csv coord field
     mouseTolerance?: number; // mouse tolerance
     touchTolerance?: number; // touch tolerance
-    metadata?: { url: string; name?: string };
+    metadata?: { url: string; name?: string, xmlType?: string, treatXmlAsMarkdown?: boolean };
     catalogueUrl?: string;
     fixtures?: any; // layer-based fixture config
     cosmetic?: boolean;


### PR DESCRIPTION
### Changes
- [FIX] The `RampLayerConfig` type is missing the `metadata.xmlType` and `metadata.treatXmlAMarkdown` proerties which causes typescript compiler errors when using these values in a typescript RAMP project.

### QA Testing

This is a typescript definition-only change and should not impact any functionality.

### Testing

Steps:
1. Add the `xmlType` and `treatXmlAsMarkdown` properties to an existing ramp config
2. Run `vue-tsc --noEmit -p` and confirm that no errors occur

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2739)
<!-- Reviewable:end -->
