### PR TITLE
Revert Lambert basemap urls

### DIFF
--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -163,7 +163,7 @@
                                             {
                                                 id: 'CBMT',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -178,7 +178,7 @@
                                             {
                                                 id: 'SMR',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -193,7 +193,7 @@
                                             {
                                                 id: 'CBME_CBCE_HS_RO_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -208,7 +208,7 @@
                                             {
                                                 id: 'CBMT_CBCT_GEOM_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -449,7 +449,7 @@
                                             {
                                                 id: 'CBCT',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -463,7 +463,7 @@
                                             {
                                                 id: 'SMR',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -478,7 +478,7 @@
                                             {
                                                 id: 'CBME_CBCE_HS_RO_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -493,7 +493,7 @@
                                             {
                                                 id: 'CBMT_CBCT_GEOM_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/qa-samples.html
+++ b/demos/qa-samples.html
@@ -147,7 +147,7 @@
                                             {
                                                 id: 'CBMT',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -161,7 +161,7 @@
                                             {
                                                 id: 'SMR',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -176,7 +176,7 @@
                                             {
                                                 id: 'CBME_CBCE_HS_RO_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -191,7 +191,7 @@
                                             {
                                                 id: 'CBMT_CBCT_GEOM_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -429,7 +429,7 @@
                                             {
                                                 id: 'CBCT',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -443,7 +443,7 @@
                                             {
                                                 id: 'SMR',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -458,7 +458,7 @@
                                             {
                                                 id: 'CBME_CBCE_HS_RO_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -473,7 +473,7 @@
                                             {
                                                 id: 'CBMT_CBCT_GEOM_3978',
                                                 layerType: 'esri-tile',
-                                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                                             }
                                         ],
                                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/basemap-fail.js
+++ b/demos/starter-scripts/basemap-fail.js
@@ -86,7 +86,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -115,7 +115,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -130,7 +130,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -307,7 +307,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -324,7 +324,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,
@@ -469,7 +469,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -484,7 +484,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -499,7 +499,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -677,7 +677,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -694,7 +694,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/basemaps.js
+++ b/demos/starter-scripts/basemaps.js
@@ -80,12 +80,12 @@ let config = {
                             {
                                 id: 'CBMT_GEOM',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3857/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3857/MapServer'
                             },
                             {
                                 id: 'CBMT_TXT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3857/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_TXT_3857/MapServer'
                             }
                         ]
                     },
@@ -99,7 +99,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         hideThumbnail: true,
@@ -114,7 +114,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         hideThumbnail: true,
@@ -130,7 +130,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         hideThumbnail: true,
@@ -146,7 +146,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         hideThumbnail: true,

--- a/demos/starter-scripts/cccs.js
+++ b/demos/starter-scripts/cccs.js
@@ -59,7 +59,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -73,7 +73,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -88,7 +88,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -103,7 +103,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -110,7 +110,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -139,7 +139,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -154,7 +154,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/cumulative-effects.js
+++ b/demos/starter-scripts/cumulative-effects.js
@@ -79,7 +79,7 @@ const enConfig = {
                     {
                         id: 'CBMT',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
@@ -94,7 +94,7 @@ const enConfig = {
                     {
                         id: 'SMR',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ const enConfig = {
                     {
                         id: 'CBME_CBCE_HS_RO_3978',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ const enConfig = {
                     {
                         id: 'CBMT_CBCT_GEOM_3978',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -510,7 +510,7 @@ const frConfig = {
                     {
                         id: 'CBCT',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -524,12 +524,12 @@ const frConfig = {
                     {
                         id: 'SMR',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                     },
                     {
                         id: 'SMW',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_TXT_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_TXT_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -544,7 +544,7 @@ const frConfig = {
                     {
                         id: 'CBME_CBCE_HS_RO_3978',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -559,7 +559,7 @@ const frConfig = {
                     {
                         id: 'CBMT_CBCT_GEOM_3978',
                         layerType: 'esri-tile',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/custom-arrow.js
+++ b/demos/starter-scripts/custom-arrow.js
@@ -43,7 +43,7 @@ let config = {
                         layers: [
                             {
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer'
                             }
                         ]
                     }

--- a/demos/starter-scripts/custom-grid-buttons.js
+++ b/demos/starter-scripts/custom-grid-buttons.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -388,7 +388,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -405,7 +405,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,
@@ -529,7 +529,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -543,7 +543,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -558,7 +558,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -573,7 +573,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -806,7 +806,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -823,7 +823,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/custom-renderer.js
+++ b/demos/starter-scripts/custom-renderer.js
@@ -79,7 +79,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -93,7 +93,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -108,7 +108,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -123,7 +123,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/custom-store.js
+++ b/demos/starter-scripts/custom-store.js
@@ -81,7 +81,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -95,7 +95,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -110,7 +110,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -125,7 +125,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/custom-symbology.js
+++ b/demos/starter-scripts/custom-symbology.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/delayed-start.js
+++ b/demos/starter-scripts/delayed-start.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -510,7 +510,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -527,7 +527,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/error-layers.js
+++ b/demos/starter-scripts/error-layers.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -506,7 +506,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -523,7 +523,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/exclusive-fields.js
+++ b/demos/starter-scripts/exclusive-fields.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/export-custom-renderer.js
+++ b/demos/starter-scripts/export-custom-renderer.js
@@ -86,7 +86,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -100,7 +100,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -115,7 +115,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -130,7 +130,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -389,7 +389,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -406,7 +406,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,
@@ -530,7 +530,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -544,7 +544,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -559,7 +559,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -574,7 +574,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -807,7 +807,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -824,7 +824,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/fog-hilight.js
+++ b/demos/starter-scripts/fog-hilight.js
@@ -100,7 +100,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -114,7 +114,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -129,7 +129,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -144,7 +144,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/form.js
+++ b/demos/starter-scripts/form.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -510,7 +510,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -527,7 +527,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/geosearch.js
+++ b/demos/starter-scripts/geosearch.js
@@ -81,7 +81,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/lambert.js
+++ b/demos/starter-scripts/lambert.js
@@ -43,7 +43,7 @@ let config = {
                         layers: [
                             {
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer'
                             }
                         ]
                     }
@@ -59,7 +59,7 @@ let config = {
                             layers: [
                                 {
                                     layerType: 'esri-tile',
-                                    url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBCT3978/MapServer'
+                                    url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBCT3978/MapServer'
                                 }
                             ]
                         }

--- a/demos/starter-scripts/legname.js
+++ b/demos/starter-scripts/legname.js
@@ -99,7 +99,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -113,7 +113,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -128,7 +128,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -143,7 +143,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/main.js
+++ b/demos/starter-scripts/main.js
@@ -86,7 +86,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -100,7 +100,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -115,7 +115,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -130,7 +130,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -389,7 +389,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -406,7 +406,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,
@@ -530,7 +530,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -544,7 +544,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -559,7 +559,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -574,7 +574,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -807,7 +807,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -824,7 +824,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/merge-grid.js
+++ b/demos/starter-scripts/merge-grid.js
@@ -48,7 +48,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/multi-instances.js
+++ b/demos/starter-scripts/multi-instances.js
@@ -91,7 +91,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -105,7 +105,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -120,7 +120,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -135,7 +135,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/multi-ramp.js
+++ b/demos/starter-scripts/multi-ramp.js
@@ -91,7 +91,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -105,7 +105,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -120,7 +120,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -135,7 +135,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -505,7 +505,7 @@ let config2 = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -519,7 +519,7 @@ let config2 = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -534,7 +534,7 @@ let config2 = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -549,7 +549,7 @@ let config2 = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -919,7 +919,7 @@ let config3 = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -933,7 +933,7 @@ let config3 = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -948,7 +948,7 @@ let config3 = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -963,7 +963,7 @@ let config3 = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/no-layers.js
+++ b/demos/starter-scripts/no-layers.js
@@ -86,7 +86,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -100,7 +100,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -115,7 +115,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -130,7 +130,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -363,7 +363,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -377,7 +377,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -392,7 +392,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -407,7 +407,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/offscale-layer.js
+++ b/demos/starter-scripts/offscale-layer.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/old-main.js
+++ b/demos/starter-scripts/old-main.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -510,7 +510,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -527,7 +527,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/panel-party.js
+++ b/demos/starter-scripts/panel-party.js
@@ -82,7 +82,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -96,7 +96,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -111,7 +111,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -126,7 +126,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/perm-filter.js
+++ b/demos/starter-scripts/perm-filter.js
@@ -84,7 +84,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -98,7 +98,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -113,7 +113,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -128,7 +128,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/r2-config-upgraded.js
+++ b/demos/starter-scripts/r2-config-upgraded.js
@@ -420,7 +420,7 @@ const r2config = {
                     {
                         id: 'CBMT',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
@@ -443,7 +443,7 @@ const r2config = {
                     {
                         id: 'SMR',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -458,7 +458,7 @@ const r2config = {
                     {
                         id: 'CBME_CBCE_HS_RO_3978',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -473,7 +473,7 @@ const r2config = {
                     {
                         id: 'CBMT_CBCT_GEOM_3978',
                         layerType: 'esriFeature',
-                        url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                        url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                     }
                 ],
                 tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/ramp-basic.js
+++ b/demos/starter-scripts/ramp-basic.js
@@ -79,7 +79,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -93,7 +93,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -108,7 +108,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -123,7 +123,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/simple-data.js
+++ b/demos/starter-scripts/simple-data.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/simple-feature.js
+++ b/demos/starter-scripts/simple-feature.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         backgroundColour: '#BFE8FE',

--- a/demos/starter-scripts/simple-file.js
+++ b/demos/starter-scripts/simple-file.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/simple-mil.js
+++ b/demos/starter-scripts/simple-mil.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/teleport-details.js
+++ b/demos/starter-scripts/teleport-details.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -515,7 +515,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -532,7 +532,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/teleport-wet.js
+++ b/demos/starter-scripts/teleport-wet.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/teleport.js
+++ b/demos/starter-scripts/teleport.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -517,7 +517,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -534,7 +534,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/demos/starter-scripts/tree-grow.js
+++ b/demos/starter-scripts/tree-grow.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/demos/starter-scripts/vector-tile.js
+++ b/demos/starter-scripts/vector-tile.js
@@ -87,7 +87,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -101,7 +101,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -116,7 +116,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -131,7 +131,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         backgroundColour: '#BFE8FE',

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',
@@ -95,7 +95,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -110,7 +110,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -125,7 +125,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978',

--- a/demos/starter-scripts/wkt-basemap.js
+++ b/demos/starter-scripts/wkt-basemap.js
@@ -146,7 +146,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -160,7 +160,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -175,7 +175,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -190,7 +190,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         backgroundColour: '#BFE8FE',

--- a/demos/starter-scripts/wms-layer.js
+++ b/demos/starter-scripts/wms-layer.js
@@ -81,7 +81,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'DEFAULT_NRCAN_Lambert_3978'

--- a/public/starter-scripts/cesi.js
+++ b/public/starter-scripts/cesi.js
@@ -99,7 +99,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -113,7 +113,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -128,7 +128,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -143,7 +143,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'

--- a/public/starter-scripts/esm.js
+++ b/public/starter-scripts/esm.js
@@ -80,7 +80,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -94,7 +94,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -109,7 +109,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -124,7 +124,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -499,7 +499,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -516,7 +516,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,

--- a/public/starter-scripts/index.js
+++ b/public/starter-scripts/index.js
@@ -79,7 +79,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -93,7 +93,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -108,7 +108,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -123,7 +123,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -356,7 +356,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -373,7 +373,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,
@@ -497,7 +497,7 @@ let config = {
                             {
                                 id: 'CBMT',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -511,7 +511,7 @@ let config = {
                             {
                                 id: 'SMR',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/Simple/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/Simple/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -526,7 +526,7 @@ let config = {
                             {
                                 id: 'CBME_CBCE_HS_RO_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBME_CBCE_HS_RO_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -541,7 +541,7 @@ let config = {
                             {
                                 id: 'CBMT_CBCT_GEOM_3978',
                                 layerType: 'esri-tile',
-                                url: 'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
+                                url: 'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT_CBCT_GEOM_3978/MapServer'
                             }
                         ],
                         tileSchemaId: 'EXT_NRCAN_Lambert_3978#LOD_NRCAN_Lambert_3978'
@@ -774,7 +774,7 @@ let config = {
                         {
                             title: 'Reservoir Manicougan, Quebec, Canada',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/285/268',
                             altText: 'Reservoir Manicougan, Quebec, Canada',
                             description:
                                 'Manicouagan Reservoir (also Lake Manicouagan) is an annular lake in central Quebec, Canada, covering an area of 1,942 km2 (750 sq mi). The structure was created 214 (±1) million years ago, in the Late Triassic, by the impact of a meteorite 5 km (3 mi) in diameter.',
@@ -791,7 +791,7 @@ let config = {
                         {
                             title: 'Gulf of St Lawrence',
                             thumbnail:
-                                'https://geoappext.nrcan.gc.ca/arcgis/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
+                                'https://maps-cartes.services.geo.ca/server2_serveur2/rest/services/BaseMaps/CBMT3978/MapServer/tile/8/286/270',
                             extent: {
                                 xmin: 2050000,
                                 xmax: 2240000,


### PR DESCRIPTION
### Related Item(s)

- Reverts https://github.com/ramp4-pcar4/ramp4-pcar4/pull/2822

### Changes
- Puts back the Lambert basemap urls to the redirected targets

### Notes

Should have waited another day. 🦥 

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 1
2. Be greeted with a working Lambert basemap 🦉

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2824)
<!-- Reviewable:end -->
