### PR TITLE
Bump vitepress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
                 "vite": "^7.0.5",
                 "vite-plugin-dts": "^4.4.0",
                 "vite-plugin-mkcert": "^1.17.6",
-                "vitepress": "1.6.1",
+                "vitepress": "1.6.4",
                 "vue-tsc": "^2.1.6",
                 "yaml": "^2.6.0"
             }
@@ -101,38 +101,54 @@
             "integrity": "sha512-WzCa7VdX2D2XMifDCG8pBXUOdrpnYGd6gT/J+HLH3oGnQAXLk31r7WvvVmgKuFD6xGetPzg4hWX79GdJssVxTQ==",
             "license": "MIT"
         },
-        "node_modules/@algolia/autocomplete-core": {
-            "version": "1.17.9",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
-            "integrity": "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==",
+        "node_modules/@algolia/abtesting": {
+            "version": "1.12.3",
+            "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.3.tgz",
+            "integrity": "sha512-0SpSdnME0RCS6UHSs9XD3ox4bMcCg1JTmjAJ3AU6rcTlX54CZOAEPc2as8uSghX6wfKGT0HWes4TeUpjJMg6FQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-plugin-algolia-insights": "1.17.9",
-                "@algolia/autocomplete-shared": "1.17.9"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/@algolia/autocomplete-core": {
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+            "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+                "@algolia/autocomplete-shared": "1.17.7"
             }
         },
         "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-            "version": "1.17.9",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.9.tgz",
-            "integrity": "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+            "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.17.9"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "search-insights": ">= 1 < 3"
             }
         },
         "node_modules/@algolia/autocomplete-preset-algolia": {
-            "version": "1.17.9",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.9.tgz",
-            "integrity": "sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+            "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-shared": "1.17.9"
+                "@algolia/autocomplete-shared": "1.17.7"
             },
             "peerDependencies": {
                 "@algolia/client-search": ">= 4.9.1 < 6",
@@ -140,9 +156,9 @@
             }
         },
         "node_modules/@algolia/autocomplete-shared": {
-            "version": "1.17.9",
-            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
-            "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
+            "version": "1.17.7",
+            "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+            "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -151,41 +167,41 @@
             }
         },
         "node_modules/@algolia/client-abtesting": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.20.0.tgz",
-            "integrity": "sha512-YaEoNc1Xf2Yk6oCfXXkZ4+dIPLulCx8Ivqj0OsdkHWnsI3aOJChY5qsfyHhDBNSOhqn2ilgHWxSfyZrjxBcAww==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.3.tgz",
+            "integrity": "sha512-i2C8sBcl3EKXuCd5nlGohW+pZ9pY3P3JKJ2OYqsbCPg6wURiR32hNDiDvDq7/dqJ7KWWwC2snxJhokZzGlckgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-analytics": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.20.0.tgz",
-            "integrity": "sha512-CIT9ni0+5sYwqehw+t5cesjho3ugKQjPVy/iPiJvtJX4g8Cdb6je6SPt2uX72cf2ISiXCAX9U3cY0nN0efnRDw==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.3.tgz",
+            "integrity": "sha512-uFmD7m3LOym1SAURHeiqupHT9jui+9HK0lAiIvm077gXEscOM5KKXM4rg/ICzQ3UDHLZEA0Lb5TglWsXnieE6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-common": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.20.0.tgz",
-            "integrity": "sha512-iSTFT3IU8KNpbAHcBUJw2HUrPnMXeXLyGajmCL7gIzWOsYM4GabZDHXOFx93WGiXMti1dymz8k8R+bfHv1YZmA==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.3.tgz",
+            "integrity": "sha512-SN+yK840nXa+2+mF72hrDfGd8+B7eBjF8TK/8KoRMdjlAkO/P3o3vtpjKRKI/Sk4L8kYYkB/avW8l+cwR+O1Ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -193,151 +209,151 @@
             }
         },
         "node_modules/@algolia/client-insights": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.20.0.tgz",
