### PR TITLE
Ensure details panel scrolls to top when selected

### DIFF
--- a/src/fixtures/details/components/result-list.vue
+++ b/src/fixtures/details/components/result-list.vue
@@ -168,6 +168,7 @@ const iApi = inject('iApi') as InstanceAPI;
 
 const detailsStore = useDetailsStore();
 const layerStore = useLayerStore();
+const emit = defineEmits(['item-selected']);
 const props = defineProps({
     uid: { type: String, required: true },
     results: { type: Object as PropType<Array<IdentifyResult>>, required: true }
@@ -441,6 +442,7 @@ const clickListItem = (idx: number) => {
         // need to update the highlight
         updateHighlight();
     }
+    emit('item-selected');
 };
 
 onMounted(() => {

--- a/src/fixtures/details/details-screen.vue
+++ b/src/fixtures/details/details-screen.vue
@@ -21,8 +21,13 @@
                 ></SymbologyList>
 
                 <!-- Main Details Panel -->
-                <div class="detailsContentSection overflow-y-auto h-full">
-                    <ResultList :uid="selectedLayer" :results="layerResults" v-if="!noResults"></ResultList>
+                <div class="detailsContentSection overflow-y-auto h-full" ref="detailsPanel">
+                    <ResultList
+                        :uid="selectedLayer"
+                        :results="layerResults"
+                        v-if="!noResults"
+                        @item-selected="() => nextTick(() => detailsPanel?.scrollTo({ top: 0 }))"
+                    ></ResultList>
                     <div :class="['text-center', { 'ml-42': layerResults.length > 1 }]" v-else>
                         {{
                             layerResults.length >= 1
@@ -57,6 +62,7 @@ const handlers = ref<Array<string>>([]);
 const watchers = ref<Array<() => void>>([]);
 const layerResults = ref<Array<IdentifyResult>>([]);
 const noResults = ref<boolean>(false);
+const detailsPanel = ref<HTMLElement | null>(null);
 
 /**
  * UID of the layer "selected" into the detail/list section. Empty string when panel is freshly opened.


### PR DESCRIPTION
### Related Item(s)
Issue #2604

### Changes
- [FIX] Ensures that selecting a feature in the details list view always scrolls to the top of the details panel, rather than retaining previously scrolled position. 

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to enhanced sample 8
2. Perform an identify on an area with many features (>15 features)
3. Click `See List` in the `Identify Details` panel
4. Scroll down the list and select a feature near the bottom
5. Verify that the main details panel scrolls to the top after feature is selected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2803)
<!-- Reviewable:end -->
