### PR TITLE
Fix focus disappearing on layer reorder

### DIFF
--- a/src/components/notification-center/notification-list.vue
+++ b/src/components/notification-center/notification-list.vue
@@ -69,7 +69,7 @@ const handleRemove = (index: number) => {
         const el = (itemRefs.value[nextComp.id] as any).$el ?? itemRefs.value[nextComp.id];
 
         if (el) {
-            const event = new CustomEvent('refocusLegendItem', { detail: { focusItem: el }, bubbles: true });
+            const event = new CustomEvent('switchFocusItem', { detail: { focusItem: el }, bubbles: true });
             el.dispatchEvent(event);
         }
     });

--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -145,9 +145,8 @@ export class FocusListManager {
         //     focusManager.onFocusOut(event);
         // });
 
-        // Focuses a legend item after it's reload button is clicked. See issue 2605.
-        // Also handles refocusing list items after removal (e.g., notifications).
-        element.addEventListener('refocusLegendItem', e => {
+        // Switches current focus item, used when the previous item is deleted from the list etc.
+        element.addEventListener('switchFocusItem', e => {
             const evt = e as CustomEvent;
             const focusItem = evt.detail.focusItem;
             focusManager.element.focus();

--- a/src/fixtures/layer-reorder/components/reorder-button.vue
+++ b/src/fixtures/layer-reorder/components/reorder-button.vue
@@ -9,7 +9,6 @@
             ${direction === 'up' ? 'rotate-180' : ''}
             ${disabled ? 'text-gray-300 cursor-not-allowed' : 'text-gray-500 hover:text-black'}
         `"
-        v-focus-item
         v-tippy="{ content: t(`layer-reorder.move.${direction}`), placement: 'top-start', aria: 'describedby' }"
         :aria-disabled="disabled"
         :aria-label="t(`layer-reorder.move.${direction}`)"

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -54,7 +54,7 @@ const keyupEvent = (e: Event) => {
 };
 
 const applyFocusToItem = (focusItem: HTMLElement) => {
-    const focusItemEvent = new CustomEvent('refocusLegendItem', { detail: { focusItem } });
+    const focusItemEvent = new CustomEvent('switchFocusItem', { detail: { focusItem } });
     el.value?.dispatchEvent(focusItemEvent);
 };
 


### PR DESCRIPTION
### Related Item(s)
#2768

### Changes
- [FEATURE] add event to `focus-list` to handle setting focus from outside the directive
- [FIX] fixes focus disappearing on layer reorder

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open a sample with multiple layers. enhanced-sample 7 works
2. Open reorder panel and tab into list
3. Reorder the layers using the keyboard and see focus be maintained on the correct button
4. Try tabbing or moving around in the list
5. Reorder the layer using mouse and everything should work properly as well

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2784)
<!-- Reviewable:end -->