-            "integrity": "sha512-w9RIojD45z1csvW1vZmAko82fqE/Dm+Ovsy2ElTsjFDB0HMAiLh2FO86hMHbEXDPz6GhHKgGNmBRiRP8dDPgJg==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.3.tgz",
+            "integrity": "sha512-5ic1liG0VucNPi6gKCWh5bEUGWQfyEmVeXiNKS+rOSppg7B7nKH0PEEJOFXBbHmgK5aPfNNZINiKcyUoH4XsFA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-personalization": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.20.0.tgz",
-            "integrity": "sha512-p/hftHhrbiHaEcxubYOzqVV4gUqYWLpTwK+nl2xN3eTrSW9SNuFlAvUBFqPXSVBqc6J5XL9dNKn3y8OA1KElSQ==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.3.tgz",
+            "integrity": "sha512-f4HNitgTip8tntKgluYBTc1LWSOkbNCdxZvRA3rRBZnEAYSvLe7jpE+AxRep6RY+prSWwMtyeCFhA/F1Um+TuQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-query-suggestions": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.20.0.tgz",
-            "integrity": "sha512-m4aAuis5vZi7P4gTfiEs6YPrk/9hNTESj3gEmGFgfJw3hO2ubdS4jSId1URd6dGdt0ax2QuapXufcrN58hPUcw==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.3.tgz",
+            "integrity": "sha512-/AaVqah2aYyJj7Cazu5QRkgcV3HF3lkBJo5TRkgqQ26xR4iHNRbLF2YsWJfJpJEFghlTF2HOCh7IgzaUCnM+8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/client-search": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.20.0.tgz",
-            "integrity": "sha512-KL1zWTzrlN4MSiaK1ea560iCA/UewMbS4ZsLQRPoDTWyrbDKVbztkPwwv764LAqgXk0fvkNZvJ3IelcK7DqhjQ==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.3.tgz",
+            "integrity": "sha512-hfpCIukPuwkrlwsYfJEWdU5R5bduBHEq2uuPcqmgPgNq5MSjmiNIzRuzxGZZgiBKcre6gZT00DR7G1AFn//wiQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/ingestion": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.20.0.tgz",
-            "integrity": "sha512-shj2lTdzl9un4XJblrgqg54DoK6JeKFO8K8qInMu4XhE2JuB8De6PUuXAQwiRigZupbI0xq8aM0LKdc9+qiLQA==",
+            "version": "1.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.3.tgz",
+            "integrity": "sha512-ChVzNkCzAVxKozTnTgPWCG69WQLjzW7X6OqD91zUh8U38ZhPEX/t3qGhXs+M9ZNaHcJ7xToMB3jywNwONhpLGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/monitoring": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.20.0.tgz",
-            "integrity": "sha512-aF9blPwOhKtWvkjyyXh9P5peqmhCA1XxLBRgItT+K6pbT0q4hBDQrCid+pQZJYy4HFUKjB/NDDwyzFhj/rwKhw==",
+            "version": "1.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.3.tgz",
+            "integrity": "sha512-MZa+Z5iPmVMxVAQ0aq4HpGsja5utSLEMcOuY01X8D46vvMrSPkP8DnlDFtu1PgJ0RwyIGqqx7v+ClFo6iRJ6bA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/recommend": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.20.0.tgz",
-            "integrity": "sha512-T6B/WPdZR3b89/F9Vvk6QCbt/wrLAtrGoL8z4qPXDFApQ8MuTFWbleN/4rHn6APWO3ps+BUePIEbue2rY5MlRw==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.3.tgz",
+            "integrity": "sha512-cr3atJRJBKgAKZl/Oxo4sig6Se0+ukbyIOOluPV5H+ZAXVcxuMoXQgwQ1M5UHPnCnEsZ4uBXhBmilRgUQpUegw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/client-common": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-browser-xhr": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.20.0.tgz",
-            "integrity": "sha512-t6//lXsq8E85JMenHrI6mhViipUT5riNhEfCcvtRsTV+KIBpC6Od18eK864dmBhoc5MubM0f+sGpKOqJIlBSCg==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.3.tgz",
+            "integrity": "sha512-/Ku9GImJf2SKoRM2S3e03MjCVaWJCP5olih4k54DRhNDdmxBkd3nsWuUXvDElY3Ucw/arBYGs5SYz79SoS5APw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0"
+                "@algolia/client-common": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-fetch": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.20.0.tgz",
-            "integrity": "sha512-FHxYGqRY+6bgjKsK4aUsTAg6xMs2S21elPe4Y50GB0Y041ihvw41Vlwy2QS6K9ldoftX4JvXodbKTcmuQxywdQ==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.3.tgz",
+            "integrity": "sha512-Uw+SPy/zpfwbH1AxQaeOWvWVzPEcO0XbtLbbSz0HPcEIiBGWyfa9LUCxD5UferbDjrSQNVimmzl3FaWi4u8Ykw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0"
+                "@algolia/client-common": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
             }
         },
         "node_modules/@algolia/requester-node-http": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.20.0.tgz",
