### PR TITLE
Fix security issues with workflows

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -25,6 +25,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   path: ramp
+                  persist-credentials: false
 
             - uses: actions/setup-node@v6
               with:
@@ -32,48 +33,6 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
                   cache: 'npm'
                   cache-dependency-path: ramp/package-lock.json
-
-            - name: Set up Git
-              run: |
-                  git config --global user.name "GitHub Action"
-                  git config --global user.email "action@github.com"
-
-            - name: Create demo-page branch (orphan) if it doesn't exist
-              run: |
-                  # ramp is already checked out in the previous step, use git there to check if demo-pages exists on origin
-                  cd ramp
-                  git fetch origin
-
-                  if git show-ref --quiet refs/remotes/origin/demo-page; then
-                      echo "Branch 'demo-page' exists on origin."
-                  else
-                      echo "Branch 'demo-page' does not exist on origin. Creating an orphan branch..."
-                      cd ../
-                      mkdir -p demo-page
-                      cd demo-page
-                      git init
-                      git checkout --orphan demo-page
-                      git commit --allow-empty -m "Create orphan branch"
-                      git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository_owner }}/ramp4-pcar4
-                      git push -u origin demo-page
-                      echo "Orphan branch 'demo-page' has been created and pushed to origin."
-                      cd ../
-                      # For simplicity we'll delete the demo-page folder now since it'll be checked out in the next step in all cases
-                      rm -rf demo-page
-                  fi
-
-            - uses: actions/checkout@v6
-              with:
-                  ref: demo-page
-                  path: demo-page
-                  fetch-depth: 0
-
-            - name: Remove the old demo if it exists and make docs folder
-              run: |
-                  rm -rf demo-page/${{ github.ref_name }}
-
-                  # this is the deepest folder we need to create
-                  mkdir -p demo-page/${{ github.ref_name }}/docs/api-tech-docs
 
             # Before building the docs we need to find and replace the version and repo owner references in the raw docs (next two steps).
             - name: Update docsite version references before docs are built
@@ -94,6 +53,7 @@ jobs:
 
             - name: Build the project and generate docs
               run: |
+                  set -euo pipefail
                   cd ramp
                   npm ci
                   npm run build
@@ -104,7 +64,7 @@ jobs:
               id: pr-checks
               if: github.ref == 'refs/heads/main'
               with:
-                  gh-token: ${{ secrets.GITHUB_TOKEN }}
+                  gh-token: ${{ github.token }}
                   ts-command: 'npm run ts:check'
                   lint-command: 'npm run lint:check'
                   format-command: 'npm run format:check'
@@ -119,7 +79,7 @@ jobs:
                   label: 'Errors'
                   status: ${{ steps.pr-checks.outputs.ts-errors }}
                   color: blue
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ github.token }}
 
             - name: Lint badge
               if: github.ref == 'refs/heads/main'
@@ -130,23 +90,80 @@ jobs:
                   label: 'Status'
                   status: 'Errors: ${{ steps.pr-checks.outputs.lint-errors }}, Warnings: ${{ steps.pr-checks.outputs.lint-warnings }}'
                   color: purple
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ github.token }}
 
             - name: Publish to NPM with Trusted Publishing for tag releases on main repo only
               if: github.repository == 'ramp4-pcar4/ramp4-pcar4' && startsWith(github.ref, 'refs/tags/v')
               run: |
