### PR TITLE
Include the error messages and loading animation on Configure layer step

### DIFF
--- a/src/fixtures/wizard/form-footer.vue
+++ b/src/fixtures/wizard/form-footer.vue
@@ -6,14 +6,11 @@
 
         <button
             class="button bg-blue-700 hover:bg-blue-700 text-white font-bold py-8 px-16 m-2 disabled:bg-gray-200 disabled:cursor-default disabled:text-gray-400"
-            ref="submitButton"
+            :class="{ 'button--loading': animation && disabled }"
             type="button"
             :disabled="disabled"
             :animation="animation"
-            @click="
-                $emit('submit');
-                loadButton();
-            "
+            @click="$emit('submit')"
         >
             <span class="button-text">{{ t('wizard.step.continue') }}</span>
         </button>
@@ -21,12 +18,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, toRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 
-const props = defineProps({
+defineProps({
     animation: {
         type: Boolean,
         default: false
@@ -36,18 +32,6 @@ const props = defineProps({
         default: true
     }
 });
-
-const submitButton = ref<HTMLButtonElement>();
-
-watch(toRef(props, 'disabled'), disabled => {
-    if (!disabled && submitButton.value!.classList.contains('button--loading')) {
-        submitButton.value!.classList.remove('button--loading');
-    }
-});
-
-const loadButton = () => {
-    if (props.animation) submitButton.value!.classList.toggle('button--loading');
-};
 </script>
 
 <style lang="scss" scoped>

--- a/src/geo/layer/support/ogc-utils.ts
+++ b/src/geo/layer/support/ogc-utils.ts
@@ -55,7 +55,7 @@ export class OgcUtils extends APIScope {
 
         // stop immediately if cancelled
         if (signal?.aborted) {
-            throw new Error('WFS load cancelled');
+            throw new DOMException('WFS load cancelled', 'AbortError');
         }
 
         // it seems that some WFS services do not return the number of matched records with every request


### PR DESCRIPTION
### Related Item(s)
Issue #2814

### Changes
- Added error messages to `Configure layer` step 

### Notes
- Previously, the loading animation was only shown on the `Select format` step. But if layer configuration took time, the `Continue` button would be disabled without visible loading state and without error messages. 
   - Added the loading animation during the` Configure layer` step as well so that progress is clear.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
1. Open any sample with a Wizard 
2. Add a WFS service with minimal params and select the correct service type: 
 https://api.weather.gc.ca//collections/ahccd-trends/items?measurement_type__type_mesure=total_precip
3. Click `Continue` and confirm the loading symbol appears briefly on the `Continue` button during the `Configure layer` step. 
4. Click `Cancel` and select an incompatible service type
5. Click `Continue`, and confirm error messages are displayed on the `Configure layer` step

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2826)
<!-- Reviewable:end -->
