### PR TITLE
Enhance focus management and tabindex handling in panel components for scroll

### DIFF
--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -49,7 +49,8 @@
             </div>
         </header>
 
-        <div v-if="content" class="p-8 flex-grow overflow-y-auto" ref="contentEl">
+        <!-- Default to non-tabbable; script promotes to tabindex=0 only for standalone scroll regions. -->
+        <div v-if="content" class="p-8 flex-grow overflow-y-auto" ref="contentEl" tabindex="-1">
             <slot name="content" v-if="$slots.content"></slot>
             <div v-else-if="screenContent" v-html="screenContent.innerHTML"></div>
         </div>
@@ -68,6 +69,7 @@ import type { PanelDirection } from '@/stores/panel';
 import { usePanelStore } from '@/stores/panel';
 import { useI18n } from 'vue-i18n';
 import { useAppbarStore } from '@/fixtures/appbar/store';
+import { keyboardTooltipTest } from '@/utils/keyboard';
 
 const { t } = useI18n();
 const panelStore = usePanelStore();
@@ -76,6 +78,8 @@ const iApi = inject('iApi') as InstanceAPI;
 const el = useTemplateRef('el');
 const contentEl = useTemplateRef('contentEl');
 const contentResizeObserver = ref<ResizeObserver | null>();
