### PR TITLE
replace unicode characters in CSV file exported by the grid

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -752,6 +752,13 @@ const exportData = () => {
         .getAllDisplayedColumns()
         .filter(column => !(column.getColDef() as any).preventExport);
 
+    // Replaces HTML symbols with their corresponding string character (i.e., &quot; -> ")
+    const temp = document.createElement('p');
+    const decodeEntities = (s: string): string => {
+        temp.innerHTML = s;
+        return temp.textContent || temp.innerText;
+    };
+
     agGridApi.value.exportDataAsCsv({
         columnKeys: columnsToExport,
         suppressQuotes: true,
@@ -768,7 +775,7 @@ const exportData = () => {
                     minute: '2-digit',
                     second: '2-digit'
                 })}"`;
-            else return `"${cell.value.toString().replace(/"/g, '""')}"`;
+            else return `"${decodeEntities(cell.value).replace(/"/g, '""')}"`;
         }
     });
 };


### PR DESCRIPTION
### Related Item(s)
From Microsoft Teams QA Chat

### Changes
- Replace any numeric Unicode character references with the character representation in the grid's export as CSV feature.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open the demo link.
2. Add this layer to the map: https://maps-cartes.dev.ec.gc.ca/arcgis/rest/services/CESI/MapServer/10
3. Open the grid.
4. Search for 'Lieu'.
5. Export the grid.
6. Ensure that apostrophes are displaying correctly (not as`&#039;`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2751)
<!-- Reviewable:end -->
