### PR TITLE
Fix colour of search icons in grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
                 "vue-i18n": "^9.13.1",
                 "vue-slider-component": "^4.1.0-beta.7",
                 "vue-tippy": "^6.4.4",
-                "vuedraggable": "*"
+                "vuedraggable": "next"
             },
             "devDependencies": {
                 "@cypress/vite-dev-server": "^2.2.2",

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -57,7 +57,7 @@
 
             <div class="flex flex-1 grow-[1.4] items-center max-w-full">
                 <!-- show global search -->
-                <div class="flex flex-1 min-w-0 items-center pb-4 mr-8" v-show="config.state.search">
+                <div class="search-bar flex flex-1 min-w-0 items-center pb-4 mr-8" v-show="config.state.search">
                     <!-- global search bar -->
                     <input
                         @input="updateQuickSearch()"
@@ -76,7 +76,7 @@
                         :placeholder="t('grid.filters.label.global')"
                     />
                     <!-- clear search button -->
-                    <div class="-ml-30">
+                    <div class="-ml-30 text-gray-500 search-clear-container">
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
                             fit=""
@@ -93,7 +93,7 @@
                             </g>
                         </svg>
                         <button
-                            class="flex justify-center fill-current ml-6 cursor-pointer"
+                            class="flex justify-center fill-current ml-6 cursor-pointer text-gray-500 hover:text-black"
                             @click="resetQuickSearch()"
                             :aria-label="t('grid.search.clear')"
                             v-else
@@ -102,7 +102,7 @@
                                 data-v-486a0302=""
                                 xmlns="http://www.w3.org/2000/svg"
                                 viewBox="0 0 352 512"
-                                class="w-18 h-18 mt-2"
+                                class="fill-current w-18 h-18 mt-2"
                             >
                                 <path
                                     data-v-486a0302=""
@@ -1777,6 +1777,12 @@ onBeforeUnmount(() => {
 :deep(a) {
     color: rgba(37, 99, 235, 1);
     text-decoration: underline;
+}
+
+.search-bar:hover {
+    .search-clear-container {
+        @apply text-black;
+    }
 }
 
 .shadow-clip {


### PR DESCRIPTION
*Add the appropriate PR labels BEFORE submitting it.*

### Related Item(s)
#2767 

### Changes
- [FIX] Turns search icon to grey before hovering
- [FIX] `clear search` icon colour behaviour matches other buttons

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open grid in any sample
2. See grey (not black) search icon
3. Hover over search bar and see icon change to black
4. Type in 3 letters and see grey `X` replace the icon
5. Hover the `X` and see it change to black

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2774)
<!-- Reviewable:end -->
