### PR TITLE
About title align

### DIFF
--- a/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/src/components/about-ramp/about-ramp-dropdown.vue
@@ -40,7 +40,7 @@
                             ></path>
                         </svg>
                     </button>
-                    <h4 class="pb-8 border-b border-gray-600 mb-10">
+                    <h4 class="pb-8 pt-1 border-b border-gray-600 mb-10">
                         {{ t('ramp.about') }}
                     </h4>
                     <div class="absolute right-5 top-5">


### PR DESCRIPTION

### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2675

### Changes
- Pushes the About title down 1px

### Notes

This improvement will usher in a groundbreaking new era for RAMP technology. Might be worthy of a `v5.0.0` minting. 

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

Steps:
1. Open Enhanced Sample 1
2. Open the About popup (:octocat: icon).
3. 🦉 
4. Try in French 🦉

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2800)
<!-- Reviewable:end -->
