### PR TITLE
Vite 8 Tree Fix

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -55,7 +55,7 @@
             <div class="relative mb-0.5" data-type="select">
                 <div v-if="multiple">
                     <div ref="treeWrapper">
-                        <treeselect
+                        <Treeselect
                             v-model="selected"
                             :multiple="true"
                             :options="options"
@@ -107,7 +107,7 @@
                                     {{ node.label }}
                                 </label>
                             </template>
-                        </treeselect>
+                        </Treeselect>
                     </div>
                     <div v-if="validation && sublayersError" class="text-red-900 text-xs">
                         {{ validationMessages?.required }}
@@ -181,7 +181,7 @@ import type { InstanceAPI } from '@/api';
 import { inject, onBeforeUnmount, onMounted, reactive, ref, useTemplateRef, watch } from 'vue';
 import type { PropType } from 'vue';
 import { useI18n } from 'vue-i18n';
-import Treeselect from '@ramp4-pcar4/vue3-treeselect';
+import { Treeselect } from '@ramp4-pcar4/vue3-treeselect';
 import '@ramp4-pcar4/vue3-treeselect/dist/vue3-treeselect.css';
 
 interface ValidationMsgs {


### PR DESCRIPTION
### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2890

### Changes
- Changes how the Tree component is imported

### Notes

I don't know why this matters.  The Tree component library is exporting the tree as default.

```
export default Treeselect
export { Treeselect, treeselectMixin }
export {
  // Delayed loading.
  LOAD_ROOT_OPTIONS,
  LOAD_CHILDREN_OPTIONS,
  ASYNC_SEARCH,
} from './constants'
```

So this line should be grabbing the default item...

```
import Treeselect from '@ramp4-pcar4/vue3-treeselect';
```

Maybe something fundamental changed in how Vite is processing `import` statements.  Something to keep an eye on (for the sake of package size...though our build size did not noticeably grow).

But we have lots of other default imports in RAMP and they all seem to be working.  Maybe it's something to do with how ancient the Tree library is, might be using some older convention ( 🤷 ).

Who to blame:

<img width="204" height="33" alt="image" src="https://github.com/user-attachments/assets/bf8e2841-b070-47c4-87cf-6c15054e91ed" />


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

1. Open Enhanced Sample 1
2. Add `https://maps-cartes.qa.ec.gc.ca/arcgis/rest/services/TestData/EcoAction/MapServer` via the wizard, as MIL.
3. See that the tree appears 🌳 
4. Add a leaf node, complete the wizard, see that the layer loads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2891)
<!-- Reviewable:end -->
