### PR TITLE
Hide native ESRI attribution

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1542,7 +1542,7 @@
                 "caching": {
                     "type": "boolean",
                     "description": "Indicates whether to preserve the layer's raw data after initiation.",
-                    "default": "false"
+                    "default": false
                 },
                 "identifyMode": {
                     "type": "string",
@@ -1637,7 +1637,7 @@
                 "caching": {
                     "type": "boolean",
                     "description": "Indicates whether to preserve the layer's raw data after initiation.",
-                    "default": "false"
+                    "default": false
                 }
             },
             "required": ["id", "layerType", "url"],
@@ -2892,12 +2892,12 @@
                             },
                             "pin": {
                                 "type": "boolean",
-                                "default": "false",
+                                "default": false,
                                 "description": "Whether to pin the panel as well (in addition to opening)."
                             }
                         },
                         "required": ["id"],
-                        "additionalProperties": "false"
+                        "additionalProperties": false
                     }
                 },
                 "reorderable": {
@@ -2906,7 +2906,7 @@
                     "default": true
                 }
             },
-            "additionalProperties": "false"
+            "additionalProperties": false
         },
         "layers": {
             "$ref": "#/$defs/layerList",

--- a/src/geo/map/caption.ts
+++ b/src/geo/map/caption.ts
@@ -128,7 +128,7 @@ export class MapCaptionAPI extends APIScope {
                 attribution.logo!.link = newAttribution.logo.link || esriLogo.link;
                 attribution.logo!.value = newAttribution.logo.value || esriLogo.value;
             } else {
-                attribution!.logo!.disabled = true; // logo is disabled, so keep logo empty
+                attribution.logo!.disabled = true; // logo is disabled, so keep logo empty
             }
 
             // Check if attribution text does not exists. If so, set to default esri text

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -283,11 +283,11 @@ export class CommonMapAPI extends APIScope {
         this.esriView.map = null;
         // TODO: explain why this is needed or remove
         this.esriView.container = null;
-        // @ts-expect-error TODO: explain why this is needed or remove
+        // @ts-expect-error I think this was needed to clear bindings/pointers/reactive nonsense. TODO dig into it at some point
         this.esriView.spatialReference = null;
-        // @ts-expect-error TODO: explain why this is needed or remove
+        // @ts-expect-error I think this was needed to clear bindings/pointers/reactive nonsense. TODO dig into it at some point
         this.esriView.extent = null;
-        // @ts-expect-error TODO: explain why this is needed or remove
+        // @ts-expect-error I think this was needed to clear bindings/pointers/reactive nonsense. TODO dig into it at some point
         this.esriView.navigation = null;
         this.esriView.destroy();
         delete this.esriView;

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -60,6 +60,7 @@ export class OverviewMapAPI extends CommonMapAPI {
                 constraints: {
                     rotationEnabled: false
                 },
+                attributionVisible: false,
                 spatialReference: this._rampSR.toESRI(),
                 extent: this.$iApi.geo.map.getExtent().toESRI().expand(expandFactor) // use the expanded main map extent
             })

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -174,6 +174,7 @@ export class MapAPI extends CommonMapAPI {
                     lods: <Array<EsriLOD>>lodSetConfig.lods,
                     rotationEnabled: false
                 },
+                attributionVisible: false,
                 spatialReference: this._rampSR.toESRI(),
                 extent: this._rampExtentSet.defaultExtent.toESRI(),
                 navigation: {


### PR DESCRIPTION
### Related Item(s)
- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2910

### Changes
- Hide the default ESRI attribution on the maps
- Cleans up some fake booleans in the schema
- Removes some typescript ignorers that were lies
- Removes an `!` that was evil

### Notes

Attribution is legally required 🚓 , but we are showing it in our caption bar. For the overview map, we are mirroring the same basemaps as the maps so there is no need to duplicate the attribution in that little window. No need to investigate this repo, internet police 👮 

### QA Testing
 
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html
 
### Testing

Steps:
1. Open Enhanced Sample 1
2. Mash the living snot out of the TAB key. Have it cycle all the way back to the browser URL box.
3. Validate that no attribution appeared on the main map. You would have seen the text lurking in the lower left, and the map would have done a lurchy pan upwards.
4. Expand the overview map and validate that half of it is not attribution text.
5. Ensure the caption is obeying the law by showing attribution and the lovely ESRI logo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2911)
<!-- Reviewable:end -->
