### PR TITLE
fix event listener console grouse when opening grid on mobile

### DIFF
--- a/src/fixtures/grid/accessibility.ts
+++ b/src/fixtures/grid/accessibility.ts
@@ -68,10 +68,10 @@ export class GridAccessibilityManager {
             this.headerRows[0].querySelectorAll('.ag-header-cell')
         ) as HTMLElement[];
         headerCells.forEach((cell, index) => {
-            if (index < 1) {
+            const buttons = Array.prototype.slice.call(cell.querySelectorAll('button')) as HTMLElement[];
+            if (index < 1 || buttons.length === 0) {
                 return;
             }
-            const buttons = Array.prototype.slice.call(cell.querySelectorAll('button')) as HTMLElement[];
 
             cell.addEventListener('keydown', (event: KeyboardEvent) => {
                 this.cellKeydownHandler(event, cell, buttons);
@@ -99,10 +99,10 @@ export class GridAccessibilityManager {
             this.headerRows[0].querySelectorAll('.ag-header-cell')
         ) as HTMLElement[];
         headerCells.forEach((cell, index) => {
-            if (index < 1) {
+            const buttons = Array.prototype.slice.call(cell.querySelectorAll('button')) as HTMLElement[];
+            if (index < 1 || buttons.length === 0) {
                 return;
             }
-            const buttons = Array.prototype.slice.call(cell.querySelectorAll('button')) as HTMLElement[];
 
             cell.removeEventListener('keydown', (event: KeyboardEvent) => {
                 this.cellKeydownHandler(event, cell, buttons);


### PR DESCRIPTION
### Related Item(s)
#2836 

### Changes
- Fixes an issue where if the details and zoom columns are unpinned, an error relating to event listeners would appear in the console. Attempting to focus on column headers that have sorting or reordering buttons would not work.

### Notes

This issue was actually related to the pinned grid columns. If the details and zoom columns are not pinned to the left (which is done by default in mobile mode), the empty column headers are included as children to the `ag-header-cell` div. Because these column headers contain no buttons, the code snippet mentioned in the original issue fails and causes the error.

Because these column headers are empty, it should be sufficient to skip adding/removing the event listeners to them.


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open the demo link and size your browser to enter mobile mode (~500px width).
2. Open the developer console.
3. Open the data grid and notice that no error appears. If you navigate to a column header that does have sort and reorder buttons, you should be able to press enter and navigate to the buttons as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2840)
<!-- Reviewable:end -->
