### PR TITLE
Fix issue in FocusContainerManager where focus could inadvertently enter a panel

### DIFF
--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -49,6 +49,13 @@ export const FocusContainer: Directive = {
  */
 class FocusContainerManager {
     element: HTMLElement;
+    isTabbingEnabled: boolean;
+    initialDisableTimeout: ReturnType<typeof setTimeout> | undefined;
+    mutationObserver: MutationObserver | undefined;
+    readonly keypressHandler: (event: KeyboardEvent) => void;
+    readonly clickHandler: () => void;
+    readonly focusOutHandler: (event: FocusEvent) => void;
+    readonly focusHandler: () => void;
 
     /**
      * Creates an instance of FocusContainerManager
@@ -58,21 +65,40 @@ class FocusContainerManager {
      */
     constructor(element: HTMLElement) {
         this.element = element;
+        this.isTabbingEnabled = false;
         this.element.toggleAttribute(CONTAINER_ATTR, true);
         this.element.tabIndex = 0;
-        setTimeout(() => this.disableTabbing(), 600); // elements of container need more time to render, otherwise they wont be detected
-        const focusManager = this;
-        this.element.addEventListener('keypress', function (event: KeyboardEvent) {
-            focusManager.onKeypress(event);
+        this.initialDisableTimeout = setTimeout(() => this.disableTabbing(), 600); // elements of container need more time to render, otherwise they wont be detected
+        this.keypressHandler = (event: KeyboardEvent) => {
+            this.onKeypress(event);
+        };
+        this.clickHandler = () => {
+            this.onClick();
+        };
+        this.focusOutHandler = (event: FocusEvent) => {
+            this.onFocusOut(event);
+        };
+        this.focusHandler = () => {
+            this.onFocus();
+        };
+
+        this.element.addEventListener('keypress', this.keypressHandler);
+        this.element.addEventListener('click', this.clickHandler);
+        this.element.addEventListener('focusout', this.focusOutHandler);
+        this.element.addEventListener('focus', this.focusHandler);
+
+        // Keep late-mounted or externally-retabbed descendants out of the tab order
+        // until the user explicitly activates the container.
+        this.mutationObserver = new MutationObserver(() => {
+            if (!this.isTabbingEnabled) {
+                this.disableTabbing();
+            }
         });
-        this.element.addEventListener('click', function () {
-            focusManager.onClick();
-        });
-        this.element.addEventListener('focusout', function (event: FocusEvent) {
-            focusManager.onFocusOut(event);
-        });
-        this.element.addEventListener('focus', function () {
-            focusManager.onFocus();
+        this.mutationObserver.observe(this.element, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['tabindex', LIST_ATTR, CONTAINER_ATTR, ICON_ATTR]
         });
     }
 
@@ -80,19 +106,14 @@ class FocusContainerManager {
      * Removes all of the event listeners on the container element.
      */
     removeEventListeners() {
-        const focusManager = this;
-        this.element.removeEventListener('keypress', function (event: KeyboardEvent) {
-            focusManager.onKeypress(event);
-        });
-        this.element.removeEventListener('click', function () {
-            focusManager.onClick();
-        });
-        this.element.removeEventListener('focusout', function (event: FocusEvent) {
-            focusManager.onFocusOut(event);
-        });
-        this.element.removeEventListener('focus', function () {
-            focusManager.onFocus();
-        });
+        if (this.initialDisableTimeout) {
+            clearTimeout(this.initialDisableTimeout);
+        }
+        this.mutationObserver?.disconnect();
+        this.element.removeEventListener('keypress', this.keypressHandler);
+        this.element.removeEventListener('click', this.clickHandler);
+        this.element.removeEventListener('focusout', this.focusOutHandler);
+        this.element.removeEventListener('focus', this.focusHandler);
     }
 
     /**
@@ -105,7 +126,7 @@ class FocusContainerManager {
             return;
         }
         if (event.key === KEYS.Enter || event.key === KEYS.Space) {
-            this.enableTabbing().focus();
+            this.enableTabbing()?.focus();
         }
     }
 
@@ -138,16 +159,21 @@ class FocusContainerManager {
      * Sets tabindex to -1 for EVERY element under the container element
      */
     disableTabbing() {
-        // Skip disabling tabbing if any element inside the container currently has focus
-        if (this.element.contains(document.activeElement)) {
+        // Keep current descendant focus intact while the user is actively traversing the container.
+        // The container itself is the locked state, so it should still trigger a rescan.
+        const activeElement = document.activeElement as HTMLElement | null;
+        if (activeElement && activeElement !== this.element && this.element.contains(activeElement)) {
             return;
         }
+        this.isTabbingEnabled = false;
         const tab_list = Array.prototype.filter.call(this.element.querySelectorAll(TABBABLE_TAGS), () => {
             return true;
         }) as HTMLElement[];
 
         tab_list.forEach((el: HTMLElement) => {
-            el.tabIndex = -1;
+            if (el.tabIndex !== -1) {
+                el.tabIndex = -1;
+            }
         });
     }
 
@@ -156,6 +182,7 @@ class FocusContainerManager {
      * @return {HTMLElement} the first valid element
      */
     enableTabbing() {
+        this.isTabbingEnabled = true;
         let first_tabbable_item: any = undefined;
         Array.prototype.map.call(this.element.querySelectorAll(TABBABLE_TAGS), el => {
             // !!el.offsetParent means it is visible
@@ -164,7 +191,9 @@ class FocusContainerManager {
                     (el.closest(FOCUS_ATTRS) === el && el.parentElement!.closest(FOCUS_ATTRS) === this.element)) &&
                 !!el.offsetParent
             ) {
-                el.tabIndex = 0;
+                if (el.tabIndex !== 0) {
+                    el.tabIndex = 0;
+                }
                 if (first_tabbable_item === undefined) {
                     first_tabbable_item = el;
                 }


### PR DESCRIPTION
### Related Item(s)
#2838 

### Changes
- [FIX] issue in `FocusContainerManager` where focus could inadvertently enter a panel

### Notes
First focus on a panel now actually locks its descendants out of the tab order. The immediate bug was in `disableTabbing()`: it treated the container itself as "focus inside" so the first-entry rescan never ran. That matches the behavior where legend items only became untabbable after focus left the panel once.

I also hardened the container against async legend content by adding a `MutationObserver` in the manager constructor. While the panel is still in its locked state, any late-mounted or externally re-tabbed descendants get pushed back to `tabindex=-1`, so legend controls that arrive after mount should no longer steal the first `Tab`.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to a test page
2. Start tabbing
3. See that focus goes onto the legend panel as expected
4. Tab again, see focus move away from the legend
5. Reload page, open another panel and see focus moves between the panels as expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2907)
<!-- Reviewable:end -->
