### PR TITLE
Bot patch protocol-buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9393,9 +9393,9 @@
             }
         },
         "node_modules/protocol-buffers-schema": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-            "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+            "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
             "license": "MIT",
             "optional": true
         },


### PR DESCRIPTION
### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/pull/2953

### Changes
- Manually applies a dependabot patch that was a Medium security grouse

### Notes

The bot is refusing to remake the request due to me nuking the yml file (or I'm being impatient, but this release will not be sabotaged!).

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

WOMM

Steps:
1. Open Enhanced Sample 5
2. Ensure the FlatGeobuf layer (pink states) loads
3. Basemaps are acting up, not this PRs fault.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2955)
<!-- Reviewable:end -->
