### PR TITLE
Boundary zoom to single point file layers now follows point zoom level

### DIFF
--- a/src/geo/layer/map-layer.ts
+++ b/src/geo/layer/map-layer.ts
@@ -1,5 +1,14 @@
 import { CommonLayer, GlobalEvents, InstanceAPI } from '@/api/internal';
-import { DefPromise, DrawState, Extent, InitiationState, LayerState, ScaleSet, SpatialReference } from '@/geo/api';
+import {
+    DefPromise,
+    DrawState,
+    Extent,
+    InitiationState,
+    LayerState,
+    Point,
+    ScaleSet,
+    SpatialReference
+} from '@/geo/api';
 import type { DrawOrder, RampLayerConfig } from '@/geo/api';
 import { EsriWatch } from '@/geo/esri';
 import { markRaw } from 'vue';
@@ -368,6 +377,13 @@ export class MapLayer extends CommonLayer {
         }
 
         if (this.mapCheck()) {
+            // Check if the layer is a single-point layer
+            // Use default point zoom level in that scenario (Issue 2607)
+            if (this.extent.xmin === this.extent.xmax && this.extent.ymin === this.extent.ymax) {
+                const point = new Point('point', [this.extent.xmin, this.extent.ymin], this.extent.sr);
+                return this.$iApi.geo.map.zoomMapTo(point);
+            }
+
             return this.$iApi.geo.map.zoomMapTo(this.extent);
         } else {
             return Promise.resolve();


### PR DESCRIPTION
### Related Item(s)
Issue #2607 

### Changes
- When a boundary zoom is performed on a single-point file layer, it now zooms to the default point zoom level instead of just centering the point

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to enhanced sample 8 
2. Run the legend menu ` Zoom to Layer Boundary` on either "GeoJson CRS Great Lakes Albers" or "GeoJson WKT Great Lakes Albers"
3. Run the boundary zoom on other items

Single-point layers should zoom to the default point zoom level while other layers should continue zooming to their full layer bouondary

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2816)
<!-- Reviewable:end -->
