### PR TITLE
Show Esri global id in grid

### DIFF
--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -462,7 +462,13 @@ export class LayerAPI extends APIScope {
             if (Array.isArray(sData.fields)) {
                 // parse fields to our format
                 const esriFields: Array<EsriField> = await Promise.all(
-                    sData.fields.map((f: any) => EsriAPI.FieldFromJson(f))
+                    sData.fields.map((f: any) => {
+                        // change global-id to string so it will show in the grid.
+                        if (f.type === 'esriFieldTypeGlobalID') {
+                            f.type = 'esriFieldTypeString';
+                        }
+                        return EsriAPI.FieldFromJson(f);
+                    })
                 );
                 md.fields = esriFields.map(f => {
                     return {

--- a/src/geo/utils/attribute.ts
+++ b/src/geo/utils/attribute.ts
@@ -52,6 +52,7 @@ const arcadeTypeMapper: Map<string, EsriArcadeVarType> = new Map([
     ['long', 'number'],
     ['oid', 'number'],
     ['string', 'text'],
+    ['global-id', 'text'],
     ['geometry', 'geometry'],
     ['date', 'date']
 ]);


### PR DESCRIPTION
### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2875

### Changes
- Swap global id field types to string types

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

1. Go to Enhanced Sample 1 (Happy)
2. Run the script below in the console.
3. Open the data grid on the new layer. See that the `GlobalID` column has values.
4. Click the Details button for any row in the grid. See the `GlobalID` attribute has a value in the Details pane.

```js
const layerConfig = {
	id: 'EsriTurbine',
	layerType: 'esri-feature',
	url: 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/WindTurbines/MapServer/0'
};

debugInstance.dev.easyLayer(layerConfig);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2884)
<!-- Reviewable:end -->
