### PR TITLE
Fix notification list removal and focus handling

### DIFF
--- a/src/components/notification-center/notification-item.vue
+++ b/src/components/notification-center/notification-item.vue
@@ -23,7 +23,7 @@
             </div>
             <button
                 type="button"
-                @click.stop="removeNotification(notification)"
+                @click.stop="() => emit('remove')"
                 class="mx-4 p-4 text-gray-500 hover:text-black"
                 :content="t('notifications.controls.dismiss')"
                 :aria-label="t('notifications.controls.dismiss')"
@@ -55,10 +55,9 @@
 import { reactive, ref } from 'vue';
 import { NotificationType } from '@/api/notifications';
 import { useI18n } from 'vue-i18n';
-import { useNotificationStore } from '@/stores/notification';
 
-const notificationStore = useNotificationStore();
 const { t } = useI18n();
+const emit = defineEmits(['remove']);
 
 const props = defineProps({
     notification: {
@@ -74,9 +73,6 @@ const icons = reactive({
     [NotificationType.ERROR]: '❌'
 });
 
-const removeNotification = (notif: any) => {
-    notificationStore.removeNotification(notif);
-};
 const tooltipShow = () => {
     if (!props.notification.messageList) {
         return false;

--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -140,8 +140,13 @@ export class FocusListManager {
         element.addEventListener('touchstart', function () {
             focusManager.onTouchstart();
         });
+        // Commenting out for now until focus behavior is revisited
+        // element.addEventListener('focusout', function (event: FocusEvent) {
+        //     focusManager.onFocusOut(event);
+        // });
 
         // Focuses a legend item after it's reload button is clicked. See issue 2605.
+        // Also handles refocusing list items after removal (e.g., notifications).
         element.addEventListener('refocusLegendItem', e => {
             const evt = e as CustomEvent;
             const focusItem = evt.detail.focusItem;
@@ -476,4 +481,18 @@ export class FocusListManager {
     onTouchstart() {
         this.isTapped = true;
     }
+
+    // /**
+    //  * Callback for the FOCUSOUT event listener on the focus list element.
+    //  */
+    // onFocusOut(event: FocusEvent) {
+    //     // only defocus if focus is leaving the list entirely
+    //     const next = event.relatedTarget as HTMLElement;
+    //     if (next && !this.element.contains(next)) {
+    //         // clear active item and aria state when focus exits the list
+    //         this.defocusItem(this.highlightedItem);
+    //         this.highlightedItem = this.element;
+    //         this.element.removeAttribute('aria-activedescendant');
+    //     }
+    // }
 }

--- a/src/stores/notification/notification-state.ts
+++ b/src/stores/notification/notification-state.ts
@@ -3,6 +3,7 @@ import type { NotificationType } from '@/api';
 export interface Notification {
     message: string;
     type: NotificationType;
+    id: string;
 }
 
 export interface NotificationGroup {

--- a/src/stores/notification/notification-store.ts
+++ b/src/stores/notification/notification-store.ts
@@ -17,6 +17,7 @@ export interface NotificationStore {
 }
 
 export const useNotificationStore = defineStore('notification', () => {
+    let notificationIdCounter = 0;
     const notificationStack = ref<(Notification | NotificationGroup)[]>([]);
     const groups = ref<{ [id: string]: NotificationGroup }>({});
 
@@ -25,7 +26,8 @@ export const useNotificationStore = defineStore('notification', () => {
     });
 
     function showNotification(notification: Notification) {
-        notificationStack.value = [notification, ...notificationStack.value];
+        const notificationWithId = { ...notification, id: `notif-${notificationIdCounter++}` };
+        notificationStack.value = [notificationWithId, ...notificationStack.value];
     }
 
     function removeNotification(notification: Notification | NotificationGroup) {


### PR DESCRIPTION
### Related Item(s)
Issues #2567 & #2608 

### Changes
- [FIX] Move focus to the next item in the notification list after removal by dispatching a refocus event.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 5
2. Toggle language button multiple times to produce notifications
3. Navigate to the notification list
4. Use arrow keys to navigate through the list
5. Delete a notification 
6. After deleting, focus should now move to the next item 
7. Tab/Shift+Tab and notification list container should now receive focus

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2791)
<!-- Reviewable:end -->
