### PR TITLE
fix duplicate notification tray warnings

### DIFF
--- a/demos/enhanced-scripts/006-simple-data.js
+++ b/demos/enhanced-scripts/006-simple-data.js
@@ -45,7 +45,6 @@ const runPostTest = instance => {
         methods: {
             createSection(title, id) {
                 var val = this.identifyData.loaded ? this.identifyData.data[id] : 'Loading...';
-
                 return `
                 <div style="display: flex; flex-direction: column; padding-top: 5px;">
                     <span style="color: #a0aec0; font-weight: bold;">
@@ -66,7 +65,6 @@ const runPostTest = instance => {
                     '<img width="24" height="24" src="https://img.icons8.com/material-sharp/24/b0b0b0/star--v1.png" alt="star--v1"/>'.repeat(
                         5 - this.identifyData.data[n]
                     );
-
                 return `
                 <div style="display: flex; flex-direction: column; padding-top: 5px;">
                     <span style="color: #a0aec0; font-weight: bold;">

--- a/src/fixtures/details/lang/lang.csv
+++ b/src/fixtures/details/lang/lang.csv
@@ -32,3 +32,4 @@ details.item.alert.defaultAltText,Image associated with {alias} field,1,Image as
 details.togglehilight.title,Toggle Highlight,1,Basculer vers l'élément principal,1
 details.item.open,Expand,1,Développer,1
 details.item.collapse,Collapse,1,Réduire,1
+details.template.notFound,Could not find custom details template named {layer}. It may not have been registered correctly.,1,Impossible de trouver le modèle de détails personnalisé nommé {layer}. Il n'a peut-être pas été enregistré correctement.,0


### PR DESCRIPTION
### Related Item(s)
#2737 

### Changes
- Fixes an issue where pushing a notification to the tray within a computed property would result in the property being calculated twice.

### Notes
I'll revert the enhanced sample 6 code before merging.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 6.
2. Open the "Tasty Eats" data grid.
3. Open the details panel for one of the points in the grid.
4. Notice that the "missing template" warning is pushed to the notification tray.
5. Swap to French and make sure it works there too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2794)
<!-- Reviewable:end -->
