### PR TITLE
[feat] Adding "legendField" support for feature layers.

### DIFF
--- a/docs/api-guides/layers.md
+++ b/docs/api-guides/layers.md
@@ -607,6 +607,12 @@ Set the Arcade formula that calculates the content for `tooltipValue`. An empty 
 myLayer.setNameArcade("'Visit sunny ' + $attr.landmark"); // Promise<void>
 ```
 
+Get or set the field that provides the content for `legendValue` for a feature. This value will be ignored if missing or empty string or if the symbology is not `uniqueValue`.
+
+```js
+myLayer.legendField; // "site_name"
+```
+
 ### Methods
 
 Request the set of attributes. The result includes an array of attributes (key value objects), and an object that provides an indexed lookup by Object ID into the array. The first request will incur the server hit. Subsequent requests will use the cached result.

--- a/docs/using-ramp4/layer-overview.md
+++ b/docs/using-ramp4/layer-overview.md
@@ -25,6 +25,7 @@ Below is a list of the various properties that can be specified for a layer conf
 - [initialFilteredQuery](./layers/fancy-properties.md#initialfilteredquery)
 - [latField](./layers/fancy-properties.md#latfield)
 - [layerType](./layers/required-properties.md#layertype)
+- [legendField](./layers/fancy-properties.md#legendfield)
 - [longField](./layers/fancy-properties.md#longfield)
 - [maxLoadTime](./layers/basic-properties.md#maxloadtime)
 - [metadata](./layers/basic-properties.md#metadata)

--- a/docs/using-ramp4/layers/fancy-properties.md
+++ b/docs/using-ramp4/layers/fancy-properties.md
@@ -224,6 +224,23 @@ Specifies the attribute field containing the latitude co-ordinate of the layer. 
 }
 ```
 
