### PR TITLE
VScode extension doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,8 @@ Static site generated in the `ts-docs` directory. Open `index.html` to preview.
 
 #### Important:
 
-1. Install [Volar](https://marketplace.visualstudio.com/items?itemName=vue.volar).
+1. Install [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=vue.volar).
 2. Disable/remove [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur).
-3. Type `@builtin typescript` in the search box on the VSCode extensions tab and **disable** "TypeScript and JavaScript Language Features". Volar has its own TS language server so we don't want to run two concurrently.
 
 ### public vs demos folders
 

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -82,9 +82,8 @@ Open `http://localhost:5050` in your browser.
 [VSCode](https://code.visualstudio.com/) with the recommended extensions (VSCode should bug you to install them).
 
 ::: tip
-1. Install [Volar](https://marketplace.visualstudio.com/items?itemName=vue.volar).
+1. Install [Vue (Official)](https://marketplace.visualstudio.com/items?itemName=vue.volar).
 2. Disable/remove [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur).
-3. Type `@builtin typescript` in the search box on the VSCode extensions tab and **disable** "TypeScript and JavaScript Language Features". Volar has its own TS language server so we don't want to run two concurrently.
 :::
 
 ## public vs demos folders


### PR DESCRIPTION
### Changes
- Renames `Volar` to `Vue (Official)` in docs
- Removes instructions about disabling the built-in JS/TS support

### Notes

- Volar was rebranded two years ago.
- I tried following our instructions to disable `TypeScript and JavaScript Language Features` and ended up with no hover-hints at all.
  - If anyone wants to try this locally and gets different results, please comment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2923)
<!-- Reviewable:end -->
