### PR TITLE
MIL Initial Invisible Flicker Fixer

### DIFF
--- a/src/geo/layer/map-image-layer.ts
+++ b/src/geo/layer/map-image-layer.ts
@@ -322,6 +322,9 @@ export class MapImageLayer extends MapLayer {
                     );
                 }
 
+                // align the esri sublayer with our initial setting
+                subLayer.visible = this._sublayers[sid].visibility;
+
                 const _sublayer = this._sublayers[sid] as MapImageSublayer;
 
                 if (_sublayer.isRemoved) {
@@ -488,7 +491,13 @@ export class MapImageLayer extends MapLayer {
         });
 
         // defaults to true
-        this.visibility = this.origState.visibility ?? true;
+        const initialVis = this.origState.visibility ?? true;
+
+        // ensure ESRI layer is set to real value to avoid any flicker.
+        // the this.visibility setter has timeout shenanigans that can work
+        // against us at first load.
+        this.esriLayer!.visible = initialVis;
+        this.visibility = initialVis;
 
         return loadPromises;
     }


### PR DESCRIPTION
### Related Item(s)

- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/2994

### Changes
- Forces MIL ESRI layers/sublayers to initial visibility, as the RAMP trickery doesn't seem to play well with initial states / no previous layer paints.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Difficult to test, as it was intermittent.  I did lots locally with mangled samples, don't want to push any mangled samples.

This console script will add a layer with the settings, so just watch to see that you don't see the points flicker on the map when you add it.

```js
const sheshi = {
	id: 'cesi',
	layerType: 'esri-map-image',
	name: 'Cesi',
	url: 'https://maps-cartes.ec.gc.ca/ArcGIS/rest/services/CESI/MapServer',      
	sublayers: [
		{ index: 9, state: { visibility: false } },
		{ index: 10, state: { visibility: false } },
		{ index: 11, state: { visibility: false } }
	],
	state: { visibility: false }
};

debugInstance.dev.easyLayer(sheshi);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2996)
<!-- Reviewable:end -->
