### PR TITLE
Hide column options long text truncates with tooltip

### DIFF
--- a/src/directives/truncate/truncate.ts
+++ b/src/directives/truncate/truncate.ts
@@ -75,12 +75,30 @@ function onShow(instance: any) {
     // cancel showing the tooltip if the text isn't truncated
     // clientWidth is the visible width of the element, scrollWidth is the width of the content
     // clientHeight is the visible height of the element, scrollHeight is the height of the content
-    const isTruncated =
-        instance.reference.clientWidth < instance.reference.scrollWidth ||
-        instance.reference.clientHeight < instance.reference.scrollHeight;
+    const el = instance.reference as HTMLElement;
+    if (!el) return false;
 
-    if (!isTruncated) {
-        // returning false tells tippy to cancel
+    // scrollWidth and clientWidth return rounded values so there is an edge case wehere
+    // they return the same value even when the text is truncated
+    // clone a copy of the element temporarily to measure accurate values
+    // if full text width is shorter than display width or element is 
+    // wrapping (multiple lines) then disable tooltip
+    const temp = el.cloneNode(true) as HTMLElement;
+    temp.style.position = 'fixed';
+    temp.style.overflow = 'visible';
+    temp.style.whiteSpace = 'nowrap';
+    temp.style.visibility = 'hidden';
+
+    el.parentElement?.appendChild(temp);
+
+    const fullWidth = temp.getBoundingClientRect().width;
+    const displayWidth = el.getBoundingClientRect().width;
+    const lineHeight = temp.getBoundingClientRect().height
+    const displayHeight = el.getBoundingClientRect().height
+
+    temp.remove();
+
+    if (fullWidth <= displayWidth || displayHeight > lineHeight) {
         return false;
     }
 }

--- a/src/fixtures/grid/column-dropdown.vue
+++ b/src/fixtures/grid/column-dropdown.vue
@@ -27,6 +27,8 @@
             </div>
         </template>
         <a
+            truncate-trigger
+            tabindex="0"
             v-for="col in columnDefs.filter(
                 c =>
                     c.headerName &&
@@ -41,11 +43,21 @@
                 $emit('refreshHeaders');
             "
             href="javascript:;"
-            class="flex leading-snug items-center w-256"
+            class="flex leading-snug items-center max-w-[268px]"
         >
-            <div class="md-icon-small inline">
-                {{ col.headerName }}
-                <svg height="18" width="18" viewBox="0 0 24 24" class="inline float-right" v-if="!col.hide">
+            <div class="md-icon-small flex w-full">
+                <span
+                    v-truncate="{
+                        externalTrigger: true,
+                        options: {
+                            placement: 'left'
+                        }
+                    }"
+                    class="flex-1 truncate whitespace-nowrap overflow-hidden pr-4"
+                >
+                    {{ col.headerName }}
+                </span>
+                <svg height="18" width="18" viewBox="0 0 24 24" :class="{ invisible: col.hide }">
                     <g id="done">
                         <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
                     </g>


### PR DESCRIPTION
### Related Item(s)
Issue #2788 

### Changes
- If the column name is too long it is now truncated with a tooltip

### QA Testing
Please test against main branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps:
1. Go to the default classic sample
2. Click the WFSLayer
3. Click the Hide columns button on the top right of the datatable
4. Verify: long column names are truncated, truncated column names have working tooltips, column toggle functionality still working as expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2797)
<!-- Reviewable:end -->
