### PR TITLE
Symbol Visibility Toggle Fix

### DIFF
--- a/src/fixtures/legend/components/checkbox.vue
+++ b/src/fixtures/legend/components/checkbox.vue
@@ -47,6 +47,22 @@ const props = defineProps({
     disabled: { type: Boolean }
 });
 
+/**
+ * What this is wasn't documented when it was written.
+ * Appears to be some kind of initialization mismatch check?
+ * The checkbox will never appear as "checked" if this var is false.
+ * When we mount, it gets set to false if the legend item this checkbox belongs to has a different visibility
+ * value than the checkbox's "checked" value (via props).
+ * If the checkbox gets toggled by the user, this flag gets set to true. I guess because things are now forced
+ * to be in-synch.
+ *
+ * TODO It would also appear that if this mis-matched state happens,
+ *      our aria-label and content attributes will be telling big lies?
+ *
+ * Given that every usage of this Checkbox template initilzes with a variant of:
+ *    :checked="item.visibility"
+ * does this value even matter? I'm not seeing how it could ever be false when mounting happens.
+ */
 const initialChecked = ref(props.legendItem.visibility);
 
 onMounted(() => {
@@ -59,13 +75,12 @@ onMounted(() => {
  */
 const toggleVisibility = (): void => {
     if (props.value instanceof LegendItem) {
-        // Toggle parent symbology checkbox
+        // Checkbox is sitting in a normal legend block. Toggle its visibility
         props.legendItem.toggleVisibility();
     } else if (props.legendItem instanceof LayerItem) {
-        // we clicked a symbol checkbox thats a child of a layer item
-        props.legendItem.clickSymbology(props.value.uid, !props.value.lastVisbility);
+        // Checkbox is sitting in a symbol block, and is the child of a layer item
+        props.legendItem.clickSymbology(props.value.uid);
 
-        // TODO figure out and document what this prop is actually accomplishing and why.
         initialChecked.value = true;
     }
 };

--- a/src/fixtures/legend/components/item.vue
+++ b/src/fixtures/legend/components/item.vue
@@ -406,10 +406,10 @@
             class="symbology-stack default-focus-style"
         >
             <div v-if="symbologyStack.length > 0">
-                <!-- display each symbol -->
                 <p v-if="legendItem instanceof LayerItem && legendItem.description" class="m-5">
                     {{ legendItem.description }}
                 </p>
+                <!-- display each symbol -->
                 <div class="m-5" v-for="item in symbologyStack" :key="item.uid">
                     <!-- for WMS layers and image render styles -->
                     <div

--- a/src/fixtures/legend/components/symbology-stack.vue
+++ b/src/fixtures/legend/components/symbology-stack.vue
@@ -33,6 +33,9 @@
 </template>
 
 <script setup lang="ts">
+// this generates the icon / icon stack that sits in the layer item. I.e. the thing you can click to expand the symbology under the layer item.
+// it does not generate the symbology entries that appear when expanded.
+
 import type { LegendSymbology } from '@/geo/api';
 import { toRaw, onMounted, type PropType, ref } from 'vue';
 import type { LayerItem } from '../store/layer-item';

--- a/src/fixtures/legend/lang/lang.csv
+++ b/src/fixtures/legend/lang/lang.csv
@@ -6,8 +6,8 @@ legend.header.groups,Toggle Groups,1,Basculer les Groupes,1
 legend.header.groups.expand,Expand All,1,Élargir les groupes,1
 legend.header.groups.collapse,Collapse All,1,Réduire les groupes,1
 legend.header.visible,Toggle Visibility,1,Basculer la Visibilité,1
-legend.header.visible.show,Show All,1,Montrer tout,1
-legend.header.visible.hide,Hide All,1,Cacher tout,1
+legend.header.visible.show,Show All Layers,1,Montrer tous les couches,0
+legend.header.visible.hide,Hide All Layers,1,Cacher tous les couches,0
 legend.group.expand,Expand Group,1,Développer un groupe,1
 legend.group.collapse,Collapse Group,1,Réduire un groupe,1
 legend.visibility.showLayer,Show layer,1,Afficher la couche,1

--- a/src/fixtures/legend/store/legend-item.ts
+++ b/src/fixtures/legend/store/legend-item.ts
@@ -245,7 +245,8 @@ export class LegendItem extends APIScope {
             // if parent is not visible and legend item has visibility control, turn visiblity off
             this.toggleVisibility(false, false);
         } else if (this.parent?.exclusive) {
-            // toggle not visible if item is part of a exclusive set with another item's visibility already toggled on
+            // if item is part of a exclusive set, and another item in that set is already visibe,
+            // set this item to invisible
             const siblingVisible = this.parent.children.some(
                 item => item.visibility && item !== this && item.type === LegendType.Item
             );

--- a/src/fixtures/panguard/map-panguard.vue
+++ b/src/fixtures/panguard/map-panguard.vue
@@ -61,7 +61,6 @@ const setup = () => {
         );
 
         esriHandlers.push(
-            //@ts-expect-error TODO: explain why this is needed or remove
             iApi.geo.map.esriView!.on(['pointer-up', 'pointer-leave'], e => {
                 if (e.pointerType !== 'touch') return;
                 // small delay as to not offend panguard when lifting more than one finger

--- a/src/geo/layer/attrib-layer.ts
+++ b/src/geo/layer/attrib-layer.ts
@@ -410,7 +410,7 @@ export class AttribLayer extends MapLayer {
             }
         };
 
-        setTimeout(refreshCheck, 100);
+        setTimeout(refreshCheck, 80);
     }
 
     applySqlFilter(exclusions: Array<string> = []): void {


### PR DESCRIPTION
### Related Item(s)

Donethankses #2778

### Changes
- Fixes the logic for turning on a symbol when layer is currently invisible
  - When the symbol checkbox setting logic got moved to an API, the toggler on the screen checkbox started using the value of  `!lastVisible` too early. That early value could cause the "currently invisible" edge case code to get skipped.
- Comments updates

### Notes

When testing, you'll notice a "double draw" on the layer when you turn on the symbol. The layer will render as it was when it went invisible, then re-render with the current symbol filter on.  I've tried to change the timing of stuff but it always happens, even when the filter is set prior to becoming visible.  

This happened in past RAMP versions (prior to this issue getting broken). Best I can tell it's just how ESRI is handling MILs becoming visible...draw, then re-evaluate any changes.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Specific Test Steps:

1. Open classic sample 24 (CESI)
2. In the legend, use the 👁️ menu and `Hide All`
3. Scroll down to bottom of the legend, expand the symbol stack of `Greenhouse gas ...`
4. Check one of the symbol entry visibility toggles.
5. Ensure the map updates and shows just the filtered points (see note above about the double-render) 🦉 

General Testing:

Try various visibility stuff. 
- Parent child fun. 
- Try having a subset of symbols unchecked. Then turn off the layer visibility. Then re-enable the layer visibility. Confirm the same subset of symbols become checked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2779)
<!-- Reviewable:end -->
