### PR TITLE
Added padding to detail page properties

### DIFF
--- a/src/fixtures/details/templates/esri-default.vue
+++ b/src/fixtures/details/templates/esri-default.vue
@@ -7,7 +7,7 @@
         >
             <span class="inline font-bold">{{ val.alias }}</span>
             <span class="flex-auto"></span>
-            <span class="inline" v-html="formatValues(val.value, val.alias, val.type)"></span>
+            <span class="inline ml-8" v-html="formatValues(val.value, val.alias, val.type)"></span>
         </div>
     </div>
 </template>


### PR DESCRIPTION
### Related Item(s)
Issue #2825 

### Changes
- Added some padding between the property name and value in details panel

### Notes
- I modified the happy sample for easy testing, will revert when approved

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to happy sample 01
2. Open the details panel for the left eye, right eye, and mouth

Left eye is how it looks when the text is just long enough to wrap to another line
Right eye is how it looks with just enough space to fit both the name and value on the same line
Mouth is how the original property from the issue looks (although before adding padding it was already on separate lines for me)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2831)
<!-- Reviewable:end -->
