### PR TITLE
Add metadata fallback notifications

### DIFF
--- a/src/fixtures/metadata/lang/lang.csv
+++ b/src/fixtures/metadata/lang/lang.csv
@@ -2,6 +2,8 @@ key,enValue,enValid,frValue,frValid
 metadata.title,Metadata,1,Métadonnées,1
 metadata.loading,Loading...,1,Chargement en cours...,1
 metadata.error,There was an error retrieving this resource. Please try again.,1,Une erreur s'est produite lors du chargement de cette ressource. Veuillez essayer de nouveau.,1
+metadata.notification.rawFallback,Metadata could not be displayed in formatted view. Raw metadata is available instead.,1,Les métadonnées n'ont pas pu être affichées en format structuré. Les métadonnées brutes sont disponibles à la place.,0
+metadata.notification.rawFallbackWithReason,Metadata could not be displayed in formatted view. Raw metadata is available instead. Reason: {reason},1,Les métadonnées n'ont pas pu être affichées en format structuré. Les métadonnées brutes sont disponibles à la place. Raison : {reason},0
 metadata.label.no.layer,No metadata to show because the layer has been removed,1,Aucune métadonnée à afficher, car la couche a été supprimée.,1
 metadata.xslt.Abstract,Abstract,1,Résumé,1
 metadata.xslt.Scope,Scope,1,Portée,1

