### PR TITLE
Prevent tooltip party when moving panels and in layer reorder component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -417,6 +417,15 @@
                 "@esri/calcite-components": "^5.0.2"
             }
         },
+        "node_modules/@arcgis/common-components/node_modules/@arcgis/toolkit": {
+            "version": "5.0.10",
+            "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.0.10.tgz",
+            "integrity": "sha512-ZEKolhmoAOl5wl4DoMjn57YqPLNu1QM+x1e3Z4KhwegI9B+An2LXQBM+/UwWPKavKthB8ePPAqXnfctREd2OOQ==",
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
         "node_modules/@arcgis/core": {
             "version": "5.0.10",
             "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-5.0.10.tgz",
@@ -435,9 +444,9 @@
             }
         },
         "node_modules/@arcgis/core/node_modules/marked": {
-            "version": "17.0.3",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.3.tgz",
-            "integrity": "sha512-jt1v2ObpyOKR8p4XaUJVk3YWRJ5n+i4+rjQopxvV32rSndTJXvIzuUdWWIy/1pFQMkQmvTXawzDNqOH/CUmx6A==",
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+            "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
             "license": "MIT",
             "bin": {
                 "marked": "bin/marked.js"
@@ -485,10 +494,19 @@
                 "@esri/calcite-components": "^5.0.2"
             }
         },
-        "node_modules/@arcgis/toolkit": {
+        "node_modules/@arcgis/map-components/node_modules/@arcgis/toolkit": {
             "version": "5.0.10",
             "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.0.10.tgz",
             "integrity": "sha512-ZEKolhmoAOl5wl4DoMjn57YqPLNu1QM+x1e3Z4KhwegI9B+An2LXQBM+/UwWPKavKthB8ePPAqXnfctREd2OOQ==",
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "tslib": "^2.8.1"
+            }
+        },
+        "node_modules/@arcgis/toolkit": {
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/@arcgis/toolkit/-/toolkit-5.0.12.tgz",
+            "integrity": "sha512-jW8Fq8+JCeR2hMd1UbhjMJIGa8I6BplJHd5Az8+oHpyXRGUJF5vHyj3g8mAn1JrnOXOTlcghGVZzfWLrPdhWqQ==",
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "tslib": "^2.8.1"
@@ -680,9 +698,9 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-            "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -692,9 +710,9 @@
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-            "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -924,28 +942,28 @@
             }
         },
         "node_modules/@floating-ui/core": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-            "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+            "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/utils": "^0.2.10"
+                "@floating-ui/utils": "^0.2.11"
             }
         },
         "node_modules/@floating-ui/dom": {
-            "version": "1.7.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-            "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+            "version": "1.7.6",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+            "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
             "license": "MIT",
             "dependencies": {
-                "@floating-ui/core": "^1.7.4",
-                "@floating-ui/utils": "^0.2.10"
+                "@floating-ui/core": "^1.7.5",
+                "@floating-ui/utils": "^0.2.11"
             }
         },
         "node_modules/@floating-ui/utils": {
-            "version": "0.2.10",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-            "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+            "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
             "license": "MIT"
         },
         "node_modules/@foliojs-fork/fontkit": {
@@ -1425,20 +1443,10 @@
             "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
             "license": "MIT"
         },
-        "node_modules/@oxc-project/runtime": {
-            "version": "0.115.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
-            "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^20.19.0 || >=22.12.0"
-            }
-        },
         "node_modules/@oxc-project/types": {
-            "version": "0.115.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-            "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+            "version": "0.120.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
+            "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1799,9 +1807,9 @@
             "license": "MIT"
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
             "cpu": [
                 "arm64"
             ],
@@ -1816,9 +1824,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
             "cpu": [
                 "arm64"
             ],
@@ -1833,9 +1841,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
             "cpu": [
                 "x64"
             ],
@@ -1850,9 +1858,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
             "cpu": [
                 "x64"
             ],
@@ -1867,9 +1875,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-            "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
+            "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
             "cpu": [
                 "arm"
             ],
@@ -1884,9 +1892,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
             "cpu": [
                 "arm64"
             ],
@@ -1901,9 +1909,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-            "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
+            "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
             "cpu": [
                 "arm64"
             ],
@@ -1918,9 +1926,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
             "cpu": [
                 "ppc64"
             ],
@@ -1935,9 +1943,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
             "cpu": [
                 "s390x"
             ],
@@ -1952,9 +1960,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-            "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
             "cpu": [
                 "x64"
             ],
@@ -1969,9 +1977,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-            "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
             "cpu": [
                 "x64"
             ],
@@ -1986,9 +1994,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-            "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
             "cpu": [
                 "arm64"
             ],
@@ -2003,9 +2011,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-            "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
             "cpu": [
                 "wasm32"
             ],
@@ -2020,9 +2028,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-            "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
+            "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2037,9 +2045,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-            "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
+            "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
             "cpu": [
                 "x64"
             ],
@@ -3388,34 +3396,34 @@
             "license": "ISC"
         },
         "node_modules/@vaadin/a11y-base": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-25.0.4.tgz",
