### PR TITLE
Basic support for text symbols

### DIFF
--- a/src/geo/utils/symbology.ts
+++ b/src/geo/utils/symbology.ts
@@ -234,6 +234,37 @@ export class SymbologyAPI extends APIScope {
     }
 
     /**
+     * Generates a letter SVG (a single char in a box) in an active svg draw object. Used in placeholders and special symbols.
+     *
+     * @param {svgjs.Doc} svgDrawer an active svg draw object that has already been created and sized. Will be modified.
+     * @param  {String} letter what letter to use. If a longer string is supplied, will use first letter
+     * @param  {String} colour colour to use in the background
+     */
+    private generateLetterSvg(svgDrawer: svgjs.Doc, letter: string, colour = '#000'): void {
+        svgDrawer
+            .rect(this.CONTENT_IMAGE_SIZE, this.CONTENT_IMAGE_SIZE)
+            .center(this.CONTAINER_CENTER, this.CONTAINER_CENTER)
+            .fill(colour);
+
+        const firstLetter = letter[0].toUpperCase();
+
+        const textElement = svgDrawer
+            .text(firstLetter)
+            .size(23)
+            .fill('#fff')
+            .attr({
+                'font-weight': 'bold',
+                'font-family': 'Roboto'
+            })
+            .center(this.CONTAINER_CENTER, this.CONTAINER_CENTER);
+
+        textElement.tspan(firstLetter).addClass('grid-icons').attr({
+            dy: '29.900000000000002',
+            x: '7.6875'
+        });
+    }
+
+    /**
      * Generates a placeholder symbology graphic.
      * @function generatePlaceholderSymbology
      * @private
@@ -246,24 +277,7 @@ export class SymbologyAPI extends APIScope {
             .size(this.CONTAINER_SIZE, this.CONTAINER_SIZE)
             .viewbox(0, 0, this.CONTAINER_SIZE, this.CONTAINER_SIZE);
 
-        draw.rect(this.CONTENT_IMAGE_SIZE, this.CONTENT_IMAGE_SIZE)
-            .center(this.CONTAINER_CENTER, this.CONTAINER_CENTER)
-            .fill(colour);
-
-        const textElement = draw
-            .text(name[0].toUpperCase()) // take the first letter
-            .size(23)
-            .fill('#fff')
-            .attr({
-                'font-weight': 'bold',
-                'font-family': 'Roboto'
-            })
-            .center(this.CONTAINER_CENTER, this.CONTAINER_CENTER);
-
-        textElement.tspan(name[0].toUpperCase()).addClass('grid-icons').attr({
-            dy: '29.900000000000002',
-            x: '7.6875'
-        });
+        this.generateLetterSvg(draw, name, colour);
 
         return {
             name,
@@ -545,7 +559,8 @@ export class SymbologyAPI extends APIScope {
 
             text() {
                 // esriTS
-                console.error('no support for feature service legend of text symbols');
+                // for basic support, we are just drawing an 'A'.
+                _this.generateLetterSvg(draw, 'A', '#2e8b57');
             },
 
             'picture-fill'() {
@@ -611,7 +626,7 @@ export class SymbologyAPI extends APIScope {
         // jscs:enable requireSpacesInAnonymousFunctionExpression
 
         try {
-            // @ts-expect-error TODO: explain why this is needed or remove
+            // @ts-expect-error we are trusting our key alignment without making fancy types
             await Promise.resolve(symbolTypes[symbol.type]());
 
             // remove element from the page


### PR DESCRIPTION
### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2871

### Changes
- Provides an `A` ramp symbol for TextSymbol renderers.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 1 (Happy)
2. Run the script below in dev console `F12`
3. See the layer load. See the `A` symbol in the legend. See the text to the right of James Bay (the best bay).



```js
const layerConfig = {
  id: 'Point_4_Text',
  name: 'James Bay Lablel Layer',
  layerType: 'file-geojson',
  state: {
    maptips: false
  },
  customRenderer: {
    type: 'simple',
    symbol: {
      type: 'esriTS',
      color: [0, 155, 255, 255],
      xoffset: 75,
      yoffset: -5,
      haloColor: [0, 0, 0, 200],
      haloSize: 1,
      text: 'James Bay, Canada',
      font: {
        size: 13,
        family: 'Arial',
        weight: 'bolder'
      }
    }
  },
  rawData: {
    type: 'FeatureCollection',
    features: [
      {
        type: 'Feature',
        properties: {},
        geometry: {
          type: 'Point',
          coordinates: [-81.5813, 52.2728]
        }
      }
    ]
  }
};

debugInstance.dev.easyLayer(layerConfig);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2881)
<!-- Reviewable:end -->
