### PR TITLE
Tile Mismatch Draw State Fix

### DIFF
--- a/src/geo/layer/common-tile-layer.ts
+++ b/src/geo/layer/common-tile-layer.ts
@@ -1,5 +1,5 @@
 import { InstanceAPI, MapLayer, NotificationType } from '@/api/internal';
-import { DataFormat, LayerState } from '@/geo/api';
+import { DataFormat, DrawState, LayerState } from '@/geo/api';
 import type { RampLayerConfig } from '@/geo/api';
 
 /**
@@ -58,6 +58,11 @@ export class CommonTileLayer extends MapLayer {
 
             grouse();
             this.onError();
+
+            // typically happens after projection change. The layer-views get regenerated but the layers
+            // themselves do not reload. The new view flips the layer into drawing state.
+            // The onError doesn't mess with drawing state, so turn it off here.
+            this.updateDrawState(DrawState.NOT_LOADED);
         } else if (this.layerState === LayerState.ERROR && isEqual) {
             // the layer has errored and the projections now match, reload the layer
             this.reload();


### PR DESCRIPTION

### Related Item(s)

Donethankses
- #2750

### Changes
- Smartens up the draw state of tiles that fail a reprojection


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

Url:

```
https://maps-cartes.ec.gc.ca/arcgis/rest/services/Overlays/Provinces/MapServer
```

1. Go to Enhanced Sample 1. Be in a Lambert map.
2. Add the above Url via the wizard ✨ **as a Tile Layer** ✨.
3. It will load as expected.
4. Change the basemap to a Mercator map.
5. Layer will fail, legend goes red and unhappy, notifications appear. This is expected.
6. Notice the animated loading bar at the bottom of the legend block disappears shortly after legend goes red 🦉

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2785)
<!-- Reviewable:end -->
