### PR TITLE
Clean up appbar console warnings in dev mode

### DIFF
--- a/src/components/notification-center/appbar-button.vue
+++ b/src/components/notification-center/appbar-button.vue
@@ -1,5 +1,10 @@
 <template>
-    <appbar-button :onClickFunction="onClick" :tooltip="t('notifications.title')" class="notification-button" id="">
+    <appbar-button
+        :onClickFunction="onClick"
+        :tooltip="t('notifications.title')"
+        class="notification-button"
+        button-id="notificationsButton"
+    >
         <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Anotifications -->
         <svg class="fill-current w-24 h-24 mx-8 sm:mx-20" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path

--- a/src/fixtures/appbar/default-button.vue
+++ b/src/fixtures/appbar/default-button.vue
@@ -1,5 +1,9 @@
 <template>
-    <appbar-button v-if="panelButton" :onClickFunction="onClickFunction" :tooltip="t(panelButton.tooltip)" :id="panelId"
+    <appbar-button
+        v-if="panelButton"
+        :onClickFunction="onClickFunction"
+        :tooltip="t(panelButton.tooltip)"
+        :button-id="panelId"
         ><div
             class="default fill-current w-24 h-24 ml-8 sm:ml-20"
             :class="{ 'ml-20': overflow }"


### PR DESCRIPTION
### Related Item(s)
Issue #2657 

### Changes
- Replaced `id` usage with `button-id` prop on Appbar buttons

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
- Run app in dev mode (`npm run dev`), and verify no console warnings appear for appbar buttons
- Open classic sample 2 (Lots of panels), resize window vertically until you see the `...` overflow, and verify that app remains responsive

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2802)
<!-- Reviewable:end -->
