### PR TITLE
Keep the Draw Shape Inspector action footer aligned when the panel content is scrollable

### DIFF
--- a/src/fixtures/draw/shape-inspector-screen.vue
+++ b/src/fixtures/draw/shape-inspector-screen.vue
@@ -1273,7 +1273,7 @@ onUnmounted(() => {
 }
 .rv-content-actions {
     position: sticky;
-    bottom: -8px;
+    bottom: 0;
     z-index: 2;
     display: flex;
     align-items: center;


### PR DESCRIPTION
### Related Item(s)
#2987

### Changes
- [FIX] Keep the Draw Shape Inspector action footer aligned when the panel content is scrollable.

### Notes
The Shape Inspector action footer was using a sticky offset that placed it slightly below the expected position until the scroll area reached the bottom. The sticky offset now aligns with the scroll viewport.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open the enhanced samples page in a browser.
2. Load sample 13, Drawing Tools.
3. Click the Inspector icon in the toolbar.
4. Click the large line shape on the map.
5. In the Shape Inspector panel, check each tab with footer actions.
6. With the panel content scrolled to the top, confirm the footer is aligned at the bottom of the visible panel content.
7. Scroll the panel content to the bottom and confirm the footer does not jump or change vertical position.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2998)
<!-- Reviewable:end -->
