### PR TITLE
Fix caption icon hover color

### DIFF
--- a/src/components/about-ramp/about-ramp-dropdown.vue
+++ b/src/components/about-ramp/about-ramp-dropdown.vue
@@ -4,10 +4,11 @@
         :position="position"
         :tooltip="t('ramp.about')"
         :tooltipPlacement="position"
+        trigger-class="text-gray-500 hover:text-white"
         v-focus-item
     >
         <template #header>
-            <div class="flex hover:text-white">
+            <div class="flex">
                 <svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 24 24"

--- a/src/components/controls/dropdown-menu.vue
+++ b/src/components/controls/dropdown-menu.vue
@@ -2,7 +2,8 @@
     <div ref="el">
         <button
             type="button"
-            class="text-gray-500 hover:text-black dropdown-button"
+            class="dropdown-button"
+            :class="triggerClass"
             @click="toggleDropdown"
             :content="tooltip"
             :aria-label="ariaLabel ? String(ariaLabel) : String(tooltip)"
@@ -57,6 +58,7 @@ const props = defineProps({
     tooltipPlacementAlt: { type: String, default: 'top' },
     tooltipTheme: { type: String, default: 'ramp4' },
     tooltipAnimation: { type: String, default: 'scale' },
+    triggerClass: { type: String, default: 'text-gray-500 hover:text-black' },
     centered: { type: Boolean, default: true },
     ariaLabel: { type: String }
 });

--- a/src/components/notification-center/caption-button.vue
+++ b/src/components/notification-center/caption-button.vue
@@ -3,10 +3,11 @@
         position="top-start"
         :tooltip="t('notifications.title')"
         tooltipPlacement="top"
+        trigger-class="text-gray-500 hover:text-white"
         class="pointer-events-auto sm:flex ml-4 mr-8"
     >
         <template #header>
-            <div class="flex items-center hover:text-white">
+            <div class="flex items-center">
                 <!-- https://fonts.google.com/icons?selected=Material%20Icons%3Anotifications -->
                 <svg
                     class="fill-current w-24 h-24"


### PR DESCRIPTION
### Related Item(s)
#2942

### Changes
- [FIX] Moved the About and Notification dropdown hover styling onto the full dropdown trigger button so the icons no longer briefly turn black when hovering near them.

### Notes
The shared dropdown trigger now supports configurable trigger classes. About and Notification caption dropdowns use white hover styling across the full button hitbox, which removes the thin hover area where the icons previously appeared black.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

1. Open Enhanced Sample one.
2. Slowly move the cursor toward the About and Notification icons from above and below.
3. Confirm the icons highlight white when hovered.
4. Confirm there is no thin area near the icons where they turn black before becoming white.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2982)
<!-- Reviewable:end -->
