### PR TITLE
Fix geosearch highlighting and remove extra swiper tab

### DIFF
--- a/src/fixtures/geosearch/store/geosearch-store.ts
+++ b/src/fixtures/geosearch/store/geosearch-store.ts
@@ -2,7 +2,7 @@ import type { MapExtent, QueryParams } from './geosearch-state';
 import { defineStore } from 'pinia';
 import { GeoSearchUI } from './geosearch.feature';
 import { computed, ref } from 'vue';
-import type { IProvinceInfo, ISearchResult} from '../definitions';
+import type { IProvinceInfo, ISearchResult } from '../definitions';
 
 /**
  * Helper function that filters based on query parameters.
@@ -246,21 +246,24 @@ export const useGeosearchStore = defineStore('geosearch', () => {
         // For highlighting purposes, we want to treat accented characters as normal ones & vice versa
         searchTerm = cleanVal(searchTerm);
 
-        searchRegex.value = Array.from(searchTerm)
-            .map(c => {
-                // If character has accents, add them as equivalent replacements to the regex
-                if (Object.keys(accentedChars).includes(c)) {
-                    return '[' + c + accentedChars[c] + ']';
-                }
+        searchRegex.value = searchTerm
+            .trim()
+            .split(/\s+/)
+            .map(word =>
+                Array.from(word)
+                    .map(c => {
+                        // If character has accents, add them as equivalent replacements to the regex
+                        if (Object.keys(accentedChars).includes(c)) {
+                            return '[' + c + accentedChars[c] + ']';
+                        }
 
-                // Replace bad characters with empty string
-                // Escape special regex characters (like '.'), so the string isn't broken
-                return c
-                    .replace(/["$!*+?^{}()|[\]\\]/g, '')
-                    .replace(/[.\\]/g, '\\$&')
-                    .trim();
-            })
-            .join('');
+                        // Replace bad characters with empty string
+                        // Escape special regex characters (like '.'), so the string isn't broken
+                        return c.replace(/["$!*+?^{}()|[\]\\]/g, '').replace(/[.\\]/g, '\\$&');
+                    })
+                    .join('')
+            )
+            .join('|');
     }
 
     /**

--- a/src/fixtures/swipe/swipe.vue
+++ b/src/fixtures/swipe/swipe.vue
@@ -19,6 +19,7 @@
             :style="{ 'z-index': 10 }"
         />
         <arcgis-swipe
+            tabindex="-1"
             direction="horizontal"
             :swipe-position="swipeComponentPosition"
             :view="view"


### PR DESCRIPTION
### Related Item(s)
Issues #2925 & #2957

### Changes
- Added `tabindex=-1` to remove `arcgis-swipe` from tab order, preventing the extra tab in swiper
- Updated handling of search regex value so that spaces don't prevent highlighting text (uses token-based matching to support partial search results)

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Go to Enhanced Sample 12
2. Do a Shift-TAB and use the left / right arrows.
3. Confirm no extra tab
4. Open `Geolocation Search`
5. Type string with spaces (e.g., Varty Lake) and confirm:
     - Matching terms are highlighted within results
     - Both full and partial matches (e.g., "Varty Lake”, “Varty Road")  highlight matching tokens/words

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2973)
<!-- Reviewable:end -->