+                  set -euo pipefail
                   cd ramp
                   TAG_VERSION=${GITHUB_REF#refs/tags/v}
                   PACKAGE_VERSION=$(node -p "require('./package.json').version")
                   if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
                       npm version --allow-same-version --no-git-tag-version $TAG_VERSION
-                   fi
+                  fi
 
                   npm publish
 
-            - name: Move the built project and docs into the demo-page folder for deployment
+            - name: Set up Git
               run: |
-                  TARGET_DIR="demo-page/${{ github.ref_name }}"
+                  set -euo pipefail
+                  git config --global user.name "GitHub Action"
+                  git config --global user.email "action@github.com"
+
+            - name: Create demo-page branch (orphan) if it doesn't exist
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  set -euo pipefail
+
+                  # ramp is already checked out in the previous step, use git there to check if demo-pages exists on origin
+                  cd ramp
+                  git fetch origin
+
+                  if git show-ref --quiet refs/remotes/origin/demo-page; then
+                      echo "Branch 'demo-page' exists on origin."
+                  else
+                      echo "Branch 'demo-page' does not exist on origin. Creating an orphan branch..."
+                      cd ../
+                      mkdir -p demo-page
+                      cd demo-page
+                      git init
+                      git checkout --orphan demo-page
+                      git commit --allow-empty -m "Create orphan branch"
+                      git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+                      git push -u origin demo-page
+                      echo "Orphan branch 'demo-page' has been created and pushed to origin."
+                      cd ../
+                      # For simplicity we'll delete the demo-page folder now since it'll be checked out in the next step in all cases
+                      rm -rf -- demo-page
+                  fi
+
+            - uses: actions/checkout@v6
+              with:
+                  ref: demo-page
+                  path: demo-page
+                  fetch-depth: 0
+
+            - name: Remove the old demo if it exists and make docs folder
+              env:
+                  REF_NAME: ${{ github.ref_name }}
+              run: |
+                  set -euo pipefail
+
+                  TARGET_DIR="demo-page/${REF_NAME}"
+                  rm -rf -- "$TARGET_DIR"
+
+                  # this is the deepest folder we need to create
+                  mkdir -p "$TARGET_DIR/docs/api-tech-docs"
+
+            - name: Move the built project and docs into the demo-page folder for deployment
+              env:
+                  REF_NAME: ${{ github.ref_name }}
+              run: |
+                  set -euo pipefail
+
+                  TARGET_DIR="demo-page/${REF_NAME}"
 
                   if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
                       # Tagged releases do not publish every dist build type.
@@ -154,30 +171,31 @@ jobs:
                       for dir in demos docs file-layers help; do
                           if [[ -d "ramp/dist/${dir}" ]]; then
                               mkdir -p "${TARGET_DIR}/${dir}"
-                              cp -a "ramp/dist/${dir}/." "${TARGET_DIR}/${dir}/"
+                              cp -a -- "ramp/dist/${dir}/." "${TARGET_DIR}/${dir}/"
                           fi
                       done
 
                       if [[ -f ramp/dist/ramp.css ]]; then
-                          cp ramp/dist/ramp.css "${TARGET_DIR}/"
+                          cp -- ramp/dist/ramp.css "${TARGET_DIR}/"
                       fi
                   else
-                      mv ramp/dist/* "${TARGET_DIR}"
+                      mv -- ramp/dist/* "${TARGET_DIR}"
                   fi
 
-                  mv ramp/vite-docs/* "${TARGET_DIR}/docs"
-                  mv ramp/ts-docs/* "${TARGET_DIR}/docs/api-tech-docs"
+                  mv -- ramp/vite-docs/* "${TARGET_DIR}/docs"
+                  mv -- ramp/ts-docs/* "${TARGET_DIR}/docs/api-tech-docs"
 
             - name: Commit and squash to the demo-page branch
               run: |
+                  set -euo pipefail
                   cd demo-page
                   git add .
                   git commit -m "Applied changes from demo-folder to demo-page"
 
                   # Squash the commit history into a single commit
-                  git reset --soft $(git rev-list --max-parents=0 HEAD)
+                  git reset --soft "$(git rev-list --max-parents=0 HEAD)"
                   git commit -m "Applied changes from demo-folder to demo-page"
-                  git push origin HEAD --force
+                  git push origin HEAD:demo-page --force
 
             - name: Upload artifact
               uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/demo-cleanup.yml
+++ b/.github/workflows/demo-cleanup.yml
@@ -11,6 +11,10 @@ permissions:
     pages: write
     id-token: write
 
+concurrency:
+    group: 'pages'
+    cancel-in-progress: false
+
 jobs:
     clean_folders:
         runs-on: ubuntu-latest
@@ -26,6 +30,7 @@ jobs:
 
             - name: Set up Git
               run: |
+                  set -euo pipefail
                   git config --global user.name "GitHub Action"
                   git config --global user.email "action@github.com"
 
@@ -34,6 +39,8 @@ jobs:
 
             - name: Run cleanup script
               run: |
+                  set -euo pipefail
+
                   # Get all remote branch names from origin
                   remote_branches=$(git branch -r | grep -v '\->' | grep "origin/" | sed "s# *origin/##g")
 
@@ -52,28 +59,30 @@ jobs:
                       if ! echo "$remote_refs" | grep -qw "$folder"; then
                           # If the folder name doesn't exist in the remote refs, delete the folder
                           echo "Deleting folder: $folder"
-                          rm -rf "$folder"
+                          rm -rf -- "$folder"
                       fi
                   done
 
             - name: Commit and push changes
               id: commit-changes
               run: |
+                  set -euo pipefail
+
                   git add .
                   if ! git diff --cached --exit-code > /dev/null; then
                       git commit -m "Automated folder cleanup"
-                    
+
                       # Squash the commit history into a single commit
-                      git reset --soft $(git rev-list --max-parents=0 HEAD)
+                      git reset --soft "$(git rev-list --max-parents=0 HEAD)"
                       git commit -m "Automated folder cleanup"
-                      
+
                       git push -f origin demo-page
                       # Let the next steps know that changes were made and deployment is needed
-                      echo "changes=true" >> $GITHUB_ENV
+                      echo "changes=true" >> "$GITHUB_ENV"
                   else
                       echo "No changes to commit"
                       # Let the next steps know that no changes were made and deployment will be skipped
-                      echo "changes=false" >> $GITHUB_ENV
+                      echo "changes=false" >> "$GITHUB_ENV"
                   fi
 
             - name: Upload artifact

--- a/.github/workflows/demo-pr-links.yml
+++ b/.github/workflows/demo-pr-links.yml
@@ -4,6 +4,10 @@ on:
     pull_request_target:
         types: [opened]
 
+permissions:
+    issues: write
+    pull-requests: read
+
 jobs:
     comment-on-pr:
         runs-on: ubuntu-latest
@@ -16,12 +20,12 @@ jobs:
                       Your demo site is ready! 🚀
 
                       Enhanced Testing:
-                      Samples: https://${{github.event.pull_request.head.repo.owner.login}}.github.io/ramp4-pcar4/${{github.head_ref}}/demos/enhanced-samples.html
-                      Catalogue: https://${{github.event.pull_request.head.repo.owner.login}}.github.io/ramp4-pcar4/${{github.head_ref}}/demos/enhanced-all.html
+                      Samples: https://${{ github.event.pull_request.head.repo.owner.login }}.github.io/ramp4-pcar4/${{ github.head_ref }}/demos/enhanced-samples.html
+                      Catalogue: https://${{ github.event.pull_request.head.repo.owner.login }}.github.io/ramp4-pcar4/${{ github.head_ref }}/demos/enhanced-all.html
 
                       Legacy Testing:
-                      Main: https://${{github.event.pull_request.head.repo.owner.login}}.github.io/ramp4-pcar4/${{github.head_ref}}/
-                      Catalogue: https://${{github.event.pull_request.head.repo.owner.login}}.github.io/ramp4-pcar4/${{github.head_ref}}/demos/index-all.html
-                      Samples: https://${{github.event.pull_request.head.repo.owner.login}}.github.io/ramp4-pcar4/${{github.head_ref}}/demos/index-samples.html
+                      Main: https://${{ github.event.pull_request.head.repo.owner.login }}.github.io/ramp4-pcar4/${{ github.head_ref }}/
+                      Catalogue: https://${{ github.event.pull_request.head.repo.owner.login }}.github.io/ramp4-pcar4/${{ github.head_ref }}/demos/index-all.html
+                      Samples: https://${{ github.event.pull_request.head.repo.owner.login }}.github.io/ramp4-pcar4/${{ github.head_ref }}/demos/index-samples.html
 
-                      ![](https://byob.yarr.is/ramp4-pcar4/ramp4-pcar4/tsbadge-${{ github.event.pull_request.head.repo.owner.login }}-${{ github.head_ref }}) ![](https://byob.yarr.is/ramp4-pcar4/ramp4-pcar4/lintbadge-${{ github.event.pull_request.head.repo.owner.login }}-${{ github.head_ref }})
+                      ![](https://byob.yarr.is/ramp4-pcar4/ramp4-pcar4/tsbadge-pr-${{ github.event.pull_request.number }}) ![](https://byob.yarr.is/ramp4-pcar4/ramp4-pcar4/lintbadge-pr-${{ github.event.pull_request.number }})

--- a/.github/workflows/pr-check-badges.yml
+++ b/.github/workflows/pr-check-badges.yml
@@ -1,0 +1,67 @@
+name: PR Check Badges
+
+on:
+    workflow_run:
+        workflows: ['PR Status Checks']
+        types: [completed]
+
+permissions:
+    actions: read
+    contents: write
+
+jobs:
+    update-pr-badges:
+        if: github.event.workflow_run.event == 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download PR check result
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RUN_ID: ${{ github.event.workflow_run.id }}
+              run: |
+                  set -euo pipefail
+                  mkdir -p pr-check-result
+                  gh run download "$RUN_ID" --name pr-check-result --dir pr-check-result
+
+            - name: Validate PR check result
+              id: result
+              run: |
+                  set -euo pipefail
+                  result="pr-check-result/result.json"
+
+                  pr="$(jq -r '.pr // empty' "$result")"
+                  ts="$(jq -r '.tsErrors // "unknown"' "$result")"
+                  lint_errors="$(jq -r '.lintErrors // "unknown"' "$result")"
+                  lint_warnings="$(jq -r '.lintWarnings // "unknown"' "$result")"
+
+                  [[ "$pr" =~ ^[0-9]+$ ]]
+                  [[ "$ts" =~ ^[0-9]+$ ]] || ts="unknown"
+                  [[ "$lint_errors" =~ ^[0-9]+$ ]] || lint_errors="unknown"
+                  [[ "$lint_warnings" =~ ^[0-9]+$ ]] || lint_warnings="unknown"
+
+                  {
+                    echo "pr=$pr"
+                    echo "ts=$ts"
+                    echo "lint_errors=$lint_errors"
+                    echo "lint_warnings=$lint_warnings"
+                  } >> "$GITHUB_OUTPUT"
+
+            - name: Typescript badge
+              uses: RubbaBoy/BYOB@v1.3.0
+              with:
+                  name: 'tsbadge-pr-${{ steps.result.outputs.pr }}'
+                  icon: typescript
+                  label: 'Errors (PR)'
+                  status: ${{ steps.result.outputs.ts }}
+                  color: blue
+                  github_token: ${{ github.token }}
+
+            - name: Lint badge
+              uses: RubbaBoy/BYOB@v1.3.0
+              with:
+                  name: 'lintbadge-pr-${{ steps.result.outputs.pr }}'
+                  icon: codecov
+                  label: 'Status (PR)'
+                  status: 'Errors: ${{ steps.result.outputs.lint_errors }}, Warnings: ${{ steps.result.outputs.lint_warnings }}'
+                  color: purple
+                  github_token: ${{ github.token }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,6 +1,11 @@
+name: PR Status Checks
+
 on:
-    pull_request_target:
-        types: [opened, synchronize]
+    pull_request:
+        types: [opened, synchronize, reopened]
+
+permissions:
+    contents: read
 
 jobs:
     pr-status-checks:
@@ -9,50 +14,44 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  ref: ${{ github.event.pull_request.head.sha }}
+                  persist-credentials: false
 
             - uses: actions/setup-node@v6
               with:
                   node-version: '24.15.0'
-                  cache: 'npm'
 
-            - name: Try to restore node_modules folder from cache
-              id: cache-node-modules
-              uses: actions/cache@v5
-              with:
-                  path: ./node_modules
-                  key: npm-${{ hashFiles('./package-lock.json') }}
-
-            - name: Otherwise install npm dependencies
-              if: steps.cache-node-modules.outputs.cache-hit != 'true'
+            - name: Install npm dependencies
               run: npm ci
 
             - uses: ramp4-pcar4/status-checks@main
               id: pr-checks
               with:
-                  gh-token: ${{ secrets.GITHUB_TOKEN }}
+                  gh-token: ${{ github.token }}
                   ts-command: 'npm run ts:check'
                   lint-command: 'npm run lint:check'
                   format-command: 'npm run format:check'
 
-            - name: Typescript badge
+            - name: Write PR check result
               if: always()
-              uses: RubbaBoy/BYOB@v1.3.0
-              with:
-                  name: 'tsbadge-${{ github.event.pull_request.head.repo.owner.login }}-${{ github.head_ref }}'
-                  icon: typescript
-                  label: 'Errors (PR)'
-                  status: ${{ steps.pr-checks.outputs.ts-errors }}
-                  color: blue
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+              env:
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  TS_ERRORS: ${{ steps.pr-checks.outputs.ts-errors }}
+                  LINT_ERRORS: ${{ steps.pr-checks.outputs.lint-errors }}
+                  LINT_WARNINGS: ${{ steps.pr-checks.outputs.lint-warnings }}
+              run: |
+                  set -euo pipefail
+                  mkdir -p pr-check-result
+                  jq -n \
+                    --arg pr "$PR_NUMBER" \
+                    --arg ts "$TS_ERRORS" \
+                    --arg lintErrors "$LINT_ERRORS" \
+                    --arg lintWarnings "$LINT_WARNINGS" \
+                    '{pr: $pr, tsErrors: $ts, lintErrors: $lintErrors, lintWarnings: $lintWarnings}' \
+                    > pr-check-result/result.json
 
-            - name: Lint badge
+            - uses: actions/upload-artifact@v5
               if: always()
-              uses: RubbaBoy/BYOB@v1.3.0
               with:
-                  name: 'lintbadge-${{ github.event.pull_request.head.repo.owner.login }}-${{ github.head_ref }}'
-                  icon: codecov
-                  label: 'Status (PR)'
-                  status: 'Errors: ${{ steps.pr-checks.outputs.lint-errors }}, Warnings: ${{ steps.pr-checks.outputs.lint-warnings }}'
-                  color: purple
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  name: pr-check-result
+                  path: pr-check-result/result.json
+                  retention-days: 1

--- a/.github/workflows/slack-bot-redux.yml
+++ b/.github/workflows/slack-bot-redux.yml
@@ -15,8 +15,9 @@ jobs:
             - name: Check user permissions (allow only those w/ write access)
               id: permission_check
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ github.token }}
               run: |
+                  set -euo pipefail
                   user_permission=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
                     "https://api.github.com/repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission" | jq -r .permission)
                   if [[ "$user_permission" != "write" && "$user_permission" != "admin" ]]; then
@@ -26,6 +27,10 @@ jobs:
 
             - name: Checkout
               uses: actions/checkout@v6
+              with:
+                  repository: ${{ github.event.pull_request.base.repo.full_name }}
+                  ref: ${{ github.event.pull_request.base.sha }}
+                  persist-credentials: false
 
             - name: Set up Python
               uses: actions/setup-python@v6


### PR DESCRIPTION
### Related Item(s)
Security code scanning alerts: #63, #65, #69, #71, #72

### Changes
- [FIX] Hardened GitHub Actions workflows for fork-based PRs by moving PR code checks from `pull_request_target` to `pull_request`.
- [FIX] Removed unsafe Actions cache usage from PR/untrusted workflows to prevent cache poisoning.
- [FIX] Added explicit least-privilege workflow permissions.
- [FIX] Prevented write credentials from being persisted during checkouts that do not need to push.
- [FIX] Split privileged badge updates into a separate `workflow_run` workflow that consumes validated passive JSON artifacts and does not checkout or execute PR code.
- [FIX] Kept `pull_request_target` only for metadata/comment workflows that do not run PR-head code.
- [REFACTOR] Updated demo build/deploy workflow ordering so build scripts run before any checkout with push credentials.

### Notes
Patched the reported GitHub Actions security risks:
- `pull_request_target` no longer builds or runs PR-head code.
- PR checks now run under unprivileged `pull_request` against the PR merge ref.
- Cache poisoning risk was reduced by removing Actions cache usage from PR/untrusted workflows.
- Default token exposure was reduced with explicit `permissions` and `persist-credentials: false`.
- BYOB badge writes were moved to a privileged `workflow_run` workflow that does not execute PR-controlled content.

> set -euo pipefail

This makes Bash scripts fail more predictably in GitHub Actions.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

[Test PR](https://github.com/milespetrov/ramp4-pcar4/pull/21) looks good, slack bot fails as expected b/c of missing token on fork. 

Steps:
1. Open a PR from a fork and confirm `PR Status Checks` runs on the PR merge ref.
2. Confirm `npm ci`, `npm run ts:check`, `npm run lint:check`, and `npm run format:check` run successfully in the PR checks workflow.
3. Confirm the PR commenter still posts fork GitHub Pages demo links.
4. Confirm PR badge updates are handled by the new `PR Check Badges` workflow.
5. Confirm no `pull_request_target` workflow checks out or executes PR-head code.
6. Confirm demo builds still deploy from fork pushes to the fork’s `demo-page` branch / GitHub Pages.
7. Confirm scheduled/manual demo cleanup still deploys Pages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2989)
<!-- Reviewable:end -->