-            "integrity": "sha512-I3Qyw5JhdOzUs5rGcOcwMWj878VtRBB1feGGEzv8oNcftuzubehXu1FD6iHI/S+/ljjpNZ39FOQqR2JSi5P3pA==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/a11y-base/-/a11y-base-25.0.8.tgz",
+            "integrity": "sha512-syfKJ6taE1E7Bt8V3EDx1h4H6S12vKAWZ53mxJ/JITEOSicRtOXhIY1SNEdG2zHgISS9efrFFlRDCLo3U8SGQg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@vaadin/component-base": "~25.0.4",
+                "@vaadin/component-base": "~25.0.8",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/checkbox": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-25.0.4.tgz",
-            "integrity": "sha512-f6dRaJaOOok+O5g0RK7BoWdx75fYfE2R60FnAr8f8W1e+Fq/is5jtRjan8G6XvGZ+4M2xwsuab5muAZrpl3DOg==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/checkbox/-/checkbox-25.0.8.tgz",
+            "integrity": "sha512-Ws5OvlH4HvSkb7gpAU6bBIBgAffys3apHTVq5I9l3QfbhZqLe9kZya7+arFLWt4tClLClDffTZEDiEi0bFmfeA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@vaadin/a11y-base": "~25.0.4",
-                "@vaadin/component-base": "~25.0.4",
-                "@vaadin/field-base": "~25.0.4",
-                "@vaadin/vaadin-themable-mixin": "~25.0.4",
+                "@vaadin/a11y-base": "~25.0.8",
+                "@vaadin/component-base": "~25.0.8",
+                "@vaadin/field-base": "~25.0.8",
+                "@vaadin/vaadin-themable-mixin": "~25.0.8",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/component-base": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-25.0.4.tgz",
-            "integrity": "sha512-SQ7+3y/DdEzfWancMaOKpQ3O6lwXnVGbmLVMEiVfYrLU+LM+AaFm6EXKlUvUf16C4FPhaOdJjzcswmXOjCLQjA==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/component-base/-/component-base-25.0.8.tgz",
+            "integrity": "sha512-Om7M6xRPUlQNTmn/tE2rLzDMhpMzgS0gznwf93C+EXnW7OPuDNBH1TdAPFNiTFYjudblj0MG1M2vJ9pSw1FFbg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
@@ -3425,65 +3433,65 @@
             }
         },
         "node_modules/@vaadin/field-base": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-25.0.4.tgz",
