### PR TITLE
MIL Flicker fix

### DIFF
--- a/demos/starter-scripts/cesi.js
+++ b/demos/starter-scripts/cesi.js
@@ -459,48 +459,7 @@ let config = {
                         }
                     }
                 },
-                {
-                    id: 'Conserved_Areas',
-                    name: 'Conserved areas',
-                    layerType: 'esri-map-image',
-                    url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
-                    metadata: {
-                        url: 'https://indicators-map.ec.gc.ca/metadata/en/Protected%20Areas.xml'
-                    },
-                    catalogueUrl: 'https://open.canada.ca/data/en/dataset/2888ff57-a21c-448c-a4fa-570c4cabd956',
-                    state: {
-                        visibility: false,
-                        opacity: 1
-                    },
-                    sublayers: [
-                        {
-                            index: 32,
-                            state: {
-                                visibility: false,
-                                opacity: 1
-                            },
-                            nameField: 'E_PA_Name',
-                            fixtures: {
-                                grid: {
-                                    columns: [
-                                        { field: 'E_PA_Name' },
-                                        { field: 'E_PA_Bio_Name' },
-                                        { field: 'E_Province' },
-                                        { field: 'E_PA_Type' },
-                                        { field: 'PA_Area_ha' },
-                                        { field: 'Protected_Date' },
-                                        { field: 'E_Management' },
-                                        { field: 'E_PA_Zone_Desc' },
-                                        { field: 'E_URL' },
-                                        { field: 'Report_Year' },
-                                        { field: 'E_DetailPageURL' }
-                                    ]
-                                }
-                            }
-                        }
-                    ],
-                    singleEntryCollapse: true
-                },
+
                 {
                     id: 'Water_Quality',
                     nameField: 'Name',
@@ -556,14 +515,14 @@ let config = {
                     url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/CESI/MapServer',
                     state: {
                         query: false,
-                        visibility: true,
+                        visibility: false,
                         opacity: 1
                     },
                     sublayers: [
                         {
                             index: 33,
                             state: {
-                                visibility: true,
+                                visibility: false,
                                 opacity: 1
                             }
                         },
@@ -581,13 +540,6 @@ let config = {
                         }
                     ],
                     disabledControls: ['identify', 'data']
-                },
-                {
-                    id: 'AAFC',
-                    name: 'AAFC Land Use',
-                    layerType: 'esri-imagery',
-                    url: 'https://agriculture.canada.ca/atlas/rest/services/servicesimage/utilisation_des_terres_30m_2020/ImageServer',
-                    catalogueUrl: 'https://open.canada.ca/data/en/dataset/fa84a70f-03ad-4946-b0f8-a3b481dd5248'
                 }
             ],
             fixtures: {
@@ -609,10 +561,7 @@ let config = {
                                     }
                                 ]
                             },
-                            {
-                                name: 'Agriculture and Agri-Food Canada',
-                                layerId: 'AAFC'
-                            },
+
                             {
                                 name: 'Water quantity at monitoring stations',
                                 layerId: 'Water_Quantity'
@@ -620,11 +569,6 @@ let config = {
                             {
                                 name: 'Water quality at monitoring sites',
                                 layerId: 'Water_Quality'
-                            },
-                            {
-                                name: 'Conserved areas',
-                                layerId: 'Conserved_Areas',
-                                sublayerIndex: 32
                             },
                             {
                                 name: 'Releases of lead to water by facility',

--- a/src/fixtures/legend/store/layer-item.ts
+++ b/src/fixtures/legend/store/layer-item.ts
@@ -413,7 +413,7 @@ export class LayerItem extends LegendItem {
                 this.handlers.push(
                     this.$iApi.event.on(
                         GlobalEvents.LAYER_DRAWSTATECHANGE,
-                        (payload: { layer: LayerInstance; state: string }) => {
+                        (payload: { layer: LayerInstance; state: DrawState }) => {
                             if (this.layer.uid === payload.layer.uid) {
                                 if (payload.layer.drawState === DrawState.REFRESH) {
                                     // if layer is redrawing, turn on the indicator right away

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -545,6 +545,7 @@ export const enum CoreFilter {
     EXTENT = 'extent', // captures a filter based on an extent. leveraged by the grid to only show rows visible on screen
     INITIAL = 'initial', // used to track an initial filter provided by the layer config
     API = 'api', // this would be a default api key. e.g. if someone just does an API filter set with no key parameter, it would use this.
+    MIL_FLICKER_ERASER = 'mileraser', // used by MILs to force a blank redraw prior to going invisible, to avoid a flicker when becoming visible again.
     PERMANENT = 'permanent' // a filter that is always on and will influence server calls (i.e. prevent data from being downloaded). can only be set via layer config
 }
 


### PR DESCRIPTION
### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2815

### Changes

- Anti-Flicker technology on MIL layers
- Removed dead layers from CESI sample

### Notes

Solution based on the stellar R&D efforts by @rrjk76 ( https://github.com/ramp4-pcar4/ramp4-pcar4/pull/2844 ). Well done :trophy:

### QA Testing


Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

**Testing helper guide:**

There are two situations that could trigger the flicker:

- a sublayer going invisible, then becoming visible with a different symbol configuration
- the parent layer going invisible, then becoming visible with a different symbol OR sublayer viz configuration

That's what you want to pay attention to.

**Single Entry Collapse scenario**

This one handles where sublayer and parent layer visibility are essentially bound, as the legend hides the parent and there is only one child.

1. Open Classic Sample 24 (CESI).
2. Turn off layer visibility for Greenhouse Gas Emissions layer
3. Expand symbols and toggle on one of them.
4. Observe that no flicker occurs.


**Parent / Child scenarios**

This script in the console (via Enhanced Sample 1 - Happy) can be used for these tests.

```js
let cesiMIL;
let cesiMerc;

const config =  {
	id: 'CESI',
	layerType: 'esri-map-image',
	name: 'Sheshi',
	url: 'https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/CESI/MapServer/',
	sublayers: [{ index: 36, name: 'Cadmium Cream Egg' }, { index: 37, name: 'Mercury, the Courier' } ]
};

const runFun = async () => {
  cesiMIL = await debugInstance.dev.easyLayer(config);
  await cesiMIL.loadPromise();
  cesiMerc = cesiMIL.getSublayer(37);
  console.log('stuff is loaded');
};

runFun();
```

1. Run that script
2. Turn off visibility at sublayer level for Mercury
3. Turn on one of the symbols for Mercury (the darker ones are easier to see, avoid the grey one)
4. Observe no flicker.   This covers the sublayer off / parent stayed on case.
5. Reset by turning off the symbol, then turning on Mecury at sublayer leve.
6. Turn off visibility at sublayer level for Cadmium.
7. Turn off visibility at sublayer level for Mercury.  Notice the parent layer is now invisible too (no checkbox).
8. Turn on one of the symbols for Mercury
9. Observe no flicker.   This covers the sublayer off / parent off case.
10. Reset everything again for full visibility.
11. Turn off visibility at parent level ("Sheshi").
12. Turn on one of the symbols for Mercury
13. Observe no flicker.   This covers the parent off case.

Extra credit: mod that script so it only has one sublayer, and punch at that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2851)
<!-- Reviewable:end -->
