### PR TITLE
Update action runners to Node24

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -22,11 +22,11 @@ jobs:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   path: ramp
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: '24.14.0'
                   registry-url: 'https://registry.npmjs.org'
@@ -62,7 +62,7 @@ jobs:
                       rm -rf demo-page
                   fi
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: demo-page
                   path: demo-page

--- a/.github/workflows/demo-cleanup.yml
+++ b/.github/workflows/demo-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
 
         steps:
             - name: Checkout the repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
               with:
                   ref: demo-page
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,11 +7,11 @@ jobs:
         name: PR Status Checks
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: '24.14.0'
                   cache: 'npm'

--- a/.github/workflows/slack-bot-redux.yml
+++ b/.github/workflows/slack-bot-redux.yml
@@ -1,77 +1,77 @@
 name: slack-PR-message
 on:
-  pull_request_target:
-    types:
-      - opened
+    pull_request_target:
+        types:
+            - opened
 
 permissions:
-  contents: read
-  pull-requests: read
+    contents: read
+    pull-requests: read
 
 jobs:
-  post-to-slack:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check user permissions (allow only those w/ write access)
-        id: permission_check
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          user_permission=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission" | jq -r .permission)
-          if [[ "$user_permission" != "write" && "$user_permission" != "admin" ]]; then
-            echo "User does not have write access. Exiting."
-            exit 1
-          fi
+    post-to-slack:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check user permissions (allow only those w/ write access)
+              id: permission_check
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  user_permission=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+                    "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission" | jq -r .permission)
+                  if [[ "$user_permission" != "write" && "$user_permission" != "admin" ]]; then
+                    echo "User does not have write access. Exiting."
+                    exit 1
+                  fi
 
-      - name: Checkout
-        uses: actions/checkout@v4
+            - name: Checkout
+              uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: '3.x'
 
-      - name: Install Python dependency
-        run: pip install -r .github/requirements.txt
+            - name: Install Python dependency
+              run: pip install -r .github/requirements.txt
 
-      - name: Summarize PR body and process labels
-        id: summarize
-        env:
-          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: python .github/slack-bot.py
+            - name: Summarize PR body and process labels
+              id: summarize
+              env:
+                  PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
+                  PR_BODY: ${{ github.event.pull_request.body }}
+              run: python .github/slack-bot.py
 
-      - name: Post to a Slack channel
-        id: slack
-        uses: slackapi/slack-github-action@v1.27.0
-        with:
-          channel-id: 'C092GN5MG1H'
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "New *ramp4-pcar4* PR by *${{ github.event.pull_request.user.login }}*"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Title*: ${{ github.event.pull_request.title }}\n*PR Type*: ${{ env.PR_LABEL_STR }}\n*Other labels*: ${{ env.REG_LABEL_STR }}\n*Link*: ${{ github.event.pull_request.html_url }}"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*PR Summary*:\n${{ env.NEUTRAL_SUMMARY }}"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            - name: Post to a Slack channel
+              id: slack
+              uses: slackapi/slack-github-action@v1.27.0
+              with:
+                  channel-id: 'C092GN5MG1H'
+                  payload: |
+                      {
+                        "blocks": [
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": "New *ramp4-pcar4* PR by *${{ github.event.pull_request.user.login }}*"
+                            }
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": "*Title*: ${{ github.event.pull_request.title }}\n*PR Type*: ${{ env.PR_LABEL_STR }}\n*Other labels*: ${{ env.REG_LABEL_STR }}\n*Link*: ${{ github.event.pull_request.html_url }}"
+                            }
+                          },
+                          {
+                            "type": "section",
+                            "text": {
+                              "type": "mrkdwn",
+                              "text": "*PR Summary*:\n${{ env.NEUTRAL_SUMMARY }}"
+                            }
+                          }
+                        ]
+                      }
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
### Changes
- Updates Github action runners to versions that support the upcoming Node24 conversion

### Notes

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Interestingly, our action logs still complain about three runners.

- `actions/configure-pages@v5`, which has not been updated in two years
- `actions/deploy-pages@v4`, which has not been updated in two years
- `actions/upload-artifact@v4`, which has new updates, but I cannot find any reference to it in our scripts

So we will have to see if everything explodes in June when Github switches to Node24 runners environment.

### Testing

- No angry red stuff in the action logs
- Demo builds appear, work gud
- The bot pings on this PR (very important 🚨 )

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2903)
<!-- Reviewable:end -->