-            "integrity": "sha512-Uz0Yusz219uOxmYmznOvcr5JizAfCHKWYYN/hh8KgnvY2n4JUGrQ5kb9LIN1Z/aqxIQkCKECvNl4EsmlQ5Wi/w==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/field-base/-/field-base-25.0.8.tgz",
+            "integrity": "sha512-7RyzDTDdHQTYyuANkpY+4K46LWtIZ6Ve6CtSNA+H5oCQYDqlDg6w5zEqwNhcHx/GGlMzsp3XD+AUMRDIliuszg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@vaadin/a11y-base": "~25.0.4",
-                "@vaadin/component-base": "~25.0.4",
+                "@vaadin/a11y-base": "~25.0.8",
+                "@vaadin/component-base": "~25.0.8",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/grid": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-25.0.4.tgz",
-            "integrity": "sha512-FbG8c50fhJbB34dLvXg9cCcs9sYQK7ZHTVaZb6xCwY2sLoMtL76mVtKoeDwwpZEDcvB/uRXJc4xfPD47gLLb1g==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/grid/-/grid-25.0.8.tgz",
+            "integrity": "sha512-W1DsPQ/G64khAaEUJaOF4JRDw/ab9wJHAgVVvnd6aAbAI7TBn4czmgn78Mmvl9xaqO0zyuNwa4kuFSydIeM+5Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@vaadin/a11y-base": "~25.0.4",
-                "@vaadin/checkbox": "~25.0.4",
-                "@vaadin/component-base": "~25.0.4",
-                "@vaadin/lit-renderer": "~25.0.4",
-                "@vaadin/text-field": "~25.0.4",
-                "@vaadin/vaadin-themable-mixin": "~25.0.4",
+                "@vaadin/a11y-base": "~25.0.8",
+                "@vaadin/checkbox": "~25.0.8",
+                "@vaadin/component-base": "~25.0.8",
+                "@vaadin/lit-renderer": "~25.0.8",
+                "@vaadin/text-field": "~25.0.8",
+                "@vaadin/vaadin-themable-mixin": "~25.0.8",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/input-container": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-25.0.4.tgz",
-            "integrity": "sha512-yLV7Yr8hhWAUZYVkNgasr5b/v5UdBd0DKkYzgvbFo/Vz7Ew4au+st3ID/30xvLj4f84qoDB0wmtPw6PJZ10rEA==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/input-container/-/input-container-25.0.8.tgz",
+            "integrity": "sha512-xx9rRHyYD9m/Ke7RRDfxUvtKsbcpMAMHsH7OLIB00iMIwYkIF+FTlS1EFMSHf6+QoEdmualQu3XyOIexaClz7A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@vaadin/component-base": "~25.0.4",
-                "@vaadin/vaadin-themable-mixin": "~25.0.4",
+                "@vaadin/component-base": "~25.0.8",
+                "@vaadin/vaadin-themable-mixin": "~25.0.8",
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/lit-renderer": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-25.0.4.tgz",
-            "integrity": "sha512-Kpc69Uv/TNTX3izdu8F9rI+h16znKrRZntvIr4Cs9PeG6hWWlszf2NZmcLJZGLFK7/OYGM50bELYWPiP3hhvyw==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/lit-renderer/-/lit-renderer-25.0.8.tgz",
+            "integrity": "sha512-FQhj8Z8dIy52Yx/7fC3B1L6JfyMelBAE0vY1oRXtDkcprgbi8soqO/vgwAjdEtqtcWBg+F/TMGZGnNoEV2sxKQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "lit": "^3.0.0"
             }
         },
         "node_modules/@vaadin/text-field": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-25.0.4.tgz",
-            "integrity": "sha512-c8ZLg8AwbUTYONUjI7WPTNs7YMY7gg6ofVTIoZcQSFMQ+bHD1v0ThjWWEsLvuPN2OHQLCxJln5m2CVUUGVDh2A==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/text-field/-/text-field-25.0.8.tgz",
+            "integrity": "sha512-9ldoknIrDbfel4ACQs06z23In8GXdUd9EfUClO2lDK86mqxa/M7gG6X8o7rs8Qh/2Nb8Sxu+Q1AeuzPzRaOEJQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@vaadin/a11y-base": "~25.0.4",
-                "@vaadin/component-base": "~25.0.4",
-                "@vaadin/field-base": "~25.0.4",
-                "@vaadin/input-container": "~25.0.4",
-                "@vaadin/vaadin-themable-mixin": "~25.0.4",
+                "@vaadin/a11y-base": "~25.0.8",
+                "@vaadin/component-base": "~25.0.8",
+                "@vaadin/field-base": "~25.0.8",
+                "@vaadin/input-container": "~25.0.8",
+                "@vaadin/vaadin-themable-mixin": "~25.0.8",
                 "lit": "^3.0.0"
             }
         },
@@ -3494,13 +3502,13 @@
             "license": "Apache-2.0"
         },
         "node_modules/@vaadin/vaadin-themable-mixin": {
-            "version": "25.0.4",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-25.0.4.tgz",
-            "integrity": "sha512-4RxJy2Kj59Kqak+0cJtiLcpGfXJVumhnEOiZVyZM02wzDkj5hXfvNj0zYVtV2izvq2fsb6n5BJYaCJASiN0jdg==",
+            "version": "25.0.8",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-25.0.8.tgz",
+            "integrity": "sha512-R5UUDnEYOwPnCJZ81T4E8lYeL0jEdmAcXSaxCTqdCO9q1FaxjDgkwzVMMqCyzW3Qv0zFVv/N2VpNHtBMxOkiBg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@open-wc/dedupe-mixin": "^1.3.0",
-                "@vaadin/component-base": "~25.0.4",
+                "@vaadin/component-base": "~25.0.8",
                 "lit": "^3.0.0"
             }
         },
