### PR TITLE
Fix wizard French translation

### DIFF
--- a/src/fixtures/wizard/screen.vue
+++ b/src/fixtures/wizard/screen.vue
@@ -23,7 +23,7 @@
                             @upload="updateFile"
                             :aria-label="t('wizard.upload.file.label')"
                         />
-                        <span class="block text-center mb-10">or</span>
+                        <span class="block text-center mb-10">{{ t('wizard.upload.or') }}</span>
 
                         <!-- Provide layer URL -->
                         <wizard-input


### PR DESCRIPTION
### Related Item(s)
#2975

### Changes
- [FIX] Replaced the hardcoded wizard upload separator with the existing localized `wizard.upload.or` text key.

### Notes
The separator now displays `or` in English and `ou` in French.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open a demo page.
2. Change the map language to French with `window.debugInstance.setLanguage('fr')`.
3. Open the wizard from the Legend panel `+` button.
4. Confirm Step 1 shows `ou` between the file upload area and URL field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2980)
<!-- Reviewable:end -->