--- a/src/fixtures/metadata/screen.vue
+++ b/src/fixtures/metadata/screen.vue
@@ -44,7 +44,7 @@
 <script setup lang="ts">
 import { computed, inject, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 import type { PropType } from 'vue';
-import { GlobalEvents, InstanceAPI, LayerInstance } from '@/api';
+import { GlobalEvents, InstanceAPI, LayerInstance, NotificationType } from '@/api';
 import type { PanelInstance } from '@/api';
 import type { MetadataCache, MetadataPayload, MetadataResult } from './store';
 import { useMetadataStore } from './store';
@@ -114,59 +114,63 @@ onBeforeUnmount(() => {
     watchers.forEach(unwatch => unwatch());
 });
 
-const loadMetadata = () => {
+const loadMetadata = async () => {
     // check if layer has not been removed
     layerExists.value = props.payload.layer !== undefined && !props.payload.layer!.isRemoved;
 
+    if (!layerExists.value) {
+        return;
+    }
+
     if (props.payload.type === 'xml') {
-        loadFromURL(props.payload.url, []).then((r: any) => {
-            metadataStore.status = 'success';
+        const r = await loadFromURL(props.payload.url, []);
 
-            // Append the content to the panel.
-            if (r !== null) {
-                const textContainer = document.createElement('div');
+        metadataStore.status = 'success';
 
-                textContainer.appendChild(stringToFragment(`${r.firstElementChild.outerHTML}`));
+        // Append the content to the panel.
+        if (r?.firstElementChild) {
+            const textContainer = document.createElement('div');
 
-                if (props.payload.catalogueUrl || props.payload.url) {
-                    textContainer.appendChild(
-                        stringToFragment(`<h5 class="text-xl font-bold mb-3">${t('metadata.xslt.metadata')}</h5>`)
-                    );
-                }
+            textContainer.appendChild(stringToFragment(`${r.firstElementChild.outerHTML}`));
 
-                // Append catalogue URL link if it exists
-                if (props.payload.catalogueUrl) {
-                    textContainer.appendChild(
-                        stringToFragment(
-                            `<p><a style="color: blue;" href="${props.payload.catalogueUrl}" target="_blank">${t(
-                                'metadata.xslt.cataloguePage'
-                            )}</a></p>`
-                        )
-                    );
-                }
+            if (props.payload.catalogueUrl || props.payload.url) {
+                textContainer.appendChild(
+                    stringToFragment(`<h5 class="text-xl font-bold mb-3">${t('metadata.xslt.metadata')}</h5>`)
+                );
+            }
 
-                // Append raw XML link
+            // Append catalogue URL link if it exists
+            if (props.payload.catalogueUrl) {
                 textContainer.appendChild(
                     stringToFragment(
-                        `<p><a style="color: blue;" href="${props.payload.url}" target="_blank">${t(
-                            'metadata.xslt.metadataPage'
-                        )}</a> (xml)</p>`
+                        `<p><a style="color: blue;" href="${props.payload.catalogueUrl}" target="_blank">${t(
+                            'metadata.xslt.cataloguePage'
+                        )}</a></p>`
                     )
                 );
-
-                metadataStore.response = textContainer.outerHTML;
             }
-        });
+
+            // Append raw XML link
+            textContainer.appendChild(
+                stringToFragment(
+                    `<p><a style="color: blue;" href="${props.payload.url}" target="_blank">${t(
+                        'metadata.xslt.metadataPage'
+                    )}</a> (xml)</p>`
+                )
+            );
+
+            metadataStore.response = textContainer.outerHTML;
+        }
     } else if (props.payload.type === 'html') {
-        requestContent(props.payload.url).then(r => {
-            metadataStore.status = r.status;
-            metadataStore.response = r.response;
-        });
+        const r = await requestContent(props.payload.url);
+
+        metadataStore.status = r.status;
+        metadataStore.response = r.response;
     } else if (props.payload.type === 'md') {
-        requestContent(props.payload.url).then(r => {
-            metadataStore.status = r.status;
-            metadataStore.response = marked(r.response, { async: false });
-        });
+        const r = await requestContent(props.payload.url);
+
+        metadataStore.status = r.status;
+        metadataStore.response = marked(r.response, { async: false });
     }
 };
 
@@ -191,6 +195,13 @@ const loadFromURL = async (xmlUrl: string, params: any[]) => {
 
     if (!cache[xmlUrl]) {
         const xmlData = await requestContent(xmlUrl);
+        if (xmlData.status === 'error') {
+            const message = xmlData.reason
+                ? t('metadata.notification.rawFallbackWithReason', { reason: xmlData.reason })
+                : t('metadata.notification.rawFallback');
+
+            iApi.notify.show(NotificationType.WARNING, message);
+        }
         cache[xmlUrl] = xmlData.response;
     }
 
@@ -257,9 +268,11 @@ const requestContent = (url: string): Promise<MetadataResult> => {
             if (xobj.status === 200) {
                 resolve({ status: 'success', response: xobj.response });
             } else {
+                const reason = xobj.statusText ? `${xobj.status} ${xobj.statusText}` : `HTTP ${xobj.status}`;
                 resolve({
                     status: 'error',
-                    response: 'Could not load results from remote service.'
+                    response: 'Could not load results from remote service.',
+                    reason: reason || undefined
                 });
             }
         };

--- a/src/fixtures/metadata/store/metadata-state.ts
+++ b/src/fixtures/metadata/store/metadata-state.ts
@@ -23,4 +23,5 @@ export interface MetadataCache {
 export interface MetadataResult {
     status: string;
     response: string;
+    reason?: string;
 }


### PR DESCRIPTION
### Related Item(s)
#2967 

### Changes
- [FIX] Added a warning notification when XML metadata falls back to raw metadata after formatted metadata fails to load.
- [FIX] Added a reasoned fallback notification when an HTTP status is available, such as `HTTP 404`.
- [REFACTOR] Converted `loadMetadata()` to async/await and return early when the layer no longer exists.

### Notes
CORS/network-style failures use the generic fallback notification because browsers do not expose reliable error details to app code. HTTP responses with visible failure status codes use the reasoned notification.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/index-samples.html?sample=20

### Testing

Generic fallback notification:
1. Open Sample 20 from index samples: https://hashirnoor1.github.io/ramp4-pcar4/metadata-fallback-notification/demos/index-samples.html?sample=20 
2. Open the legend-layer menu for `Happy - DCAT metadata` (green).
3. Select `Metadata`.
4. Confirm raw metadata fallback appears.
5. Open the notification tray and confirm a warning explains that formatted metadata could not be displayed and raw metadata is available instead.

Reasoned fallback notification:
1. Temporarily change the `metadata.url` for the `Happy - DCAT metadata` layer in `demos/starter-scripts/layer-metadata.js` to `/missing-metadata-test.xml`.
2. Open Sample 20 from index samples.
3. Open the legend-layer menu for `Happy - DCAT metadata`.
4. Select `Metadata`.
5. Confirm raw metadata fallback appears.
6. Open the notification pop up and confirm the warning includes a reason such as `HTTP 404`.
7. Revert the temporary metadata URL change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2983)
<!-- Reviewable:end -->
