### PR TITLE
Maptips on Highlights

### DIFF
--- a/src/fixtures/hilight/api/hilight.ts
+++ b/src/fixtures/hilight/api/hilight.ts
@@ -137,14 +137,18 @@ export class HilightAPI extends FixtureInstance {
      * Return a deconstructed graphic key.
      *
      * @param key The graphic key to deconstruct
+     * @param [silent=false] Flag to stop console warns for bad keys (e.g. using this method as a test)
      */
-    deconstructGraphicKey(key: string): {
+    deconstructGraphicKey(
+        key: string,
+        silent: boolean = false
+    ): {
         origin: string;
         uid: string;
         oid: number;
     } {
         const ids = key.split('~');
-        if (ids.length !== 4) {
+        if (ids.length !== 4 && !silent) {
             console.warn('Malformed Hilight Graphic key provided:', key);
         }
         return { origin: ids[1], uid: ids[2], oid: parseInt(ids[3]) };
@@ -160,5 +164,12 @@ export class HilightAPI extends FixtureInstance {
             console.warn('API get layer request before highlight mode object exists');
             return undefined;
         }
+    }
+
+    /**
+     * Return the hilight Layer name
+     */
+    get hilightLayerName(): string {
+        return HILIGHT_LAYER_NAME;
     }
 }

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -1,3 +1,4 @@
+import type { LayerInstance } from '@/api';
 import type { BaseGeometry, Extent, Graphic, Point, SpatialReference } from '@/geo/api';
 import type { EsriFeatureReductionCluster, EsriRenderer } from '@/geo/esri';
 
@@ -538,6 +539,11 @@ export interface GraphicHitResult {
      * layer id of layer the graphic lives in
      */
     layerId: string;
+
+    /**
+     * The layer instance the graphic lives in, if available
+     */
+    layer?: LayerInstance;
 }
 
 export interface MaptipProperties {

--- a/src/geo/map/maptip.ts
+++ b/src/geo/map/maptip.ts
@@ -31,7 +31,7 @@ export class MaptipAPI extends APIScope {
         this.#currentCheck = screenPoint;
 
         // Get the graphic object
-        const graphicHit: GraphicHitResult | undefined = await this.$iApi.geo.map.getGraphicAtCoord(screenPoint);
+        const graphicHit = await this.$iApi.geo.map.getGraphicAtCoord(screenPoint);
 
         // cancel if new check came in while waiting for `getGraphicAtCoord`
         // If the same point is checked twice technically it can get out of sync but then we're checking the same point anyways
@@ -47,7 +47,7 @@ export class MaptipAPI extends APIScope {
             return;
         }
         // Get the layer
-        const layerInstance: LayerInstance | undefined = this.$iApi.geo.layer.getLayer(graphicHit.layerId);
+        const layerInstance = graphicHit.layer ?? this.$iApi.geo.layer.getLayer(graphicHit.layerId);
 
         if (layerInstance?.geomType != GeometryType.POLYGON) {
             // Check if the same maptip already exists

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -31,7 +31,7 @@ import type {
 } from '@/geo/api';
 
 import { EsriAPI, EsriWatch } from '@/geo/esri';
-import type { EsriExtent, EsriFeatureLayer, EsriGraphic, EsriLOD, EsriUserSettings } from '@/geo/esri';
+import type { EsriExtent, EsriFeatureLayer, EsriLOD, EsriUserSettings } from '@/geo/esri';
 
 import { useLayerStore } from '@/stores/layer';
 import { MapCaptionAPI } from './caption';
@@ -39,6 +39,7 @@ import { markRaw, toRaw } from 'vue';
 import { useConfigStore } from '@/stores/config';
 import { debounce, throttle } from 'es-toolkit/function';
 import type { DrawAPI } from '@/fixtures/draw/api/drawApi';
+import type { HilightAPI } from '@/fixtures/hilight/api/hilight';
 
 export class MapAPI extends CommonMapAPI {
     // API for managing the maptip
@@ -52,6 +53,12 @@ export class MapAPI extends CommonMapAPI {
      * @private
      */
     private mapMouseThrottle: number;
+
+    /**
+     * Id of the highlight layer, if exists. Saves us from looking it up via fixture API every mouse move.
+     * @private
+     */
+    private _hilighLightLayerId: string = '';
 
     /**
      * Map wide defaults for layer times. Layers can override.
@@ -1357,6 +1364,15 @@ export class MapAPI extends CommonMapAPI {
             return;
         }
 
+        // check if we need to setup highlight layer detection
+        if (!this._hilighLightLayerId) {
+            // if fixture exists, get layer id and set our prop
+            const hlFixture = this.$iApi.fixture.get('hilight') as HilightAPI;
+            if (hlFixture) {
+                this._hilighLightLayerId = hlFixture.hilightLayerName;
+            }
+        }
+
         // Get layers that are on the map and supports graphics.
         // We also need to take graphic layers, which dont currently "support features"
         // but they do actually have features lurking on the map, so need to consider those are
@@ -1384,7 +1400,7 @@ export class MapAPI extends CommonMapAPI {
         const hitResults = hitTest.results.filter(hr => hr.type === 'graphic');
 
         let hitLayer: LayerInstance | undefined;
-        let topGraphic: EsriGraphic | undefined;
+        let topOID: number | undefined;
 
         // help us avoid redundant fun
         const dupeSet = new Set<string>();
@@ -1407,10 +1423,31 @@ export class MapAPI extends CommonMapAPI {
                 // - cosmetic layer, sad times. it's blocking anything under it.
                 // - graphic layer, sad times. Until we implement issue #998
                 // - clusterer symbol, sad times. Unless we decide how and what kind of tip we should show
+                // - EXECEPTION! The highlight layer is a cosmetic graphic layer. But we will use science to find the graphic it's highlighting.
 
                 if (!(layerHunt.isCosmetic || layerHunt.layerType === LayerType.GRAPHIC || gHit.graphic.isAggregate)) {
+                    // top graphic was in standard layer
                     hitLayer = layerHunt;
-                    topGraphic = gHit.graphic;
+                    topOID = gHit.graphic.getObjectId() as number;
+                } else if (layerHunt.id === this._hilighLightLayerId && (gHit.graphic as any).id) {
+                    // top graphic was in highlight layer.
+                    // attempt to decode the graphic id.
+                    // note the ".id" has been stuck onto the esri graphic by the highlighter using trickery,
+                    // which is why we keep casting to ANY
+                    const hlFixture = this.$iApi.fixture.get('hilight') as HilightAPI;
+                    if (hlFixture) {
+                        const decodedMetadata = hlFixture.deconstructGraphicKey((gHit.graphic as any).id, true);
+                        if (decodedMetadata.oid && decodedMetadata.uid) {
+                            // find the source layer
+                            const layerHuntPartDeux = layers.find(l => l.uid === decodedMetadata.uid);
+
+                            if (layerHuntPartDeux && layerHuntPartDeux.supportsFeatures) {
+                                // hurrah, all the data has lined up. the highlight points to a valid layer, and that layer supports features.
+                                hitLayer = layerHuntPartDeux;
+                                topOID = decodedMetadata.oid;
+                            }
+                        }
+                    }
                 }
 
                 // stop looping regardless. we've found topmost and were able to make sense of it.
@@ -1424,12 +1461,13 @@ export class MapAPI extends CommonMapAPI {
             }
         });
 
-        if (hitLayer && topGraphic) {
+        if (hitLayer && topOID) {
             // make a fancy bundle
             return {
-                oid: topGraphic.getObjectId() as number,
+                oid: topOID,
                 layerId: hitLayer.id,
-                layerIdx: hitLayer.layerIdx
+                layerIdx: hitLayer.layerIdx,
+                layer: hitLayer
             };
         }
     }


### PR DESCRIPTION
### Related Item(s)
- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2901

### Changes
- Adds trickery to route highlight graphics to the real features they represent in the maptip generator.
- Adds optional layer pointer on the Graphic Hit result to eliminate a redundant layer lookup 🐎 

### QA Testing


Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

File Layer:

1. Open Enhanced Sample 1
2. Mouse over happy. See the maptip.
3. Click a happy feature. See that it highlights.
4. Mouse over the highlight. See the maptip.

Feature Layer:

1. Open Enhanced Sample 3
2. Do the same stuff as above with the Leafs or Waters.

MIL Layer:

1. Open Enhanced Sample 4
2. Mouse over Leafs and Waters. See no maptips.
3. Click a Leaf or Water. Note you need to click near the middle of the symbol. See that it highlights.
4. Mouse over the highlight. See no maptips.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2902)
<!-- Reviewable:end -->
