### PR TITLE
Remove unused Legend Config

### DIFF
--- a/demos/qa-scripts/002-custom-renderer.js
+++ b/demos/qa-scripts/002-custom-renderer.js
@@ -283,11 +283,6 @@ const runPreTest = (config, options, utils) => {
                 }
             ]
         },
-        fixtures: {
-            legend: {
-                toggleSymbology: false
-            }
-        },
         state: {
             opacity: 1,
             visibility: false

--- a/demos/starter-scripts/custom-renderer.js
+++ b/demos/starter-scripts/custom-renderer.js
@@ -501,11 +501,6 @@ let config = {
                             }
                         ]
                     },
-                    fixtures: {
-                        legend: {
-                            toggleSymbology: false
-                        }
-                    },
                     state: {
                         opacity: 1,
                         visibility: false

--- a/demos/starter-scripts/info-section.js
+++ b/demos/starter-scripts/info-section.js
@@ -61,11 +61,6 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
-                            },
-                            fixtures: {
-                                legend: {
-                                    toggleSymbology: false
-                                }
                             }
                         },
                         {
@@ -73,11 +68,6 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
-                            },
-                            fixtures: {
-                                legend: {
-                                    toggleSymbology: false
-                                }
                             }
                         }
                     ],

--- a/demos/starter-scripts/map-image-layer.js
+++ b/demos/starter-scripts/map-image-layer.js
@@ -61,11 +61,6 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
-                            },
-                            fixtures: {
-                                legend: {
-                                    toggleSymbology: false
-                                }
                             }
                         },
                         {
@@ -73,11 +68,6 @@ let config = {
                             state: {
                                 opacity: 1,
                                 visibility: true
-                            },
-                            fixtures: {
-                                legend: {
-                                    toggleSymbology: false
-                                }
                             }
                         }
                     ],

