### PR TITLE
Remove unused details prop

### DIFF
--- a/src/fixtures/details/details-screen.vue
+++ b/src/fixtures/details/details-screen.vue
@@ -14,7 +14,6 @@
                 <!-- Layer Picker, symbology stacks -->
                 <SymbologyList
                     :results="layerResults"
-                    :detailsProperties="detailProperties"
                     :selected="selectedLayer"
                     @selection-changed="changeLayerSelection"
                     v-if="layerResults.length > 1"
@@ -49,7 +48,6 @@ import ResultList from './components/result-list.vue';
 
 import type { PropType } from 'vue';
 import type { IdentifyResult, InstanceAPI, PanelInstance } from '@/api';
-import type { DetailsItemInstance } from './store';
 
 import { useI18n } from 'vue-i18n';
 import { useDetailsStore } from './store';
@@ -74,7 +72,6 @@ const selectedLayer = ref<string>('');
  */
 const activeGreedy = computed<number>(() => detailsStore.activeGreedy);
 const payload = computed<IdentifyResult[]>(() => detailsStore.payload);
-const detailProperties = computed<{ [id: string]: DetailsItemInstance }>(() => detailsStore.properties);
 
 defineProps({
     panel: {


### PR DESCRIPTION
### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2590

### Changes
- Remove unused property from details symbol template

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 7 (O.G. Main)
2. Do an identify in southern ontario where there are lots of features piled up
3. Look at the details pane. Pay attention to the symbol stack / layer swapper thing on the left.
4. Be appeased that everything is in order.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2885)
<!-- Reviewable:end -->