+const contentMutationObserver = ref<MutationObserver | null>();
+const contentTabIndexObserver = ref<MutationObserver | null>();
 defineExpose({ el });
 
 const props = defineProps({
@@ -106,9 +110,55 @@ const props = defineProps({
 const temporary = computed((): Array<string> | undefined => (iApi.fixture.get('appbar') ? appbarStore.temporary : []));
 const mobileView = computed(() => panelStore.mobileView);
 const reorderable = computed(() => panelStore.reorderable);
+// Managed focus descendants own keyboard traversal; wrapper should not become a competing tab stop.
+const MANAGED_FOCUS_SELECTOR = '[focus-list], [focus-container]';
+const isScrollable = (element: HTMLElement) => element.scrollHeight > element.clientHeight;
+const getManagedFocusTarget = (element: HTMLElement) => element.querySelector<HTMLElement>(MANAGED_FOCUS_SELECTOR);
+const getExpectedContentTabIndex = () => {
+    if (!contentEl.value) {
+        return '-1';
+    }
 
-const isScrollable = (element: HTMLElement) => {
-    return element.scrollHeight > element.clientHeight;
+    const hasManagedFocusChildren = !!getManagedFocusTarget(contentEl.value);
+    // Focus wrapper only for pure scroll containers; defer to managed focus systems otherwise.
+    return isScrollable(contentEl.value) && !hasManagedFocusChildren ? '0' : '-1';
+};
+const syncContentTabIndex = () => {
+    if (!contentEl.value) {
+        return;
+    }
+
+    const expectedTabIndex = getExpectedContentTabIndex();
+    // Self-heal tabindex if external code mutates it.
+    if (contentEl.value.getAttribute('tabindex') !== expectedTabIndex) {
+        contentEl.value.setAttribute('tabindex', expectedTabIndex);
+    }
+};
+const contentFocusEvent = (e: FocusEvent) => {
+    if (e.target !== contentEl.value || !contentEl.value) {
+        return;
+    }
+
+    const focusTarget = getManagedFocusTarget(contentEl.value);
+    if (!focusTarget) {
+        return;
+    }
+
+    // Avoid trapping backward traversal if focus is leaving descendants.
+    const previous = e.relatedTarget as HTMLElement | null;
+    if (previous && contentEl.value.contains(previous)) {
+        return;
+    }
+
+    focusTarget.focus();
+};
+const blurEvent = () => {
+    (el.value as any)?._tippy?.hide();
+};
+const keyupEvent = (e: Event) => {
+    if (keyboardTooltipTest(e, el.value as HTMLElement)) {
+        (el.value as any)?._tippy?.show();
+    }
 };
 
 const checkMode = () => !mobileView.value && !props.panel.teleport;
@@ -126,37 +176,39 @@ const screenContent = computed(() => {
 });
 
 onMounted(() => {
-    el.value?.addEventListener('blur', () => {
-        (el.value as any)?._tippy?.hide();
-    });
+    el.value?.addEventListener('blur', blurEvent);
+    el.value?.addEventListener('keyup', keyupEvent);
 
-    el.value?.addEventListener('keyup', (e: KeyboardEvent) => {
-        if (e.key === 'Tab' && el.value?.matches(':focus')) {
-            (el.value as any)._tippy.show();
-        }
-    });
-
-    contentResizeObserver.value = new ResizeObserver(() => {
-        if (isScrollable(contentEl.value!)) {
-            contentEl.value?.setAttribute('tabIndex', '0');
-        } else {
-            contentEl.value?.removeAttribute('tabIndex');
-        }
-    });
-    contentResizeObserver.value.observe(contentEl.value!);
+    if (contentEl.value) {
+        contentEl.value.addEventListener('focus', contentFocusEvent);
+        // Keep rule in sync when layout/overflow changes (e.g., panel resize, async content growth).
+        contentResizeObserver.value = new ResizeObserver(syncContentTabIndex);
+        contentResizeObserver.value.observe(contentEl.value);
+        // Keep rule in sync when focus-managed descendants are mounted/unmounted.
+        contentMutationObserver.value = new MutationObserver(syncContentTabIndex);
+        contentMutationObserver.value.observe(contentEl.value, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['focus-list', 'focus-container']
+        });
+        // Guard against outside tabindex mutations on the wrapper itself.
+        contentTabIndexObserver.value = new MutationObserver(syncContentTabIndex);
+        contentTabIndexObserver.value.observe(contentEl.value, {
+            attributes: true,
+            attributeFilter: ['tabindex']
+        });
+        syncContentTabIndex();
+    }
 });
 
 onBeforeUnmount(() => {
-    el.value?.removeEventListener('blur', () => {
-        (el.value as any)._tippy.hide();
-    });
-
-    el.value?.removeEventListener('keyup', (e: KeyboardEvent) => {
-        if (e.key === 'Tab' && el.value?.matches(':focus')) {
-            (el.value as any)._tippy.show();
-        }
-    });
-    contentResizeObserver.value!.disconnect();
+    el.value?.removeEventListener('blur', blurEvent);
+    el.value?.removeEventListener('keyup', keyupEvent);
+    contentEl.value?.removeEventListener('focus', contentFocusEvent);
+    contentResizeObserver.value?.disconnect();
+    contentMutationObserver.value?.disconnect();
+    contentTabIndexObserver.value?.disconnect();
 });
 </script>
 

--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -10,7 +10,7 @@ const CONTAINER_ATTR = 'focus-container';
 const LIST_ATTR = 'focus-list';
 const ICON_ATTR = 'focus-icon';
 const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
-const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}],[${ICON_ATTR}],[tabIndex]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}],[${ICON_ATTR}],[tabindex]`;
 
 let managers: FocusContainerManager[] = [];
 

--- a/src/directives/focus-list/focus-list.ts
+++ b/src/directives/focus-list/focus-list.ts
@@ -24,7 +24,7 @@ const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
 const TRUNCATE_ATTR = 'truncate-text';
 const SHOW_TRUNCATE = 'show-truncate';
 const FOCUSED_CLASS = 'focused';
-const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}],[${ICON_ATTR}],[tabIndex]`;
+const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],[${LIST_ATTR}],[${ICON_ATTR}],[tabindex]`;
 
 // TODO: Figure out a way to put the control scheme into the description of the focus-list for screen readers (hidden text?), or see if the help file would be sufficient.
 

--- a/src/fixtures/basemap/item.vue
+++ b/src/fixtures/basemap/item.vue
@@ -5,7 +5,7 @@
             type="button"
             :aria-label="t('basemap.select')"
             @click="selectBasemap(basemap)"
-            v-focus-item
+            v-focus-item="'show-truncate'"
         >
             <!-- thumbnail -->
             <div>
@@ -133,6 +133,8 @@ const keyupEvent = (e: Event) => {
         (basemapInfo.value as any)._tippy.show();
     }
 };
+const mouseEnterEvent = () => (basemapInfo.value as any)?._tippy?.show();
+const mouseLeaveEvent = () => (basemapInfo.value as any)?._tippy?.hide();
 
 const blurEvent = () => {
     infoTooltipToggle.value = false;
@@ -152,19 +154,19 @@ const mobileTouchEvent = (e: Event) => {
 };
 
 onMounted(() => {
-    basemapInfo.value?.addEventListener('mouseenter', () => (basemapInfo.value as any)._tippy.show());
-    basemapInfo.value?.addEventListener('mouseleave', () => (basemapInfo.value as any)._tippy.hide());
+    basemapInfo.value?.addEventListener('mouseenter', mouseEnterEvent);
+    basemapInfo.value?.addEventListener('mouseleave', mouseLeaveEvent);
     basemapInfo.value?.addEventListener('click', mobileTouchEvent);
     basemapInfo.value?.addEventListener('keyup', keyupEvent);
     basemapInfo.value?.addEventListener('blur', blurEvent);
 });
 
 onBeforeUnmount(() => {
-    basemapInfo.value?.removeEventListener('mouseenter', () => (basemapInfo.value as any)._tippy.show());
-    basemapInfo.value?.removeEventListener('mouseleave', () => (basemapInfo.value as any)._tippy.hide());
+    basemapInfo.value?.removeEventListener('mouseenter', mouseEnterEvent);
+    basemapInfo.value?.removeEventListener('mouseleave', mouseLeaveEvent);
     basemapInfo.value?.removeEventListener('click', mobileTouchEvent);
-    basemapInfo.value?.removeEventListener('focus', () => keyupEvent);
-    basemapInfo.value?.removeEventListener('blur', () => blurEvent);
+    basemapInfo.value?.removeEventListener('keyup', keyupEvent);
+    basemapInfo.value?.removeEventListener('blur', blurEvent);
 });
 </script>
 


### PR DESCRIPTION
### Related Item(s)
#2842 

### Changes
- [FIX] focus moves to inner list/container for scrollable panel contents

### Notes
Changes the panel content logic so that scrollable content does not get focus if there is a child  `v-focus-list` or `v-focus-container`.  

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to Classic Sample 27 "Basic Map with File Layers"
2. Open Basemap panel
3. Tab to basemap panel. Mash Enter to hop into the panel. Tab through the header.
4. See the focus on entire basemap list. 
5. Arrow to the first Lambert map (Transportation), which is truncated. See a tooltip

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2874)
<!-- Reviewable:end -->
