### PR TITLE
Fix flicker when toggling symbol visibility

### DIFF
--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -598,7 +598,18 @@ const addAriaLabels = () => {
 const somethingVisible = computed(() =>
     origLayerIds.value.some(layerId => {
         const layer = iApi.geo.layer.getLayer(layerId);
-        return layer?.layerState === LayerState.LOADED && layer?.visibility;
+
+        if (!layer || layer.layerState !== LayerState.LOADED) {
+            return false;
+        }
+
+        if (layer.mapLayer) {
+            const layerFilter = layer.getSqlFilter(CoreFilter.SYMBOL);
+            // using 1=2 as a hide all features filter instead of relying on layer.visibility
+            if (layerFilter === '1=2') return false;
+        }
+
+        return layer.visibility;
     })
 );
 

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -30,6 +30,8 @@ export class LayerItem extends LegendItem {
 
     handlers: Array<string> = [];
 
+    private symbolSql = ''; // symbol filter SQL used for visibility toggling
+
     /**
      * Creates a new single layer item.
      */
@@ -245,13 +247,30 @@ export class LayerItem extends LegendItem {
 
         // LayerItem additionally deals with symbology and layers
         if (this.layer && this.layer.layerExists) {
-            this.layer.visibility = this.visibility;
+            // If layer supports features, apply the layer visibility filter
+            if (
+                this.layer.supportsFeatures &&
+                this.layer.mapLayer &&
+                this.layer.visibility &&
+                this.layer.canModifyLayer
+            ) {
+                // Use SQL filtering to toggle visibility for feature layers instead of solely updating
+                // this.layer.visibility, which caused flickering/"double draw" when toggling visibility (issue 2815).
+                // Only apply the SQL filter if the layer has been made visible at least once
+                if (!this.visibility) {
+                    this.layer.setSqlFilter(CoreFilter.SYMBOL, '1=2');
+                } else {
+                    this.layer.setSqlFilter(CoreFilter.SYMBOL, this.symbolSql !== '1=2' ? this.symbolSql : '');
+                }
+            } else {
+                this.layer.visibility = this.visibility;
+            }
 
             // check child symbols for visibility
             const someVisible = this._symbologyStack.some((item: LegendSymbology) => item.lastVisbility);
 
             this._symbologyStack.forEach((item: LegendSymbology) => {
-                if (!someVisible) {
+                if (!someVisible && this.visibility) {
                     // if no symbols are visible and we toggled the parent layer on
                     // then set all the child symbols to visible
                     item.lastVisbility = true;
@@ -336,6 +355,8 @@ export class LayerItem extends LegendItem {
                 sql = filterGuts.join(' OR ');
             }
 
+            // save the symbol SQL
+            this.symbolSql = sql;
             this.layer.setSqlFilter(CoreFilter.SYMBOL, sql);
         }
     }


### PR DESCRIPTION
### Related Item(s)
Issue #2815

### Changes
- To prevent the double draw/layer flicker when toggling layer or symbol visibility, switched to use SQL filtering instead of relying on `this.layer.visibility = this.visibility`.
- Updated  grid visibility detection to include the SQL-filtered layers.
- Updated  `Identify Details`  to only display results for layers that are actually visible and not SQL-hidden (`1=2`). 


### Notes
- `EcoGeo` layers don't seem to respond to SQL visibility filtering, so their visibility still relies on `layer.visibility`
- I tried to also fix the existing console errors for toggling individual symbol items by only conditionally updating `layer.visibility`, but the result was inconsistent, so I did not include those fixes.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to Classic Sample 24 (CESI)
2. Disable the visibility of the `Greenhouse gas emissions` layer.
3. Expand the symbology stack and toggle the visibility of an individual symbol 
4. Confirm no double draw/flickering

General testing: 
* Try toggling visibility on different layers and symbols
* Try different samples (e.g., Sample 38 (Merge Grid))
* Open grid and ensure the hidden layers/filtered layers section works as expected
* Run identify and inspect `Identify Details` panel , toggle visibility, and verify behaviour is as expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2844)
<!-- Reviewable:end -->
