### PR TITLE
Cleaned up basemap altTexts saying 'altText - '

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -105,7 +105,7 @@ let config = {
                         name: 'Canada Base Map - Transportation (CBMT)',
                         description:
                             'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                        altText: 'altText - The Canada Base Map - Transportation (CBMT)',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
                         layers: [
                             {
                                 id: 'CBMT',
@@ -119,7 +119,7 @@ let config = {
                         id: 'baseSimple',
                         name: 'Canada Base Map - Simple',
                         description: 'Canada Base Map - Simple',
-                        altText: 'altText - Canada base map - Simple',
+                        altText: 'Canada base map - Simple',
                         layers: [
                             {
                                 id: 'SMR',
@@ -134,7 +134,7 @@ let config = {
                         name: 'Canada Base Map - Elevation (CBME)',
                         description:
                             'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
-                        altText: 'altText - Canada Base Map - Elevation (CBME)',
+                        altText: 'Canada Base Map - Elevation (CBME)',
                         layers: [
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
@@ -149,7 +149,7 @@ let config = {
                         name: 'Canada Base Map - Transportation (CBMT)',
                         description:
                             ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                        altText: 'altText - Canada Base Map - Transportation (CBMT)',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
                         layers: [
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
@@ -164,7 +164,7 @@ let config = {
                         name: 'World Imagery',
                         description:
                             'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
-                        altText: 'altText - World Imagery',
+                        altText: 'World Imagery',
                         layers: [
                             {
                                 id: 'World_Imagery',
@@ -179,7 +179,7 @@ let config = {
                         name: 'World Physical Map',
                         description:
                             'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
-                        altText: 'altText - World Physical Map',
+                        altText: 'World Physical Map',
                         layers: [
                             {
                                 id: 'World_Physical_Map',
@@ -194,7 +194,7 @@ let config = {
                         name: 'World Shaded Relief',
                         description:
                             'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
-                        altText: 'altText - World Shaded Relief',
+                        altText: 'World Shaded Relief',
                         layers: [
                             {
                                 id: 'World_Shaded_Relief',
@@ -208,7 +208,7 @@ let config = {
                         id: 'baseEsriStreet',
                         name: 'World Street Map',
                         description: 'This worldwide street map presents highway-level data for the world.',
-                        altText: 'altText - ESWorld Street Map',
+                        altText: 'ESWorld Street Map',
                         layers: [
                             {
                                 id: 'World_Street_Map',
@@ -223,7 +223,7 @@ let config = {
                         name: 'World Terrain Base',
                         description:
                             'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
-                        altText: 'altText - World Terrain Base',
+                        altText: 'World Terrain Base',
                         layers: [
                             {
                                 id: 'World_Terrain_Base',
@@ -238,7 +238,7 @@ let config = {
                         name: 'World Topographic Map',
                         description:
                             'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
-                        altText: 'altText - World Topographic Map',
+                        altText: 'World Topographic Map',
                         layers: [
                             {
                                 id: 'World_Topo_Map',

--- a/demos/starter-scripts/cumulative-effects.js
+++ b/demos/starter-scripts/cumulative-effects.js
@@ -505,7 +505,7 @@ const frConfig = {
                 name: 'Carte de base du Canada - transport (CBCT) avec étiquettes',
                 description:
                     "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-                altText: 'altText - La carte de base du Canada - transport (CBCT)',
+                altText: 'La carte de base du Canada - transport (CBCT)',
                 layers: [
                     {
                         id: 'CBCT',
@@ -519,7 +519,7 @@ const frConfig = {
                 id: 'baseSimple',
                 name: 'Carte de base du Canada - simple',
                 description: 'La carte de base du Canada - simple',
-                altText: 'altText - La carte de base du Canada - simple',
+                altText: 'La carte de base du Canada - simple',
                 layers: [
                     {
                         id: 'SMR',
@@ -539,7 +539,7 @@ const frConfig = {
                 name: 'Carte de base du Canada - élévation (CBCE)',
                 description:
                     "La carte de base du Canada - élévation (CBCE) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-                altText: 'altText - La carte de base du Canada - élévation (CBCE)',
+                altText: 'La carte de base du Canada - élévation (CBCE)',
                 layers: [
                     {
                         id: 'CBME_CBCE_HS_RO_3978',
@@ -554,7 +554,7 @@ const frConfig = {
                 name: 'Carte de base du Canada - transport (CBCT)',
                 description:
                     "La carte de base du Canada - transport (CBCT) du Secteur des sciences de la Terre de Ressources naturelles Canada est un service Internet qui s'adresse principalement aux utilisateurs et développeurs d'applications cartographiques en ligne.",
-                altText: 'altText - La carte de base du Canada - transport (CBCT)',
+                altText: 'La carte de base du Canada - transport (CBCT)',
                 layers: [
                     {
                         id: 'CBMT_CBCT_GEOM_3978',
@@ -569,7 +569,7 @@ const frConfig = {
                 name: 'Imagerie mondiale',
                 description:
                     "L'imagerie mondiale fournit une imagerie satellitaire et aérienne dans de nombreuses régions du monde avec une résolution de 1 mètres et moins et des images satellitaires de résolution inférieure dans le monde entier.",
-                altText: "altText - L'imagerie mondiale",
+                altText: "L'imagerie mondiale",
                 layers: [
                     {
                         id: 'World_Imagery',
@@ -584,7 +584,7 @@ const frConfig = {
                 name: 'Monde physique',
                 description:
                     "La carte du monde physique représente l'aspect physique naturel de la Terre à 1.24 kilomètres par pixel pour le monde et à 500 mètres pour les États-Unis.",
-                altText: 'altText - La carte du monde physique',
+                altText: 'La carte du monde physique',
                 layers: [
                     {
                         id: 'World_Physical_Map',
@@ -599,7 +599,7 @@ const frConfig = {
                 name: 'Monde en relief ombragé',
                 description:
                     "La carte du monde en relief ombragé représente l'élévation de la surface de la Terre comme un relief ombragé. Cette carte est utilisée comme couche de fond afin d'ajouter un relief ombragé à d'autres cartes SIG, comme la carte ArcGIS Online World Street Map.",
-                altText: 'altText - La carte du monde en relief ombragé',
+                altText: 'La carte du monde en relief ombragé',
                 layers: [
                     {
                         id: 'World_Shaded_Relief',
@@ -613,7 +613,7 @@ const frConfig = {
                 id: 'baseEsriStreet',
                 name: 'Monde routier',
                 description: 'La carte du monde routier présente des données au niveau des autoroutes pour le monde.',
-                altText: 'altText - La carte du monde routier',
+                altText: 'La carte du monde routier',
                 layers: [
                     {
                         id: 'World_Street_Map',
@@ -628,7 +628,7 @@ const frConfig = {
                 name: 'Monde terrain',
                 description:
                     "La carte du monde terrain est conçue pour être utilisée comme une carte de base par les professionnels du SIG pour superposer d'autres couches thématiques comme la démographie ou la couverture terrestre.",
-                altText: 'altText - La carte du monde terrain',
+                altText: 'La carte du monde terrain',
                 layers: [
                     {
                         id: 'World_Terrain_Base',
@@ -643,7 +643,7 @@ const frConfig = {
                 name: 'Monde topographique',
                 description:
                     'La carte du monde topographique est conçue pour être utilisée comme une carte de base par les professionnels du SIG et comme une carte de référence par quiconque.',
-                altText: 'altText - La carte du monde topographique',
+                altText: 'La carte du monde topographique',
                 layers: [
                     {
                         id: 'World_Topo_Map',

--- a/demos/starter-scripts/fog-hilight.js
+++ b/demos/starter-scripts/fog-hilight.js
@@ -95,7 +95,7 @@ let config = {
                         name: 'Canada Base Map - Transportation (CBMT)',
                         description:
                             'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                        altText: 'altText - The Canada Base Map - Transportation (CBMT)',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
                         layers: [
                             {
                                 id: 'CBMT',
@@ -109,7 +109,7 @@ let config = {
                         id: 'baseSimple',
                         name: 'Canada Base Map - Simple',
                         description: 'Canada Base Map - Simple',
-                        altText: 'altText - Canada base map - Simple',
+                        altText: 'Canada base map - Simple',
                         layers: [
                             {
                                 id: 'SMR',
@@ -124,7 +124,7 @@ let config = {
                         name: 'Canada Base Map - Elevation (CBME)',
                         description:
                             'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
-                        altText: 'altText - Canada Base Map - Elevation (CBME)',
+                        altText: 'Canada Base Map - Elevation (CBME)',
                         layers: [
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
@@ -139,7 +139,7 @@ let config = {
                         name: 'Canada Base Map - Transportation (CBMT)',
                         description:
                             ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                        altText: 'altText - Canada Base Map - Transportation (CBMT)',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
                         layers: [
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
@@ -154,7 +154,7 @@ let config = {
                         name: 'World Imagery',
                         description:
                             'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
-                        altText: 'altText - World Imagery',
+                        altText: 'World Imagery',
                         layers: [
                             {
                                 id: 'World_Imagery',
@@ -169,7 +169,7 @@ let config = {
                         name: 'World Physical Map',
                         description:
                             'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
-                        altText: 'altText - World Physical Map',
+                        altText: 'World Physical Map',
                         layers: [
                             {
                                 id: 'World_Physical_Map',
@@ -184,7 +184,7 @@ let config = {
                         name: 'World Shaded Relief',
                         description:
                             'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
-                        altText: 'altText - World Shaded Relief',
+                        altText: 'World Shaded Relief',
                         layers: [
                             {
                                 id: 'World_Shaded_Relief',
@@ -198,7 +198,7 @@ let config = {
                         id: 'baseEsriStreet',
                         name: 'World Street Map',
                         description: 'This worldwide street map presents highway-level data for the world.',
-                        altText: 'altText - ESWorld Street Map',
+                        altText: 'ESWorld Street Map',
                         layers: [
                             {
                                 id: 'World_Street_Map',
@@ -213,7 +213,7 @@ let config = {
                         name: 'World Terrain Base',
                         description:
                             'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
-                        altText: 'altText - World Terrain Base',
+                        altText: 'World Terrain Base',
                         layers: [
                             {
                                 id: 'World_Terrain_Base',
@@ -228,7 +228,7 @@ let config = {
                         name: 'World Topographic Map',
                         description:
                             'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
-                        altText: 'altText - World Topographic Map',
+                        altText: 'World Topographic Map',
                         layers: [
                             {
                                 id: 'World_Topo_Map',

--- a/demos/starter-scripts/r2-config-upgraded.js
+++ b/demos/starter-scripts/r2-config-upgraded.js
@@ -415,7 +415,7 @@ const r2config = {
                 name: 'Canada Base Map - Transportation (CBMT)',
                 description:
                     'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                altText: 'altText - The Canada Base Map - Transportation (CBMT)',
+                altText: 'The Canada Base Map - Transportation (CBMT)',
                 layers: [
                     {
                         id: 'CBMT',
@@ -438,7 +438,7 @@ const r2config = {
                 id: 'baseSimple',
                 name: 'Canada Base Map - Simple',
                 description: 'Canada Base Map - Simple',
-                altText: 'altText - Canada base map - Simple',
+                altText: 'Canada base map - Simple',
                 layers: [
                     {
                         id: 'SMR',
@@ -453,7 +453,7 @@ const r2config = {
                 name: 'Canada Base Map - Elevation (CBME)',
                 description:
                     'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
-                altText: 'altText - Canada Base Map - Elevation (CBME)',
+                altText: 'Canada Base Map - Elevation (CBME)',
                 layers: [
                     {
                         id: 'CBME_CBCE_HS_RO_3978',
@@ -468,7 +468,7 @@ const r2config = {
                 name: 'Canada Base Map - Transportation (CBMT)',
                 description:
                     ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                altText: 'altText - Canada Base Map - Transportation (CBMT)',
+                altText: 'Canada Base Map - Transportation (CBMT)',
                 layers: [
                     {
                         id: 'CBMT_CBCT_GEOM_3978',
@@ -483,7 +483,7 @@ const r2config = {
                 name: 'World Imagery',
                 description:
                     'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
-                altText: 'altText - World Imagery',
+                altText: 'World Imagery',
                 layers: [
                     {
                         id: 'World_Imagery',
@@ -498,7 +498,7 @@ const r2config = {
                 name: 'World Physical Map',
                 description:
                     'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
-                altText: 'altText - World Physical Map',
+                altText: 'World Physical Map',
                 layers: [
                     {
                         id: 'World_Physical_Map',
@@ -513,7 +513,7 @@ const r2config = {
                 name: 'World Shaded Relief',
                 description:
                     'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
-                altText: 'altText - World Shaded Relief',
+                altText: 'World Shaded Relief',
                 layers: [
                     {
                         id: 'World_Shaded_Relief',
@@ -527,7 +527,7 @@ const r2config = {
                 id: 'baseEsriStreet',
                 name: 'World Street Map',
                 description: 'This worldwide street map presents highway-level data for the world.',
-                altText: 'altText - ESWorld Street Map',
+                altText: 'ESWorld Street Map',
                 layers: [
                     {
                         id: 'World_Street_Map',
@@ -542,7 +542,7 @@ const r2config = {
                 name: 'World Terrain Base',
                 description:
                     'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
-                altText: 'altText - World Terrain Base',
+                altText: 'World Terrain Base',
                 layers: [
                     {
                         id: 'World_Terrain_Base',
@@ -557,7 +557,7 @@ const r2config = {
                 name: 'World Topographic Map',
                 description:
                     'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
-                altText: 'altText - World Topographic Map',
+                altText: 'World Topographic Map',
                 layers: [
                     {
                         id: 'World_Topo_Map',

--- a/public/starter-scripts/cesi.js
+++ b/public/starter-scripts/cesi.js
@@ -94,7 +94,7 @@ let config = {
                         name: 'Canada Base Map - Transportation (CBMT)',
                         description:
                             'The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                        altText: 'altText - The Canada Base Map - Transportation (CBMT)',
+                        altText: 'The Canada Base Map - Transportation (CBMT)',
                         layers: [
                             {
                                 id: 'CBMT',
@@ -108,7 +108,7 @@ let config = {
                         id: 'baseSimple',
                         name: 'Canada Base Map - Simple',
                         description: 'Canada Base Map - Simple',
-                        altText: 'altText - Canada base map - Simple',
+                        altText: 'Canada base map - Simple',
                         layers: [
                             {
                                 id: 'SMR',
@@ -123,7 +123,7 @@ let config = {
                         name: 'Canada Base Map - Elevation (CBME)',
                         description:
                             'The Canada Base Map - Elevation (CBME) web mapping services of the Earth Sciences Sector at Natural Resources Canada, is intended primarily for online mapping application users and developers.',
-                        altText: 'altText - Canada Base Map - Elevation (CBME)',
+                        altText: 'Canada Base Map - Elevation (CBME)',
                         layers: [
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
@@ -138,7 +138,7 @@ let config = {
                         name: 'Canada Base Map - Transportation (CBMT)',
                         description:
                             ' The Canada Base Map - Transportation (CBMT) web mapping services of the Earth Sciences Sector at Natural Resources Canada, are intended primarily for online mapping application users and developers.',
-                        altText: 'altText - Canada Base Map - Transportation (CBMT)',
+                        altText: 'Canada Base Map - Transportation (CBMT)',
                         layers: [
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
@@ -153,7 +153,7 @@ let config = {
                         name: 'World Imagery',
                         description:
                             'World Imagery provides one meter or better satellite and aerial imagery in many parts of the world and lower resolution satellite imagery worldwide.',
-                        altText: 'altText - World Imagery',
+                        altText: 'World Imagery',
                         layers: [
                             {
                                 id: 'World_Imagery',
@@ -168,7 +168,7 @@ let config = {
                         name: 'World Physical Map',
                         description:
                             'This map presents the Natural Earth physical map at 1.24km per pixel for the world and 500m for the coterminous United States.',
-                        altText: 'altText - World Physical Map',
+                        altText: 'World Physical Map',
                         layers: [
                             {
                                 id: 'World_Physical_Map',
@@ -183,7 +183,7 @@ let config = {
                         name: 'World Shaded Relief',
                         description:
                             'This map portrays surface elevation as shaded relief. This map is used as a basemap layer to add shaded relief to other GIS maps, such as the ArcGIS Online World Street Map.',
-                        altText: 'altText - World Shaded Relief',
+                        altText: 'World Shaded Relief',
                         layers: [
                             {
                                 id: 'World_Shaded_Relief',
@@ -197,7 +197,7 @@ let config = {
                         id: 'baseEsriStreet',
                         name: 'World Street Map',
                         description: 'This worldwide street map presents highway-level data for the world.',
-                        altText: 'altText - ESWorld Street Map',
+                        altText: 'ESWorld Street Map',
                         layers: [
                             {
                                 id: 'World_Street_Map',
@@ -212,7 +212,7 @@ let config = {
                         name: 'World Terrain Base',
                         description:
                             'This map is designed to be used as a base map by GIS professionals to overlay other thematic layers such as demographics or land cover.',
-                        altText: 'altText - World Terrain Base',
+                        altText: 'World Terrain Base',
                         layers: [
                             {
                                 id: 'World_Terrain_Base',
@@ -227,7 +227,7 @@ let config = {
                         name: 'World Topographic Map',
                         description:
                             'This map is designed to be used as a basemap by GIS professionals and as a reference map by anyone.',
-                        altText: 'altText - World Topographic Map',
+                        altText: 'World Topographic Map',
                         layers: [
                             {
                                 id: 'World_Topo_Map',


### PR DESCRIPTION
### Changes
- Some configs had "`altText - `" before the corresponding altText, just removed it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2749)
<!-- Reviewable:end -->
