### PR TITLE
Geosearch zoom event

### DIFF
--- a/docs/using-ramp4/default-setup.md
+++ b/docs/using-ramp4/default-setup.md
@@ -71,11 +71,12 @@ These events will be present if the associated core fixtures are running
 | Event Name                           | Payload                                                 | Event Announces                                                |
 | ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------- |
 | DETAILS_TOGGLE<br>'details/toggle'   | { data: any, uid: string, format: string }, boolean (optional)         | A feature's details panel toggle was requested with optional force open/close       |
-| GRID_TOGGLE<br>'grid/toggle'         | _layer_: LayerInstance, _open_: boolean (optional)        | Grid panel toggle was requested with optional force open/close |
+| GEOSEARCH_ZOOM<br>'geosearch/zoom'   | _zoomPromise_: Promise, _searchItem_: ISearchResult     | An item in GeoSearch was selected and zoomed to |
+| GRID_TOGGLE<br>'grid/toggle'         | _layer_: LayerInstance, _open_: boolean (optional)      | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |
-| METADATA_TOGGLE<br>'metadata/toggle' | { type: string, layerName: string, url: string, _layer_: LayerInstance }, open: boolean (optional)        | Metadata panel toggle was requested with optional force open/close                                 |
+| METADATA_TOGGLE<br>'metadata/toggle' | { type: string, layerName: string, url: string, layer: LayerInstance }, open: boolean (optional)        | Metadata panel toggle was requested with optional force open/close                                 |
 | REORDER_TOGGLE<br>'reorder/toggle'   | boolean (optional)                                      | Layer reorder panel toggle was requested with optional force open/close |
-| SETTINGS_TOGGLE<br>'settings/toggle' | _layer_: LayerInstance, _open_: boolean (optional)        | Settings panel toggle was requested for a layer with optional force open/close |
+| SETTINGS_TOGGLE<br>'settings/toggle' | _layer_: LayerInstance, _open_: boolean (optional)      | Settings panel toggle was requested for a layer with optional force open/close |
 | WIZARD_TOGGLE<br>'wizard/open'       | boolean (optional)                                      | Wizard panel toggle was requested with optional force open/close |
 
 ## Default Events Handlers

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -69,6 +69,12 @@ export enum GlobalEvents {
     FIXTURE_REMOVED = 'fixture/removed',
 
     /**
+     * Fires when a result in GeoSearch is selected and zoomed to.
+     * Payload: `({ zoomPromise: Promise<void>, searchItem: ISearchResult })`
+     */
+    GEOSEARCH_ZOOM = 'geosearch/zoom',
+
+    /**
      * Fires when a request is issued to toggle (show if hidden, hide if showing) the grid of attributes.
      * Payload: `(uid: string, force?: boolean)`
      */

--- a/src/fixtures/geosearch/screen.vue
+++ b/src/fixtures/geosearch/screen.vue
@@ -67,9 +67,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, inject } from 'vue';
+import { computed, inject, toRaw } from 'vue';
 import type { PropType } from 'vue';
 import type { InstanceAPI, PanelInstance } from '@/api';
+import { GlobalEvents } from '@/api';
 import { Polygon, SpatialReference } from '@/geo/api';
 import { useGeosearchStore } from './store';
 import GeosearchBar from './search-bar.vue';
@@ -100,6 +101,8 @@ const fsaLookupUrl = computed<string>(() => geosearchStore.GSservice.config.fsaU
 
 // zoom in to a clicked result
 const zoomIn = async (result: ISearchResult): Promise<void> => {
+    let zoomPromise: Promise<void> | undefined;
+
     // use fancy fsa boundary service if appropriate
     if (result.flav === 'fsa' && fsaLookupUrl.value) {
         const targetedUrl = fsaLookupUrl.value.replace(FSATOKEN, result.name);
@@ -115,10 +118,7 @@ const zoomIn = async (result: ISearchResult): Promise<void> => {
                 SpatialReference.fromConfig(rRes.spatialReference), // technically not from a config, but config follows esri spec. this server result is raw, does not have esri class wrapper
                 true
             );
-            iApi.geo.map.zoomMapTo(poly);
-
-            // donethanks
-            return;
+            zoomPromise = iApi.geo.map.zoomMapTo(poly);
         }
 
         // solution if the response time here becomes too noticeable.
@@ -128,21 +128,27 @@ const zoomIn = async (result: ISearchResult): Promise<void> => {
         // 4. the logic here changes to check if result.esriPoly exists. if so, makes the new Polygon() and zoomies it
     }
 
-    const zoom = new Polygon(
-        'zoomies',
-        [
+    if (!zoomPromise) {
+        // we found nothing in the FSA logic above. do a normie zoom.
+        const zoom = new Polygon(
+            'zoomies',
             [
-                [result.bbox[0], result.bbox[1]],
-                [result.bbox[0], result.bbox[3]],
-                [result.bbox[2], result.bbox[3]],
-                [result.bbox[2], result.bbox[1]],
-                [result.bbox[0], result.bbox[1]]
-            ]
-        ],
-        SpatialReference.latLongSR(),
-        true
-    );
-    iApi.geo.map.zoomMapTo(zoom);
+                [
+                    [result.bbox[0], result.bbox[1]],
+                    [result.bbox[0], result.bbox[3]],
+                    [result.bbox[2], result.bbox[3]],
+                    [result.bbox[2], result.bbox[1]],
+                    [result.bbox[0], result.bbox[1]]
+                ]
+            ],
+            SpatialReference.latLongSR(),
+            true
+        );
+        zoomPromise = iApi.geo.map.zoomMapTo(zoom);
+    }
+
+    // raise event that we zoomed to zomthing.
+    iApi.event.emit(GlobalEvents.GEOSEARCH_ZOOM, { zoomPromise, searchItem: toRaw(result) });
 };
 
 /**


### PR DESCRIPTION
### Changes
- Adds an event to signal a GeoSearch result was selected / zoomed to.

### Notes

This was a client request, but given the rising popularity of GeoSearch over the past year, I think it could come in handy in other scenarios.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Console code:

```js
debugInstance.event.on('geosearch/zoom', x=> console.log(x));
```

Steps:
1. Open Enhanced Sample 1
2. Run the above line in the console.
3. Open Geosearch.
4. Search for something fun and zoom to it.
5. Look at the console output. May it please you.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2962)
<!-- Reviewable:end -->
