### PR TITLE
Draw tools: add support for distance and area measurements 

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -59,6 +59,7 @@ import { useNortharrowStore } from '@/fixtures/northarrow/store';
 import { useNotificationStore } from '@/stores/notification';
 import { useOverviewmapStore } from '@/fixtures/overviewmap/store';
 import { usePanelStore } from '@/stores/panel';
+import { usePanguardStore } from '@/fixtures/panguard/store';
 import { useScrollguardStore } from '@/fixtures/scrollguard/store';
 import { useWizardStore } from '@/fixtures/wizard/store';
 
@@ -524,6 +525,7 @@ export class InstanceAPI {
             'metadata',
             'northarrow',
             'overviewmap',
+            'panguard',
             'scrollguard',
             'wizard'
         ];
@@ -563,6 +565,8 @@ export class InstanceAPI {
                 return <Readonly<T>>useNortharrowStore(this.$vApp.$pinia);
             case 'overviewmap':
                 return <Readonly<T>>useOverviewmapStore(this.$vApp.$pinia);
+            case 'panguard':
+                return <Readonly<T>>usePanguardStore(this.$vApp.$pinia);
             case 'scrollguard':
                 return <Readonly<T>>useScrollguardStore(this.$vApp.$pinia);
             case 'wizard':

--- a/src/fixtures/draw/draw-nav-section.vue
+++ b/src/fixtures/draw/draw-nav-section.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         v-if="filteredDrawingTools.length"
-        :class="{ active: drawStore.activeTool || drawStore.activeTool == '' }"
+        :class="{ active: drawStore.activeTool || drawStore.activeTool == '' || drawStore.measurementsEnabled }"
         class="mapnav-section bg-white-75 hover:bg-white"
     >
         <mapnav-button
@@ -17,6 +17,16 @@
         >
             <component :is="tool.icon" class="fill-current w-32 h-20"></component>
         </mapnav-button>
+        <mapnav-button
+            :onClickFunction="toggleMeasurements"
+            :tooltip="t('draw.measurements.tooltip')"
+            :ariaLabel="t('draw.measurements.tooltip')"
+            :ariaPressed="drawStore.measurementsEnabled"
+            :showOutline="showOutline"
+            :class="{ 'active-tool': drawStore.measurementsEnabled }"
+        >
+            <measure-icon class="fill-current w-32 h-20"></measure-icon>
+        </mapnav-button>
     </div>
 </template>
 
@@ -26,6 +36,7 @@ import type { ActiveToolList } from './store';
 import { useI18n } from 'vue-i18n';
 import { markRaw, defineAsyncComponent, computed, inject, useTemplateRef } from 'vue';
 import { InstanceAPI } from '@/api/internal';
+import MeasureIcon from './icons/measure-icon.vue';
 
 defineProps({
     showOutline: {
@@ -86,6 +97,10 @@ const toggleTool = (toolType: ActiveToolList) => {
         // Activate the selected tool
         drawStore.setActiveTool(toolType);
     }
+};
+
+const toggleMeasurements = () => {
+    drawStore.toggleMeasurements();
 };
 
 const mouseFocus = () => {

--- a/src/fixtures/draw/draw.vue
+++ b/src/fixtures/draw/draw.vue
@@ -1,6 +1,9 @@
 |
 <template>
     <arcgis-sketch ref="sketchEl" style="display: none" />
+    <div v-if="drawStore.measurementsEnabled" class="sr-only" aria-live="polite" aria-atomic="true">
+        {{ measurementSummary }}
+    </div>
 </template>
 <script lang="ts">
 export const DRAW_GRAPHICS_LAYER_ID = 'RampDrawGraphicsLayer';
@@ -18,22 +21,34 @@ export const DRAW_GRAPHICS_LAYER_ID = 'RampDrawGraphicsLayer';
 /* --------------------------------------------------------------------------
  * IMPORTS
  * -------------------------------------------------------------------------- */
-import { inject, onMounted, onUnmounted, watch, reactive, useTemplateRef } from 'vue';
+import { inject, onMounted, onUnmounted, watch, reactive, ref, toRaw, useTemplateRef } from 'vue';
 import { useDrawStore } from './store';
 import { InstanceAPI } from '@/api/internal';
+import type { PanguardAPI } from '@/fixtures/panguard/api/panguard';
 
 import { LayerType } from '@/geo/api';
 import { useI18n } from 'vue-i18n';
 import {
+    EsriAreaOperator,
+    EsriCentroidOperator,
+    EsriGeodeticAreaOperator,
+    EsriGeodeticAreaOperatorIsLoaded,
+    EsriGeodeticAreaOperatorLoad,
+    EsriGeodeticLengthOperator,
+    EsriGeodeticLengthOperatorIsLoaded,
+    EsriGeodeticLengthOperatorLoad,
     EsriGraphic,
+    EsriLengthOperator,
     EsriPoint,
     EsriPolygon,
     EsriPolyline,
     EsriSimpleFillSymbol,
     EsriSimpleLineSymbol,
-    EsriSimpleMarkerSymbol
+    EsriSimpleMarkerSymbol,
+    EsriTextSymbol
 } from '@/geo/esri';
 import type {
+    EsriGeometry,
     EsriGraphicHit,
     EsriGraphicsLayer,
     EsriSketchCreateEvent,
@@ -70,6 +85,12 @@ let graphicsLayer: EsriGraphicsLayer | null = null;
 let viewClickHandler: { remove: () => void } | null = null;
 let sketchEventsRegistered = false;
 let drawToolsInitId = 0;
+let sketchUpdateFrame: number | null = null;
+let measurementRefreshFrame: number | null = null;
+let measurementRefreshRunId = 0;
+let measurementOperatorLoadPromise: Promise<void> | null = null;
+let measurementGraphics: EsriGraphic[] = [];
+let pendingMeasurementRefresh: { activeGraphic?: EsriGraphic; activeTool?: string } | null = null;
 
 // Variables for selected and highlighted graphics
 let selectedGraphic: EsriGraphic | null = null;
@@ -84,6 +105,25 @@ let multiPointVertices: Vertex[] = [];
 
 const rampEventHandlers = reactive<Array<string>>([]);
 let keyboardNamespace: string | undefined;
+const measurementSummary = ref('');
+let panguardEnabledBeforeDraw: boolean | null = null;
+
+const setPanguardForActiveTool = (tool = drawStore.activeTool) => {
+    const panguard = iApi.fixture.get<PanguardAPI>('panguard');
+
+    if (tool !== null && tool !== '') {
+        if (panguard && panguardEnabledBeforeDraw === null) {
+            panguardEnabledBeforeDraw = panguard.enabled;
+            panguard.setEnabled(false);
+        }
+        return;
+    }
+
+    if (panguardEnabledBeforeDraw !== null) {
+        panguard?.setEnabled(panguardEnabledBeforeDraw);
+        panguardEnabledBeforeDraw = null;
+    }
+};
 
 const onSketchCreate = (event: Event) => {
     handleSketchCreateEvent((event as CustomEvent<EsriSketchCreateEvent>).detail);
@@ -99,6 +139,13 @@ const cancelSketch = () => {
     } catch (e) {
         console.warn('Unable to cancel draw sketch.', e);
     }
+};
+
+const cancelPendingSketchUpdate = () => {
+    if (sketchUpdateFrame === null) return;
+
+    window.cancelAnimationFrame(sketchUpdateFrame);
+    sketchUpdateFrame = null;
 };
 
 async function handleKeyboardShortcuts() {
@@ -163,6 +210,14 @@ async function handleKeyboardShortcuts() {
                 handler: () => {
                     drawStore.setActiveTool('edit');
                 }
+            },
+            {
+                key: 'M',
+                description: buildLocaleRecord('draw.keyboard.key.measurements'),
+                handler: () => {
+                    drawStore.toggleMeasurements();
+                    return 'reset';
+                }
             }
         ]
     });
@@ -219,6 +274,509 @@ const highlightSelectedGraphic = (graphic?: EsriGraphic | undefined) => {
     graphicsLayer?.add(highlightGraphic);
 };
 
+const startSketchUpdate = (graphic: EsriGraphic) => {
+    if (!sketch || drawStore.activeTool !== 'edit') return;
+
+    selectedGraphic = graphic;
+    if (graphic.attributes?.id) {
+        drawStore.selectGraphic(graphic.attributes.id);
+    }
+    highlightSelectedGraphic(graphic);
+
+    cancelPendingSketchUpdate();
+    sketchUpdateFrame = window.requestAnimationFrame(() => {
+        sketchUpdateFrame = null;
+
+        if (!sketch || drawStore.activeTool !== 'edit' || selectedGraphic !== graphic || sketch.state === 'active') {
+            return;
+        }
+
+        void sketch.triggerUpdate([graphic], {
+            tool: 'transform',
+            enableRotation: true,
+            enableScaling: true,
+            toggleToolOnClick: false,
+            highlightOptions: { enabled: false }
+        });
+    });
+};
+
+type FormattedMeasurement = {
+    display: string;
+    spoken: string;
+};
+
+type MeasurementLabelInfo = {
+    graphic: EsriGraphic;
+    accessibleText: string;
+};
+
+type MeasurableGraphic = {
+    id: string;
+    type: string;
+    geometry: EsriGeometry;
+};
+
+const formatMeasurementNumber = (value: number, maximumFractionDigits: number): string =>
+    value.toLocaleString(locale.value, {
+        maximumFractionDigits,
+        minimumFractionDigits: 0
+    });
+
+const formatLength = (meters: number): FormattedMeasurement => {
+    const absMeters = Math.abs(meters);
+
+    if (absMeters >= 1000) {
+        const kilometers = absMeters / 1000;
+        const decimals = kilometers >= 10 ? 1 : 2;
+        const value = formatMeasurementNumber(kilometers, decimals);
+        return {
+            display: `${value} km`,
+            spoken: `${value} kilometers`
+        };
+    }
+
+    if (absMeters >= 1) {
+        const decimals = absMeters >= 10 ? 0 : 1;
+        const value = formatMeasurementNumber(absMeters, decimals);
+        return {
+            display: `${value} m`,
+            spoken: `${value} meters`
+        };
+    }
+
+    const centimeters = absMeters * 100;
+    const value = formatMeasurementNumber(centimeters, centimeters >= 10 ? 0 : 1);
+    return {
+        display: `${value} cm`,
+        spoken: `${value} centimeters`
+    };
+};
+
+const formatArea = (squareMeters: number): FormattedMeasurement => {
+    const absSquareMeters = Math.abs(squareMeters);
+
+    if (absSquareMeters >= 1000000) {
+        const squareKilometers = absSquareMeters / 1000000;
+        const decimals = squareKilometers >= 10 ? 1 : 2;
+        const value = formatMeasurementNumber(squareKilometers, decimals);
+        return {
+            display: `${value} sq km`,
+            spoken: `${value} square kilometers`
+        };
+    }
+
+    const decimals = absSquareMeters >= 100 ? 0 : absSquareMeters >= 10 ? 1 : 2;
+    const value = formatMeasurementNumber(absSquareMeters, decimals);
+    return {
+        display: `${value} sq m`,
+        spoken: `${value} square meters`
+    };
+};
+
+const shouldUseGeodesicMeasurement = (geometry: EsriGeometry): boolean =>
+    !!geometry.spatialReference?.isGeographic || !!geometry.spatialReference?.isWebMercator;
+
+const loadMeasurementOperators = async (): Promise<void> => {
+    measurementOperatorLoadPromise ??= Promise.all([
+        EsriGeodeticAreaOperatorIsLoaded() ? Promise.resolve() : EsriGeodeticAreaOperatorLoad(),
+        EsriGeodeticLengthOperatorIsLoaded() ? Promise.resolve() : EsriGeodeticLengthOperatorLoad()
+    ]).then(() => undefined);
+
+    await measurementOperatorLoadPromise;
+};
+
+const executeLengthMeters = (polyline: EsriPolyline, geodesic: boolean): number =>
+    geodesic
+        ? EsriGeodeticLengthOperator(polyline, { unit: 'meters' })
+        : EsriLengthOperator(polyline, { unit: 'meters' });
+
+const measurePolylineMeters = (polyline: EsriPolyline): number | undefined => {
+    const geodesic = shouldUseGeodesicMeasurement(polyline);
+
+    try {
+        const length = Math.abs(executeLengthMeters(polyline, geodesic));
+        if (Number.isFinite(length)) return length;
+    } catch {
+        // Try the alternate measurement below.
+    }
+
+    try {
+        const length = Math.abs(executeLengthMeters(polyline, !geodesic));
+        return Number.isFinite(length) ? length : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const executeAreaSquareMeters = (polygon: EsriPolygon, geodesic: boolean): number =>
+    geodesic
+        ? EsriGeodeticAreaOperator(polygon, { unit: 'square-meters' })
+        : EsriAreaOperator(polygon, { unit: 'square-meters' });
+
+const measurePolygonSquareMeters = (polygon: EsriPolygon): number | undefined => {
+    const geodesic = shouldUseGeodesicMeasurement(polygon);
+
+    try {
+        const area = Math.abs(executeAreaSquareMeters(polygon, geodesic));
+        if (Number.isFinite(area)) return area;
+    } catch {
+        // Try the alternate measurement below.
+    }
+
+    try {
+        const area = Math.abs(executeAreaSquareMeters(polygon, !geodesic));
+        return Number.isFinite(area) ? area : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const segmentMidpoint = (start: Vertex, end: Vertex, spatialReference: EsriGeometry['spatialReference']): EsriPoint =>
+    new EsriPoint({
+        x: (start[0] + end[0]) / 2,
+        y: (start[1] + end[1]) / 2,
+        spatialReference
+    });
+
+const normalizeTextAngle = (angle: number): number => {
+    if (angle > 90) return angle - 180;
+    if (angle < -90) return angle + 180;
+    return angle;
+};
+
+const segmentAngle = (start: Vertex, end: Vertex, spatialReference: EsriGeometry['spatialReference']): number => {
+    const view = iApi.geo.map.esriView;
+    if (view) {
+        const startScreen = view.toScreen(new EsriPoint({ x: start[0], y: start[1], spatialReference }));
+        const endScreen = view.toScreen(new EsriPoint({ x: end[0], y: end[1], spatialReference }));
+        if (startScreen && endScreen) {
+            return normalizeTextAngle(
+                (Math.atan2(endScreen.y - startScreen.y, endScreen.x - startScreen.x) * 180) / Math.PI
+            );
+        }
+    }
+
+    return normalizeTextAngle((Math.atan2(end[1] - start[1], end[0] - start[0]) * 180) / Math.PI);
+};
+
+const segmentLengthMeters = (
+    start: Vertex,
+    end: Vertex,
+    spatialReference: EsriGeometry['spatialReference']
+): number | undefined =>
+    measurePolylineMeters(
+        new EsriPolyline({
+            paths: [
+                [
+                    [start[0], start[1]],
+                    [end[0], end[1]]
+                ]
+            ],
+            spatialReference
+        })
+    );
+
+const polygonLabelPoint = (polygon: EsriPolygon): EsriPoint | undefined => {
+    try {
+        const centroid = EsriCentroidOperator(polygon);
+        if (centroid) {
+            return centroid;
+        }
+    } catch {
+        // Fall back to the extent center below.
+    }
+
+    const extent = polygon.extent;
+    if (!extent) return undefined;
+
+    return new EsriPoint({
+        x: (extent.xmin + extent.xmax) / 2,
+        y: (extent.ymin + extent.ymax) / 2,
+        spatialReference: polygon.spatialReference
+    });
+};
+
+const createMeasurementTextGraphic = (
+    point: EsriPoint,
+    text: string,
+    kind: 'distance' | 'area',
+    angle = 0
+): EsriGraphic =>
+    new EsriGraphic({
+        geometry: point,
+        symbol: new EsriTextSymbol({
+            text,
+            angle,
+            color: kind === 'area' ? [255, 255, 255, 1] : [17, 24, 39, 1],
+            haloColor: kind === 'area' ? [17, 24, 39, 1] : [255, 255, 255, 1],
+            haloSize: 1.5,
+            backgroundColor: kind === 'area' ? [17, 24, 39, 0.92] : [255, 255, 255, 0.9],
+            borderLineColor: kind === 'area' ? [255, 255, 255, 0.95] : [17, 24, 39, 0.85],
+            borderLineSize: 0.6,
+            horizontalAlignment: 'center',
+            verticalAlignment: 'middle',
+            yoffset: kind === 'area' ? 0 : 8,
+            font: {
+                family: 'Arial',
+                size: 11,
+                weight: 'bold'
+            }
+        }),
+        attributes: {
+            drawMeasurement: true
+        }
+    });
+
+const buildSegmentMeasurementLabels = (geometry: EsriGeometry, toolType: string): MeasurementLabelInfo[] => {
+    if (toolType === 'circle') {
+        return [];
+    }
+
+    const paths =
+        geometry.type === 'polyline'
+            ? (geometry as EsriPolyline).paths
+            : geometry.type === 'polygon'
+              ? (geometry as EsriPolygon).rings
+              : [];
+
+    let segmentIndex = 0;
+    return paths.flatMap(path => {
+        const labels: MeasurementLabelInfo[] = [];
+        for (let index = 0; index < path.length - 1; index++) {
+            const start = path[index] as Vertex;
+            const end = path[index + 1] as Vertex;
+            const length = segmentLengthMeters(start, end, geometry.spatialReference);
+
+            if (!length || length < 0.01) {
+                continue;
+            }
+
+            segmentIndex++;
+            const formatted = formatLength(length);
+            labels.push({
+                graphic: createMeasurementTextGraphic(
+                    segmentMidpoint(start, end, geometry.spatialReference),
+                    formatted.display,
+                    'distance',
+                    segmentAngle(start, end, geometry.spatialReference)
+                ),
+                accessibleText: t('draw.measurements.segment', {
+                    index: segmentIndex,
+                    distance: formatted.spoken
+                })
+            });
+        }
+        return labels;
+    });
+};
+
+const buildAreaMeasurementLabel = (geometry: EsriGeometry): MeasurementLabelInfo | undefined => {
+    if (geometry.type !== 'polygon') {
+        return undefined;
+    }
+
+    const polygon = geometry as EsriPolygon;
+    const area = measurePolygonSquareMeters(polygon);
+    const point = polygonLabelPoint(polygon);
+
+    if (!area || area < 0.01 || !point) {
+        return undefined;
+    }
+
+    const formatted = formatArea(area);
+    return {
+        graphic: createMeasurementTextGraphic(point, formatted.display, 'area'),
+        accessibleText: t('draw.measurements.area', {
+            area: formatted.spoken
+        })
+    };
+};
+
+const buildGraphicMeasurementLabels = (graphic: MeasurableGraphic): MeasurementLabelInfo[] => {
+    const geometry = graphic.geometry;
+    if (!geometry || geometry.type === 'point' || geometry.type === 'multipoint') {
+        return [];
+    }
+
+    const labels = buildSegmentMeasurementLabels(geometry, graphic.type);
+    const areaLabel = buildAreaMeasurementLabel(geometry);
+    if (areaLabel) {
+        labels.push(areaLabel);
+    }
+
+    return labels;
+};
+
+const getGraphicId = (graphic: EsriGraphic): string | undefined => graphic.attributes?.id;
+
+const makeMeasurableGraphic = (
+    id: string,
+    type: string | undefined,
+    geometry: EsriGeometry | null | undefined
+): MeasurableGraphic | undefined => {
+    if (!geometry) return undefined;
+
+    return {
+        id,
+        type: type ?? geometry.type,
+        geometry
+    };
+};
+
+const getStoredMeasurableGraphics = (): MeasurableGraphic[] =>
+    drawStore.graphics
+        .map(graphic =>
+            makeMeasurableGraphic(
+                String(graphic.id ?? graphic.attributes?.id ?? ''),
+                graphic.type ?? graphic.attributes?.type,
+                toRaw(graphic.geometry) as EsriGeometry | null | undefined
+            )
+        )
+        .filter((graphic): graphic is MeasurableGraphic => !!graphic?.id);
+
+const getLayerMeasurableGraphics = (): MeasurableGraphic[] =>
+    (graphicsLayer?.graphics.toArray() ?? [])
+        .filter(graphic => !!getGraphicId(graphic))
+        .map(graphic =>
+            makeMeasurableGraphic(
+                getGraphicId(graphic)!,
+                graphic.attributes?.type,
+                graphic.geometry as EsriGeometry | null | undefined
+            )
+        )
+        .filter((graphic): graphic is MeasurableGraphic => !!graphic);
+
+const getActiveMeasurableGraphic = (
+    activeGraphic?: EsriGraphic,
+    activeTool?: string
+): MeasurableGraphic | undefined => {
+    if (!activeGraphic) return undefined;
+
+    return makeMeasurableGraphic(
+        getGraphicId(activeGraphic) ?? 'active-draw-measurement',
+        activeTool ?? activeGraphic.attributes?.type,
+        activeGraphic.geometry as EsriGeometry | null | undefined
+    );
+};
+
+const buildMeasurementLabels = (activeGraphic?: EsriGraphic, activeTool?: string): MeasurementLabelInfo[] => {
+    const sources = new Map<string, MeasurableGraphic>();
+
+    getStoredMeasurableGraphics().forEach(graphic => sources.set(graphic.id, graphic));
+    getLayerMeasurableGraphics().forEach(graphic => sources.set(graphic.id, graphic));
+
+    const activeSource = getActiveMeasurableGraphic(activeGraphic, activeTool);
+    if (activeSource) {
+        sources.set(activeSource.id, activeSource);
+    }
+
+    return Array.from(sources.values()).flatMap(graphic => buildGraphicMeasurementLabels(graphic));
+};
+
+const clearMeasurementGraphics = () => {
+    measurementRefreshRunId++;
+
+    if (measurementRefreshFrame !== null) {
+        window.cancelAnimationFrame(measurementRefreshFrame);
+        measurementRefreshFrame = null;
+    }
+    pendingMeasurementRefresh = null;
+    measurementSummary.value = '';
+
+    try {
+        iApi.geo.map.esriView?.graphics.removeMany(measurementGraphics);
+    } catch (e) {
+        console.warn('Unable to clear draw measurement graphics.', e);
+    }
+    measurementGraphics = [];
+};
+
+const updateMeasurementSummary = (labels: MeasurementLabelInfo[]) => {
+    const nextSummary = labels.length
+        ? t('draw.measurements.summary', {
+              measurements: labels.map(label => label.accessibleText).join('. ')
+          })
+        : t('draw.measurements.none');
+
+    if (measurementSummary.value !== nextSummary) {
+        measurementSummary.value = nextSummary;
+    }
+};
+
+const refreshMeasurementGraphics = async (activeGraphic?: EsriGraphic, activeTool?: string) => {
+    const refreshRunId = ++measurementRefreshRunId;
+
+    if (measurementRefreshFrame !== null) {
+        window.cancelAnimationFrame(measurementRefreshFrame);
+        measurementRefreshFrame = null;
+        pendingMeasurementRefresh = null;
+    }
+
+    if (!drawStore.measurementsEnabled) {
+        clearMeasurementGraphics();
+        return;
+    }
+
+    try {
+        await loadMeasurementOperators();
+    } catch (e) {
+        console.warn('Unable to load draw measurement operators.', e);
+        return;
+    }
+
+    if (refreshRunId !== measurementRefreshRunId || !drawStore.measurementsEnabled) {
+        return;
+    }
+
+    const labels = buildMeasurementLabels(activeGraphic, activeTool);
+    const viewGraphics = iApi.geo.map.esriView?.graphics;
+
+    if (!viewGraphics) {
+        return;
+    }
+
+    try {
+        if (measurementGraphics.length) {
+            viewGraphics.removeMany(measurementGraphics);
+        }
+    } catch (e) {
+        console.warn('Unable to remove stale draw measurement graphics.', e);
+    }
+
+    measurementGraphics = labels.map(label => label.graphic);
+
+    try {
+        if (measurementGraphics.length) {
+            viewGraphics.addMany(measurementGraphics);
+        }
+    } catch (e) {
+        console.warn('Unable to add draw measurement graphics.', e);
+        measurementGraphics = [];
+    }
+
+    updateMeasurementSummary(labels);
+};
+
+const scheduleMeasurementRefresh = (activeGraphic?: EsriGraphic, activeTool?: string) => {
+    if (!drawStore.measurementsEnabled) {
+        clearMeasurementGraphics();
+        return;
+    }
+
+    pendingMeasurementRefresh = { activeGraphic, activeTool };
+    if (measurementRefreshFrame !== null) {
+        return;
+    }
+
+    measurementRefreshFrame = window.requestAnimationFrame(() => {
+        measurementRefreshFrame = null;
+        const refreshRequest = pendingMeasurementRefresh;
+        pendingMeasurementRefresh = null;
+        void refreshMeasurementGraphics(refreshRequest?.activeGraphic, refreshRequest?.activeTool);
+    });
+};
+
 /* --------------------------------------------------------------------------
  * WATCHERS
  * -------------------------------------------------------------------------- */
@@ -228,16 +786,29 @@ watch(
     (newId, oldId) => {
         if (!sketch || !graphicsLayer) return;
         if (!newId) {
+            cancelPendingSketchUpdate();
             cancelSketch();
             highlightSelectedGraphic();
         } else if (newId !== oldId) {
             const graphics = graphicsLayer.graphics.toArray();
             const selectedEsriGraphic = graphics.find(g => g.attributes && g.attributes.id === newId);
             if (selectedEsriGraphic) {
-                sketch.triggerUpdate([selectedEsriGraphic]);
                 highlightSelectedGraphic(selectedEsriGraphic);
             }
         }
+    }
+);
+
+watch(
+    () => drawStore.measurementsEnabled,
+    enabled => {
+        if (enabled) {
+            void refreshMeasurementGraphics();
+        } else {
+            clearMeasurementGraphics();
+        }
+
+        iApi.updateAlert(t(enabled ? 'draw.measurements.enabled' : 'draw.measurements.disabled'));
     }
 );
 
@@ -258,23 +829,20 @@ const selectCenteredGraphic = async () => {
         width: 20,
         height: 20
     };
-    const response = await view.hitTest(searchArea);
+    const response = await view.hitTest(searchArea, { include: graphicsLayer });
     const hits = response.results.filter((result): result is EsriGraphicHit => {
         if (!('graphic' in result) || result.graphic.layer !== graphicsLayer) return false;
         return !!result.graphic.attributes?.id;
     });
     if (hits.length > 0) {
-        selectedGraphic = hits[0].graphic;
-        sketch.triggerUpdate([selectedGraphic]);
-        if (selectedGraphic.attributes?.id) {
-            drawStore.selectGraphic(selectedGraphic.attributes.id);
-        }
+        startSketchUpdate(hits[0].graphic);
         iApi.updateAlert(
             t('draw.graphic.selected', {
-                type: translateTerm(selectedGraphic.attributes?.type)
+                type: translateTerm(hits[0].graphic.attributes?.type)
             })
         );
     } else {
+        cancelPendingSketchUpdate();
         sketch.cancel();
         selectedGraphic = null;
         drawStore.clearSelection();
@@ -389,6 +957,7 @@ const createGraphicAtCenter = async () => {
             geometry: graphic.geometry,
             attributes: graphic.attributes
         });
+        void refreshMeasurementGraphics();
 
         // cancel sketch if graphic is not a point
         if (drawStore.activeTool !== 'point') {
@@ -457,6 +1026,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                         }
                         multiPointGraphic.attributes = { id: `temp-graphic-${Date.now()}`, type: drawStore.activeTool };
                         graphicsLayer?.add(multiPointGraphic);
+                        void refreshMeasurementGraphics(multiPointGraphic, drawStore.activeTool ?? undefined);
 
                         iApi.updateAlert(
                             t('draw.multiPoint.started', {
@@ -477,6 +1047,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                                 spatialReference: view.spatialReference
                             });
                         }
+                        void refreshMeasurementGraphics(multiPointGraphic!, drawStore.activeTool ?? undefined);
 
                         iApi.updateAlert(
                             t('draw.multiPoint.pointAdded', {
@@ -512,6 +1083,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                 }
                 // Notify geometry change using public API
                 multiPointGraphic!.set('geometry', multiPointGraphic?.geometry);
+                void refreshMeasurementGraphics(multiPointGraphic!, drawStore.activeTool ?? undefined);
                 iApi.updateAlert(
                     t('draw.multiPoint.pointRemoved', {
                         type: translateTerm(drawStore.activeTool ?? undefined),
@@ -526,6 +1098,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                 multiPointGraphic = null;
                 multiPointVertices = [];
                 multiPointMode = false;
+                void refreshMeasurementGraphics();
                 iApi.updateAlert(t('draw.multiPoint.canceled'));
             } else if (selectedGraphic) {
                 e.preventDefault();
@@ -536,6 +1109,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                 }
                 selectedGraphic = null;
                 highlightSelectedGraphic(undefined);
+                void refreshMeasurementGraphics();
                 iApi.updateAlert(t('draw.graphic.deleted'));
             }
             break;
@@ -546,6 +1120,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
             selectedGraphic = null;
             highlightSelectedGraphic(undefined);
             drawStore.clearSelection();
+            void refreshMeasurementGraphics();
             iApi.updateAlert(t('draw.tool.canceled'));
             break;
     }
@@ -694,6 +1269,7 @@ const handleGraphicKeyboardEdit = (e: KeyboardEvent) => {
         if (selectedGraphic.attributes?.id) {
             drawStore.updateGraphicGeometry(selectedGraphic.attributes.id, newGeometry);
         }
+        scheduleMeasurementRefresh(selectedGraphic, selectedGraphic.attributes?.type);
         const action = isResizing ? 'resized' : isRotating ? 'rotated' : 'moved';
         iApi.updateAlert(t(`draw.graphic.${action}`));
     }
@@ -708,16 +1284,30 @@ const handleGraphicKeyboardEdit = (e: KeyboardEvent) => {
  * @param event The view click event.
  */
 const handleViewClick = async (event: EsriViewClickEvent) => {
+    if (drawStore.activeTool !== 'edit') return;
+
     const view = iApi.geo.map.esriView!;
-    const response = await view.hitTest(event);
+    const response = await view.hitTest(event, { include: graphicsLayer });
     const hit = response.results.find(
         (result): result is EsriGraphicHit =>
             'graphic' in result && result.graphic.layer === graphicsLayer && !!result.graphic.attributes?.id
     );
 
-    if (hit && drawStore.activeTool === 'edit') {
-        sketch?.triggerUpdate([hit.graphic]);
-    } else {
+    if (hit) {
+        if (sketch?.state === 'active') {
+            selectedGraphic = hit.graphic;
+            if (hit.graphic.attributes?.id) {
+                drawStore.selectGraphic(hit.graphic.attributes.id);
+            }
+            highlightSelectedGraphic(hit.graphic);
+        } else {
+            startSketchUpdate(hit.graphic);
+        }
+        return;
+    }
+
+    if (sketch?.state !== 'active') {
+        cancelPendingSketchUpdate();
         sketch?.cancel();
         selectedGraphic = null;
         drawStore.clearSelection();
@@ -766,7 +1356,12 @@ const initializeDrawTools = async () => {
             selectionTools: { enable: true },
             settingsMenu: false
         },
-        defaultUpdateOptions: { highlightOptions: { enabled: false } }
+        defaultUpdateOptions: {
+            enableRotation: true,
+            enableScaling: true,
+            highlightOptions: { enabled: false },
+            toggleToolOnClick: false
+        }
     });
     iApi.geo.map.esriView!.ui.add(sketchEl.value!, 'bottom-right');
 
@@ -785,6 +1380,10 @@ const initializeDrawTools = async () => {
 
     if (drawStore.activeTool && drawStore.activeTool !== 'edit') {
         sketch.create(drawStore.activeTool);
+    }
+
+    if (drawStore.measurementsEnabled) {
+        void refreshMeasurementGraphics();
     }
 };
 
@@ -825,6 +1424,7 @@ const cleanupDrawTools = ({
         if (iApi.geo.map.esriView) {
             iApi.geo.map.esriView.ui.remove(sketch);
         }
+        cancelPendingSketchUpdate();
         cancelSketch();
         if (destroySketch) {
             sketch.destroy();
@@ -842,6 +1442,8 @@ const cleanupDrawTools = ({
 
     selectedGraphic = null;
     highlightSelectedGraphic(undefined);
+    cancelPendingSketchUpdate();
+    clearMeasurementGraphics();
     drawStore.clearSelection();
     if (clearActiveTool && drawStore.activeTool) {
         drawStore.setActiveTool(null);
@@ -857,6 +1459,16 @@ const cleanupDrawTools = ({
 
 // Extract the existing sketch event handlers for reuse
 const handleSketchCreateEvent = (event: EsriSketchCreateEvent) => {
+    if (event.state === 'active' && event.graphic) {
+        scheduleMeasurementRefresh(event.graphic, event.tool);
+        return;
+    }
+
+    if (event.state === 'cancel') {
+        void refreshMeasurementGraphics();
+        return;
+    }
+
     if (event.state === 'complete') {
         const graphic = event.graphic;
         if (!graphic) {
@@ -865,12 +1477,14 @@ const handleSketchCreateEvent = (event: EsriSketchCreateEvent) => {
         const id = `graphic-${Date.now()}`;
         graphic.attributes = graphic.attributes || {};
         graphic.attributes.id = id;
+        graphic.attributes.type = event.tool;
         drawStore.addGraphic({
             id,
             type: event.tool,
             geometry: graphic.geometry,
             attributes: graphic.attributes
         });
+        void refreshMeasurementGraphics(graphic, event.tool);
 
         if (event.tool !== 'point') {
             drawStore.setActiveTool('');
@@ -889,6 +1503,7 @@ const handleSketchUpdateEvent = (event: EsriSketchUpdateEvent) => {
             return;
         }
 
+        cancelPendingSketchUpdate();
         selectedGraphic = graphic;
         if (graphic.attributes?.id) {
             drawStore.selectGraphic(graphic.attributes.id);
@@ -901,11 +1516,13 @@ const handleSketchUpdateEvent = (event: EsriSketchUpdateEvent) => {
     } else if (event.state === 'active') {
         // update highlight while editing
         highlightSelectedGraphic(graphic);
+        scheduleMeasurementRefresh(graphic, graphic.attributes?.type);
     } else if (event.state === 'complete') {
         if (graphic.attributes?.id) {
             drawStore.updateGraphicGeometry(graphic.attributes.id, graphic.geometry);
             iApi.updateAlert(t('draw.graphic.updated'));
         }
+        void refreshMeasurementGraphics(graphic, graphic.attributes?.type);
     }
 };
 
@@ -936,6 +1553,13 @@ onMounted(() => {
             initializeDrawTools();
         })
     );
+    rampEventHandlers.push(
+        iApi.event.on(GlobalEvents.FIXTURE_ADDED, fixture => {
+            if (fixture.id === 'panguard') {
+                setPanguardForActiveTool();
+            }
+        })
+    );
 });
 
 /* --------------------------------------------------------------------------
@@ -944,13 +1568,17 @@ onMounted(() => {
 watch(
     () => drawStore.activeTool,
     newTool => {
+        setPanguardForActiveTool(newTool);
+
         if (!sketch) return;
 
+        cancelPendingSketchUpdate();
         cancelSketch();
         highlightSelectedGraphic();
         multiPointGraphic = null;
         multiPointVertices = [];
         multiPointMode = false;
+        void refreshMeasurementGraphics();
         if (newTool && newTool != 'edit') {
             try {
                 sketch.create(newTool);
@@ -958,13 +1586,18 @@ watch(
                 console.warn('Unable to start draw sketch.', e);
             }
         }
-    }
+    },
+    { immediate: true }
 );
 
 /* --------------------------------------------------------------------------
  * CLEANUP ON UNMOUNT
  * -------------------------------------------------------------------------- */
 onUnmounted(() => {
+    if (panguardEnabledBeforeDraw !== null) {
+        iApi.fixture.get<PanguardAPI>('panguard')?.setEnabled(panguardEnabledBeforeDraw);
+        panguardEnabledBeforeDraw = null;
+    }
     cleanupDrawTools();
 
     // Remove RAMP event handlers

--- a/src/fixtures/draw/draw.vue
+++ b/src/fixtures/draw/draw.vue
@@ -1,6 +1,9 @@
 |
 <template>
     <arcgis-sketch ref="sketchEl" style="display: none" />
+    <div v-if="drawStore.measurementsEnabled" class="sr-only" aria-live="polite" aria-atomic="true">
+        {{ measurementSummary }}
+    </div>
 </template>
 <script lang="ts">
 export const DRAW_GRAPHICS_LAYER_ID = 'RampDrawGraphicsLayer';
@@ -18,22 +21,33 @@ export const DRAW_GRAPHICS_LAYER_ID = 'RampDrawGraphicsLayer';
 /* --------------------------------------------------------------------------
  * IMPORTS
  * -------------------------------------------------------------------------- */
-import { inject, onMounted, onUnmounted, watch, reactive, useTemplateRef } from 'vue';
+import { inject, onMounted, onUnmounted, watch, reactive, ref, toRaw, useTemplateRef } from 'vue';
 import { useDrawStore } from './store';
 import { InstanceAPI } from '@/api/internal';
 
 import { LayerType } from '@/geo/api';
 import { useI18n } from 'vue-i18n';
 import {
+    EsriAreaOperator,
+    EsriCentroidOperator,
+    EsriGeodeticAreaOperator,
+    EsriGeodeticAreaOperatorIsLoaded,
+    EsriGeodeticAreaOperatorLoad,
+    EsriGeodeticLengthOperator,
+    EsriGeodeticLengthOperatorIsLoaded,
+    EsriGeodeticLengthOperatorLoad,
     EsriGraphic,
+    EsriLengthOperator,
     EsriPoint,
     EsriPolygon,
     EsriPolyline,
     EsriSimpleFillSymbol,
     EsriSimpleLineSymbol,
-    EsriSimpleMarkerSymbol
+    EsriSimpleMarkerSymbol,
+    EsriTextSymbol
 } from '@/geo/esri';
 import type {
+    EsriGeometry,
     EsriGraphicHit,
     EsriGraphicsLayer,
     EsriSketchCreateEvent,
@@ -70,6 +84,12 @@ let graphicsLayer: EsriGraphicsLayer | null = null;
 let viewClickHandler: { remove: () => void } | null = null;
 let sketchEventsRegistered = false;
 let drawToolsInitId = 0;
+let sketchUpdateFrame: number | null = null;
+let measurementRefreshFrame: number | null = null;
+let measurementRefreshRunId = 0;
+let measurementOperatorLoadPromise: Promise<void> | null = null;
+let measurementGraphics: EsriGraphic[] = [];
+let pendingMeasurementRefresh: { activeGraphic?: EsriGraphic; activeTool?: string } | null = null;
 
 // Variables for selected and highlighted graphics
 let selectedGraphic: EsriGraphic | null = null;
@@ -84,6 +104,7 @@ let multiPointVertices: Vertex[] = [];
 
 const rampEventHandlers = reactive<Array<string>>([]);
 let keyboardNamespace: string | undefined;
+const measurementSummary = ref('');
 
 const onSketchCreate = (event: Event) => {
     handleSketchCreateEvent((event as CustomEvent<EsriSketchCreateEvent>).detail);
@@ -99,6 +120,13 @@ const cancelSketch = () => {
     } catch (e) {
         console.warn('Unable to cancel draw sketch.', e);
     }
+};
+
+const cancelPendingSketchUpdate = () => {
+    if (sketchUpdateFrame === null) return;
+
+    window.cancelAnimationFrame(sketchUpdateFrame);
+    sketchUpdateFrame = null;
 };
 
 async function handleKeyboardShortcuts() {
@@ -163,6 +191,14 @@ async function handleKeyboardShortcuts() {
                 handler: () => {
                     drawStore.setActiveTool('edit');
                 }
+            },
+            {
+                key: 'M',
+                description: buildLocaleRecord('draw.keyboard.key.measurements'),
+                handler: () => {
+                    drawStore.toggleMeasurements();
+                    return 'reset';
+                }
             }
         ]
     });
@@ -219,6 +255,507 @@ const highlightSelectedGraphic = (graphic?: EsriGraphic | undefined) => {
     graphicsLayer?.add(highlightGraphic);
 };
 
+const startSketchUpdate = (graphic: EsriGraphic) => {
+    if (!sketch || drawStore.activeTool !== 'edit') return;
+
+    selectedGraphic = graphic;
+    if (graphic.attributes?.id) {
+        drawStore.selectGraphic(graphic.attributes.id);
+    }
+    highlightSelectedGraphic(graphic);
+
+    cancelPendingSketchUpdate();
+    sketchUpdateFrame = window.requestAnimationFrame(() => {
+        sketchUpdateFrame = null;
+
+        if (!sketch || drawStore.activeTool !== 'edit' || selectedGraphic !== graphic || sketch.state === 'active') {
+            return;
+        }
+
+        void sketch.triggerUpdate([graphic], {
+            tool: 'transform',
+            toggleToolOnClick: false,
+            highlightOptions: { enabled: false }
+        });
+    });
+};
+
+type FormattedMeasurement = {
+    display: string;
+    spoken: string;
+};
+
+type MeasurementLabelInfo = {
+    graphic: EsriGraphic;
+    accessibleText: string;
+};
+
+type MeasurableGraphic = {
+    id: string;
+    type: string;
+    geometry: EsriGeometry;
+};
+
+const formatMeasurementNumber = (value: number, maximumFractionDigits: number): string =>
+    value.toLocaleString(locale.value, {
+        maximumFractionDigits,
+        minimumFractionDigits: 0
+    });
+
+const formatLength = (meters: number): FormattedMeasurement => {
+    const absMeters = Math.abs(meters);
+
+    if (absMeters >= 1000) {
+        const kilometers = absMeters / 1000;
+        const decimals = kilometers >= 10 ? 1 : 2;
+        const value = formatMeasurementNumber(kilometers, decimals);
+        return {
+            display: `${value} km`,
+            spoken: `${value} kilometers`
+        };
+    }
+
+    if (absMeters >= 1) {
+        const decimals = absMeters >= 10 ? 0 : 1;
+        const value = formatMeasurementNumber(absMeters, decimals);
+        return {
+            display: `${value} m`,
+            spoken: `${value} meters`
+        };
+    }
+
+    const centimeters = absMeters * 100;
+    const value = formatMeasurementNumber(centimeters, centimeters >= 10 ? 0 : 1);
+    return {
+        display: `${value} cm`,
+        spoken: `${value} centimeters`
+    };
+};
+
+const formatArea = (squareMeters: number): FormattedMeasurement => {
+    const absSquareMeters = Math.abs(squareMeters);
+
+    if (absSquareMeters >= 1000000) {
+        const squareKilometers = absSquareMeters / 1000000;
+        const decimals = squareKilometers >= 10 ? 1 : 2;
+        const value = formatMeasurementNumber(squareKilometers, decimals);
+        return {
+            display: `${value} sq km`,
+            spoken: `${value} square kilometers`
+        };
+    }
+
+    const decimals = absSquareMeters >= 100 ? 0 : absSquareMeters >= 10 ? 1 : 2;
+    const value = formatMeasurementNumber(absSquareMeters, decimals);
+    return {
+        display: `${value} sq m`,
+        spoken: `${value} square meters`
+    };
+};
+
+const shouldUseGeodesicMeasurement = (geometry: EsriGeometry): boolean =>
+    !!geometry.spatialReference?.isGeographic || !!geometry.spatialReference?.isWebMercator;
+
+const loadMeasurementOperators = async (): Promise<void> => {
+    measurementOperatorLoadPromise ??= Promise.all([
+        EsriGeodeticAreaOperatorIsLoaded() ? Promise.resolve() : EsriGeodeticAreaOperatorLoad(),
+        EsriGeodeticLengthOperatorIsLoaded() ? Promise.resolve() : EsriGeodeticLengthOperatorLoad()
+    ]).then(() => undefined);
+
+    await measurementOperatorLoadPromise;
+};
+
+const executeLengthMeters = (polyline: EsriPolyline, geodesic: boolean): number =>
+    geodesic
+        ? EsriGeodeticLengthOperator(polyline, { unit: 'meters' })
+        : EsriLengthOperator(polyline, { unit: 'meters' });
+
+const measurePolylineMeters = (polyline: EsriPolyline): number | undefined => {
+    const geodesic = shouldUseGeodesicMeasurement(polyline);
+
+    try {
+        const length = Math.abs(executeLengthMeters(polyline, geodesic));
+        if (Number.isFinite(length)) return length;
+    } catch {
+        // Try the alternate measurement below.
+    }
+
+    try {
+        const length = Math.abs(executeLengthMeters(polyline, !geodesic));
+        return Number.isFinite(length) ? length : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const executeAreaSquareMeters = (polygon: EsriPolygon, geodesic: boolean): number =>
+    geodesic
+        ? EsriGeodeticAreaOperator(polygon, { unit: 'square-meters' })
+        : EsriAreaOperator(polygon, { unit: 'square-meters' });
+
+const measurePolygonSquareMeters = (polygon: EsriPolygon): number | undefined => {
+    const geodesic = shouldUseGeodesicMeasurement(polygon);
+
+    try {
+        const area = Math.abs(executeAreaSquareMeters(polygon, geodesic));
+        if (Number.isFinite(area)) return area;
+    } catch {
+        // Try the alternate measurement below.
+    }
+
+    try {
+        const area = Math.abs(executeAreaSquareMeters(polygon, !geodesic));
+        return Number.isFinite(area) ? area : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+const segmentMidpoint = (start: Vertex, end: Vertex, spatialReference: EsriGeometry['spatialReference']): EsriPoint =>
+    new EsriPoint({
+        x: (start[0] + end[0]) / 2,
+        y: (start[1] + end[1]) / 2,
+        spatialReference
+    });
+
+const normalizeTextAngle = (angle: number): number => {
+    if (angle > 90) return angle - 180;
+    if (angle < -90) return angle + 180;
+    return angle;
+};
+
+const segmentAngle = (start: Vertex, end: Vertex, spatialReference: EsriGeometry['spatialReference']): number => {
+    const view = iApi.geo.map.esriView;
+    if (view) {
+        const startScreen = view.toScreen(new EsriPoint({ x: start[0], y: start[1], spatialReference }));
+        const endScreen = view.toScreen(new EsriPoint({ x: end[0], y: end[1], spatialReference }));
+        if (startScreen && endScreen) {
+            return normalizeTextAngle(
+                (Math.atan2(endScreen.y - startScreen.y, endScreen.x - startScreen.x) * 180) / Math.PI
+            );
+        }
+    }
+
+    return normalizeTextAngle((Math.atan2(end[1] - start[1], end[0] - start[0]) * 180) / Math.PI);
+};
+
+const segmentLengthMeters = (
+    start: Vertex,
+    end: Vertex,
+    spatialReference: EsriGeometry['spatialReference']
+): number | undefined =>
+    measurePolylineMeters(
+        new EsriPolyline({
+            paths: [
+                [
+                    [start[0], start[1]],
+                    [end[0], end[1]]
+                ]
+            ],
+            spatialReference
+        })
+    );
+
+const polygonLabelPoint = (polygon: EsriPolygon): EsriPoint | undefined => {
+    try {
+        const centroid = EsriCentroidOperator(polygon);
+        if (centroid) {
+            return centroid;
+        }
+    } catch {
+        // Fall back to the extent center below.
+    }
+
+    const extent = polygon.extent;
+    if (!extent) return undefined;
+
+    return new EsriPoint({
+        x: (extent.xmin + extent.xmax) / 2,
+        y: (extent.ymin + extent.ymax) / 2,
+        spatialReference: polygon.spatialReference
+    });
+};
+
+const createMeasurementTextGraphic = (
+    point: EsriPoint,
+    text: string,
+    kind: 'distance' | 'area',
+    angle = 0
+): EsriGraphic =>
+    new EsriGraphic({
+        geometry: point,
+        symbol: new EsriTextSymbol({
+            text,
+            angle,
+            color: kind === 'area' ? [255, 255, 255, 1] : [17, 24, 39, 1],
+            haloColor: kind === 'area' ? [17, 24, 39, 1] : [255, 255, 255, 1],
+            haloSize: 1.5,
+            backgroundColor: kind === 'area' ? [17, 24, 39, 0.92] : [255, 255, 255, 0.9],
+            borderLineColor: kind === 'area' ? [255, 255, 255, 0.95] : [17, 24, 39, 0.85],
+            borderLineSize: 0.6,
+            horizontalAlignment: 'center',
+            verticalAlignment: 'middle',
+            yoffset: kind === 'area' ? 0 : 8,
+            font: {
+                family: 'Arial',
+                size: 11,
+                weight: 'bold'
+            }
+        }),
+        attributes: {
+            drawMeasurement: true
+        }
+    });
+
+const buildSegmentMeasurementLabels = (geometry: EsriGeometry, toolType: string): MeasurementLabelInfo[] => {
+    if (toolType === 'circle') {
+        return [];
+    }
+
+    const paths =
+        geometry.type === 'polyline'
+            ? (geometry as EsriPolyline).paths
+            : geometry.type === 'polygon'
+              ? (geometry as EsriPolygon).rings
+              : [];
+
+    let segmentIndex = 0;
+    return paths.flatMap(path => {
+        const labels: MeasurementLabelInfo[] = [];
+        for (let index = 0; index < path.length - 1; index++) {
+            const start = path[index] as Vertex;
+            const end = path[index + 1] as Vertex;
+            const length = segmentLengthMeters(start, end, geometry.spatialReference);
+
+            if (!length || length < 0.01) {
+                continue;
+            }
+
+            segmentIndex++;
+            const formatted = formatLength(length);
+            labels.push({
+                graphic: createMeasurementTextGraphic(
+                    segmentMidpoint(start, end, geometry.spatialReference),
+                    formatted.display,
+                    'distance',
+                    segmentAngle(start, end, geometry.spatialReference)
+                ),
+                accessibleText: t('draw.measurements.segment', {
+                    index: segmentIndex,
+                    distance: formatted.spoken
+                })
+            });
+        }
+        return labels;
+    });
+};
+
+const buildAreaMeasurementLabel = (geometry: EsriGeometry): MeasurementLabelInfo | undefined => {
+    if (geometry.type !== 'polygon') {
+        return undefined;
+    }
+
+    const polygon = geometry as EsriPolygon;
+    const area = measurePolygonSquareMeters(polygon);
+    const point = polygonLabelPoint(polygon);
+
+    if (!area || area < 0.01 || !point) {
+        return undefined;
+    }
+
+    const formatted = formatArea(area);
+    return {
+        graphic: createMeasurementTextGraphic(point, formatted.display, 'area'),
+        accessibleText: t('draw.measurements.area', {
+            area: formatted.spoken
+        })
+    };
+};
+
+const buildGraphicMeasurementLabels = (graphic: MeasurableGraphic): MeasurementLabelInfo[] => {
+    const geometry = graphic.geometry;
+    if (!geometry || geometry.type === 'point' || geometry.type === 'multipoint') {
+        return [];
+    }
+
+    const labels = buildSegmentMeasurementLabels(geometry, graphic.type);
+    const areaLabel = buildAreaMeasurementLabel(geometry);
+    if (areaLabel) {
+        labels.push(areaLabel);
+    }
+
+    return labels;
+};
+
+const getGraphicId = (graphic: EsriGraphic): string | undefined => graphic.attributes?.id;
+
+const makeMeasurableGraphic = (
+    id: string,
+    type: string | undefined,
+    geometry: EsriGeometry | null | undefined
+): MeasurableGraphic | undefined => {
+    if (!geometry) return undefined;
+
+    return {
+        id,
+        type: type ?? geometry.type,
+        geometry
+    };
+};
+
+const getStoredMeasurableGraphics = (): MeasurableGraphic[] =>
+    drawStore.graphics
+        .map(graphic =>
+            makeMeasurableGraphic(
+                String(graphic.id ?? graphic.attributes?.id ?? ''),
+                graphic.type ?? graphic.attributes?.type,
+                toRaw(graphic.geometry) as EsriGeometry | null | undefined
+            )
+        )
+        .filter((graphic): graphic is MeasurableGraphic => !!graphic?.id);
+
+const getLayerMeasurableGraphics = (): MeasurableGraphic[] =>
+    (graphicsLayer?.graphics.toArray() ?? [])
+        .filter(graphic => !!getGraphicId(graphic))
+        .map(graphic =>
+            makeMeasurableGraphic(
+                getGraphicId(graphic)!,
+                graphic.attributes?.type,
+                graphic.geometry as EsriGeometry | null | undefined
+            )
+        )
+        .filter((graphic): graphic is MeasurableGraphic => !!graphic);
+
+const getActiveMeasurableGraphic = (
+    activeGraphic?: EsriGraphic,
+    activeTool?: string
+): MeasurableGraphic | undefined => {
+    if (!activeGraphic) return undefined;
+
+    return makeMeasurableGraphic(
+        getGraphicId(activeGraphic) ?? 'active-draw-measurement',
+        activeTool ?? activeGraphic.attributes?.type,
+        activeGraphic.geometry as EsriGeometry | null | undefined
+    );
+};
+
+const buildMeasurementLabels = (activeGraphic?: EsriGraphic, activeTool?: string): MeasurementLabelInfo[] => {
+    const sources = new Map<string, MeasurableGraphic>();
+
+    getStoredMeasurableGraphics().forEach(graphic => sources.set(graphic.id, graphic));
+    getLayerMeasurableGraphics().forEach(graphic => sources.set(graphic.id, graphic));
+
+    const activeSource = getActiveMeasurableGraphic(activeGraphic, activeTool);
+    if (activeSource) {
+        sources.set(activeSource.id, activeSource);
+    }
+
+    return Array.from(sources.values()).flatMap(graphic => buildGraphicMeasurementLabels(graphic));
+};
+
+const clearMeasurementGraphics = () => {
+    measurementRefreshRunId++;
+
+    if (measurementRefreshFrame !== null) {
+        window.cancelAnimationFrame(measurementRefreshFrame);
+        measurementRefreshFrame = null;
+    }
+    pendingMeasurementRefresh = null;
+    measurementSummary.value = '';
+
+    try {
+        iApi.geo.map.esriView?.graphics.removeMany(measurementGraphics);
+    } catch (e) {
+        console.warn('Unable to clear draw measurement graphics.', e);
+    }
+    measurementGraphics = [];
+};
+
+const updateMeasurementSummary = (labels: MeasurementLabelInfo[]) => {
+    const nextSummary = labels.length
+        ? t('draw.measurements.summary', {
+              measurements: labels.map(label => label.accessibleText).join('. ')
+          })
+        : t('draw.measurements.none');
+
+    if (measurementSummary.value !== nextSummary) {
+        measurementSummary.value = nextSummary;
+    }
+};
+
+const refreshMeasurementGraphics = async (activeGraphic?: EsriGraphic, activeTool?: string) => {
+    const refreshRunId = ++measurementRefreshRunId;
+
+    if (measurementRefreshFrame !== null) {
+        window.cancelAnimationFrame(measurementRefreshFrame);
+        measurementRefreshFrame = null;
+        pendingMeasurementRefresh = null;
+    }
+
+    if (!drawStore.measurementsEnabled) {
+        clearMeasurementGraphics();
+        return;
+    }
+
+    try {
+        await loadMeasurementOperators();
+    } catch (e) {
+        console.warn('Unable to load draw measurement operators.', e);
+        return;
+    }
+
+    if (refreshRunId !== measurementRefreshRunId || !drawStore.measurementsEnabled) {
+        return;
+    }
+
+    const labels = buildMeasurementLabels(activeGraphic, activeTool);
+    const viewGraphics = iApi.geo.map.esriView?.graphics;
+
+    if (!viewGraphics) {
+        return;
+    }
+
+    try {
+        if (measurementGraphics.length) {
+            viewGraphics.removeMany(measurementGraphics);
+        }
+    } catch (e) {
+        console.warn('Unable to remove stale draw measurement graphics.', e);
+    }
+
+    measurementGraphics = labels.map(label => label.graphic);
+
+    try {
+        if (measurementGraphics.length) {
+            viewGraphics.addMany(measurementGraphics);
+        }
+    } catch (e) {
+        console.warn('Unable to add draw measurement graphics.', e);
+        measurementGraphics = [];
+    }
+
+    updateMeasurementSummary(labels);
+};
+
+const scheduleMeasurementRefresh = (activeGraphic?: EsriGraphic, activeTool?: string) => {
+    if (!drawStore.measurementsEnabled) {
+        clearMeasurementGraphics();
+        return;
+    }
+
+    pendingMeasurementRefresh = { activeGraphic, activeTool };
+    if (measurementRefreshFrame !== null) {
+        return;
+    }
+
+    measurementRefreshFrame = window.requestAnimationFrame(() => {
+        measurementRefreshFrame = null;
+        const refreshRequest = pendingMeasurementRefresh;
+        pendingMeasurementRefresh = null;
+        void refreshMeasurementGraphics(refreshRequest?.activeGraphic, refreshRequest?.activeTool);
+    });
+};
+
 /* --------------------------------------------------------------------------
  * WATCHERS
  * -------------------------------------------------------------------------- */
@@ -228,16 +765,29 @@ watch(
     (newId, oldId) => {
         if (!sketch || !graphicsLayer) return;
         if (!newId) {
+            cancelPendingSketchUpdate();
             cancelSketch();
             highlightSelectedGraphic();
         } else if (newId !== oldId) {
             const graphics = graphicsLayer.graphics.toArray();
             const selectedEsriGraphic = graphics.find(g => g.attributes && g.attributes.id === newId);
             if (selectedEsriGraphic) {
-                sketch.triggerUpdate([selectedEsriGraphic]);
                 highlightSelectedGraphic(selectedEsriGraphic);
             }
         }
+    }
+);
+
+watch(
+    () => drawStore.measurementsEnabled,
+    enabled => {
+        if (enabled) {
+            void refreshMeasurementGraphics();
+        } else {
+            clearMeasurementGraphics();
+        }
+
+        iApi.updateAlert(t(enabled ? 'draw.measurements.enabled' : 'draw.measurements.disabled'));
     }
 );
 
@@ -258,23 +808,20 @@ const selectCenteredGraphic = async () => {
         width: 20,
         height: 20
     };
-    const response = await view.hitTest(searchArea);
+    const response = await view.hitTest(searchArea, { include: graphicsLayer });
     const hits = response.results.filter((result): result is EsriGraphicHit => {
         if (!('graphic' in result) || result.graphic.layer !== graphicsLayer) return false;
         return !!result.graphic.attributes?.id;
     });
     if (hits.length > 0) {
-        selectedGraphic = hits[0].graphic;
-        sketch.triggerUpdate([selectedGraphic]);
-        if (selectedGraphic.attributes?.id) {
-            drawStore.selectGraphic(selectedGraphic.attributes.id);
-        }
+        startSketchUpdate(hits[0].graphic);
         iApi.updateAlert(
             t('draw.graphic.selected', {
-                type: translateTerm(selectedGraphic.attributes?.type)
+                type: translateTerm(hits[0].graphic.attributes?.type)
             })
         );
     } else {
+        cancelPendingSketchUpdate();
         sketch.cancel();
         selectedGraphic = null;
         drawStore.clearSelection();
@@ -389,6 +936,7 @@ const createGraphicAtCenter = async () => {
             geometry: graphic.geometry,
             attributes: graphic.attributes
         });
+        void refreshMeasurementGraphics();
 
         // cancel sketch if graphic is not a point
         if (drawStore.activeTool !== 'point') {
@@ -457,6 +1005,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                         }
                         multiPointGraphic.attributes = { id: `temp-graphic-${Date.now()}`, type: drawStore.activeTool };
                         graphicsLayer?.add(multiPointGraphic);
+                        void refreshMeasurementGraphics(multiPointGraphic, drawStore.activeTool ?? undefined);
 
                         iApi.updateAlert(
                             t('draw.multiPoint.started', {
@@ -477,6 +1026,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                                 spatialReference: view.spatialReference
                             });
                         }
+                        void refreshMeasurementGraphics(multiPointGraphic!, drawStore.activeTool ?? undefined);
 
                         iApi.updateAlert(
                             t('draw.multiPoint.pointAdded', {
@@ -512,6 +1062,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                 }
                 // Notify geometry change using public API
                 multiPointGraphic!.set('geometry', multiPointGraphic?.geometry);
+                void refreshMeasurementGraphics(multiPointGraphic!, drawStore.activeTool ?? undefined);
                 iApi.updateAlert(
                     t('draw.multiPoint.pointRemoved', {
                         type: translateTerm(drawStore.activeTool ?? undefined),
@@ -526,6 +1077,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                 multiPointGraphic = null;
                 multiPointVertices = [];
                 multiPointMode = false;
+                void refreshMeasurementGraphics();
                 iApi.updateAlert(t('draw.multiPoint.canceled'));
             } else if (selectedGraphic) {
                 e.preventDefault();
@@ -536,6 +1088,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
                 }
                 selectedGraphic = null;
                 highlightSelectedGraphic(undefined);
+                void refreshMeasurementGraphics();
                 iApi.updateAlert(t('draw.graphic.deleted'));
             }
             break;
@@ -546,6 +1099,7 @@ const handleNavigationKeyDown = (e: KeyboardEvent) => {
             selectedGraphic = null;
             highlightSelectedGraphic(undefined);
             drawStore.clearSelection();
+            void refreshMeasurementGraphics();
             iApi.updateAlert(t('draw.tool.canceled'));
             break;
     }
@@ -694,6 +1248,7 @@ const handleGraphicKeyboardEdit = (e: KeyboardEvent) => {
         if (selectedGraphic.attributes?.id) {
             drawStore.updateGraphicGeometry(selectedGraphic.attributes.id, newGeometry);
         }
+        scheduleMeasurementRefresh(selectedGraphic, selectedGraphic.attributes?.type);
         const action = isResizing ? 'resized' : isRotating ? 'rotated' : 'moved';
         iApi.updateAlert(t(`draw.graphic.${action}`));
     }
@@ -708,16 +1263,30 @@ const handleGraphicKeyboardEdit = (e: KeyboardEvent) => {
  * @param event The view click event.
  */
 const handleViewClick = async (event: EsriViewClickEvent) => {
+    if (drawStore.activeTool !== 'edit') return;
+
     const view = iApi.geo.map.esriView!;
-    const response = await view.hitTest(event);
+    const response = await view.hitTest(event, { include: graphicsLayer });
     const hit = response.results.find(
         (result): result is EsriGraphicHit =>
             'graphic' in result && result.graphic.layer === graphicsLayer && !!result.graphic.attributes?.id
     );
 
-    if (hit && drawStore.activeTool === 'edit') {
-        sketch?.triggerUpdate([hit.graphic]);
-    } else {
+    if (hit) {
+        if (sketch?.state === 'active') {
+            selectedGraphic = hit.graphic;
+            if (hit.graphic.attributes?.id) {
+                drawStore.selectGraphic(hit.graphic.attributes.id);
+            }
+            highlightSelectedGraphic(hit.graphic);
+        } else {
+            startSketchUpdate(hit.graphic);
+        }
+        return;
+    }
+
+    if (sketch?.state !== 'active') {
+        cancelPendingSketchUpdate();
         sketch?.cancel();
         selectedGraphic = null;
         drawStore.clearSelection();
@@ -766,7 +1335,10 @@ const initializeDrawTools = async () => {
             selectionTools: { enable: true },
             settingsMenu: false
         },
-        defaultUpdateOptions: { highlightOptions: { enabled: false } }
+        defaultUpdateOptions: {
+            highlightOptions: { enabled: false },
+            toggleToolOnClick: false
+        }
     });
     iApi.geo.map.esriView!.ui.add(sketchEl.value!, 'bottom-right');
 
@@ -785,6 +1357,10 @@ const initializeDrawTools = async () => {
 
     if (drawStore.activeTool && drawStore.activeTool !== 'edit') {
         sketch.create(drawStore.activeTool);
+    }
+
+    if (drawStore.measurementsEnabled) {
+        void refreshMeasurementGraphics();
     }
 };
 
@@ -825,6 +1401,7 @@ const cleanupDrawTools = ({
         if (iApi.geo.map.esriView) {
             iApi.geo.map.esriView.ui.remove(sketch);
         }
+        cancelPendingSketchUpdate();
         cancelSketch();
         if (destroySketch) {
             sketch.destroy();
@@ -842,6 +1419,8 @@ const cleanupDrawTools = ({
 
     selectedGraphic = null;
     highlightSelectedGraphic(undefined);
+    cancelPendingSketchUpdate();
+    clearMeasurementGraphics();
     drawStore.clearSelection();
     if (clearActiveTool && drawStore.activeTool) {
         drawStore.setActiveTool(null);
@@ -857,6 +1436,16 @@ const cleanupDrawTools = ({
 
 // Extract the existing sketch event handlers for reuse
 const handleSketchCreateEvent = (event: EsriSketchCreateEvent) => {
+    if (event.state === 'active' && event.graphic) {
+        scheduleMeasurementRefresh(event.graphic, event.tool);
+        return;
+    }
+
+    if (event.state === 'cancel') {
+        void refreshMeasurementGraphics();
+        return;
+    }
+
     if (event.state === 'complete') {
         const graphic = event.graphic;
         if (!graphic) {
@@ -865,12 +1454,14 @@ const handleSketchCreateEvent = (event: EsriSketchCreateEvent) => {
         const id = `graphic-${Date.now()}`;
         graphic.attributes = graphic.attributes || {};
         graphic.attributes.id = id;
+        graphic.attributes.type = event.tool;
         drawStore.addGraphic({
             id,
             type: event.tool,
             geometry: graphic.geometry,
             attributes: graphic.attributes
         });
+        void refreshMeasurementGraphics(graphic, event.tool);
 
         if (event.tool !== 'point') {
             drawStore.setActiveTool('');
@@ -889,6 +1480,7 @@ const handleSketchUpdateEvent = (event: EsriSketchUpdateEvent) => {
             return;
         }
 
+        cancelPendingSketchUpdate();
         selectedGraphic = graphic;
         if (graphic.attributes?.id) {
             drawStore.selectGraphic(graphic.attributes.id);
@@ -901,11 +1493,13 @@ const handleSketchUpdateEvent = (event: EsriSketchUpdateEvent) => {
     } else if (event.state === 'active') {
         // update highlight while editing
         highlightSelectedGraphic(graphic);
+        scheduleMeasurementRefresh(graphic, graphic.attributes?.type);
     } else if (event.state === 'complete') {
         if (graphic.attributes?.id) {
             drawStore.updateGraphicGeometry(graphic.attributes.id, graphic.geometry);
             iApi.updateAlert(t('draw.graphic.updated'));
         }
+        void refreshMeasurementGraphics(graphic, graphic.attributes?.type);
     }
 };
 
@@ -946,11 +1540,13 @@ watch(
     newTool => {
         if (!sketch) return;
 
+        cancelPendingSketchUpdate();
         cancelSketch();
         highlightSelectedGraphic();
         multiPointGraphic = null;
         multiPointVertices = [];
         multiPointMode = false;
+        void refreshMeasurementGraphics();
         if (newTool && newTool != 'edit') {
             try {
                 sketch.create(newTool);

--- a/src/fixtures/draw/icons/measure-icon.vue
+++ b/src/fixtures/draw/icons/measure-icon.vue
@@ -1,0 +1,19 @@
+<template>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path
+            d="M20 17.5 6.5 4 4 6.5 17.5 20 20 17.5z"
+            fill="none"
+            stroke="currentColor"
+            stroke-linejoin="round"
+            stroke-width="2"
+        />
+        <path
+            d="m16 16 1.5-1.5M13.5 13.5 15 12M11 11l1.5-1.5M8.5 8.5 10 7"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-width="1.5"
+        />
+    </svg>
+</template>

--- a/src/fixtures/draw/icons/measure-icon.vue
+++ b/src/fixtures/draw/icons/measure-icon.vue
@@ -1,0 +1,19 @@
+<template>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+        <path d="M0 0h24v24H0z" fill="none" />
+        <path
+            d="M4 17.5 17.5 4l2.5 2.5L6.5 20 4 17.5z"
+            fill="none"
+            stroke="currentColor"
+            stroke-linejoin="round"
+            stroke-width="2"
+        />
+        <path
+            d="m8 16-1.5-1.5M10.5 13.5 9 12M13 11l-1.5-1.5M15.5 8.5 14 7"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-width="1.5"
+        />
+    </svg>
+</template>

--- a/src/fixtures/draw/lang/lang.csv
+++ b/src/fixtures/draw/lang/lang.csv
@@ -27,18 +27,27 @@ draw.button.polyline,Draw line,1,Dessiner une ligne,0
 draw.button.polygon,Draw polygon,1,Dessiner un polygone,0
 draw.button.rectangle,Draw rectangle,1,Dessiner un rectangle,0
 draw.button.circle,Draw circle,1,Dessiner un cercle,0
+draw.button.measurements,Toggle measurements,1,Afficher ou masquer les mesures,0
 draw.point.tooltip,Draw point,1,Dessiner un point,0
 draw.polyline.tooltip,Draw polyline,1,Dessiner une polyligne,0
 draw.polygon.tooltip,Draw polygon,1,Dessiner un polygone,0
 draw.circle.tooltip,Draw circle,1,Dessiner un cercle,0
 draw.rectangle.tooltip,Draw rectangle,1,Dessiner un rectangle,0
 draw.edit.tooltip,Edit Mode,1,Mode édition,0
+draw.measurements.tooltip,Toggle measurements,1,Afficher ou masquer les mesures,0
+draw.measurements.enabled,Measurements displayed,1,Mesures affichees,0
+draw.measurements.disabled,Measurements hidden,1,Mesures masquees,0
+draw.measurements.summary,Draw measurements. {measurements},1,Mesures de dessin. {measurements},0
+draw.measurements.none,No draw measurements available,1,Aucune mesure disponible,0
+draw.measurements.segment,Segment {index} distance {distance},1,Segment {index} distance {distance},0
+draw.measurements.area,Area {area},1,Superficie {area},0
 draw.keyboard.namespace,Draw Tools,1,Outils de dessin,0
 draw.keyboard.key.point,Draw a point,1,Dessine un point,0
 draw.keyboard.key.polyline,Draw a line,1,Dessine une ligne,0
 draw.keyboard.key.polygon,Draw a polygon,1,Dessine un polygone,0
 draw.keyboard.key.circle,Draw a circle,1,Dessine un cercle,0
 draw.keyboard.key.rectangle,Draw a rectangle,1,Dessine un rectangle,0
+draw.keyboard.key.measurements,Toggle measurements,1,Afficher ou masquer les mesures,0
 draw.keyboard.key.edit,Edit geometry,1,Mode édition,0
 draw.graphic.moved,Graphic moved,1,Graphique déplacé,0
 draw.shape,shape,1,forme,0

--- a/src/fixtures/draw/store/draw-store.ts
+++ b/src/fixtures/draw/store/draw-store.ts
@@ -13,6 +13,7 @@ export const useDrawStore = defineStore('draw', () => {
     const graphics = reactive<any[]>([]);
     const selectedGraphicId = ref<string | null>(null);
     const mapNavEl = ref<unknown | null>(null);
+    const measurementsEnabled = ref(false);
 
     function setSupportedTypes(types: DrawTypeConfig[]) {
         supportedTypes.value.splice(0, supportedTypes.value.length, ...types);
@@ -64,12 +65,21 @@ export const useDrawStore = defineStore('draw', () => {
         }
     }
 
+    function setMeasurementsEnabled(enabled: boolean) {
+        measurementsEnabled.value = enabled;
+    }
+
+    function toggleMeasurements() {
+        measurementsEnabled.value = !measurementsEnabled.value;
+    }
+
     return {
         supportedTypes,
         configParsed,
         activeTool,
         graphics,
         selectedGraphicId,
+        measurementsEnabled,
         setSupportedTypes,
         setActiveTool,
         addGraphic,
@@ -78,6 +88,8 @@ export const useDrawStore = defineStore('draw', () => {
         clearSelection,
         getSelectedGraphic,
         updateGraphicGeometry,
+        setMeasurementsEnabled,
+        toggleMeasurements,
         mapNavEl
     };
 });

--- a/src/fixtures/mapnav/button.vue
+++ b/src/fixtures/mapnav/button.vue
@@ -11,7 +11,8 @@
             @click="onClickFunction()"
             v-focus-item
             :content="tooltip"
-            :aria-label="typeof tooltip === 'string' ? tooltip : ''"
+            :aria-label="ariaLabel || (typeof tooltip === 'string' ? tooltip : '')"
+            :aria-pressed="ariaPressed"
             v-tippy="{ placement: 'left' }"
         >
             <slot></slot>
@@ -28,6 +29,14 @@ defineProps({
     tooltip: {
         type: [String, Boolean],
         default: false
+    },
+    ariaLabel: {
+        type: String,
+        default: ''
+    },
+    ariaPressed: {
+        type: Boolean,
+        default: undefined
     },
     showOutline: {
         type: Boolean,

--- a/src/fixtures/panguard/api/panguard.ts
+++ b/src/fixtures/panguard/api/panguard.ts
@@ -1,0 +1,20 @@
+import { FixtureInstance } from '@/api';
+import { usePanguardStore } from '../store';
+
+export class PanguardAPI extends FixtureInstance {
+    /**
+     * Whether panguard is currently blocking one-finger touch panning.
+     */
+    get enabled(): boolean {
+        return usePanguardStore(this.$vApp.$pinia).enabled;
+    }
+
+    /**
+     * Enables the panguard on the map when set to true.
+     *
+     * @param value whether panguard should block one-finger touch panning
+     */
+    setEnabled(value: boolean) {
+        usePanguardStore(this.$vApp.$pinia).setEnabled(value);
+    }
+}

--- a/src/fixtures/panguard/index.ts
+++ b/src/fixtures/panguard/index.ts
@@ -1,8 +1,9 @@
 import messages from './lang/lang.csv?raw';
 import PanguardV from './map-panguard.vue';
-import { FixtureInstance } from '@/api';
+import { PanguardAPI } from './api/panguard';
+import { usePanguardStore } from './store';
 
-class PanguardFixture extends FixtureInstance {
+class PanguardFixture extends PanguardAPI {
     added(): void {
         // console.log(`[fixture] ${this.id} added`);
         // Manually add lang entries to i18n
@@ -18,6 +19,9 @@ class PanguardFixture extends FixtureInstance {
         this.removed = () => {
             // console.log(`[fixture] ${this.id} removed`);
             destroy();
+
+            const panguardStore = usePanguardStore(this.$vApp.$pinia);
+            panguardStore.$reset();
         };
     }
 }

--- a/src/fixtures/panguard/map-panguard.vue
+++ b/src/fixtures/panguard/map-panguard.vue
@@ -5,18 +5,48 @@
 </template>
 
 <script setup lang="ts">
-import { inject, onBeforeUnmount, onMounted, reactive, ref } from 'vue';
+import { computed, inject, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 import { GlobalEvents, InstanceAPI } from '@/api';
 import { useI18n } from 'vue-i18n';
 import type { EsriViewPointerEventCommon } from '@/geo/esri';
+import { usePanguardStore } from './store';
 
 const { t } = useI18n();
 const iApi = inject('iApi') as InstanceAPI;
+const panguardStore = usePanguardStore();
 const panGuard = ref<HTMLElement>();
 
+const enabled = computed(() => panguardStore.enabled);
 const timeoutID = ref(-1);
 const esriHandlers = reactive<Array<any>>([]);
 const rampHanders = reactive<Array<string>>([]);
+const pointers = new Map<number, { x: number; y: number }>();
+
+const hidePanGuard = () => {
+    panGuard.value?.classList.remove('pg-active');
+
+    if (timeoutID.value !== -1) {
+        clearTimeout(timeoutID.value);
+        timeoutID.value = -1;
+    }
+};
+
+const resetPanGuard = () => {
+    pointers.clear();
+    hidePanGuard();
+};
+
+const setSingleTouchPan = (enabled: boolean) => {
+    const view = iApi.geo.map.esriView;
+
+    if (view?.navigation) {
+        view.navigation.browserTouchPanEnabled = enabled;
+    }
+};
+
+const updateMapNavigation = () => {
+    setSingleTouchPan(!enabled.value);
+};
 
 onMounted(() => {
     setup();
@@ -28,11 +58,13 @@ onMounted(() => {
     );
     rampHanders.push(
         iApi.event.on(GlobalEvents.MAP_DESTROYED, () => {
+            resetPanGuard();
             esriHandlers.forEach(h => h.remove());
         })
     );
     rampHanders.push(
         iApi.event.on(GlobalEvents.MAP_REFRESH_START, () => {
+            resetPanGuard();
             esriHandlers.forEach(h => h.remove());
         })
     );
@@ -44,14 +76,21 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+    setSingleTouchPan(true);
     rampHanders.forEach(h => iApi.event.off(h));
     esriHandlers.forEach(h => h.remove());
+    resetPanGuard();
+});
+
+watch(enabled, value => {
+    setSingleTouchPan(!value);
+
+    if (!value) {
+        resetPanGuard();
+    }
 });
 
 const setup = () => {
-    // keep track of how many concurrent pointers are on the screen and their initial positions. This is a javascript map, not a map-map
-    const pointers = new Map();
-
     const touchOffHandler = (e: EsriViewPointerEventCommon): void => {
         if (e.pointerType === 'touch') {
             // small delay as to not offend panguard when more than one finger lifts or leaves the map
@@ -63,9 +102,11 @@ const setup = () => {
 
     // prevent possible issues with esri event registration if this fixture runs before the map has built itself
     iApi.geo.map.viewPromise.then(() => {
+        updateMapNavigation();
+
         esriHandlers.push(
             iApi.geo.map.esriView!.on('pointer-down', e => {
-                if (e.pointerType !== 'touch') return;
+                if (!enabled.value || e.pointerType !== 'touch') return;
                 pointers.set(e.pointerId, { x: e.x, y: e.y });
             })
         );
@@ -76,11 +117,16 @@ const setup = () => {
 
         esriHandlers.push(
             iApi.geo.map.esriView!.on('pointer-move', e => {
+                if (!enabled.value) {
+                    resetPanGuard();
+                    return;
+                }
+
                 const { pointerId, pointerType, x, y } = e;
                 const pointer = pointers.get(pointerId);
 
                 if (!pointer || pointerType !== 'touch' || pointers.size !== 1) {
-                    panGuard.value!.classList.remove('pg-active');
+                    hidePanGuard();
                     return;
                 }
 
@@ -89,14 +135,15 @@ const setup = () => {
                 if (distance < 20) return;
 
                 // show the text on screen and remove after 2 seconds of no movement
-                panGuard.value!.classList.add('pg-active');
+                panGuard.value?.classList.add('pg-active');
 
                 if (timeoutID.value !== -1) {
                     clearTimeout(timeoutID.value);
                 }
 
                 timeoutID.value = window.setTimeout(() => {
-                    panGuard.value!.classList.remove('pg-active');
+                    panGuard.value?.classList.remove('pg-active');
+                    timeoutID.value = -1;
                 }, 2000);
             })
         );

--- a/src/fixtures/panguard/store/index.ts
+++ b/src/fixtures/panguard/store/index.ts
@@ -1,0 +1,1 @@
+export * from './panguard-store';

--- a/src/fixtures/panguard/store/panguard-store.ts
+++ b/src/fixtures/panguard/store/panguard-store.ts
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const usePanguardStore = defineStore('panguard', () => {
+    const enabled = ref(true);
+
+    function setEnabled(value: boolean) {
+        enabled.value = value;
+    }
+
+    return { enabled, setEnabled };
+});

--- a/src/geo/esri.ts
+++ b/src/geo/esri.ts
@@ -26,7 +26,20 @@ import EsriPoint from '@arcgis/core/geometry/Point';
 import EsriPolygon from '@arcgis/core/geometry/Polygon';
 import EsriPolyline from '@arcgis/core/geometry/Polyline';
 import EsriSpatialReference from '@arcgis/core/geometry/SpatialReference';
+import { execute as EsriAreaOperator } from '@arcgis/core/geometry/operators/areaOperator';
+import { execute as EsriCentroidOperator } from '@arcgis/core/geometry/operators/centroidOperator';
+import {
+    execute as EsriGeodeticAreaOperator,
+    isLoaded as EsriGeodeticAreaOperatorIsLoaded,
+    load as EsriGeodeticAreaOperatorLoad
+} from '@arcgis/core/geometry/operators/geodeticAreaOperator';
+import {
+    execute as EsriGeodeticLengthOperator,
+    isLoaded as EsriGeodeticLengthOperatorIsLoaded,
+    load as EsriGeodeticLengthOperatorLoad
+} from '@arcgis/core/geometry/operators/geodeticLengthOperator';
 import * as EsriIntersectsOperator from '@arcgis/core/geometry/operators/intersectsOperator';
+import { execute as EsriLengthOperator } from '@arcgis/core/geometry/operators/lengthOperator';
 import { fromJSON as EsriGeometryFromJson } from '@arcgis/core/geometry/support/jsonUtils';
 
 import type EsriFeatureLayer from '@arcgis/core/layers/FeatureLayer';
@@ -78,6 +91,7 @@ import EsriPictureMarkerSymbol from '@arcgis/core/symbols/PictureMarkerSymbol';
 import EsriSimpleFillSymbol from '@arcgis/core/symbols/SimpleFillSymbol';
 import EsriSimpleLineSymbol from '@arcgis/core/symbols/SimpleLineSymbol';
 import EsriSimpleMarkerSymbol from '@arcgis/core/symbols/SimpleMarkerSymbol';
+import EsriTextSymbol from '@arcgis/core/symbols/TextSymbol';
 import type { Symbol2DUnion as EsriSymbol } from '@arcgis/core/symbols/types';
 import { fromJSON as EsriSymbolFromJson } from '@arcgis/core/symbols/support/jsonUtils';
 
@@ -235,7 +249,9 @@ class EsriAPI {
 export {
     EsriAPI,
     type EsriArcadeExecutor,
+    EsriAreaOperator,
     type EsriBasemap,
+    EsriCentroidOperator,
     type EsriClassBreakInfo,
     type EsriClassBreaksRenderer,
     type EsriCollection,
@@ -250,6 +266,12 @@ export {
     type EsriFeatureReductionCluster,
     type EsriField,
     type EsriFieldProperties,
+    EsriGeodeticAreaOperator,
+    EsriGeodeticAreaOperatorIsLoaded,
+    EsriGeodeticAreaOperatorLoad,
+    EsriGeodeticLengthOperator,
+    EsriGeodeticLengthOperatorIsLoaded,
+    EsriGeodeticLengthOperatorLoad,
     type EsriGeometry,
     EsriGeometryFromJson,
     type EsriGoToOptions2D,
@@ -266,6 +288,7 @@ export {
     type EsriLayer,
     type EsriLayerLayerviewCreateEvent,
     type EsriLayerView,
+    EsriLengthOperator,
     type EsriLOD,
     type EsriMap,
     type EsriMapImageLayer,
@@ -297,6 +320,7 @@ export {
     type EsriSublayer,
     type EsriSymbol,
     EsriSymbolFromJson,
+    EsriTextSymbol,
     type EsriTileLayer,
     type EsriTileLayerProperties,
     type EsriUniqueValueInfo,

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -192,7 +192,7 @@ export class MapAPI extends CommonMapAPI {
                 spatialReference: this._rampSR.toESRI(),
                 extent: this._rampExtentSet.defaultExtent.toESRI(),
                 navigation: {
-                    browserTouchPanEnabled: false
+                    browserTouchPanEnabled: true
                 },
                 background: { color: bm.backgroundColour }
             })


### PR DESCRIPTION
### Related Item(s)
#2940

### Changes
- [FEATURE] Draw tools: add support for distance and area measurements 

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open the draw tools sample page https://milespetrov.github.io/ramp4-pcar4/2034-distance/demos/enhanced-samples.html?sample=13
2. Draw a shape on the map
3. Click on the new measure button (in mapnav right above the zoom in button)
4. See the distance and area displayed on the drawn shape
5. Draw a polyline with measure still enabled, see the distances update as you draw
6. Try the keyboard shortcut `S D M` to toggle this feature

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2968)
<!-- Reviewable:end -->
