### PR TITLE
Disable container focus for single-item lists and container tooltips on item focus

### DIFF
--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -329,7 +329,8 @@ export class FocusListManager {
             case KEYS.EscapeIE:
             case KEYS.Escape:
                 // we only care about escape presses if the highlighted item isnt the list
-                if (this.highlightedItem !== this.element) {
+                // and if there is more than one list element
+                if (this.highlightedItem !== this.element && listOfItems.length > 1) {
                     event.preventDefault();
                     event.stopPropagation();
                     // defocus current item, move focus to the list
@@ -366,9 +367,9 @@ export class FocusListManager {
                         this.defocusItem(this.highlightedItem);
                     }
 
-                    // If the Shift key was clicked alongside Tab, prevent the default behavior
-                    // and return focus to the focus list
-                    if (event.shiftKey) {
+                    // If the Shift key was clicked alongside Tab with more than one list item,
+                    // prevent the default behavior and return focus to the focus list
+                    if (event.shiftKey && listOfItems.length > 1) {
                         event.preventDefault();
                         event.stopPropagation();
                         this.defocusItem(this.highlightedItem);
@@ -423,6 +424,17 @@ export class FocusListManager {
      * This is used to pull back the `focusedItem` id and the aria-activedescendant attribute when a list is focused
      */
     onFocus() {
+        // For lists with only one item, focus the item directly
+        if (this.highlightedItem === this.element) {
+            const items = this.element.querySelectorAll<HTMLElement>(`[${ITEM_ATTR}]`);
+            if (items.length === 1) {
+                this.defocusItem(this.highlightedItem);
+                this.highlightedItem = items[0];
+                this.focusItem(items[0]);
+                return;
+            }
+        }
+
         // If the highlighted item has a tooltip then show it
         // Don't show if the list was clicked, it will cause the tooltip to flicker
         if (this.highlightedItem && !this.isClicked) {

--- a/src/fixtures/appbar/appbar.vue
+++ b/src/fixtures/appbar/appbar.vue
@@ -120,6 +120,7 @@ import NotificationsAppbarButton from '@/components/notification-center/appbar-b
 import AboutRampDropdown from '@/components/about-ramp/about-ramp-dropdown.vue';
 import { usePanelStore } from '@/stores/panel';
 import { useAppbarStore } from './store';
+import { keyboardTooltipTest } from '@/utils/keyboard';
 import { useI18n } from 'vue-i18n';
 
 const panelStore = usePanelStore();
@@ -157,8 +158,7 @@ const blurEvent = () => {
 };
 
 const keyupEvent = (e: Event) => {
-    const evt = e as KeyboardEvent;
-    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+    if (keyboardTooltipTest(e, el.value)) {
         (el.value as any)._tippy.show();
     }
 };

--- a/src/fixtures/basemap/screen.vue
+++ b/src/fixtures/basemap/screen.vue
@@ -50,6 +50,7 @@ import type { RampBasemapConfig, RampMapConfig, RampTileSchemaConfig } from '@/g
 import type { PanelInstance } from '@/api';
 import { useI18n } from 'vue-i18n';
 import { useConfigStore } from '@/stores/config';
+import { keyboardTooltipTest } from '@/utils/keyboard';
 
 const { t } = useI18n();
 const configStore = useConfigStore();
@@ -63,8 +64,7 @@ const el = useTemplateRef('el');
 const tileSchemas = ref<Array<RampTileSchemaConfig>>([]);
 const basemaps = ref<Array<RampBasemapConfig>>([]);
 const keyupEvent = (e: Event) => {
-    const evt = e as KeyboardEvent;
-    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+    if (keyboardTooltipTest(e, el.value as HTMLElement)) {
         (el.value as any)._tippy.show();
     }
 };

--- a/src/fixtures/legend/screen.vue
+++ b/src/fixtures/legend/screen.vue
@@ -29,6 +29,7 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { keyboardTooltipTest } from '@/utils/keyboard';
 
 import type { InstanceAPI, PanelInstance } from '@/api';
 import type { PropType } from 'vue';
@@ -47,8 +48,7 @@ const blurEvent = () => {
 };
 
 const keyupEvent = (e: Event) => {
-    const evt = e as KeyboardEvent;
-    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+    if (keyboardTooltipTest(e, el.value)) {
         (el.value as any)._tippy.show();
     }
 };

--- a/src/fixtures/mapnav/mapnav.vue
+++ b/src/fixtures/mapnav/mapnav.vue
@@ -90,6 +90,7 @@ import ZoomNavSection from './buttons/zoom-nav.vue';
 import DividerNav from './buttons/divider-nav.vue';
 import { InstanceAPI } from '@/api/internal';
 import DrawNavSection from '../draw/draw-nav-section.vue';
+import { keyboardTooltipTest } from '@/utils/keyboard';
 
 const rootResizeObserver = ref<ResizeObserver | undefined>(undefined);
 
@@ -118,8 +119,7 @@ const blurEvent = () => {
 };
 
 const keyupEvent = (e: Event) => {
-    const evt = e as KeyboardEvent;
-    if (evt.key === 'Tab' && el.value?.matches(':focus')) {
+    if (keyboardTooltipTest(e, el.value)) {
         (el.value as any)._tippy.show();
     }
 };

--- a/src/utils/keyboard.ts
+++ b/src/utils/keyboard.ts
@@ -1,0 +1,13 @@
+/**
+ * Determines whether the container tooltip should be shown on keyboard navigation.
+ *
+ * Show tooltip only if:
+ *  - Tab or Escape was pressed
+ *  - container itself is the focused element
+ *  - no descendant element is active
+ */
+export function keyboardTooltipTest(e: Event, el?: Element): boolean {
+    const evt = e as KeyboardEvent;
+
+    return ['Tab', 'Escape'].includes(evt.key) && !!el?.matches(':focus') && !el?.hasAttribute('aria-activedescendant');
+}


### PR DESCRIPTION
### Related Item(s)
Issues #2336 & #2573

### Changes
- Updated container tooltip behaviour so that it doesn't show when a list item is focused/selected
- Updated focus handling to avoid container focus when list has only one item

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open sample with single legend item (e.g., Happy)
2. Navigate to the `Appbar` and select an item using arrow keys
3. Tab away from the `Appbar` and `Shift+Tab` back
4. Verify that item is highlighted and the "use arrow keys..." tooltip doesn't appear unless you `Shift+Tab` again or press `esc` 
5. Next, tab through the single item legend
6. Verify that there is no outer box focus (focus goes directly to the item) and there is no more "use arrow keys..." tooltip

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2821)
<!-- Reviewable:end -->