-            "integrity": "sha512-kmtQClq/w3vtPteDSPvaW9SPZL/xrIgMrxZyAgsFwrJk0vJxqyC5/hwHmrCraDnStnGSADnLpBf4SpZnwnkwWw==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.3.tgz",
+            "integrity": "sha512-4No9iTjr1GZ0JWsFbQJj9aZBnmKyY1sTxOoEud9+SGe3U6iAulF0A0lI4cWi/F/Gcfg8V3jkaddcqSQKDnE45w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-common": "5.20.0"
+                "@algolia/client-common": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -709,33 +725,33 @@
             }
         },
         "node_modules/@docsearch/css": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.3.tgz",
-            "integrity": "sha512-1nELpMV40JDLJ6rpVVFX48R1jsBFIQ6RnEQDsLFGmzOjPWTOMlZqUcXcvRx8VmYV/TqnS1l784Ofz+ZEb+wEOQ==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+            "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@docsearch/js": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.3.tgz",
-            "integrity": "sha512-CQsX1zeoPJIWxN3IGoDSWOqzRc0JsOE9Bclegf9llwjYN2rzzJF93zagGcT3uI3tF31oCqTuUOVGW/mVFb7arw==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+            "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@docsearch/react": "3.8.3",
+                "@docsearch/react": "3.8.2",
                 "preact": "^10.0.0"
             }
         },
         "node_modules/@docsearch/react": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.3.tgz",
-            "integrity": "sha512-6UNrg88K7lJWmuS6zFPL/xgL+n326qXqZ7Ybyy4E8P/6Rcblk3GE8RXxeol4Pd5pFpKMhOhBhzABKKwHtbJCIg==",
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+            "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/autocomplete-core": "1.17.9",
-                "@algolia/autocomplete-preset-algolia": "1.17.9",
-                "@docsearch/css": "3.8.3",
+                "@algolia/autocomplete-core": "1.17.7",
+                "@algolia/autocomplete-preset-algolia": "1.17.7",
+                "@docsearch/css": "3.8.2",
                 "algoliasearch": "^5.14.2"
             },
             "peerDependencies": {
@@ -4634,25 +4650,26 @@
             "license": "MIT"
         },
         "node_modules/algoliasearch": {
-            "version": "5.20.0",
-            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.20.0.tgz",
-            "integrity": "sha512-groO71Fvi5SWpxjI9Ia+chy0QBwT61mg6yxJV27f5YFf+Mw+STT75K6SHySpP8Co5LsCrtsbCH5dJZSRtkSKaQ==",
+            "version": "5.46.3",
+            "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.3.tgz",
+            "integrity": "sha512-n/NdPglzmkcNYZfIT3Fo8pnDR/lKiK1kZ1Yaa315UoLyHymADhWw15+bzN5gBxrCA8KyeNu0JJD6mLtTov43lQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@algolia/client-abtesting": "5.20.0",
-                "@algolia/client-analytics": "5.20.0",
-                "@algolia/client-common": "5.20.0",
-                "@algolia/client-insights": "5.20.0",
-                "@algolia/client-personalization": "5.20.0",
-                "@algolia/client-query-suggestions": "5.20.0",
-                "@algolia/client-search": "5.20.0",
-                "@algolia/ingestion": "1.20.0",
-                "@algolia/monitoring": "1.20.0",
-                "@algolia/recommend": "5.20.0",
-                "@algolia/requester-browser-xhr": "5.20.0",
-                "@algolia/requester-fetch": "5.20.0",
-                "@algolia/requester-node-http": "5.20.0"
+                "@algolia/abtesting": "1.12.3",
+                "@algolia/client-abtesting": "5.46.3",
+                "@algolia/client-analytics": "5.46.3",
+                "@algolia/client-common": "5.46.3",
+                "@algolia/client-insights": "5.46.3",
+                "@algolia/client-personalization": "5.46.3",
+                "@algolia/client-query-suggestions": "5.46.3",
+                "@algolia/client-search": "5.46.3",
+                "@algolia/ingestion": "1.46.3",
+                "@algolia/monitoring": "1.46.3",
+                "@algolia/recommend": "5.46.3",
+                "@algolia/requester-browser-xhr": "5.46.3",
+                "@algolia/requester-fetch": "5.46.3",
+                "@algolia/requester-node-http": "5.46.3"
             },
             "engines": {
                 "node": ">= 14.0.0"
@@ -10375,9 +10392,9 @@
             "dev": true
         },
         "node_modules/preact": {
-            "version": "10.25.4",
-            "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.4.tgz",
-            "integrity": "sha512-jLdZDb+Q+odkHJ+MpW/9U5cODzqnB+fy2EiHSZES7ldV5LK7yjlVzTp7R8Xy6W6y75kfK8iWYtFVH7lvjwrCMA==",
+            "version": "10.28.2",
+            "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+            "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -12658,18 +12675,18 @@
             }
         },
         "node_modules/vitepress": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.1.tgz",