@@ -3926,9 +3934,9 @@
             }
         },
         "node_modules/@zip.js/zip.js": {
-            "version": "2.8.21",
-            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.21.tgz",
-            "integrity": "sha512-fkyzXISE3IMrstDO1AgPkJCx14MYHP/suIGiAovEYEuBjq3mffsuL6aMV7ohOSjW4rXtuACuUfpA3GtITgdtYg==",
+            "version": "2.8.23",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.23.tgz",
+            "integrity": "sha512-RB+RLnxPJFPrGvQ9rgO+4JOcsob6lD32OcF0QE0yg24oeW9q8KnTTNlugcDaIveEcCbclobJcZP+fLQ++sH0bw==",
             "license": "BSD-3-Clause",
             "engines": {
                 "bun": ">=0.7.0",
@@ -8417,9 +8425,9 @@
             }
         },
         "node_modules/nan": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
-            "integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
+            "version": "2.26.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+            "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
             "license": "MIT",
             "optional": true
         },
@@ -9645,14 +9653,14 @@
             "license": "Unlicense"
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
-            "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
+            "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.115.0",
-                "@rolldown/pluginutils": "1.0.0-rc.9"
+                "@oxc-project/types": "=0.120.0",
+                "@rolldown/pluginutils": "1.0.0-rc.10"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -9661,27 +9669,27 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
             }
         },
         "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.9",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
-            "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
+            "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
             "dev": true,
             "license": "MIT"
         },
@@ -9831,9 +9839,9 @@
             }
         },
         "node_modules/sax": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-            "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
@@ -10931,17 +10939,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
-            "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
+            "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/runtime": "0.115.0",
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.3",
                 "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.9",
+                "rolldown": "1.0.0-rc.10",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -10958,7 +10965,7 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
-                "@vitejs/devtools": "^0.0.0-alpha.31",
+                "@vitejs/devtools": "^0.1.0",
                 "esbuild": "^0.27.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",

--- a/src/components/panel-stack/controls/left.vue
+++ b/src/components/panel-stack/controls/left.vue
@@ -1,12 +1,14 @@
 <template>
     <div class="relative">
         <button
+            ref="buttonRef"
             type="button"
             class="p-8 move-left"
             :class="{
                 'text-gray-500 hover:text-black focus:text-black': active,
                 'text-gray-300': !active
             }"
+            @click="syncTooltipAfterKeyboardMove"
             :content="t('panels.controls.moveLeft')"
             :aria-label="t('panels.controls.moveLeft')"
             v-tippy="{
@@ -23,12 +25,16 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { usePanelMoveTooltip } from './use-panel-move-tooltip';
 
