### PR TITLE
Pin Drop fixture

### DIFF
--- a/demos/enhanced-all.html
+++ b/demos/enhanced-all.html
@@ -25,7 +25,7 @@
             </li>
             <li>
                 03.
-                <a href="enhanced-samples.html?sample=3">Feature Layers</a>. Couple of feature layers
+                <a href="enhanced-samples.html?sample=3">Feature Layers</a>. Couple of feature layers.
             </li>
             <li>
                 04.
@@ -46,19 +46,23 @@
             </li>
             <li>
                 09.
-                <a href="enhanced-samples.html?sample=9">Custom HTML panels</a>. Contains custom HTML panels
+                <a href="enhanced-samples.html?sample=9">Custom HTML panels</a>. Contains custom HTML panels.
             </li>
             <li>
                 12.
-                <a href="enhanced-samples.html?sample=12">Layer Swipe</a>. Contains demo of layer swipe feature
+                <a href="enhanced-samples.html?sample=12">Layer Swipe</a>. Contains demo of layer swipe feature.
             </li>
             <li>
                 13.
-                <a href="enhanced-samples.html?sample=13">Drawing Tools</a>. Contains demo of drawing tools
+                <a href="enhanced-samples.html?sample=13">Drawing Tools</a>. Contains demo of drawing tools.
             </li>
             <li>
                 14.
-                <a href="enhanced-samples.html?sample=14">Custom Geosearch</a>. Demo of custom geosearch types
+                <a href="enhanced-samples.html?sample=14">Custom Geosearch</a>. Demo of custom geosearch types.
+            </li>
+            <li>
+                15.
+                <a href="enhanced-samples.html?sample=15">Pin Drop</a>. Pin drop fixture enabled.
             </li>
         </ul>
 

--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -30,6 +30,7 @@
                 <option value="012-layer-swipe">12. Layer Swipe</option>
                 <option value="013-drawing-tools">13. Drawing Tools</option>
                 <option value="014-geosearch-sources">14. Custom Geosearch Sources</option>
+                <option value="015-pin-fixture">15. Pin Drop</option>
             </select>
             <nav class="linky-container">
                 <a class="linky" href="enhanced-all.html">Catalogue</a

--- a/demos/enhanced-scripts/015-pin-fixture.js
+++ b/demos/enhanced-scripts/015-pin-fixture.js
@@ -1,0 +1,34 @@
+/*
+Test 15: Pin Drop
+- Adds the pin drop fixture to the sample.
+ */
+
+const runPreTest = (config, options, utils) => {
+    const happy = {
+        id: 'Happy',
+        name: 'Pin Face',
+        layerType: 'file-geojson',
+        url: '../file-layers/geojson.json',
+        colour: '#f52ac9',
+        nameField: 'name'
+    };
+
+    utils.addLayerLegend(happy);
+
+    config.startingFixtures.push('pindrop');
+
+    const pinConfig = {
+        linkIdentify: true,
+        linkDetails: true
+    };
+    config.configs.en.fixtures.pindrop = structuredClone(pinConfig);
+    config.configs.fr.fixtures.pindrop = structuredClone(pinConfig);
+
+    return { config, options };
+};
+
+const runPostTest = () => {
+    // Not used in this test
+};
+
+export { runPreTest, runPostTest };

--- a/docs/using-ramp4/fixtures/custom-fixtures.md
+++ b/docs/using-ramp4/fixtures/custom-fixtures.md
@@ -28,10 +28,13 @@ This can be accomplished via the `startingFixtures` array in the instance config
 
 The current list of available fixture names are
 
-- `areas-of-interest`
-- `export`
-- `extentguard`
-- `metadata`
+- `areas-of-interest`: A panel to select pre-defined places and zoom to them.
+- `draw`: Drawing and measuring map tools.
+- `export`: Generates a PNG of the map and other information.
+- `extentguard`: Forces the map view to stay within a defined extent.
+- `metadata`: A layer-linked panel to view metadata sources.
+- `pindrop`: Places pin markers on the map. Can be bound to identify / details.
+- `swipe`: Creates a draggable swipe on the map for layer comparison.
 
 ## Creation
 

