### PR TITLE
Define select process variables needed for IIFE build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,11 @@ import dts from 'vite-plugin-dts';
 
 const distName = resolve(__dirname, process.env.DIST_NAME || 'dist');
 
+const browserBuildDefines = {
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    'process.env.ESRI_INTERNAL': JSON.stringify(false)
+};
+
 const baseConfig = {
     plugins: [
         vue({
@@ -50,6 +55,7 @@ const baseConfig = {
 
 function inlineConfig() {
     return mergeConfig(baseConfig, {
+        define: browserBuildDefines,
         build: {
             sourcemap: true,
             lib: {
@@ -67,6 +73,7 @@ function inlineConfig() {
 
 function esDynamicConfig() {
     const config = mergeConfig(baseConfig, {
+        define: browserBuildDefines,
         build: {
             outDir: `${distName}/esDynamic`,
             copyPublicDir: false,
@@ -86,6 +93,7 @@ function npmBundleConfig() {
     const externalImports = Object.keys(pkg.dependencies).map(dep => new RegExp(`^${dep}`));
 
     const config = mergeConfig(baseConfig, {
+        define: browserBuildDefines,
         build: {
             outDir: `${distName}/bundler`,
             copyPublicDir: false,
@@ -107,6 +115,7 @@ function testBuildConfig() {
     delete baseConfig.build.lib;
 
     const config = mergeConfig(baseConfig, {
+        define: browserBuildDefines,
         publicDir: false,
         root: 'demos',
         build: {


### PR DESCRIPTION
### Related Item(s)
#2945 

### Changes
- [FIX] Define select process variables needed for IIFE build

### Notes
The unresolved process references were coming from ArcGIS packages, especially `@arcgis/lumina`, where `process.env.NODE_ENV` and `process.env.ESRI_INTERNAL` are used as dev/test/internal guards. In the IIFE build there is no downstream bundler to replace those Node-style env checks, so the browser evaluates `process.env...` directly and throws `ReferenceError: process is not defined`.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open https://milespetrov.github.io/ramp4-pcar4/2945-process-error/
2. See the page loads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2946)
<!-- Reviewable:end -->
