### PR TITLE
Fix layer var in Merge Grid

### DIFF
--- a/demos/starter-scripts/merge-grid.js
+++ b/demos/starter-scripts/merge-grid.js
@@ -58,12 +58,12 @@ let config = {
             },
             layers: [
                 {
-                    id: 'NPRI',
+                    id: 'JOSM',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/NPRI_INRP/NPRI_INRP/MapServer/0',
+                    url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/OilsandsLambert/MapServer/0',
                     fixtures: {
                         grid: {
-                            title: 'NPRI Data'
+                            title: 'Oilsands Data'
                         }
                     }
                 },
@@ -84,9 +84,11 @@ let config = {
                     url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/SupportData/MapServer/1'
                 },
                 {
-                    id: 'Heroni',
+                    // this has its ojbectid field in lowercase. which makes it special for the test.
+                    // very difficult to find layers that dont use standard OBJECTID field name.
+                    id: 'EsriTurbine',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/D01/456ce087-4711-442c-8445-30520f96e98e/MapServer/0'
+                    url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/WindTurbines/MapServer/0'
                 },
                 {
                     id: 'CESI',
@@ -95,9 +97,9 @@ let config = {
                     sublayers: [{ index: 22 }, { index: 24 }, { index: 26 }]
                 },
                 {
-                    id: 'ReleaseDisposals',
+                    id: 'DartBird',
                     layerType: 'esri-feature',
-                    url: 'https://maps-cartes.ec.gc.ca/arcgis/rest/services/StoryRAMP/410b88da_0ed1_4749_903f_5e76c24e2e5f/MapServer/2'
+                    url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/BadDates/MapServer/0'
                 },
                 {
                     id: 'ErroredLayer',
@@ -119,7 +121,7 @@ let config = {
                 },
                 {
                     id: 'table',
-                    name: 'OilSands',
+                    name: 'OilSands Table',
                     layerType: 'data-esri-table',
                     url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/Oilsands/MapServer/5'
                 }
@@ -138,8 +140,8 @@ let config = {
                                         content: 'Represents a simple grid with a single layer.'
                                     },
                                     {
-                                        name: 'NPRI',
-                                        layerId: 'NPRI'
+                                        name: 'Oil Sands',
+                                        layerId: 'JOSM'
                                     }
                                 ]
                             },
@@ -192,8 +194,8 @@ let config = {
                                         name: 'Major Cities'
                                     },
                                     {
-                                        layerId: 'Heroni',
-                                        name: 'Heroni'
+                                        layerId: 'EsriTurbine',
+                                        name: 'ESRI Turbines'
                                     }
                                 ]
                             },
@@ -234,8 +236,8 @@ let config = {
                                         content: 'A merge grid where one layer has failed to load.'
                                     },
                                     {
-                                        name: 'Release Disposals',
-                                        layerId: 'ReleaseDisposals'
+                                        name: 'Smoking Bird',
+                                        layerId: 'DartBird'
                                     },
                                     {
                                         name: 'Errored Layer',
@@ -279,7 +281,7 @@ let config = {
                                     layerId: 'MajorCities'
                                 },
                                 {
-                                    layerId: 'Heroni'
+                                    layerId: 'EsriTurbine'
                                 }
                             ],
                             options: {
@@ -320,7 +322,7 @@ let config = {
                             gridId: 'ErrorMergeGrid',
                             layers: [
                                 {
-                                    layerId: 'ReleaseDisposals'
+                                    layerId: 'DartBird'
                                 },
                                 {
                                     layerId: 'ErroredLayer'


### PR DESCRIPTION
 ### Related Item(s)

- Donethankses https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2827

### Changes
- Changes layer visibility detection in grid to consider merge grids / multiple layer sources
- Fixes expired layer urls in merge grid sample

### Notes

As we're pushing this in fast, I'm not caring about the special grid message saying "Layer Hidden" when a grammar grouse would proclaim it should be "Layers Hidden".  We can enhance this later if its really needed.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

Single Layer Grid

1. Open Enhanced Sample 1 (Happy)
2. Open the Grid for the happy layer
3. Ensure grid has title 🦉 
4. Turn layer viz off.  See the special filter message in the grid 🦉 
5. Turn layer viz on. See filter message become unspecial 🦉 
6. Try with active grid filter if ya wanna.

Merge Grid

1. Open Classic Sample 38 (Merge Grid)
2. Open a grid in the Homogenous Merge Grid legend section.
3. See the grid opens without hysterics.  See the grid has a title. See the filter message is normal. 🦉 
4. Turn viz off for one of the five layers. See filter message adapt but not get special 🦉 
5. Turn viz off for the remaining layers. See filter message becomes special when the final layer is turned off 🦉 
6. Turn one layer viz back on. See message become unspecial 🦉 
7. Open the Smoking Bird layer grid.
8. See the grid opens without hysterics.  See the grid has a title. See the filter message is normal. 🦉 
9. Turn viz off for Smoking Bird. See the filter message become special 🦉 
10. Turn viz back on. See message become unspecial 🦉

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2828)
<!-- Reviewable:end -->
