### PR TITLE
Details Highlight Fixes

### DIFF
--- a/src/fixtures/details/details-screen.vue
+++ b/src/fixtures/details/details-screen.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeMount, onBeforeUnmount, ref, inject, watch } from 'vue';
+import { computed, inject, nextTick, onBeforeMount, onBeforeUnmount, ref, watch } from 'vue';
 
 import SymbologyList from './components/symbology-list.vue';
 import ResultList from './components/result-list.vue';
@@ -152,8 +152,7 @@ const autoOpen = (newPayload: Array<IdentifyResult>): void => {
 
                 if (selectedResult.items.length > 0) {
                     // got a hit. update items screen with new results and turn off greedy loading
-                    detailsStore.activeGreedy = 0;
-                    noResults.value = false;
+                    openDoneThanks(false);
                 } else {
                     // current layer has no hits, fall back to examining all.
                     autoOpenAny(newPayload);
@@ -207,8 +206,22 @@ const autoOpenAny = (newPayload: Array<IdentifyResult>, priorityStack?: Array<[n
     if (priStack.length === 0) {
         // handles case of no identifiable layers (either from initial conditions, or all priorities have been popped).
         // Stop & exit.
-        detailsStore.activeGreedy = 0;
-        noResults.value = true;
+
+        if (payload.value.length) {
+            openDoneThanks(true);
+        } else {
+            // shenanigans to fix issue #2765
+            // when there is no valid things in the payload to inspect, we flip our noResults flag
+            // before ever getting into the async inspection stuff below.
+            // this is apparently too fast. The noResults=true causes the ResultList component to unmount.
+            // that component has watchers that update the highlight when stuff changes. Without a little
+            // delay, the unmount occurs before the watcher can watch.
+
+            nextTick().then(() => {
+                openDoneThanks(true);
+            });
+        }
+
         return;
     }
 
@@ -219,6 +232,7 @@ const autoOpenAny = (newPayload: Array<IdentifyResult>, priorityStack?: Array<[n
         .map(payloadIR =>
             payloadIR.loading.then(() => (payloadIR.items.length > 0 ? Promise.resolve(payloadIR) : Promise.reject()))
         );
+
     const lastTime = newPayload.length === 0 ? 0 : newPayload[0].requestTime;
 
     // wait on any layer promise to resolve first with new identify results
@@ -230,9 +244,9 @@ const autoOpenAny = (newPayload: Array<IdentifyResult>, priorityStack?: Array<[n
             }
 
             // open results item screen and turn off greedy loading
-            detailsStore.activeGreedy = 0;
+
             selectedLayer.value = winningResult.uid;
-            noResults.value = false;
+            openDoneThanks(false);
         })
         .catch(() => {
             if (lastTime === activeGreedy.value) {
@@ -242,6 +256,14 @@ const autoOpenAny = (newPayload: Array<IdentifyResult>, priorityStack?: Array<[n
                 autoOpenAny(newPayload, priStack);
             }
         });
+};
+
+/**
+ * Common flag setting when we've concluded our opening process
+ */
+const openDoneThanks = (nothingFound: boolean) => {
+    detailsStore.activeGreedy = 0;
+    noResults.value = nothingFound;
 };
 
 /* Vue Lifecycle Functions */


### PR DESCRIPTION


### Related Item(s)
Donethankses
- #2765
- #2780 

### Changes
- Gives details component watchers more time to react to changes before a nothing-result unmounts it
- Adds highlight updating when identify payload changes and panel is in List View



### QA Testing


Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

Nothingburger result case

1. Go to enhanced samples 1
2. Click on smile
3. Turn off layer visibility
4. Click on map away from smile
5. See highlight get removed 🦉 

List highlight test case

1. Go to enhanced samples 3
2. Click on a big pile of points in the maritimes.
3. Click `See List` button in the identify details panel.
4. Observe the points in the list highlight.
5. Click somewhere else that is also a pile and has points belonging to the layer currently displayed in the list.
6. Observe the highlight updates to the new list.
7. Click where there is no points.
8. Observe the highlight is removed 🦉

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2781)
<!-- Reviewable:end -->
