### PR TITLE
Ignore NPM Scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,5 @@
 # boost heap memory limit for node. see issue #2610
 node-options=--max-old-space-size=8192
+
+# stop rando scripts in hacked packages from running
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -15,12 +15,10 @@
         "dist/*.css"
     ],
     "scripts": {
-        "predev": "node scripts/check-node.mjs",
-        "dev": "vite",
+        "dev": "node scripts/check-node.mjs && vite",
         "dev-http": "vite --https=false",
         "launch": "vite --no-open",
-        "prebuild": "node scripts/check-node.mjs",
-        "build": "rm -rf dist && run-p -c -s build:* && npm run ts:copy",
+        "build": "node scripts/check-node.mjs && rm -rf dist && run-p -c -s build:* && npm run ts:copy",
         "build:npm": "vite build --mode npm",
         "build:esDynamic": "vite build --mode esDynamic",
         "build:inline": "vite build --mode inline",


### PR DESCRIPTION
### Changes
- Tells NPM to ignore package scripts

### Notes

In the last half-year there have been a number of npm packages that have been compromised and nasty code injected.  Often the attack uses post-install scripts in the packages to run code and do naughty things.

[This article](https://blog.uxtly.com/getting-rid-of-npm-scripts) gives the suggestion of telling NPM to ignore any such scripts, which appears like something we can do as our dependencies don't require any valid post-install processing.


### Testing

Things I did locally:

- Did a fresh `npm install`, no problems encountered
- Tried the standard local dev command line things
  - `npm run dev`
  - `npm run build`
  - `npm run ts-docs:generate`
  - `npm run vite-docs:generate`
  - `npx vitepress dev docs`

Thing on Github

- Demo build on this PR built


@milespetrov would appreciate you giving this a look, see if anything bad jumps out at you. Mainly for things I haven't tried above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2777)
<!-- Reviewable:end -->
