### PR TITLE
Class binding syntax on a select

### DIFF
--- a/src/fixtures/wizard/form-input.vue
+++ b/src/fixtures/wizard/form-input.vue
@@ -118,7 +118,7 @@
                 <div v-else>
                     <select
                         class="block border-solid border-gray-300 w-full p-3 overflow-y-auto"
-                        v-bind:class="size && 'configure-select'"
+                        :class="size ? 'configure-select' : ''"
                         :size="size"
                         :value="modelValue"
                         @input="handleServiceSelection(size, $event)"


### PR DESCRIPTION
### Changes
- Changes the binding syntax for a class on a `<select>` in the wizard


### Notes

This syntax was popping a new and very angry error on the build console. I suspect either the bump to Vite 8 or Typescript 6 started making it ping.  Correcting it as every build is giving me a jumpscare.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

It would be great if someone who is wise in the ways of Vue bindings and CSS classes gives the code change a good eyeballing.

Steps:
1. Open Enhanced Sample 1
2. Add a file layer or feature layer via the wizard.
3. Ensure stuff in all steps looks appropriate, and wizard does its thing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2934)
<!-- Reviewable:end -->