+## legendField
+
+*string*, only applies to layers that [support attributes](./additional-layer-sections.md#layer-abilities)
+
+Specifies an attribute field name to use as the `legendValue` for a feature.
+
+- This will be utilized in the Legend fixture.
+- Will be ignored unless the symbology is `uniqueValue`
+- If missing, will use the symbology provided by the server.
+- Field name is case sensitive.
+
+```js
+{
+    legendField: "alt_street_name"
+}
+```
+
 ## longField
 
 *string*, only applies to `file-csv`

--- a/docs/using-ramp4/layers/sublayer-properties.md
+++ b/docs/using-ramp4/layers/sublayer-properties.md
@@ -19,6 +19,7 @@ The sublayer also supports the following properties (see above for details). Som
 - `labels` (see below)
 - `name`
 - `nameField` (feature only)
+- `legendField` (feature only)
 - `state`
 
 ```js

--- a/schema.json
+++ b/schema.json
@@ -1124,6 +1124,11 @@
                     "default": "",
                     "description": "An arcade formula to be used for the feature name. If not present, the viewer will use value of nameField."
                 },
+                "legendField": {
+                    "type": "string",
+                    "default": "",
+                    "description": "The field to be used for the legend for a feature. Ignored unless the layer's symbology is set to 'uniqueValue'."
+                },
                 "extent": {
                     "$ref": "#/$defs/extentWithReference"
                 },
@@ -1351,6 +1356,11 @@
                     "type": "string",
                     "default": "",
                     "description": "An arcade formula to be used for tooltips. If not present, the viewer will use tooltipField."
+                },
+                "legendField": {
+                    "type": "string",
+                    "default": "",
+                    "description": "The field to be used for the legend for a feature. Ignored unless the layer's symbology is set to 'uniqueValue'."
                 },
                 "url": {
                     "type": "string",

--- a/src/fixtures/wizard/lang/lang.csv
+++ b/src/fixtures/wizard/lang/lang.csv
@@ -31,6 +31,7 @@ wizard.configure.name.error.required,Name is required,1,Le champ Nom est obligat
 wizard.configure.name.label,Layer Name,1,Nom de la couche,1
 wizard.configure.nameField.label,Primary Field,1,Champ clé,1
 wizard.configure.tooltipField.label,Tooltip Field,1,Champ infobulle,1
+wizard.configure.legendField.label,Legend Field,1,Champ légende,1
 wizard.configure.latField.label,Latitude Field,1,Champ latitude,1
 wizard.configure.longField.label,Longitude Field,1,Champ longitude,1
 wizard.configure.sublayers.error.required,Sublayers are required,1,Des sous-couches sont requises,1

--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -143,6 +143,16 @@
                             :options="fieldOptions()"
                         />
                         <wizard-input
+                            v-if="layerInfo?.configOptions.includes(`legendField`)"
+                            type="select"
+                            name="legendField"
+                            v-model="layerInfo.config.legendField"
+                            :label="t('wizard.configure.legendField.label')"
+                            :aria-label="t('wizard.configure.legendField.label')"
+                            :defaultOption="true"
+                            :options="fieldOptions()"
+                        />
+                        <wizard-input
                             v-if="layerInfo?.configOptions.includes(`latField`)"
                             type="select"
                             name="latField"

--- a/src/fixtures/wizard/store/layer-source.ts
+++ b/src/fixtures/wizard/store/layer-source.ts
@@ -137,13 +137,14 @@ export class LayerSource extends APIScope {
             name: response.data.name,
             nameField: response.data.displayField,
             tooltipField: response.data.displayField,
+            legendField: response.data.drawingInfo?.renderer?.field1 || response.data.typeIdField,
             state: { opacity: 1, visibility: true }
         };
 
         return {
             config,
             fields: response.data.fields,
-            configOptions: ['name', 'nameField', 'tooltipField']
+            configOptions: ['name', 'nameField', 'tooltipField', 'legendField']
         };
     }
 

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -433,6 +433,7 @@ export interface ArcGisServerMetadata {
     fields: Array<FieldDefinition>;
     displayField: string;
     objectIdField: string;
+    typeIdField?: string;
     renderer?: EsriRenderer;
     currentVersion: number;
     name: string;
@@ -701,6 +702,7 @@ export interface RampLayerMapImageSublayerConfig {
     name?: string;
     nameField?: string;
     nameArcade?: string;
+    legendField?: string;
     state?: RampLayerStateConfig;
 
     extent?: RampExtentConfig;
@@ -751,6 +753,7 @@ export interface RampLayerConfig {
     nameArcade?: string;
     tooltipField?: string;
     tooltipArcade?: string;
+    legendField?: string;
     featureInfoMimeType?: string; // used by WMS layer
     controls?: Array<LayerControl>;
     disabledControls?: Array<LayerControl>;

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -725,4 +725,23 @@ export class CommonLayer extends LayerInstance {
             return '';
         }
     }
+
+    /**
+     * Handles initialization logic for feature names.
+     * Only valid for layers that support attributes.
+     * Typically called by internal processes.
+     *
+     * @param config a ramp layer configuration object. Can pass empty object if n/a.
+     * @param serviceDefault legend field as defined by the layer service. Not required
+     */
+    async legendInitializer(
+        config: RampLayerConfig | RampLayerMapImageSublayerConfig,
+        serviceDefault: string = ''
+    ): Promise<void> {
+        if (this.supportsFeatures) {
+            this.legendField = (config?.legendField || '').trim() || serviceDefault || this.oidField;
+        } else {
+            console.error('Attempted to init a legend field on an unsupported layer.');
+        }
+    }
 }

--- a/src/geo/layer/feature-layer.ts
+++ b/src/geo/layer/feature-layer.ts
@@ -123,6 +123,7 @@ export class FeatureLayer extends AttribLayer {
                 //      .nameField will already contian any server-based definitions
                 await this.nameInitializer(this.origRampConfig, this.nameField);
                 await this.tooltipInitializer(this.origRampConfig);
+                await this.legendInitializer(this.origRampConfig, this.legendField);
             }
         };
 

--- a/src/geo/layer/layer-instance.ts
+++ b/src/geo/layer/layer-instance.ts
@@ -135,6 +135,11 @@ export class LayerInstance extends APIScope {
     nameField: string;
 
     /**
+     * Field name used for the legend. Applicable only for unique value fields.
+     */
+    legendField: string;
+
+    /**
      * Arcade formula to derive name of feature. Empty string indicates no formula in use. Not applicable for attribute-less layers.
      */
     get nameArcade(): string {
@@ -323,6 +328,7 @@ export class LayerInstance extends APIScope {
         this.fields = [];
         this.fieldList = '';
         this.nameField = '';
+        this.legendField = '';
         this.tooltipField = '';
         this.oidField = '';
         this.supportsSublayers = false;

--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -426,6 +426,7 @@ export class LayerAPI extends APIScope {
             defaultVisibility: true,
             fields: [],
             displayField: '',
+            typeIdField: '',
             objectIdField: '',
             renderer: undefined,
             currentVersion: 0,
@@ -454,6 +455,7 @@ export class LayerAPI extends APIScope {
         if (sData.type === 'Feature Layer' || sData.type === 'Table') {
             md.dataFormat = DataFormat.ESRI_FEATURE;
             md.displayField = sData.displayField || '';
+            md.typeIdField = sData.drawingInfo?.renderer?.field1 || sData.typeIdField || '';
 
             if (Array.isArray(sData.fields)) {
                 // parse fields to our format

--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -366,6 +366,7 @@ export class MapImageLayer extends MapLayer {
                 //      .nameField already contains the service value of the sublayer from the miSL.loadLayerMetadata()
                 //      call above.
                 await miSL.nameInitializer(subC, miSL.nameField);
+                await miSL.legendInitializer(subC, miSL.legendField);
 
                 // get feature count
                 const count = await this.$iApi.geo.layer.loadFeatureCount(


### PR DESCRIPTION
### Related Item(s)

* https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/2745

### Changes
- [FEATURE] Adds support for a new `legendField` configuration properly to allow feature layers with uniqueValue legends to dynamically change the field used for display.

### QA Testing

* Navigate to https://pangaeatech.github.io/ramp4-pcar4/AddingLegendFieldSupport/demos/enhanced-samples.html?sample=1
* Click "Add Layer"
* Enter the URL  `https://services7.arcgis.com/oF9CDB4lUYF7Um9q/ArcGIS/rest/services/NA_Watersheds/FeatureServer/6`
* Click "Continue"
* Select "ESRI Feature Layer" and Click "Continue"
* Enter "Bassins hydrographiques" as the "Layer Name"
* Set "Primary Field" to be "NAW4_FR"
* Set "Tooltip Field" to be "NAW4_FR"
* Set "Legend Field" to be "NAW2_FR"
* Click "Continue"
* Observe that the legend is now properly internationalized:
 
<img width="760" height="589" alt="image" src="https://github.com/user-attachments/assets/2e510cb9-3976-49a5-a047-d841cb7ee8c0" />

Please test using the demo links in the first comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2748)
<!-- Reviewable:end -->
