### PR TITLE
Tiny fixes

### DIFF
--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -179,9 +179,9 @@ function mapUpgrader(r2Map: any, r4c: any): void {
                 },
                 scaleBar: {
                     disabled: false,
-                    imperialScale:
-                        r2Map?.components?.scaleBar?.scalebarUnit === 'english' ||
-                        (r2Map?.components?.scaleBar?.scalebarUnit === 'dual' && Math.floor(Math.random() * 2) === 0)
+                    // old ESRI docs have been removed from internet (rude!).
+                    // 'english' was imperial. 'metric' was....metric. 'dual' would show both, which doesnt fly for us, so dual goes to metric
+                    imperialScale: r2Map?.components?.scaleBar?.scalebarUnit === 'english'
                 }
             };
             switch (r2Map.components?.mouseInfo?.spatialReference?.wkid) {

--- a/src/fixtures/geosearch/definitions.ts
+++ b/src/fixtures/geosearch/definitions.ts
@@ -1,5 +1,3 @@
-import type { ICustomSource } from "./store";
-
 export interface IGenericObjectType {
     [key: string]: string;
 }
@@ -29,7 +27,7 @@ export interface IGeosearchConfig {
     language: string;
     types: ITypes;
     provinces: IProvinces;
-    customSources : ICustomSource[];
+    customSources: ICustomSource[];
 }
 
 /**


### PR DESCRIPTION

### Related Item(s)

- #2740
- #2760

### Changes
- Removes an import that doesn't exist
- Removes coin flip on scale bar setting in config converter

### Testing

No real tests. 

If the demo starts, it means the removal of the import didn't go 💥 .

If one is really eager, they can brew up an old Ramp2 config and run the converter through the console (assuming you can even get at it there).  Realistically, nobody is using that, and visually reviewing the code change should suffice. It's only being removed so it stops pinging the security sniffer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2773)
<!-- Reviewable:end -->
