### PR TITLE
CSS Font Removal - Sketchy Version

### DIFF
--- a/scripts/vite-css-font-remover-plugin.ts
+++ b/scripts/vite-css-font-remover-plugin.ts
@@ -1,0 +1,31 @@
+/*
+Strips embedded fonts from CSS file
+
+See https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2947 for the WHY
+
+*/
+
+import type { Plugin } from 'vite';
+
+function cssFontRemoverPlugin(): Plugin {
+    const esriFontFaceBlock = /@font-face\s*{[^{}]*font-family\s*:\s*["']?["']?[^{}]*}/g;
+    const arcgisCssId = /[\\/]node_modules[\\/]@arcgis[\\/].*\.css(?:\?.*)?$/;
+
+    return {
+        name: 'css-font-remover',
+        enforce: 'pre',
+        transform: {
+            filter: { id: arcgisCssId },
+            handler(code: string, id: string) {
+                if (!arcgisCssId.test(id)) {
+                    return null;
+                }
+
+                const strippedCode = code.replace(esriFontFaceBlock, '');
+                return strippedCode === code ? null : { code: strippedCode, map: null };
+            }
+        }
+    };
+}
+
+export default cssFontRemoverPlugin;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import vue from '@vitejs/plugin-vue';
 import VitePluginI18n from './scripts/vite-plugin-i18n';
 import VitePluginVersion from './scripts/vite-plugin-version';
 import ViteMinifyEsPlugin from './scripts/vite-minify-es-plugin';
+import ViteCssFontRemovalPlugin from './scripts/vite-css-font-remover-plugin';
 import { resolve } from 'path';
 import pkg from './package.json';
 import dts from 'vite-plugin-dts';
@@ -17,6 +18,7 @@ const browserBuildDefines = {
 
 const baseConfig = {
     plugins: [
+        ViteCssFontRemovalPlugin(),
         vue({
             template: {
                 compilerOptions: {


### PR DESCRIPTION


### Related Item(s)
- Temporary solution to https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2947

### Changes
- Build now strips certain embedded fonts from our `ramp.css` build files.

### Notes
A more civilized solution is to find the correct configuration in the Vite build to simply exclude the fonts to begin with. Could be tricky, given ESRI is doing the inclusion behind their curtain of secrecy.

The new plugin keeps the original file as `ramp-original.css`, in case we ever find out this was a giant mistake. Can quickly drop in a working file for a given release.

### QA Testing


Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html



### Testing

- General testing: keep a sharp eye out for any visual nonsense that would indicate our CSS broke or our text/font stuff broke.
- Enhanced Sample 13 (draw tools). To ensure the sketch component didn't break.
- Enhanced Sample 12 (swiper no swiping). To ensure the swipe component didn't break.
- The Legacy "Main" sample (3rd link in the demo blarb below). This will test the CSS file of the IIFE build.
- Inspect the [demo build file system](https://github.com/james-rae/ramp4-pcar4/tree/demo-page/nukedafont)
  - Look at file size of `ramp.css`. Look at the contents, nod in your head in approval at the minified css.
  - Look at `ramp-original.css`, admire the legacy content.
  - Do the same in the `esDynamic` folder. Github might refuse to show all the files, so here are friendly hotlinks ([small css](https://github.com/james-rae/ramp4-pcar4/blob/demo-page/nukedafont/esDynamic/ramp.css), [large css](https://github.com/james-rae/ramp4-pcar4/blob/demo-page/nukedafont/esDynamic/ramp-original.css)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2964)
<!-- Reviewable:end -->
