### PR TITLE
Stop crash on unsupported page lang

### DIFF
--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="iu">
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/lang/index.ts
+++ b/src/lang/index.ts
@@ -11,6 +11,9 @@ export type I18nComponentOptions = {
 
 const lang = 'en';
 
+// This should align with the columns in the language CSV files
+const supportedLangs = ['en', 'fr'];
+
 // default number localization
 // settings can be overidden when the $n is called
 const numberFormats = {
@@ -31,11 +34,19 @@ const numberFormats = {
 };
 
 export function i18n(): I18n<LocaleMessages<VueMessageType>, IntlDateTimeFormats, IntlNumberFormats, string, false> {
+    let validLang = document.documentElement!.getAttribute('lang') || lang;
+
+    if (!supportedLangs.includes(validLang)) {
+        // setting `locale` below to something not supported causes issues, despite the `fallbackLocale`.
+        // the fallback only helps in i18n string lookups. Stuff in RAMP still gets confused.
+        validLang = lang;
+    }
+
     // @ts-expect-error TODO: explain why this is needed or remove
     return createI18n({
         legacy: false,
         // get the language of the page from the root `html` node
-        locale: document.documentElement!.getAttribute('lang') || lang,
+        locale: validLang,
         fallbackLocale: lang,
         globalInjection: true,
         messages,


### PR DESCRIPTION
### Related Item(s)

- #2868

### Changes
- Adds additional validation when setting local based on page language

### Notes

Needed for a Storylines sitting in an Inuktitut page.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open any Enhanced Sample. The page lang is temporarily Inuktitut.  See that English loads.
2. Open any Classic Sample. The page lang is English. See that English loads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2869)
<!-- Reviewable:end -->
