### PR TITLE
Minor grid enhancements

### DIFF
--- a/src/fixtures/grid/store/table-state-manager.ts
+++ b/src/fixtures/grid/store/table-state-manager.ts
@@ -119,9 +119,12 @@ export default class TableStateManager {
     }
 
     _checkFilters() {
-        // TODO should we be skipping static filters in this check?  clearFilters above seems to suggest we should
+        // examine every filter. if we find an active one that is not static, set the filtered flag
         this._filtered = Object.values(this._columns).some(config => {
-            return config.filter.value !== '' || config.filter.min !== '' || config.filter.max !== '';
+            return (
+                !config.filter.static &&
+                (config.filter.value !== '' || config.filter.min !== '' || config.filter.max !== '')
+            );
         });
     }
 

--- a/src/fixtures/grid/table-component.vue
+++ b/src/fixtures/grid/table-component.vue
@@ -823,8 +823,9 @@ const exportData = (): void => {
         suppressQuotes: true,
         processCellCallback: cell => {
             const cellType = cell.column.getColDef().cellRendererParams;
-            if (!cell.value || (cellType && cellType.type === 'number')) return cell.value;
-            else if (cellType && cellType.type === 'date')
+            if (!cell.value || (cellType && cellType.type === 'number')) {
+                return cell.value;
+            } else if (cellType && cellType.type === 'date') {
                 return `"${new Date(cell.value).toLocaleDateString('en-CA', {
                     timeZone: 'UTC',
                     year: 'numeric',
@@ -834,7 +835,9 @@ const exportData = (): void => {
                     minute: '2-digit',
                     second: '2-digit'
                 })}"`;
-            else return `"${decodeEntities(cell.value).replace(/"/g, '""')}"`;
+            } else {
+                return `"${decodeEntities(cell.value).replace(/"/g, '""')}"`;
+            }
         }
     });
 };
@@ -1564,9 +1567,8 @@ const setUpColumns = async (): Promise<void> => {
         );
 
         // add source table fields to the merge grid fields.
-        // TODO wouldn't this make duplicate objects across multiple layer sources? is there some kind of cleanup later?
-        //      like we'd concact "name" from layer one, then concat "name" from layer two.
-        //      run a console log test if no obvious answer
+        // NOTE this will make duplicate "fields" objects across multiple layer sources.
+        //      these values are only used to derive the data type for columns. So it will do a first-match
         mergedTableAttrs.fields = mergedTableAttrs.fields.concat(
             sourceTableAttribs.fields.map(field => {
                 // Add system columns to the set if they need to be hidden
@@ -1680,27 +1682,26 @@ const setUpColumns = async (): Promise<void> => {
             setUpSpecialColumns(col, columnDefs.value, mergedGridConfig.value.state);
         } else {
             // retrieve the field info for the column
-            // TODO would this have collisions for multiple fields? I suspect the first of many would get matched.
-            const fieldInfo = mergedTableAttrs.fields.find(field => field.name === col.field);
+            const fieldInfo = mergedTableAttrs.fields.find(field => field.name === col.field)!;
 
             col.cellRenderer = colConfig.template === '' ? CellRendererV : iApi.component(colConfig.template);
             col.autoHeight = true;
 
             // set up column filters according to their respective types
-            if (NUM_TYPES.indexOf(fieldInfo!.type) > -1) {
+            if (NUM_TYPES.indexOf(fieldInfo.type) > -1) {
                 setUpNumberFilter(col, mergedGridConfig.value.state);
                 col.filter = 'agNumberColumnFilter';
                 col.cellRendererParams = {
                     type: 'number'
                 };
-            } else if (fieldInfo!.type === FieldType.DATE) {
+            } else if (fieldInfo.type === FieldType.DATE) {
                 setUpDateFilter(col, mergedGridConfig.value.state);
                 col.filter = 'agDateColumnFilter';
                 col.minWidth = 400;
                 col.cellRendererParams = {
                     type: 'date'
                 };
-            } else if (fieldInfo!.type === FieldType.STRING) {
+            } else if (fieldInfo.type === FieldType.STRING) {
                 if (isSelector) {
                     // set up a selector filter instead of a text filter if the `isSelector` flag is true.
                     setUpSelectorFilter(col, mergedTableAttrs.rows, mergedGridConfig.value.state);


### PR DESCRIPTION
### Changes
- Makes the grid clear filter button ignore static filters
- Enhances code structure of grid export to standard syntax
- Clears up a TODO question regarding duplicate fields when assembling a Merge Grid

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Classic sample 29 (Grid Config)
2. Open the grid for layer "WFS Layer"
3. Click the Clear Filter button in the grid.
4. See the Station ID filter clears. See the Object ID filters remain. See the Clear Filter button is now disabled.
5. Type a letter in the Station ID filter.
6. See the Clear Filter button re-enables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2886)
<!-- Reviewable:end -->
