### PR TITLE
Update clear grid filter behaviour

### DIFF
--- a/src/fixtures/grid/lang/lang.csv
+++ b/src/fixtures/grid/lang/lang.csv
@@ -6,7 +6,7 @@ grid.splash.loading,Loading data...,1,Chargement des données...,1
 grid.splash.building,Building table...,1,Création du tableau...,1
 grid.splash.cancel,Cancel,1,Annuler,1
 grid.search.clear,Clear search filter,1,Effacer le filtre de recherche,0
-grid.clearAll,Clear search and filters,1,Effacer la recherche et les filtres,1
+grid.clearAll,Clear search and grid-based filters,1,Effacer la recherche et les filtres de la grille,0
 grid.layer.loading,The layer is loading...,1,La couche est en cours de téléchargement...,1
 grid.label.pinColumns,Pin columns,1,Épingler les colonnes,1
 grid.label.export,Export,1,Exporter,1
@@ -31,6 +31,7 @@ grid.filters.date.max,Max Date,1,Date max,1
 grid.filters.date.min,Min Date,1,Date min,1
 grid.filters.label.info,{range} of {total} entries shown,1,{range} de {total} saisies affichées,1
 grid.filters.label.filtered,(filtered from {max} total entries),1,(filtré à partir d'un total de {max} saisies),1
+grid.filters.label.hidden,Layer hidden,1,Couche masquée,0
 grid.filters.label.extent,Filter by extent,1,Filtrer par étendue,1
 grid.cells.controls,Use arrow keys to navigate grid cells. Press Tab to proceed,1,Utilisez les flèches pour parcourir les cellules de la grille. Appuyez sur Tab pour continuer,0
 grid.cells.zoom,Zoom to feature,1,Zoom à l'élément,1

--- a/src/fixtures/grid/store/table-state-manager.ts
+++ b/src/fixtures/grid/store/table-state-manager.ts
@@ -115,12 +115,15 @@ export default class TableStateManager {
         });
         this._filterByExtent = false;
         this._filtered = false;
-        this._searchFilter = '';
     }
 
     _checkFilters() {
         this._filtered = Object.values(this._columns).some(config => {
-            return config.filter.value !== '' || config.filter.min || config.filter.max;
+            return (
+                config.filter.value !== '' ||
+                (config.filter.min !== '' && config.filter.min !== null) ||
+                (config.filter.max !== '' && config.filter.max !== null)
+            );
         });
     }
 

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -40,6 +40,9 @@
 
                 <div class="w-full text-sm" v-truncate>
                     {{
+                        (!layer.visibility && filterInfo.visibleRows === 0
+                            ? `${t('grid.filters.label.hidden')} — `
+                            : '') +
                         t('grid.filters.label.info', {
                             range:
                                 filterInfo.visibleRows !== 0 ? `${filterInfo.firstRow} - ${filterInfo.lastRow}` : '0',
@@ -47,7 +50,7 @@
                         })
                     }}
 
-                    <span v-if="filterInfo.visibleRows !== rowData.length">{{
+                    <span v-if="filterInfo.visibleRows !== rowData.length && layer.visibility">{{
                         t('grid.filters.label.filtered', {
                             max: rowData.length
                         })
@@ -125,8 +128,9 @@
                     <!-- clear all filters -->
                     <button
                         type="button"
-                        class="grid-clearall p-4 h-40 text-gray-500 hover:text-black"
-                        @click="clearSearchAndFilters()"
+                        class="grid-clearall p-4 h-40"
+                        :class="canClearFilters ? 'text-gray-500 hover:text-black' : 'text-gray-300 cursor-default'"
+                        @click="canClearFilters && clearSearchAndFilters()"
                         :content="t('grid.clearAll')"
                         :aria-label="t('grid.clearAll')"
                         v-tippy="{
@@ -565,6 +569,7 @@ const gridLayers = computed(() => {
             .filter(layer => layer !== undefined);
     } else return [];
 });
+const canClearFilters = computed(() => config.value.state.filtered || config.value.state.searchFilter);
 
 const systemCols = ref<Set<string>>(new Set<string>());
 


### PR DESCRIPTION
### Related Item(s)
Issues #2343 & #2806

### Changes
-  Adjusted `Datatable` info messaging, so layer visibility state is distinguished from grid filtering 
   - No longer shows "filtered from..." when layers are hidden
   - Disabled clear button when no filters or search are applied, and updated tooltip text
   
- Updated filter detection logic so that values of `0` are recognized as filtered

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 5
2. Toggle the layer visibility checkbox for `Zipped FlatGeobeuf` and open its data grid
3. Description now says `Layer hidden — 0 of 0 entries shown` and clear button is disabled
4. Make layer visible again 
5. Enter `0` for one of the number filters (e.g., `LAND_KM`)
6. Clear filter icon to the left of the grid should now be enabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2817)
<!-- Reviewable:end -->