--- a/schema.json
+++ b/schema.json
@@ -1957,14 +1957,7 @@
                 },
                 "legend": {
                     "type": "object",
-                    "description": "Layer-specific legend configuration",
-                    "properties": {
-                        "toggleSymbology": {
-                            "type": "boolean",
-                            "default": true,
-                            "description": "Allows individual symbols to have visibility toggled on/off."
-                        }
-                    }
+                    "description": "Layer-specific legend configuration. Currently no settings available"
                 },
                 "settings": {
                     "type": "object",

--- a/src/api/config-upgrade.ts
+++ b/src/api/config-upgrade.ts
@@ -771,93 +771,92 @@ function layerCommonPropertiesUpgrader(r2layer: any) {
     // deal with fields mayhem
     fieldsSausageGrinder(r2layer, r4layer);
 
-    if (typeof r2layer.toggleSymbology !== 'undefined' || r2layer.table) {
-        r4layer.fixtures = {};
-        if (typeof r2layer.toggleSymbology !== 'undefined') {
-            r4layer.fixtures.legend = {
-                toggleSymbology: r2layer.toggleSymbology
-            };
-        }
-        if (r2layer.table) {
-            r4layer.fixtures.grid = {};
-            if (r2layer.table.title) {
-                r4layer.fixtures.grid.title = r2layer.table.title;
-            }
-            if (r2layer.table.description) {
-                console.warn(
-                    `description property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
-                );
-            }
-            if (typeof r2layer.table.maximize !== 'undefined') {
-                console.warn(
-                    `maximize property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
-                );
-            }
-            if (r2layer.table.search) {
-                if (r2layer.table.search.enabled) {
-                    r4layer.fixtures.grid.search = r2layer.table.search.enabled;
-                }
-                if (r2layer.table.search.value) {
-                    r4layer.fixtures.grid.searchFilter = r2layer.table.search.value;
-                }
-            }
+    if (typeof r2layer.toggleSymbology !== 'undefined') {
+        console.warn(`toggleSymbology property provided in layer ${r2layer.id} cannot be mapped and will be skipped.`);
+    }
 
-            if (typeof r2layer.table.lazyFilter !== 'undefined') {
-                console.warn(
-                    `lazyFilter property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
-                );
+    if (r2layer.table) {
+        r4layer.fixtures = {
+            grid: {}
+        };
+
+        if (r2layer.table.title) {
+            r4layer.fixtures.grid.title = r2layer.table.title;
+        }
+        if (r2layer.table.description) {
+            console.warn(
+                `description property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
+            );
+        }
+        if (typeof r2layer.table.maximize !== 'undefined') {
+            console.warn(
+                `maximize property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
+            );
+        }
+        if (r2layer.table.search) {
+            if (r2layer.table.search.enabled) {
+                r4layer.fixtures.grid.search = r2layer.table.search.enabled;
             }
-            if (typeof r2layer.table.applyMap !== 'undefined') {
-                r4layer.fixtures.grid.applyMap = r2layer.table.applyMap;
+            if (r2layer.table.search.value) {
+                r4layer.fixtures.grid.searchFilter = r2layer.table.search.value;
             }
-            if (typeof r2layer.table.showFilter !== 'undefined') {
-                r4layer.fixtures.grid.showFilter = r2layer.table.showFilter;
-            }
-            if (typeof r2layer.table.filterByExtent !== 'undefined') {
-                r4layer.fixtures.grid.filterByExtent = r2layer.table.filterByExtent;
-            }
-            if (typeof r2layer.table.searchStrictMatch !== 'undefined') {
-                console.warn(
-                    `searchStrictMatch property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
-                );
-            }
-            if (typeof r2layer.table.printEnabled !== 'undefined') {
-                console.warn(
-                    `printEnabled property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
-                );
-            }
-            if (r2layer.table.columns) {
-                r4layer.fixtures.grid.columns = [];
-                r2layer.table.columns.forEach((r2tableColumn: any) => {
-                    const r4tableColumn: any = {
-                        field: r2tableColumn.data
-                    };
-                    if (r2tableColumn.title) {
-                        r4tableColumn.title = r2tableColumn.title;
-                    }
-                    if (r2tableColumn.description) {
-                        console.warn(
-                            `description property provided in column property in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
-                        );
-                    }
-                    if (typeof r2tableColumn.visible !== 'undefined') {
-                        r4tableColumn.visible = r2tableColumn.visible;
-                    }
-                    if (r2tableColumn.width) {
-                        r4tableColumn.width = r2tableColumn.width;
-                    }
-                    if (r2tableColumn.sort) {
-                        r4tableColumn.sort = r2tableColumn.sort;
-                    }
-                    if (typeof r2tableColumn.searchable !== 'undefined') {
-                        r4tableColumn.searchable = r2tableColumn.searchable;
-                    }
-                    if (r2tableColumn.filter) {
-                        r4tableColumn.filter = r2tableColumn.filter;
-                    }
-                    r4layer.fixtures.grid.columns.push(r4tableColumn);
-                });
-            }
+        }
+
+        if (typeof r2layer.table.lazyFilter !== 'undefined') {
+            console.warn(
+                `lazyFilter property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
+            );
+        }
+        if (typeof r2layer.table.applyMap !== 'undefined') {
+            r4layer.fixtures.grid.applyMap = r2layer.table.applyMap;
+        }
+        if (typeof r2layer.table.showFilter !== 'undefined') {
+            r4layer.fixtures.grid.showFilter = r2layer.table.showFilter;
+        }
+        if (typeof r2layer.table.filterByExtent !== 'undefined') {
+            r4layer.fixtures.grid.filterByExtent = r2layer.table.filterByExtent;
+        }
+        if (typeof r2layer.table.searchStrictMatch !== 'undefined') {
+            console.warn(
+                `searchStrictMatch property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
+            );
+        }
+        if (typeof r2layer.table.printEnabled !== 'undefined') {
+            console.warn(
+                `printEnabled property provided in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
+            );
+        }
+        if (r2layer.table.columns) {
+            r4layer.fixtures.grid.columns = [];
+            r2layer.table.columns.forEach((r2tableColumn: any) => {
+                const r4tableColumn: any = {
+                    field: r2tableColumn.data
+                };
+                if (r2tableColumn.title) {
+                    r4tableColumn.title = r2tableColumn.title;
+                }
+                if (r2tableColumn.description) {
+                    console.warn(
+                        `description property provided in column property in table property in layer ${r2layer.id} cannot be mapped and will be skipped.`
+                    );
+                }
+                if (typeof r2tableColumn.visible !== 'undefined') {
+                    r4tableColumn.visible = r2tableColumn.visible;
+                }
+                if (r2tableColumn.width) {
+                    r4tableColumn.width = r2tableColumn.width;
+                }
+                if (r2tableColumn.sort) {
+                    r4tableColumn.sort = r2tableColumn.sort;
+                }
+                if (typeof r2tableColumn.searchable !== 'undefined') {
+                    r4tableColumn.searchable = r2tableColumn.searchable;
+                }
+                if (r2tableColumn.filter) {
+                    r4tableColumn.filter = r2tableColumn.filter;
+                }
+                r4layer.fixtures.grid.columns.push(r4tableColumn);
+            });
         }
     }
     return r4layer;

--- a/src/fixtures/legend/api/legend.ts
+++ b/src/fixtures/legend/api/legend.ts
@@ -43,11 +43,10 @@ export class LegendAPI extends FixtureInstance {
         this.handlePanelTeleports(['legend']);
 
         // get all layer fixture configs to read layer-specific legend properties
-        const layerLegendConfigs: { [layerId: string]: any } = this.getLayerFixtureConfigs();
+        // Note: there are currently no layer-specific settings for legend blocks.
+        // const layerLegendConfigs: { [layerId: string]: any } = this.getLayerFixtureConfigs();
 
         legendConfig.root.children.forEach(legendItem => {
-            // pass the layer legend fixture config
-            legendItem.layerLegendConfigs = layerLegendConfigs;
             this.addItem(legendItem);
         });
 
@@ -89,11 +88,6 @@ export class LegendAPI extends FixtureInstance {
         // construct children
         if (children) {
             children.forEach((childConf: any) => {
-                // pass the layer fixture config to child items
-                if (itemConf.layerLegendConfigs !== undefined) {
-                    childConf.layerLegendConfigs = itemConf.layerLegendConfigs;
-                }
-
                 // ts ignoring below because returned item is "LegendItem", but accepted type is "LayerItem | SectionItem"
                 // which is the same thing! (╯°□°）╯︵ ┻━┻
                 item!.children.push(this.createItem(childConf, item));


### PR DESCRIPTION
### Changes
- Remove unused legend fixture config at the layer level
- Remove legend code pointlessly adding it to legend blocks
- Clean up samples, schema
- Give proper warning on RAMP2 config converter

### Notes

I suspect this got added during the Ramp2 --> Ramp4 feature migration, then never implemented.

The RAMP2 function would let you hide the symbol visibility toggles. This is never asked for; if we end up needing it, this PR can be reversed easy enough and then the functionality would need to get written.  As of right now its just confusing.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Nothing to really test. Open some of your favourite samples and check that the legend appears and works real good.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2854)
<!-- Reviewable:end -->
