### PR TITLE
Fix bug with infinite loop in some panels

### DIFF
--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -110,12 +110,20 @@ const props = defineProps({
 const temporary = computed((): Array<string> | undefined => (iApi.fixture.get('appbar') ? appbarStore.temporary : []));
 const mobileView = computed(() => panelStore.mobileView);
 const reorderable = computed(() => panelStore.reorderable);
+const FOCUS_CONTAINER_ATTR = 'focus-container';
+const ACTIVE_FOCUS_CONTAINER_ATTR = 'focus-container-active';
 // Managed focus descendants own keyboard traversal; wrapper should not become a competing tab stop.
-const MANAGED_FOCUS_SELECTOR = '[focus-list], [focus-container]';
+const MANAGED_FOCUS_SELECTOR = `[focus-list], [${FOCUS_CONTAINER_ATTR}]`;
 const isScrollable = (element: HTMLElement) => element.scrollHeight > element.clientHeight;
 const getManagedFocusTarget = (element: HTMLElement) => element.querySelector<HTMLElement>(MANAGED_FOCUS_SELECTOR);
 const getExpectedContentTabIndex = () => {
     if (!contentEl.value) {
+        return '-1';
+    }
+
+    const focusContainer = contentEl.value.closest<HTMLElement>(`[${FOCUS_CONTAINER_ATTR}]`);
+    // Keep the scroll wrapper locked until the surrounding focus container is explicitly activated.
+    if (focusContainer && !focusContainer.hasAttribute(ACTIVE_FOCUS_CONTAINER_ATTR)) {
         return '-1';
     }
 

--- a/src/directives/focus-list/focus-container.ts
+++ b/src/directives/focus-list/focus-container.ts
@@ -7,10 +7,17 @@ const enum KEYS {
 }
 
 const CONTAINER_ATTR = 'focus-container';
+const ACTIVE_ATTR = 'focus-container-active';
 const LIST_ATTR = 'focus-list';
 const ICON_ATTR = 'focus-icon';
 const FOCUS_ATTRS = `[${LIST_ATTR}],[${CONTAINER_ATTR}]`;
 const TABBABLE_TAGS = `button,input,select,a,textarea,[contenteditable],.ag-tab-guard,[${LIST_ATTR}],[${CONTAINER_ATTR}],[${ICON_ATTR}],[tabindex]`;
+const OBSERVER_OPTIONS: MutationObserverInit = {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['tabindex', LIST_ATTR, CONTAINER_ATTR, ICON_ATTR]
+};
 
 let managers: FocusContainerManager[] = [];
 
@@ -67,6 +74,7 @@ class FocusContainerManager {
         this.element = element;
         this.isTabbingEnabled = false;
         this.element.toggleAttribute(CONTAINER_ATTR, true);
+        this.element.toggleAttribute(ACTIVE_ATTR, false);
         this.element.tabIndex = 0;
         this.initialDisableTimeout = setTimeout(() => this.disableTabbing(), 600); // elements of container need more time to render, otherwise they wont be detected
         this.keypressHandler = (event: KeyboardEvent) => {
@@ -94,12 +102,7 @@ class FocusContainerManager {
                 this.disableTabbing();
             }
         });
-        this.mutationObserver.observe(this.element, {
-            childList: true,
-            subtree: true,
-            attributes: true,
-            attributeFilter: ['tabindex', LIST_ATTR, CONTAINER_ATTR, ICON_ATTR]
-        });
+        this.observeMutations();
     }
 
     /**
@@ -109,6 +112,7 @@ class FocusContainerManager {
         if (this.initialDisableTimeout) {
             clearTimeout(this.initialDisableTimeout);
         }
+        this.setTabbingEnabled(false);
         this.mutationObserver?.disconnect();
         this.element.removeEventListener('keypress', this.keypressHandler);
         this.element.removeEventListener('click', this.clickHandler);
@@ -165,15 +169,17 @@ class FocusContainerManager {
         if (activeElement && activeElement !== this.element && this.element.contains(activeElement)) {
             return;
         }
-        this.isTabbingEnabled = false;
+        this.setTabbingEnabled(false);
         const tab_list = Array.prototype.filter.call(this.element.querySelectorAll(TABBABLE_TAGS), () => {
             return true;
         }) as HTMLElement[];
 
-        tab_list.forEach((el: HTMLElement) => {
-            if (el.tabIndex !== -1) {
-                el.tabIndex = -1;
-            }
+        this.withPausedObserver(() => {
+            tab_list.forEach((el: HTMLElement) => {
+                if (el.tabIndex !== -1) {
+                    el.tabIndex = -1;
+                }
+            });
         });
     }
 
@@ -182,23 +188,44 @@ class FocusContainerManager {
      * @return {HTMLElement} the first valid element
      */
     enableTabbing() {
-        this.isTabbingEnabled = true;
+        this.setTabbingEnabled(true);
         let first_tabbable_item: any = undefined;
-        Array.prototype.map.call(this.element.querySelectorAll(TABBABLE_TAGS), el => {
-            // !!el.offsetParent means it is visible
-            if (
-                (el.closest(FOCUS_ATTRS) === this.element ||
-                    (el.closest(FOCUS_ATTRS) === el && el.parentElement!.closest(FOCUS_ATTRS) === this.element)) &&
-                !!el.offsetParent
-            ) {
-                if (el.tabIndex !== 0) {
-                    el.tabIndex = 0;
+        this.withPausedObserver(() => {
+            Array.prototype.map.call(this.element.querySelectorAll(TABBABLE_TAGS), el => {
+                // !!el.offsetParent means it is visible
+                if (
+                    (el.closest(FOCUS_ATTRS) === this.element ||
+                        (el.closest(FOCUS_ATTRS) === el &&
+                            el.parentElement!.closest(FOCUS_ATTRS) === this.element)) &&
+                    !!el.offsetParent
+                ) {
+                    if (el.tabIndex !== 0) {
+                        el.tabIndex = 0;
+                    }
+                    if (first_tabbable_item === undefined) {
+                        first_tabbable_item = el;
+                    }
                 }
-                if (first_tabbable_item === undefined) {
-                    first_tabbable_item = el;
-                }
-            }
+            });
         });
         return first_tabbable_item;
+    }
+
+    private setTabbingEnabled(enabled: boolean) {
+        this.isTabbingEnabled = enabled;
+        this.element.toggleAttribute(ACTIVE_ATTR, enabled);
+    }
+
+    private observeMutations() {
+        this.mutationObserver?.observe(this.element, OBSERVER_OPTIONS);
+    }
+
+    private withPausedObserver(callback: () => void) {
+        this.mutationObserver?.disconnect();
+        try {
+            callback();
+        } finally {
+            this.observeMutations();
+        }
     }
 }


### PR DESCRIPTION
### Related Item(s)
#2920 

### Changes
- [FIX] issue with infinite loop in some panels

### Notes
The issue/loop was between `focus-container` and `panel-screen`, the container observer kept forcing descendant tabindex values back to -1, while the panel screen kept restoring its scroll wrapper to tabindex="0" for scrollable unmanaged content. In the metadata panel, that produced an endless ping-pong.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to Classic Sample 20
2. Open the legend context menu for Happy HNAP and select Metadata
3. Watch the metadata panel load successfully
4. Open other panels like help and see they all load successfully

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2929)
<!-- Reviewable:end -->