-defineProps({
+const props = defineProps({
     active: Boolean
 });
 const { t } = useI18n();
+const buttonRef = ref<HTMLButtonElement | null>(null);
+const { syncTooltipAfterKeyboardMove } = usePanelMoveTooltip(buttonRef, () => !!props.active);
 </script>
 
 <style lang="scss" scoped></style>

--- a/src/components/panel-stack/controls/right.vue
+++ b/src/components/panel-stack/controls/right.vue
@@ -1,12 +1,14 @@
 <template>
     <div class="relative">
         <button
+            ref="buttonRef"
             type="button"
             class="p-8"
             :class="{
                 'text-gray-500 hover:text-black focus:text-black': active,
                 'text-gray-300': !active
             }"
+            @click="syncTooltipAfterKeyboardMove"
             :content="t('panels.controls.moveRight')"
             :aria-label="t('panels.controls.moveRight')"
             v-tippy="{
@@ -23,12 +25,16 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { usePanelMoveTooltip } from './use-panel-move-tooltip';
 
 const { t } = useI18n();
-defineProps({
+const props = defineProps({
     active: Boolean
 });
+const buttonRef = ref<HTMLButtonElement | null>(null);
+const { syncTooltipAfterKeyboardMove } = usePanelMoveTooltip(buttonRef, () => !!props.active);
 </script>
 
 <style lang="scss" scoped></style>

--- a/src/components/panel-stack/controls/use-panel-move-tooltip.ts
+++ b/src/components/panel-stack/controls/use-panel-move-tooltip.ts
@@ -1,0 +1,74 @@
+import type { Ref } from 'vue';
+import { onBeforeUnmount } from 'vue';
+
+type TippyButton = HTMLButtonElement & {
+    _tippy?: {
+        disable: () => void;
+        enable: () => void;
+        hide: () => void;
+        show: () => void;
+    };
+};
+
+export function usePanelMoveTooltip(buttonRef: Ref<HTMLButtonElement | null>, isActive: () => boolean) {
+    let restoreTooltipTimeout: ReturnType<typeof setTimeout> | null = null;
+    let detachTransitionListener: (() => void) | null = null;
+
+    const clearPendingRestore = (): void => {
+        if (restoreTooltipTimeout) {
+            clearTimeout(restoreTooltipTimeout);
+            restoreTooltipTimeout = null;
+        }
+
+        detachTransitionListener?.();
+        detachTransitionListener = null;
+    };
+
+    const syncTooltipAfterKeyboardMove = (event: MouseEvent): void => {
+        if (event.detail !== 0 || !isActive()) {
+            return;
+        }
+
+        const button = buttonRef.value as TippyButton | null;
+        const tooltip = button?._tippy;
+
+        if (!button || !tooltip) {
+            return;
+        }
+
+        clearPendingRestore();
+        tooltip.disable();
+        tooltip.hide();
+
+        const restoreTooltip = (): void => {
+            clearPendingRestore();
+            tooltip.enable();
+
+            if (document.activeElement === button) {
+                tooltip.show();
+            }
+        };
+
+        const panel = button.closest('[data-cy]') as HTMLElement | null;
+        if (panel) {
+            const onTransitionEnd = (transitionEvent: TransitionEvent): void => {
+                if (transitionEvent.target === panel && transitionEvent.propertyName === 'transform') {
+                    restoreTooltip();
+                }
+            };
+
+            panel.addEventListener('transitionend', onTransitionEnd);
+            detachTransitionListener = () => panel.removeEventListener('transitionend', onTransitionEnd);
+        }
+
+        restoreTooltipTimeout = setTimeout(restoreTooltip, panel ? 350 : 0);
+    };
+
+    onBeforeUnmount(() => {
+        clearPendingRestore();
+    });
+
+    return {
+        syncTooltipAfterKeyboardMove
+    };
+}

--- a/src/fixtures/layer-reorder/components/layer-component.vue
+++ b/src/fixtures/layer-reorder/components/layer-component.vue
@@ -67,7 +67,7 @@
                             direction="up"
                             :layerId="element.id"
                             class="px-7"
-                            @click="onMoveLayerButton(element, 1)"
+                            @click="onMoveLayerButton(element, 1, $event)"
                         />
                         <reorder-button
                             :ref="el => (buttonRefs[element.id + '-down'] = (el as any)?.buttonRef || null)"
@@ -75,7 +75,7 @@
                             direction="down"
                             :layerId="element.id"
                             class="px-7"
-                            @click="onMoveLayerButton(element, -1)"
+                            @click="onMoveLayerButton(element, -1, $event)"
                         />
                     </div>
 
@@ -319,8 +319,9 @@ const onMoveLayerDragEnd = (evt: any): void => {
  * @param {LayerModel} layerModel layer that is being moved
  * @param {number} direction direction to move the layer (+1 is up and -1 is down)
  */
-const onMoveLayerButton = async (layerModel: LayerModel, direction: number): Promise<void> => {
+const onMoveLayerButton = (layerModel: LayerModel, direction: number, event: MouseEvent): void => {
     const layer = iApi.geo.layer.getLayer(layerModel.id);
+    const clickedButton = event.currentTarget as HTMLButtonElement | null;
 
     const currRelativeIdx = layersModel.value.indexOf(layerModel);
 
@@ -349,11 +350,20 @@ const onMoveLayerButton = async (layerModel: LayerModel, direction: number): Pro
     );
 
     const directionStr = direction === 1 ? 'up' : 'down';
+    const keyboardActivated = event.detail === 0;
 
     // Prevents a race condition between setting new focus and the button existing. Unfortunately nextTick doesn't work so we get a setTimeout...
     setTimeout(() => {
         const btn = buttonRefs.value[layerModel.id + '-' + directionStr];
-        btn?.focus();
+
+        if (keyboardActivated) {
+            btn?.focus();
+            return;
+        }
+
+        const pointerButton = btn ?? clickedButton;
+        pointerButton?.blur();
+        (pointerButton as any)?._tippy?.hide();
     }, 0);
 };
 


### PR DESCRIPTION
### Related Item(s)
#2837, #2862

### Changes
- [FIX] Prevent tooltip party when moving panels and in layer reorder component

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Focus on a panel using the keyboard (when 2+ panels are open)
2. Use the keyboard to navigate to the move left/right button within the panel. Press it.
3. Notice the tooltip follows the moving panel
4. Now go to Enhanced Sample 10
5. Open the Layer Reorder panel
6. Click one of the arrow buttons to move a layer up or down. Keep your mouse still after clicking 🐁
7.  See no more tooltip appear on both the arrow your mouse is over, but also on the button you just clicked (which has now moved).
8. Rejoice

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2898)
<!-- Reviewable:end -->
