### PR TITLE
Add WFS request cancellation

### DIFF
--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -301,6 +301,7 @@ defineProps({
 const layerSource = computed(() => wizardStore.layerSource);
 const step = computed(() => wizardStore.currStep);
 
+const abortController = ref<AbortController | null>(null);
 const colour = ref();
 const componentKey = ref(0);
 const disabled = ref(false);
@@ -520,8 +521,10 @@ const onUploadContinue = (event: any) => {
 const onSelectContinue = async (event: any) => {
     event?.preventDefault();
 
+    abortController.value = new AbortController();
     disabled.value = true;
     failureError.value = false;
+    finishStep.value = false;
     validation.value = true;
 
     wizardStore.goToStep(WizardStep.CONFIGURE);
@@ -536,7 +539,8 @@ const onSelectContinue = async (event: any) => {
             : ((await layerSource.value!.fetchServiceInfo(
                   url.value,
                   typeSelection.value,
-                  wizardStore.nested
+                  wizardStore.nested,
+                  abortController.value.signal
               )) as LayerInfo);
         if (isFileLayer() && fileData.value) {
             layerInfo.value.config.url = '';
@@ -839,6 +843,7 @@ const cancelFormatStep = () => {
 const cancelNameStep = () => {
     selectedValues.value = [];
     finishStep.value = false;
+    abortController.value?.abort();
     wizardStore.goToStep(1);
 };
 </script>

--- a/src/geo/layer/support/ogc-utils.ts
+++ b/src/geo/layer/support/ogc-utils.ts
@@ -26,6 +26,7 @@ export class OgcUtils extends APIScope {
      *                 features: []
      *             }] the resulting GeoJSON being populated as we receive layer information. Undefined for initial request.
      * @param {boolean} [xyInAttribs=false] true if point co-ords should be copied to attribute values
+     * @param {AbortSignal} [signal] abort signal to cancel the WFS data request
      * @returns {Promise<any>} a promise resolving with the layer GeoJSON
      * @memberof WFSServiceSource
      */
@@ -38,7 +39,8 @@ export class OgcUtils extends APIScope {
             type: 'FeatureCollection',
             features: []
         },
-        xyInAttribs = false
+        xyInAttribs = false,
+        signal?: AbortSignal
     ): Promise<any> {
         let newQueryMap: UrlQueryMap = {
             offset: offset.toString(),
@@ -50,6 +52,11 @@ export class OgcUtils extends APIScope {
         // Tricky to locate since it appears they now call it OGC API.
         // The actual documents tend to change and old links 404, but some of the links in that
         // repo should remain current.
+
+        // stop immediately if cancelled
+        if (signal?.aborted) {
+            throw new Error('WFS load cancelled');
+        }
 
         // it seems that some WFS services do not return the number of matched records with every request
         // so, we need to get that explicitly first
@@ -68,7 +75,7 @@ export class OgcUtils extends APIScope {
         // ^ as of ESRI 4, jsonp is not likely required. The choice between esri request and axios
         //   will ultimately boil down to if a proxy should be used or not.
         //   see https://github.com/ramp4-pcar4/ramp4-pcar4/discussions/773
-        const [error, response] = await to<WFSResponse>(axios.get(requestUrl));
+        const [error, response] = await to<WFSResponse>(axios.get(requestUrl, { signal } as any));
 
         if (!response) {
             console.error(`WFS data failed to load for ${url}`, error);
@@ -78,10 +85,14 @@ export class OgcUtils extends APIScope {
         const data = response.data;
 
         // save the total number of records and start downloading the data
+        // throw an error if numberMatched is missing
         if (totalCount === -1) {
+            if (typeof data.numberMatched !== 'number') {
+                throw new Error('WFS hits missing numberMatched');
+            }
             totalCount = response.data.numberMatched;
             // note we pass url and not requestUrl here, becuase requestUrl is currently a count request
-            return this.loadWfsData(url, totalCount, offset, limit, wfsData, xyInAttribs);
+            return this.loadWfsData(url, totalCount, offset, limit, wfsData, xyInAttribs, signal);
         }
 
         // update the received features array.
@@ -98,7 +109,8 @@ export class OgcUtils extends APIScope {
                 data.features.length + offset,
                 newLimit,
                 wfsData,
-                xyInAttribs
+                xyInAttribs,
+                signal
             );
         } else {
             // finally have downloaded the entire dataset.


### PR DESCRIPTION
### Related Item(s)
Issue #2665

### Changes
- Stop WFS recursion and ongoing requests when `Cancel` is pressed by integrating `AbortController` into `loadWfsData`
- Added validation for WFS responses, so it now throws an error if `numberMatched` is missing

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any sample with the Legend/Wizard (e.g., Enhanced Sample 1)
2. Open the wizard and add a service (https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/EcoAction/MapServer)
3. Select `OGC Web Feature Service`
4. Press `Continue`, and then `Cancel`
5. Confirm that you can choose another service type and the wizard continues to function normally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2809)
<!-- Reviewable:end -->
