### PR TITLE
Remove ghost focus after datatable

### DIFF
--- a/src/fixtures/grid/accessibility.ts
+++ b/src/fixtures/grid/accessibility.ts
@@ -54,8 +54,6 @@ export class GridAccessibilityManager {
             this.element.querySelectorAll(HEADER_ROW_SELECTOR)
         ) as HTMLElement[];
 
-        this.element.querySelector('.ag-body-horizontal-scroll-viewport')?.setAttribute('tabindex', '-1');
-
         this.initAccessibilityListeners();
         this.initScrollListeners();
     }

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -360,6 +360,7 @@
                 @cell-key-press="onCellKeyPress"
                 :doesExternalFilterPass="doesExternalFilterPass"
                 :isExternalFilterPresent="isExternalFilterPresent"
+                :tabIndex="-1"
             />
         </div>
     </div>
@@ -592,6 +593,13 @@ const addAriaLabels = () => {
     });
 };
 
+const disableViewportTab = () => {
+    const viewports = el.value?.querySelectorAll<HTMLElement>('[data-ref$="Viewport"]');
+    viewports?.forEach((el: HTMLElement) => {
+        el.setAttribute('tabindex', '-1');
+    });
+};
+
 /**
  * Indicates at least one layer in this grid is loaded and visible.
  */
@@ -625,6 +633,7 @@ const onGridReady = (params: any) => {
 
     // Initial load
     addAriaLabels();
+    disableViewportTab();
 
     gridApi.value.addEventListener('rowDataUpdated', addAriaLabels);
 
@@ -689,6 +698,7 @@ const gridRendered = () => {
     gridApi.value.autoSizeAllColumns();
     gridAccessibilityManager.value = new GridAccessibilityManager(el.value!, agGridApi.value as GridApi);
     addAriaLabels();
+    disableViewportTab();
 };
 
 // Updates the global search value.


### PR DESCRIPTION
### Related Item(s)
#2833

### Changes
- Set `tabindex` to `-1` on ag grid viewport elements so that the grid doesn't steal focus when panel isn't active

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open a datatable from the legend (choose one with enough rows/columns to show scrollbars in the grid)
2. Tab to table panel without entering
3. Press tab one more time and confirm focus goes to next focusable item (e.g., next panel or the `About Ramp` icon)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2853)
<!-- Reviewable:end -->