--- a/schema.json
+++ b/schema.json
@@ -520,6 +520,29 @@
             "required": ["target"],
             "unevaluatedProperties": false
         },
+        "pindrop": {
+            "type": "object",
+            "description": "Provides configuration to the pindrop fixture.",
+            "properties": {
+                "linkIdentify": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to drop a pin when a map identify occurs."
+                },
+                "linkDetails": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to tie the pin visibility to the Details panel."
+                },
+
+                "pinSymbol": {
+                    "type": "object",
+                    "description": "Optional styling for a custom pin symbol. Object of type PointMarkerStyleOptions or PointIconStyleOptions.",
+                    "additionalProperties": true
+                }
+            },
+            "unevaluatedProperties": false
+        },
         "sectionItem": {
             "type": "object",
             "description": "A legend item not bound to a layer, used only for grouping legend items or displaying info sections.",
@@ -2817,6 +2840,10 @@
                 "overviewmap": {
                     "$ref": "#/$defs/overviewmap",
                     "description": "Provides the configuration to the overviewmap fixture"
+                },
+                "pindrop": {
+                    "$ref": "#/$defs/pindrop",
+                    "description": "Provides configuration to the pindrop fixture"
                 },
                 "scrollguard": {
                     "$ref": "#/$defs/scrollguard",

--- a/src/fixtures/pindrop/api/pindrop.ts
+++ b/src/fixtures/pindrop/api/pindrop.ts
@@ -1,0 +1,354 @@
+import { CommonGraphicLayer, FixtureInstance, GlobalEvents } from '@/api/internal';
+import { Graphic, LayerType, Point, PointStyle } from '@/geo/api';
+import type { PointIconStyleOptions, PointStyleOptions } from '@/geo/api';
+import { PointStyleType } from '@/geo/api';
+
+const IDENTIFY_EVENT_HANDLER = 'ramp-pin-identify';
+const PANEL_OPEN_EVENT_HANDLER = 'ramp-pin-panel-open';
+const PANEL_CLOSE_EVENT_HANDLER = 'ramp-pin-panel-close';
+const PANEL_MINIMIZE_EVENT_HANDLER = 'ramp-pin-panel-min';
+
+const PINDROP_LAYER_NAME = 'Ramp-Pin-Drop';
+
+const DEFAULT_PIN: PointIconStyleOptions = {
+    style: PointStyleType.ICON,
+    width: 12,
+    height: 16,
+    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAAZCAYAAADTyxWqAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAFBhaW50Lk5FVCA1LjEuN4vW9zkAAAC2ZVhJZklJKgAIAAAABQAaAQUAAQAAAEoAAAAbAQUAAQAAAFIAAAAoAQMAAQAAAAIAAAAxAQIAEAAAAFoAAABphwQAAQAAAGoAAAAAAAAAYAAAAAEAAABgAAAAAQAAAFBhaW50Lk5FVCA1LjEuNwADAACQBwAEAAAAMDIzMAGgAwABAAAAAQAAAAWgBAABAAAAlAAAAAAAAAACAAEAAgAEAAAAUjk4AAIABwAEAAAAMDEwMAAAAAAlR56NozS1xQAAAx1JREFUSEuVlV1Ik1EYx5+zuZnza26KWmp4odNUJLwQKUqxzFZgdRF0aRd9EBGGREnRRV3kVUl01U0gEVFQls4uuqgk0IwoY5VOan5O0U3TVlZup/95z7tXp1voDx7O/3nes/973vM1RhHIL7eXoDmC2IkoRKQgfIjPiBeIewM9DifaMMLM8sv3mlG6BnkUYVCKkfmDuM2JN7l6OudkaZkZjHKRtkGKUa2V90T8wEBP55BIFDMYWSBfQhaLfJ18wAgrMcJZvcisWfk30dQKHUK8ZWJ+gcb7psk7Okdej58Wk2IoMTZGdlgigxGzeMdc7QyTvRWFXoRiLBBG/cMzVF9XEayz7+KpVktgyuvVt3U819150s1sOSnEZdcQAUSZ3pqV1wixTSmBkFHLxfrgpfMNVFxUqM/JztIX2PJ0NdU7eFoC43fbu1lqcpz8gUSHmBdmVyE2KSUw7f9Nh6pKg5cvnCWTKU500jAYDKykaAt3u5zU555gJmPYJxtEZ5vUEt/gLO2rqeQmkynMKER8vEm3v7Yq6Bv8rlY0CsQPkqRWWQhQijlZzEFUlOcLi2qmkSTMZqRWsRhpZHRcLMaKOdbgynOrUU01ZoTZJ6kl2ZvN1PrQoZuYmIxo5kG99UGHLjsHhyUcp1iAdIhqmRMZY3T0btTL/JOjvKTIxs3JyeoTIvfQML/S3MIe9X5hmYkb1KrGLbHPMiH6EKlKCTDGqN/3g/ItCfxw7XaekZ4W9ExO6e47utjXWT/LsyQQ52EDn0SUqsfJfg5Ns9DL+RsI0jefHzsI5zrRSLmWeDLoIy5yA26RG4pZXrndANEFWS7ydfIKg6xyvXEEFTMBRleG5jUiVimsDQybKjCqjyLRziMOqgeLIe6p3bKyJhph9FTVS/dZCIzwGZo9Mvsvj2F0UNUKkWbzBGJKyqiMIU5JucQqM7zNjea0zKJyEv3GVa2hzdlyMH9OzN9GSLEoK7kOI3GZriLiplER99zKf6C32KpNql5FVDO8fR7NcUToeviFOObqcSzIdDURPzMEPncEn/sTUpzdM3hBu/IgIkT/AA0b/Z36q15CAAAAAElFTkSuQmCC',
+    xOffset: 0,
+    yOffset: 8
+};
+
+interface PinDropConfig {
+    pinSymbol?: PointStyleOptions;
+    linkIdentify?: boolean;
+    linkDetails?: boolean;
+}
+
+/**
+ * Exposes methods to manage a pin drop on the map
+ */
+export class PinDropAPI extends FixtureInstance {
+    /**
+     * Tracks pin point symbol
+     */
+    private _pinSymbol!: PointStyle;
+
+    /**
+     * Tracks link to identify state
+     */
+    private _linkIdentify: boolean = false;
+
+    /**
+     * Tracks link to details panel state
+     */
+    private _linkDetails: boolean = false;
+
+    /**
+     * Tracks where current pin is located. Used for hide/show when bound to details panel
+     */
+    private _pinPoint: Point | undefined;
+
+    /**
+     * Tracks if we have a pin visible (i.e. false + point = hiding)
+     */
+    private _pinVisible: boolean = false;
+
+    /**
+     * Tracks the active flag state
+     */
+    private _active: boolean = true;
+
+    /**
+     * How to symbolize the pin point
+     */
+    get pinSymbol(): PointStyleOptions {
+        return this._pinSymbol.toOptions();
+    }
+
+    set pinSymbol(newSymbol: PointStyleOptions) {
+        this._pinSymbol = new PointStyle(newSymbol);
+    }
+
+    /**
+     * Toggleable flag to enable/disable the pin drop.
+     */
+    get active(): boolean {
+        return this._active;
+    }
+
+    set active(newValue: boolean) {
+        if (!newValue) {
+            // we will use hide instead of remove.
+            // this gives the option of the API user to call .restorePin() after reactivating,
+            // but they can also just not and nobody will care.
+            this.hidePin();
+        }
+
+        this._active = newValue;
+    }
+
+    /**
+     * Makes the pin automatically drop when a map identify occurs
+     */
+    get linkIdentify(): boolean {
+        return this._linkIdentify;
+    }
+
+    set linkIdentify(newValue: boolean) {
+        if (newValue === this._linkIdentify) {
+            return;
+        }
+
+        this._linkIdentify = newValue;
+
+        if (newValue) {
+            // set up handlers
+
+            this.$iApi.event.on(
+                'map/identify',
+                async identResult => {
+                    // add the pin where we identify-clicked
+                    this.dropPin(identResult.click.mapPoint);
+                },
+                IDENTIFY_EVENT_HANDLER
+            );
+        } else {
+            // wipe handlers
+            this._cleanIdentify();
+        }
+    }
+
+    /**
+     * Makes the pin show and hide when the details panel is active.
+     */
+    get linkDetails(): boolean {
+        return this._linkDetails;
+    }
+
+    set linkDetails(newValue: boolean) {
+        if (newValue === this._linkDetails) {
+            return;
+        }
+
+        this._linkDetails = newValue;
+
+        if (newValue) {
+            // set up handlers
+
+            this.$iApi.event.on(
+                GlobalEvents.PANEL_CLOSED,
+                async panel => {
+                    if (panel.id === 'details') {
+                        // details closed. remove pin
+                        this.removePin();
+                    }
+                },
+                PANEL_CLOSE_EVENT_HANDLER
+            );
+
+            this.$iApi.event.on(
+                GlobalEvents.PANEL_MINIMIZED,
+                panel => {
+                    if (panel.id === 'details') {
+                        // details minimized. hide pin from map
+                        this.hidePin();
+                    }
+                },
+                PANEL_MINIMIZE_EVENT_HANDLER
+            );
+
+            this.$iApi.event.on(
+                GlobalEvents.PANEL_OPENED,
+                panel => {
+                    if (panel.id === 'details' && !this._pinVisible && this._pinPoint) {
+                        // details opened, pin isn't visible, but we have a point retained.
+                        // equates to minimized/hidden details becoming visible again.
+                        // restore the hidden pin
+                        this.restorePin();
+                    }
+                },
+                PANEL_OPEN_EVENT_HANDLER
+            );
+        } else {
+            // wipe handlers
+            this._cleanDetails();
+        }
+    }
+
+    initialized(): void {
+        // this fires when the map is created.
+
+        // create the pin layer once the map is available
+        this.initPinLayer();
+    }
+
+    /**
+     * Cleans up fixture when its done.
+     */
+    cleanup(): void {
+        if (this._linkDetails) {
+            this._cleanDetails();
+        }
+        if (this._linkIdentify) {
+            this._cleanIdentify();
+        }
+    }
+
+    _parseConfig(pindropConfig?: PinDropConfig) {
+        let defaultPin = true;
+
+        if (pindropConfig) {
+            if (pindropConfig.pinSymbol) {
+                this.pinSymbol = pindropConfig.pinSymbol;
+                defaultPin = false;
+            }
+
+            this.linkDetails = !!pindropConfig.linkDetails;
+            this.linkIdentify = !!pindropConfig.linkIdentify;
+        }
+
+        if (defaultPin) {
+            this.pinSymbol = DEFAULT_PIN;
+        }
+    }
+
+    /**
+     * Initialize the pin layer.
+     *
+     * @returns {Promise} resolves when layer is added to the map
+     */
+    async initPinLayer(): Promise<void> {
+        const geoAPI = this.$iApi.geo;
+        const pinLayer = geoAPI.layer.createLayer({
+            id: PINDROP_LAYER_NAME,
+            layerType: LayerType.GRAPHIC,
+            cosmetic: true,
+            system: true,
+            url: ''
+        });
+
+        await geoAPI.map.addLayer(pinLayer);
+    }
+
+    /**
+     * Place a pin at the given point on the map
+     *
+     * @param {Point} dropPoint map location for the new pin
+     */
+    dropPin(dropPoint: Point): void {
+        if (this.active) {
+            this._pinPoint = dropPoint;
+            this._insertPin();
+        }
+    }
+
+    /**
+     * Remove the pin from the map for good.
+     */
+    removePin(): void {
+        this._erasePin();
+        this._pinPoint = undefined;
+    }
+
+    /**
+     * Hide the pin but retain the position for a future restorePin() call
+     */
+    hidePin(): void {
+        this._erasePin();
+    }
+
+    /**
+     * If a pin was hidden, show it again.
+     */
+    restorePin(): void {
+        if (this.active && this._pinPoint && !this._pinVisible) {
+            this._insertPin();
+        }
+    }
+
+    /**
+     * Return the Pindrop Layer
+     */
+    getPindropLayer(): CommonGraphicLayer | undefined {
+        // NOTE not doing an async waiting here (see BaseHilightMode.layerFetcher() for example of waiting technique).
+        //      Expect the layer creation to be near-instant. Convert if we run into timing problems
+
+        return this.$iApi.geo.layer.getLayer(PINDROP_LAYER_NAME) as CommonGraphicLayer | undefined;
+    }
+
+    /**
+     * Return the Pindrop Layer name
+     */
+    get pindropLayerName(): string {
+        return PINDROP_LAYER_NAME;
+    }
+
+    /**
+     * Worker to actually insert the pin into the layer. Assumes point and style are set
+     */
+    private _insertPin(): void {
+        const pinLayer = this.getPindropLayer();
+        if (pinLayer && this._pinPoint) {
+            this._erasePin(pinLayer);
+
+            const pinGraphic = new Graphic(this._pinPoint, 'ramp-pin');
+            pinGraphic.style = this._pinSymbol;
+
+            pinLayer.addGraphic(pinGraphic);
+
+            this._pinVisible = true;
+
+            // ensure pin layer is top-most.
+            // note that the actual esri glow highlight seems to overpower the pin regardless.
+            // i'm assuming it lives above the map stack in magical glow land.
+
+            const geoAPI = this.$iApi.geo;
+            const layerOrder = geoAPI.layer.layerOrderIds();
+            const top = layerOrder.length - 1;
+            if (layerOrder[top] !== PINDROP_LAYER_NAME) {
+                geoAPI.map.reorder(pinLayer, top, false);
+            }
+        }
+    }
+
+    /**
+     * Worker to actually remove the pin from the layer
+     */
+    private _erasePin(alreadyGrabbedPinLayer?: CommonGraphicLayer): void {
+        if (this._pinVisible) {
+            const pinLayer = alreadyGrabbedPinLayer ?? this.getPindropLayer();
+            if (pinLayer) {
+                pinLayer.removeGraphic();
+            }
+            this._pinVisible = false;
+        }
+    }
+
+    /**
+     * Worker to remove events that connect to identify
+     */
+    private _cleanIdentify(): void {
+        this.$iApi.event.off(IDENTIFY_EVENT_HANDLER);
+    }
+
+    /**
+     * Worker to remove events that connect to details
+     */
+    private _cleanDetails(): void {
+        const evt = this.$iApi.event;
+        evt.off(PANEL_CLOSE_EVENT_HANDLER);
+        evt.off(PANEL_OPEN_EVENT_HANDLER);
+        evt.off(PANEL_MINIMIZE_EVENT_HANDLER);
+    }
+
+    /**
+     * Determines if the detail panel is visible
+     */
+    /*
+    private isDetailVisible(): boolean {
+        const panel = this.$iApi.panel.get('details');
+        return !!(panel && (panel.teleport || panel.isVisible));
+    }
+    */
+}

--- a/src/fixtures/pindrop/index.ts
+++ b/src/fixtures/pindrop/index.ts
@@ -1,0 +1,20 @@
+import { PinDropAPI } from './api/pindrop';
+
+class PinDropFixture extends PinDropAPI {
+    async added() {
+        // read the config values. set a watcher to check for any config updates. stop watching if fixture gets removed
+        this._parseConfig(this.config);
+        const unwatch = this.$vApp.$watch(
+            () => this.config,
+            (value: any) => this._parseConfig(value)
+        );
+
+        // override the removed method here to get access to scope
+        this.removed = () => {
+            unwatch();
+            this.cleanup();
+        };
+    }
+}
+
+export default PinDropFixture;


### PR DESCRIPTION

### Changes
- Adds pin drop fixture (optional fixture)

### Notes

The ESRI glow on the glow highlighter will always be over the pin, apparently. Its applied by secret ESRI tech, there isn't a "glow layer" in the stack we can push below the pin layer.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

Enhanced Sample 15 has the pin fixture enabled, connected to identify and bound to the details panel.  Meaning doing an identify will drop a pin, closing the detail panel will remove the pin, minimize / restore of the detail panel will hide/show the pin.


API calls via the console to change modes an experiment.

Run this first.

```js
const pinfixture = debugInstance.fixture.get('pindrop');
```

Make the fixture stop pinning without removing it

```js
pinfixture.active = false;
```

Start having fun again

```js
pinfixture.active = true;
```

Change the pin to Macho Man Randy Savage

```js
const macho =  {
    style: 'icon',
    width: 16,
    height: 16,
    icon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAOgSURBVDhPHc9ZTNN3AMDx3/8PtEgpUEBwHIIEPMAhlEMKFCnQgi00CHIUSilC5RjnhDEOmQMZ7sE4sizMgQ+Abi6IoLJMJRmLieLmlkw8MJsjZodu2dse5GEm32V7/bx9xB77AhPlVdwv0nKjtJsVaxePC/Tc05tYKzjIj+U1/NpSz9/dZl60VrNW0si3acU8yDHxV30eItExx1KRke+s2azVmlh3GflluIjVdx2cb7Ux1VzJwkAzT2fHeD47yvOL43xdWcAfLWU8c3QgspsuMz/Qz3Sbg/Mnujj7Th+mFC3BksRrksQ2IRElJHZ7eVJj0PPqn01WL07SkbqH+YIkRFvLMJlqL4JlGT/JHY27G2oh4S0JVJKEWpIJkmRCJYE2OIiNH+5wfbSdZLWKZIUCcai0izjZDX9JxkuW0CgUZERHEyK7oRES/pJEpCyIkQSFUWH8dOVjPi1LIVezhRw/BaJz6DN2KlVsk2QCJJmS1EQenellsKaUcHe3/z1SSGh91XyzcIHNa9PccOVRtn0L9mg1IrH+KrnGWoJkmWBJxpEQy28jbbw49z7jx5op1uvos5fx8PI0L1eWeHX7Jo9OteLY4U1FpBqhrbuGs/0crpIyLClJfN7VyMPuan4//TaPBxq5dczOitPInxPDbH45x8vlOW4fd2DbrqQ8xAuRVLeIxfYRpeYmJqvMXChO53ptIcvVVu622Hl6spN73TbWB+t49uEAdwadjOTupDzMk57UUIS+YQGT7RMs5k7GrAauOE3MOK2cLspgsvIAM9VZfFAYz7zLyPfvNdKTFkFNTACHQjw5a4lGZDZcJaN8itzCERoy0zmeE0O7NoJThmQWK02stlYxc/ggnbpIJuzZFIX6Ygr0oXNfCJcqExAp9UvonAtkVUyRH6+jMEzDGWsWs/ZibrVUcX+ojUtNNhoSw3HuDUOnUWPQ+LDkMnHzaA4ir36RvP8aR+bINbRiCNTQmx3LiCWZYaOWdl0MplB/MoP82K/xIdVHRZ8+nvWT9dztKEaMHB6iPdNFc3otttfN7Pf1wxCiwZEUQX6oLxlbNexTexPnrWKXUokl2IcvjhzgyQk7G8ONiJ5MF4OGN2hPqsS5y0iGKoDdCiUZwf4keHsRq1ISpfAgRulJtp+KqaJYlqsSePCmhY2hKsRo/luMmQfo1x+lN92JdWss1vA49nqq2OGhIMpDSbRCiU6lpCXSm/G0QL6qiOVJt5mf+4v5F9KrA2LWnfrvAAAAAElFTkSuQmCC',
    xOffset: 0,
    yOffset: 0
};
pinfixture.pinSymbol = macho;
```

Make the pin independent of the detail panel. Pin will remain when panel is gone.

```js
pinfixture.linkDetails = false;
```

Manually clear the pin.

```js
pinfixture.removePin();
```

Make identify stop dropping pins.

```js
pinfixture.linkIdentify = false;
```

Manually drop a pin at the Downsview office

```js
const targetPoint = new debugInstance.geo.geom.Point('downsview', [-79.4685 , 43.7816]);
pinfixture.dropPin(targetPoint);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2997)
<!-- Reviewable:end -->