-            "integrity": "sha512-n41KBL08aonxaWMnk5V+TkpZ29rZF4sgYjvIqU2k0foteNhgms5BmbVWw9xTqD5hps12H1W+EZUwc7NlHh1s3g==",
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+            "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@docsearch/css": "^3.8.2",
-                "@docsearch/js": "^3.8.2",
-                "@iconify-json/simple-icons": "^1.2.20",
-                "@shikijs/core": "^2.0.0",
-                "@shikijs/transformers": "^2.0.0",
-                "@shikijs/types": "^2.0.0",
+                "@docsearch/css": "3.8.2",
+                "@docsearch/js": "3.8.2",
+                "@iconify-json/simple-icons": "^1.2.21",
+                "@shikijs/core": "^2.1.0",
+                "@shikijs/transformers": "^2.1.0",
+                "@shikijs/types": "^2.1.0",
                 "@types/markdown-it": "^14.1.2",
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vue/devtools-api": "^7.7.0",
@@ -12679,8 +12696,8 @@
                 "focus-trap": "^7.6.4",
                 "mark.js": "8.11.1",
                 "minisearch": "^7.1.1",
-                "shiki": "^2.0.0",
-                "vite": "^5.4.12",
+                "shiki": "^2.1.0",
+                "vite": "^5.4.14",
                 "vue": "^3.5.13"
             },
             "bin": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
         "vite": "^7.0.5",
         "vite-plugin-dts": "^4.4.0",
         "vite-plugin-mkcert": "^1.17.6",
-        "vitepress": "1.6.1",
+        "vitepress": "1.6.4",
         "vue-tsc": "^2.1.6",
         "yaml": "^2.6.0"
     }


### PR DESCRIPTION

### Related Item(s)

[This screechy thing in the job log](https://github.com/ramp4-pcar4/ramp4-pcar4/actions/runs/20970631110/job/60272733990).

In particular, this message in the output:

```text
security_update_not_possible 

dependency-name: "esbuild"
latest-resolvable-version: 0.21.5
lowest-non-vulnerable-version: 0.25.0

vitepress@1.6.1 requires esbuild@^0.21.3 via vite@5.4.21
```


### Changes
- Updates `vitepress`

### Notes

Will have to see if the bot build still grouses after this gets merged. But no harm in updating the library even if it doesn't.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/docs/

### Testing

Open docsite on the PR branch. Check it for nonsense 🦉 

https://james-rae.github.io/ramp4-pcar4/veeet/docs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2808)
<!-- Reviewable:end -->
