### PR TITLE
Add initial support for identify in bounds

### DIFF
--- a/src/fixtures/draw/api/drawApi.ts
+++ b/src/fixtures/draw/api/drawApi.ts
@@ -2,6 +2,10 @@ import { FixtureInstance, InstanceAPI } from '@/api';
 import { useDrawStore } from '../store';
 import type { ActiveToolList } from '../store';
 import { DRAW_GRAPHICS_LAYER_ID } from '../draw.vue';
+import type { BaseGeometry, IdentifyGeometryProvider, MapClick } from '@/geo/api';
+import type { EsriGeometry } from '@/geo/esri';
+import { EsriIntersectsOperator } from '@/geo/esri';
+import { toRaw } from 'vue';
 
 const DEFAULT_DRAW_TYPES: DrawTypeConfig[] = [
     { type: 'point' },
@@ -22,7 +26,22 @@ export interface DrawFixtureConfig {
     defaultTool?: ActiveToolList;
 }
 
-export class DrawAPI extends FixtureInstance {
+const DRAW_IDENTIFY_MOUSE_TOLERANCE = 5;
+const DRAW_IDENTIFY_TOUCH_TOLERANCE = 15;
+
+function graphicIntersectsIdentifyClick(
+    geometry: EsriGeometry,
+    clickPoint: EsriGeometry,
+    clickBuffer: EsriGeometry
+): boolean {
+    if (geometry.type === 'polygon') {
+        return EsriIntersectsOperator.execute(geometry, clickPoint);
+    }
+
+    return EsriIntersectsOperator.execute(geometry, clickBuffer);
+}
+
+export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider {
     store: ReturnType<typeof useDrawStore>;
 
     constructor(id: string, iApi: InstanceAPI) {
@@ -66,5 +85,40 @@ export class DrawAPI extends FixtureInstance {
      */
     get graphicsLayerId(): string {
         return DRAW_GRAPHICS_LAYER_ID;
+    }
+
+    /**
+     * Prevent default map identify while the draw fixture is creating or editing graphics.
+     */
+    suppressIdentify(): boolean {
+        return !!this.store.activeTool || this.store.selectedGraphicId !== null;
+    }
+
+    /**
+     * Finds the top-most drawn graphic hit by a map click and returns that graphic's full geometry.
+     *
+     * Points and lines are considered hit when they intersect a small click buffer.
+     */
+    getIdentifyGeometry(mapClick: MapClick): BaseGeometry | undefined {
+        const clickPoint = mapClick.mapPoint.toESRI();
+        const tolerance = mapClick.input === 'touch' ? DRAW_IDENTIFY_TOUCH_TOLERANCE : DRAW_IDENTIFY_MOUSE_TOLERANCE;
+        const clickBuffer = this.$iApi.geo.query.makeClickBuffer(mapClick.mapPoint, tolerance).toESRI();
+
+        const hitGraphic = this.store.graphics
+            .slice()
+            .reverse()
+            .find(graphic => {
+                const geometry = toRaw(graphic.geometry) as EsriGeometry | undefined;
+                return geometry && graphicIntersectsIdentifyClick(geometry, clickPoint, clickBuffer);
+            });
+
+        if (!hitGraphic?.geometry) {
+            return undefined;
+        }
+
+        return this.$iApi.geo.geom.geomEsriToRamp(
+            toRaw(hitGraphic.geometry) as EsriGeometry,
+            hitGraphic.id ?? hitGraphic.attributes?.id
+        );
     }
 }

--- a/src/fixtures/draw/draw-nav-section.vue
+++ b/src/fixtures/draw/draw-nav-section.vue
@@ -1,5 +1,6 @@
 <template>
     <div
+        v-if="filteredDrawingTools.length"
         :class="{ active: drawStore.activeTool || drawStore.activeTool == '' }"
         class="mapnav-section bg-white-75 hover:bg-white"
     >
@@ -64,12 +65,17 @@ const drawingTools = [
 
 // only show tools listed in config
 const filteredDrawingTools = computed(() => {
-    const fTools = drawingTools.filter(tool => drawStore.supportedTypes.some(item => item.type === tool.type));
-    fTools.push({
-        type: 'edit',
-        icon: markRaw(defineAsyncComponent(() => import('./icons/edit-icon.vue')))
-    });
-    return fTools;
+    if (!drawStore.configParsed) {
+        return [];
+    }
+
+    return [
+        ...drawingTools.filter(tool => drawStore.supportedTypes.some(item => item.type === tool.type)),
+        {
+            type: 'edit',
+            icon: markRaw(defineAsyncComponent(() => import('./icons/edit-icon.vue')))
+        }
+    ];
 });
 
 const toggleTool = (toolType: ActiveToolList) => {

--- a/src/fixtures/draw/draw.vue
+++ b/src/fixtures/draw/draw.vue
@@ -66,8 +66,10 @@ const buildLocaleRecord = (messageKey: string): Record<string, string> => {
 // Sketch widget and graphics layer reference variables
 let sketch: HTMLArcgisSketchElement | null = null;
 const sketchEl = useTemplateRef<HTMLArcgisSketchElement>('sketchEl');
-let sketchHandler: { remove: () => void } | null = null;
 let graphicsLayer: EsriGraphicsLayer | null = null;
+let viewClickHandler: { remove: () => void } | null = null;
+let sketchEventsRegistered = false;
+let drawToolsInitId = 0;
 
 // Variables for selected and highlighted graphics
 let selectedGraphic: EsriGraphic | null = null;
@@ -82,6 +84,22 @@ let multiPointVertices: Vertex[] = [];
 
 const rampEventHandlers = reactive<Array<string>>([]);
 let keyboardNamespace: string | undefined;
+
+const onSketchCreate = (event: Event) => {
+    handleSketchCreateEvent((event as CustomEvent<EsriSketchCreateEvent>).detail);
+};
+
+const onSketchUpdate = (event: Event) => {
+    handleSketchUpdateEvent((event as CustomEvent<EsriSketchUpdateEvent>).detail);
+};
+
+const cancelSketch = () => {
+    try {
+        sketch?.cancel();
+    } catch (e) {
+        console.warn('Unable to cancel draw sketch.', e);
+    }
+};
 
 async function handleKeyboardShortcuts() {
     const keyboardNav = iApi.keyboardNav;
@@ -210,7 +228,7 @@ watch(
     (newId, oldId) => {
         if (!sketch || !graphicsLayer) return;
         if (!newId) {
-            sketch.cancel();
+            cancelSketch();
             highlightSelectedGraphic();
         } else if (newId !== oldId) {
             const graphics = graphicsLayer.graphics.toArray();
@@ -708,26 +726,35 @@ const handleViewClick = async (event: EsriViewClickEvent) => {
 };
 
 const initializeDrawTools = async () => {
+    const initId = ++drawToolsInitId;
     await iApi.geo.map.viewPromise;
+
+    if (initId !== drawToolsInitId || !sketchEl.value || !iApi.geo.map.esriView) {
+        return;
+    }
 
     // Create or get the graphics layer for drawings
     if (!iApi.geo.layer.getLayer(DRAW_GRAPHICS_LAYER_ID)) {
-        // @ts-expect-error esri type mismatch
-        graphicsLayer = iApi.geo.layer.createLayer({
+        const drawLayer = iApi.geo.layer.createLayer({
             id: DRAW_GRAPHICS_LAYER_ID,
             layerType: LayerType.GRAPHIC,
             cosmetic: true,
             system: true,
             url: ''
         });
-        // @ts-expect-error esri type mismatch
-        await iApi.geo.map.addLayer(graphicsLayer);
+        await iApi.geo.map.addLayer(drawLayer);
+        if (initId !== drawToolsInitId || !iApi.geo.map.esriView) {
+            return;
+        }
+        graphicsLayer = drawLayer.esriLayer as EsriGraphicsLayer;
     } else {
         // @ts-expect-error esri type mismatch
         graphicsLayer = iApi.geo.layer.getLayer(DRAW_GRAPHICS_LAYER_ID)!.esriLayer;
     }
-    // @ts-expect-error esri type mismatch
-    if (graphicsLayer?.esriLayer) graphicsLayer = graphicsLayer.esriLayer;
+
+    if (!graphicsLayer) {
+        return;
+    }
 
     Object.assign(sketchEl.value!, {
         view: iApi.geo.map.esriView!,
@@ -743,19 +770,22 @@ const initializeDrawTools = async () => {
     });
     iApi.geo.map.esriView!.ui.add(sketchEl.value!, 'bottom-right');
 
-    sketchEl.value?.addEventListener('arcgisCreate', e => handleSketchCreateEvent(e.detail));
-    sketchEl.value?.addEventListener('arcgisUpdate', e => handleSketchUpdateEvent(e.detail));
-
-    sketchHandler = {
-        remove: () => sketchEl.value?.removeEventListener('arcgisCreate', e => handleSketchCreateEvent(e.detail))
-    };
+    if (!sketchEventsRegistered) {
+        sketchEl.value.addEventListener('arcgisCreate', onSketchCreate);
+        sketchEl.value.addEventListener('arcgisUpdate', onSketchUpdate);
+        sketchEventsRegistered = true;
+    }
 
     sketch = sketchEl.value;
 
     // Add DOM event listeners
-    iApi.geo.map.esriView!.on('click', handleViewClick);
+    viewClickHandler = iApi.geo.map.esriView!.on('click', handleViewClick);
     document.addEventListener('keydown', handleNavigationKeyDown);
     document.addEventListener('keydown', handleGraphicKeyboardEdit, { capture: true });
+
+    if (drawStore.activeTool && drawStore.activeTool !== 'edit') {
+        sketch.create(drawStore.activeTool);
+    }
 };
 
 const cleanupKeyboardShortcuts = () => {
@@ -769,21 +799,53 @@ const cleanupKeyboardShortcuts = () => {
     keyboardNamespace = undefined;
 };
 
-const cleanupDrawTools = () => {
-    cleanupKeyboardShortcuts();
+type CleanupDrawToolsOptions = {
+    cleanupKeyboard?: boolean;
+    clearActiveTool?: boolean;
+    destroySketch?: boolean;
+};
+
+const cleanupDrawTools = ({
+    cleanupKeyboard = true,
+    clearActiveTool = false,
+    destroySketch = true
+}: CleanupDrawToolsOptions = {}) => {
+    drawToolsInitId++;
+
+    if (cleanupKeyboard) {
+        cleanupKeyboardShortcuts();
+    }
+
+    if (viewClickHandler) {
+        viewClickHandler.remove();
+        viewClickHandler = null;
+    }
 
     if (sketch) {
         if (iApi.geo.map.esriView) {
             iApi.geo.map.esriView.ui.remove(sketch);
         }
-        if (sketchHandler) {
-            sketchHandler.remove();
+        cancelSketch();
+        if (destroySketch) {
+            sketch.destroy();
         }
-        sketch.destroy();
+    }
+
+    if (sketchEventsRegistered && sketchEl.value) {
+        sketchEl.value.removeEventListener('arcgisCreate', onSketchCreate);
+        sketchEl.value.removeEventListener('arcgisUpdate', onSketchUpdate);
+        sketchEventsRegistered = false;
     }
 
     document.removeEventListener('keydown', handleNavigationKeyDown);
     document.removeEventListener('keydown', handleGraphicKeyboardEdit, { capture: true });
+
+    selectedGraphic = null;
+    highlightSelectedGraphic(undefined);
+    drawStore.clearSelection();
+    if (clearActiveTool && drawStore.activeTool) {
+        drawStore.setActiveTool(null);
+    }
 
     multiPointMode = false;
     multiPointGraphic = null;
@@ -823,7 +885,7 @@ const handleSketchUpdateEvent = (event: EsriSketchUpdateEvent) => {
 
     if (event.state === 'start') {
         if (drawStore.activeTool !== 'edit') {
-            sketch!.cancel();
+            cancelSketch();
             return;
         }
 
@@ -860,6 +922,20 @@ onMounted(() => {
             cleanupDrawTools();
         })
     );
+    rampEventHandlers.push(
+        iApi.event.on(GlobalEvents.MAP_REFRESH_START, () => {
+            cleanupDrawTools({
+                cleanupKeyboard: false,
+                clearActiveTool: true,
+                destroySketch: false
+            });
+        })
+    );
+    rampEventHandlers.push(
+        iApi.event.on(GlobalEvents.MAP_REFRESH_END, () => {
+            initializeDrawTools();
+        })
+    );
 });
 
 /* --------------------------------------------------------------------------
@@ -868,13 +944,19 @@ onMounted(() => {
 watch(
     () => drawStore.activeTool,
     newTool => {
-        sketch!.cancel();
+        if (!sketch) return;
+
+        cancelSketch();
         highlightSelectedGraphic();
         multiPointGraphic = null;
         multiPointVertices = [];
         multiPointMode = false;
         if (newTool && newTool != 'edit') {
-            sketch!.create(newTool);
+            try {
+                sketch.create(newTool);
+            } catch (e) {
+                console.warn('Unable to start draw sketch.', e);
+            }
         }
     }
 );

--- a/src/fixtures/draw/index.ts
+++ b/src/fixtures/draw/index.ts
@@ -6,6 +6,8 @@ import messages from './lang/lang.csv?raw';
 import { GlobalEvents } from '@/api';
 
 class DrawFixture extends DrawAPI {
+    private unregisterIdentifyGeometryProvider?: () => void;
+
     async init() {
         // Add language messages
         Object.entries(messages).forEach(value => this.$iApi.$i18n.mergeLocaleMessage(...value));
@@ -29,10 +31,19 @@ class DrawFixture extends DrawAPI {
     }
 
     async added() {
+        if (!this.unregisterIdentifyGeometryProvider) {
+            this.unregisterIdentifyGeometryProvider = this.$iApi.geo.map.registerIdentifyGeometryProvider(this);
+        }
+
         // Re-initialize on map create or config change
         this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
             this.init();
         });
+    }
+
+    removed() {
+        this.unregisterIdentifyGeometryProvider?.();
+        this.unregisterIdentifyGeometryProvider = undefined;
     }
 }
 

--- a/src/fixtures/draw/store/draw-store.ts
+++ b/src/fixtures/draw/store/draw-store.ts
@@ -8,6 +8,7 @@ export type ActiveToolList = 'circle' | 'point' | 'polygon' | 'polyline' | 'rect
 
 export const useDrawStore = defineStore('draw', () => {
     const supportedTypes = ref<DrawTypeConfig[]>([]);
+    const configParsed = ref(false);
     const activeTool = ref<ActiveToolList>(null);
     const graphics = reactive<any[]>([]);
     const selectedGraphicId = ref<string | null>(null);
@@ -15,6 +16,7 @@ export const useDrawStore = defineStore('draw', () => {
 
     function setSupportedTypes(types: DrawTypeConfig[]) {
         supportedTypes.value.splice(0, supportedTypes.value.length, ...types);
+        configParsed.value = true;
     }
 
     function setActiveTool(tool: ActiveToolList) {
@@ -64,6 +66,7 @@ export const useDrawStore = defineStore('draw', () => {
 
     return {
         supportedTypes,
+        configParsed,
         activeTool,
         graphics,
         selectedGraphicId,

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -329,6 +329,26 @@ export interface MapClick {
 }
 
 /**
+ * Allows optional tools to adjust or suppress map identify geometry without making identify depend on those tools.
+ */
+export interface IdentifyGeometryProvider {
+    /**
+     * Return true when this provider wants the map identify request blocked.
+     */
+    suppressIdentify?(mapClick: MapClick): boolean;
+
+    /**
+     * Return an alternate geometry to identify against for the supplied map click.
+     *
+     * Return undefined to identify against the original click point. Returning a point preserves normal
+     * point identify behavior, including layer tolerance and symbolic hit tests. Returning a line,
+     * polygon, or other non-point geometry passes that geometry to identifying layers so they can return
+     * features intersecting it.
+     */
+    getIdentifyGeometry(mapClick: MapClick): BaseGeometry | undefined;
+}
+
+/**
  * Event payload for a Map Move
  */
 export interface MapMove {

--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -26,6 +26,7 @@ import EsriPoint from '@arcgis/core/geometry/Point';
 import EsriPolygon from '@arcgis/core/geometry/Polygon';
 import EsriPolyline from '@arcgis/core/geometry/Polyline';
 import EsriSpatialReference from '@arcgis/core/geometry/SpatialReference';
+import * as EsriIntersectsOperator from '@arcgis/core/geometry/operators/intersectsOperator';
 import { fromJSON as EsriGeometryFromJson } from '@arcgis/core/geometry/support/jsonUtils';
 
 import type EsriFeatureLayer from '@arcgis/core/layers/FeatureLayer';
@@ -261,6 +262,7 @@ export {
     type EsriImageryLayerProperties,
     type EsriImageryTileLayer,
     type EsriImageryTileLayerProperties,
+    EsriIntersectsOperator,
     type EsriLayer,
     type EsriLayerLayerviewCreateEvent,
     type EsriLayerView,

--- a/src/geo/layer/wms-layer.ts
+++ b/src/geo/layer/wms-layer.ts
@@ -177,10 +177,9 @@ export class WmsLayer extends MapLayer {
         // TODO add full documentation for options parameter
 
         if (options.geometry.type !== GeometryType.POINT) {
-            // TODO too harsh? maybe a console warning and generic no result?
-            //      just thinking if someone attempts a fancy identify on a map
-            //      that happens to have a WMS on it, it will never work.
-            throw new Error('a point must be used for WMS Identify');
+            // WMS GetFeatureInfo is inherently point-based. Non-point map identifies should not break
+            // vector layers that can answer against the supplied geometry.
+            return [];
         }
 
         // early kickout check. not loaded/error

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -9,6 +9,7 @@ import {
     DefPromise,
     Extent,
     ExtentSet,
+    GeometryType,
     InitiationState,
     LayerIdentifyMode,
     LayerState,
@@ -17,7 +18,9 @@ import {
     ScaleSet
 } from '@/geo/api';
 import type {
+    BaseGeometry,
     GraphicHitResult,
+    IdentifyGeometryProvider,
     IdentifyParameters,
     LayerTimes,
     MapClick,
@@ -38,7 +41,6 @@ import { MapCaptionAPI } from './caption';
 import { markRaw, toRaw } from 'vue';
 import { useConfigStore } from '@/stores/config';
 import { debounce, throttle } from 'es-toolkit/function';
-import type { DrawAPI } from '@/fixtures/draw/api/drawApi';
 import type { HilightAPI } from '@/fixtures/hilight/api/hilight';
 
 export class MapAPI extends CommonMapAPI {
@@ -59,6 +61,11 @@ export class MapAPI extends CommonMapAPI {
      * @private
      */
     private _hilighLightLayerId: string = '';
+
+    /**
+     * Optional providers that can supply alternate geometries for map identify requests.
+     */
+    private identifyGeometryProviders: Array<IdentifyGeometryProvider> = [];
 
     /**
      * Map wide defaults for layer times. Layers can override.
@@ -1247,6 +1254,70 @@ export class MapAPI extends CommonMapAPI {
         return unaggregatedHitResults.flat();
     }
 
+    /**
+     * Register an optional provider that can adjust map identify geometry.
+     *
+     * @param provider provider to register
+     * @returns function that unregisters the provider
+     */
+    registerIdentifyGeometryProvider(provider: IdentifyGeometryProvider): () => void {
+        if (!this.identifyGeometryProviders.includes(provider)) {
+            this.identifyGeometryProviders.push(provider);
+        }
+
+        return () => this.unregisterIdentifyGeometryProvider(provider);
+    }
+
+    /**
+     * Unregister a map identify geometry provider.
+     *
+     * @param provider provider to unregister
+     */
+    unregisterIdentifyGeometryProvider(provider: IdentifyGeometryProvider): void {
+        const providerIdx = this.identifyGeometryProviders.indexOf(provider);
+        if (providerIdx !== -1) {
+            this.identifyGeometryProviders.splice(providerIdx, 1);
+        }
+    }
+
+    /**
+     * Checks whether any optional provider wants to suppress the current identify request.
+     *
+     * @param mapClick map click that initiated identify
+     * @returns true if identify should be skipped
+     */
+    private isIdentifySuppressed(mapClick: MapClick): boolean {
+        return this.identifyGeometryProviders.some(provider => {
+            try {
+                return !!provider.suppressIdentify?.(mapClick);
+            } catch (e) {
+                console.warn('Identify geometry provider failed while checking suppression.', e);
+                return false;
+            }
+        });
+    }
+
+    /**
+     * Gets the first alternate identify geometry offered by an optional provider.
+     *
+     * @param mapClick map click that initiated identify
+     * @returns alternate identify geometry, if any provider supplies one
+     */
+    private getIdentifyProviderGeometry(mapClick: MapClick): BaseGeometry | undefined {
+        for (const provider of this.identifyGeometryProviders.slice().reverse()) {
+            try {
+                const geometry = provider.getIdentifyGeometry(mapClick);
+                if (geometry) {
+                    return geometry;
+                }
+            } catch (e) {
+                console.warn('Identify geometry provider failed while resolving geometry.', e);
+            }
+        }
+
+        return undefined;
+    }
+
     // pending https://github.com/ramp4-pcar4/ramp4-pcar4/issues/130
     // commenting out to avoid any undecided constants being exposed
     /*
@@ -1297,12 +1368,8 @@ export class MapAPI extends CommonMapAPI {
             mapClick = targetPoint;
         }
 
-        const drawFixture = this.$iApi.fixture.get<DrawAPI>('draw');
-        if (drawFixture && this.esriView) {
-            // disable identify if any draw tools are active OR if a graphic is selected for editing
-            if (drawFixture.store.activeTool || drawFixture.store.selectedGraphicId !== null) {
-                return { click: mapClick, results: [] };
-            }
+        if (this.isIdentifySuppressed(mapClick)) {
+            return { click: mapClick, results: [] };
         }
 
         // Don't perform an identify request if the layers array hasn't been established yet.
@@ -1310,10 +1377,13 @@ export class MapAPI extends CommonMapAPI {
             return { click: mapClick, results: [] };
         }
 
+        const identifyGeometry = this.getIdentifyProviderGeometry(mapClick) ?? mapClick.mapPoint;
+
         // if any layers want symbolic identify, initiate the hit test now.
         // the promise will resolve in an array of any hits, providing layerid and objectid of hits
         let hitTestProm: Promise<Array<GraphicHitResult>> = Promise.resolve([]);
         if (
+            identifyGeometry.type === GeometryType.POINT &&
             layers.some(l => {
                 return l.identifyMode === LayerIdentifyMode.HYBRID || l.identifyMode === LayerIdentifyMode.SYMBOLIC;
             })
@@ -1322,7 +1392,7 @@ export class MapAPI extends CommonMapAPI {
         }
 
         const p: IdentifyParameters = {
-            geometry: mapClick.mapPoint,
+            geometry: identifyGeometry,
             hitTest: hitTestProm
         };
 


### PR DESCRIPTION
### Related Item(s)
#2034 

### Changes
- [FEATURE] Identify all features within shape boundaries
- [FIX] Switching projections no longer causes draw tools to fail

### Notes
May need some tweaking based on feedback, and 👀 on the geo changes. Currently identify within bounds is always active.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to https://milespetrov.github.io/ramp4-pcar4/2034-identify/demos/enhanced-samples.html?sample=13
2. Draw a triangle over happy face
3. Click/identify anywhere inside the triangle
4. See the identify results show all three features
5. Draw a line through two features, click/identify on the line, see identify results

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2961)
<!-- Reviewable:end -->
