### PR TITLE
v-truncate removed for select and options

### DIFF
--- a/src/fixtures/geosearch/top-filters.vue
+++ b/src/fixtures/geosearch/top-filters.vue
@@ -2,7 +2,7 @@
     <div class="rv-geosearch-top-filters sm:flex items-center w-full ml-8 mb-14">
         <div class="w-fit inline-block sm:w-1/2 h-26 mb-8 sm:mb-0 pr-16 sm:pr-0">
             <select
-                class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer"
+                class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer pr-24 truncate"
                 :value="queryParams.province"
                 :aria-label="t('geosearch.filters.province')"
                 v-on:change="
@@ -10,19 +10,18 @@
                         province: ($event.target as HTMLSelectElement).value
                     })
                 "
-                v-truncate
             >
-                <option value="" disabled hidden v-truncate>
+                <option value="" disabled hidden>
                     {{ t('geosearch.filters.province') }}
                 </option>
-                <option v-for="province in provinces" v-bind:key="province.code" v-truncate>
+                <option v-for="province in provinces" v-bind:key="province.code">
                     {{ province.name }}
                 </option>
             </select>
         </div>
         <div class="sm:w-1/2 h-26 sm:mx-16 flex">
             <select
-                class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer max-w-150"
+                class="border-b border-b-gray-600 w-full h-full py-0 cursor-pointer max-w-150 pr-24 truncate"
                 :value="queryParams.type"
                 :aria-label="t('geosearch.filters.type')"
                 v-on:change="
@@ -30,7 +29,7 @@
                         type: ($event.target as HTMLSelectElement).value
                     })
                 "
-                v-truncate
+                truncate
             >
                 <option value="" disabled hidden>
                     {{ t('geosearch.filters.type') }}


### PR DESCRIPTION
### Related Item(s)
Issue #2834 

### Changes
- Removed v-truncate from select and options in Geosearch (those don't go hand in hand)
- Added padding so ellipses don't overlap with the dropdown button

### Notes
- Behaviour should be reverted to before the v-truncate changes I made (no tooltip, only truncation)
 
### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps:
1. Open geosearch
2. Hover over Provinces and Types dropdowns— no tooltips
3. Select an option with a long name— should be truncated with no overlap with the dropdown button

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2841)
<!-- Reviewable:end -->
