### PR TITLE
Remove Geosearch position

### DIFF
--- a/src/fixtures/geosearch/definitions.ts
+++ b/src/fixtures/geosearch/definitions.ts
@@ -133,10 +133,6 @@ export interface ISearchResult {
      */
     flav: FlavourKey;
 
-    /**
-     * Encodes a position (usually a centroid) in Latlon
-     */
-    position: [number, number];
     location: {
         /**
          * Not always an actual city. Name of appropriate sub-province location, if one exists

--- a/src/fixtures/geosearch/store/geosearch.feature.ts
+++ b/src/fixtures/geosearch/store/geosearch.feature.ts
@@ -96,7 +96,6 @@ export class GeoSearchUI {
                         type: src.catName,
                         bbox: item.bbox,
                         flav: 'nme',
-                        position: [0, 0],
                         location: {
                             province: this.config.provinces.abbrToProvince(item.prov),
                             city: item.city

--- a/src/fixtures/geosearch/store/query.ts
+++ b/src/fixtures/geosearch/store/query.ts
@@ -182,7 +182,6 @@ const normalizeNameItems = (config: IGeosearchConfig, items: INameResponse[]): S
             flav: 'nme',
             bbox: nr.bbox,
             type: config.types.allTypes[nr.concise.code],
-            position: [nr.longitude, nr.latitude],
             location: {
                 city: nr.location,
                 province: config.provinces.codeToProvince(parseInt(nr.province.code))
@@ -281,7 +280,6 @@ const runLatLongQuery = async (queryPayload: QueryPayload): Promise<void> => {
         flav: 'llg',
         location: {},
         type: 'Latitude/Longitude',
-        position: [lon, lat],
         bbox: fakeBBox(lon, lat, 0.015),
         order: -1
     };
@@ -313,7 +311,6 @@ const runFSAQuery = async (queryPayload: QueryPayload): Promise<void> => {
             flav: 'fsa',
             bbox: fakeBBox(lon, lat, 0.03),
             type: config.types.allTypes.FSA,
-            position: [lon, lat],
             location: {
                 province: config.provinces.fsaToProvince(queryPayload.query)
             },
@@ -371,7 +368,6 @@ const runNTSQuery = async (queryPayload: QueryPayload): Promise<void> => {
             flav: 'nts',
             bbox: ntsNugget.bbox ?? fakeBBox(lon, lat, 0.03),
             type: config.types.allTypes.NTS, // "National Topographic System"
-            position: [lon, lat],
             location: {
                 city: location
             },
@@ -416,7 +412,6 @@ const runTextQuery = async (queryPayload: QueryPayload): Promise<void> => {
                     flav: 'add',
                     bbox: fakeBBox(lon, lat, 0.002),
                     type: config.types.allTypes.ADDRESS,
-                    position: [lon, lat],
                     location: {
                         city: city.split(' Of ').pop(), // prevents redundant label i.e. 'City Of Kingston'
                         province: config.provinces.nameToProvince(province)

--- a/src/fixtures/geosearch/tests/e2e/test.js
+++ b/src/fixtures/geosearch/tests/e2e/test.js
@@ -126,6 +126,10 @@ describe('Geosearch', () => {
             cy.get('.rv-geosearch-top-filters select :selected').eq(1).contains('Type');
         });
 
+        // .position has been removed from geosearch.
+        // if we ever resurect the tests, either keep this one nuked, or calculate the position
+        // from the .bbox property
+        /*
         it('filters to visible extent', () => {
             // zoom to a smaller extent
             cy.window()
@@ -150,5 +154,6 @@ describe('Geosearch', () => {
             });
             cy.get('.rv-geosearch-bottom-filters [type="checkbox"]').uncheck();
         });
+        */
     });
 });


### PR DESCRIPTION
### Related Item(s)

- #2759

### Changes
- Removes unused `position` value from Geosearch internals

### Notes

Will free up huge tracts of memory.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Use Enhanced sample 14
2. Try the following GeoSearch flavours

- A named thing
- An address
- An FSA (1st part of postal code)
- An NTS (e.g. `030M13`)
- A lat lon number pair
- A custom sauce (e.g. `Facility`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2787)
<!-- Reviewable:end -->
