### PR TITLE
decode search query before performing custom source search

### DIFF
--- a/src/fixtures/geosearch/store/geosearch.feature.ts
+++ b/src/fixtures/geosearch/store/geosearch.feature.ts
@@ -88,7 +88,8 @@ export class GeoSearchUI {
             onSearch: async (searchTerm: string): Promise<ISearchResult[]> => {
                 const data: Array<any> = (src as any).data ?? [];
                 const geosearchStore = useGeosearchStore();
-                const cleanedTerm = geosearchStore.cleanVal(searchTerm).replace('*', '');
+                // the main searcher is encoding the search term for web requests. Since we are now searching plain text, reverse.
+                const cleanedTerm = decodeURIComponent(geosearchStore.cleanVal(searchTerm)).replace('*', '');
                 return data
                     .filter(item => item.name.toLowerCase().includes(cleanedTerm))
                     .map<ISearchResult>(item => ({


### PR DESCRIPTION
### Related Item(s)
#2914 

### Changes
- Fixes an issue that caused no results to be returned when searching for custom geosearch source data that contains spaces.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open enhanced sample 14.
2. Open the geosearch fixture.
3. Search for "Facility" and ensure "Facility A" and "Facility B" show up.
4. Search for either "Facility A" or "Facility B" and make sure the correct entry appears.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2915)
<!-- Reviewable:end -->
