### PR TITLE
Map creation ergonomics enhancement

### DIFF
--- a/src/fixtures/draw/index.ts
+++ b/src/fixtures/draw/index.ts
@@ -125,15 +125,6 @@ class DrawFixture extends DrawAPI {
 
         // Re-initialize on map create or config change
         if (!this.eventHandlers.length) {
-            if (this.$iApi.geo.map.created) {
-                void this.init();
-            } else {
-                this.eventHandlers.push(
-                    this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
-                        void this.init();
-                    })
-                );
-            }
             this.eventHandlers.push(
                 this.$iApi.event.on(GlobalEvents.FIXTURE_ADDED, fixture => {
                     if (fixture.id === 'help') {
@@ -141,6 +132,9 @@ class DrawFixture extends DrawAPI {
                     }
                 })
             );
+
+            await this.$iApi.geo.map.loadPromise();
+            void this.init();
         }
     }
 

--- a/src/fixtures/extentguard/index.ts
+++ b/src/fixtures/extentguard/index.ts
@@ -100,14 +100,10 @@ class ExtentguardFixture extends ExtentguardAPI {
             }
         });
 
-        // do a status check when map creates, or if map already created
-        if (this.$iApi.geo.map.created) {
+        // do a status check when map creates
+        this.$iApi.geo.map.loadPromise().then(() => {
             this.checkActive();
-        } else {
-            this.$iApi.event.once(GlobalEvents.MAP_CREATED, () => {
-                this.checkActive();
-            });
-        }
+        });
     }
 
     /**

--- a/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/fog-hilight-mode.ts
@@ -24,15 +24,9 @@ export class FogHilightMode extends LiftHilightMode {
         this.onOpacity = config.options?.onOpacity ?? 0.75;
         this.offOpacity = config.options?.offOpacity > 0.02 ? config.options.offOpacity : 0.02;
 
-        if (this.$iApi.geo.map.created) {
+        this.$iApi.geo.map.loadPromise().then(() => {
             this.hilightSetup();
-        } else {
-            this.handlers.push(
-                this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
-                    this.hilightSetup();
-                })
-            );
-        }
+        });
 
         this.handlers.push(
             this.$iApi.event.on(GlobalEvents.MAP_BASEMAPCHANGE, () => {

--- a/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
+++ b/src/fixtures/hilight/api/hilight-mode/glow-hilight-mode.ts
@@ -1,4 +1,4 @@
-import { InstanceAPI, GraphicLayer, GlobalEvents } from '@/api';
+import { GraphicLayer, InstanceAPI } from '@/api';
 import type { Graphic } from '@/geo/api';
 import { HILIGHT_LAYER_NAME } from '../hilight-defs';
 import { LiftHilightMode } from './lift-hilight-mode';
@@ -13,13 +13,9 @@ export class GlowHilightMode extends LiftHilightMode {
     constructor(config: any, iApi: InstanceAPI) {
         super(config, iApi);
 
-        this.hilightSetup(config);
-
-        this.handlers.push(
-            this.$iApi.event.on(GlobalEvents.MAP_CREATED, () => {
-                this.hilightSetup(config);
-            })
-        );
+        this.$iApi.geo.map.loadPromise().then(() => {
+            this.hilightSetup(config);
+        });
     }
 
     private hilightSetup(config: any) {

--- a/src/fixtures/panguard/map-panguard.vue
+++ b/src/fixtures/panguard/map-panguard.vue
@@ -49,13 +49,10 @@ const updateMapNavigation = () => {
 };
 
 onMounted(() => {
-    setup();
-    // setup again when the map reloads
-    rampHanders.push(
-        iApi.event.on(GlobalEvents.MAP_CREATED, () => {
-            setup();
-        })
-    );
+    iApi.geo.map.loadPromise().then(() => {
+        setup();
+    });
+
     rampHanders.push(
         iApi.event.on(GlobalEvents.MAP_DESTROYED, () => {
             resetPanGuard();

--- a/src/fixtures/scrollguard/map-scrollguard.vue
+++ b/src/fixtures/scrollguard/map-scrollguard.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-import { GlobalEvents, InstanceAPI } from '@/api';
+import { InstanceAPI } from '@/api';
 import { computed, inject, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useScrollguardStore } from './store';
@@ -18,14 +18,7 @@ const scrollGuard = ref<HTMLElement>();
 const enabled = computed(() => scrollguardStore.enabled);
 
 onMounted(() => {
-    (iApi.$vApp.$el.querySelector('.inner-shell + .esri-view')! as HTMLElement)?.addEventListener(
-        'wheel',
-        wheelHandler,
-        {
-            capture: true
-        }
-    );
-    iApi.event.on(GlobalEvents.MAP_CREATED, () => {
+    iApi.geo.map.loadPromise().then(() => {
         (iApi.$vApp.$el.querySelector('.inner-shell + .esri-view')! as HTMLElement)?.addEventListener(
             'wheel',
             wheelHandler,

--- a/src/geo/layer/common-layer.ts
+++ b/src/geo/layer/common-layer.ts
@@ -53,7 +53,10 @@ export class CommonLayer extends LayerInstance {
 
     protected origRampConfig: RampLayerConfig;
 
-    protected loadDefProm: DefPromise<void>; // a deferred promise that resolves when layer is fully ready and safe to use. for convenience of caller
+    /**
+     * A deferred promise that resolves when layer is fully ready and safe to use. for convenience of caller
+     */
+    protected loadDefProm: DefPromise<void>;
 
     /**
      * A boolean to track whether the promise is pending (false) or fulfilled/rejected (true)

--- a/src/geo/map/common-map.ts
+++ b/src/geo/map/common-map.ts
@@ -49,13 +49,31 @@ export class CommonMapAPI extends APIScope {
     esriView: EsriMapView | undefined;
 
     /**
+     * Provides a promise that resolves when the map has finished loading. If using map properties or methods
+     * that depend on the map being loaded, wait on this promise before accessing them.
+     *
+     * @method loadPromise
+     * @returns {Promise} resolves when the map has finished loading
+     */
+    loadPromise(): Promise<void> {
+        return this.loadDefProm.getPromise();
+    }
+
+    /**
+     * A deferred promise that resolves when the map is loaded and safe to use. for convenience of caller
+     * @private
+     */
+    protected loadDefProm: DefPromise<void>;
+
+    /**
      * Internal deferred managing the view promise
      * @private
      */
     protected _viewPromise: DefPromise<void>;
 
     /**
-     * A promise that resolves when the map view has been created
+     * A promise that resolves when the map view has been created.
+     * Note that a schema change can re-create the map view
      */
     get viewPromise(): Promise<void> {
         return this._viewPromise.getPromise();
@@ -100,6 +118,7 @@ export class CommonMapAPI extends APIScope {
         this.esriMap = undefined;
         this._basemapStore = [];
         this._viewPromise = new DefPromise();
+        this.loadDefProm = new DefPromise();
         this.handlers = [];
         this.pointZoomScale = 50000;
         this.name = name;
@@ -228,6 +247,8 @@ export class CommonMapAPI extends APIScope {
         // clear local basemap store
         this._basemapStore.forEach(bm => bm.esriBasemap.destroy());
         this._basemapStore = [];
+
+        this.loadDefProm = new DefPromise();
     }
 
     /**

--- a/src/geo/map/overview-map.ts
+++ b/src/geo/map/overview-map.ts
@@ -135,6 +135,7 @@ export class OverviewMapAPI extends CommonMapAPI {
         this.esriView.when(() => {
             this._viewPromise.resolveMe();
             this.created = true;
+            this.loadDefProm.resolveMe();
         });
     }
 

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -107,6 +107,7 @@ export class MapAPI extends CommonMapAPI {
             // Note that we don't want to have this raised in the view creation method, since
             // the view can get rebuild during a MAP_REFRESH event, so would be disrespectful
             // to raise an incorrect MAP_CREATED
+            this.loadDefProm.resolveMe();
             this.$iApi.event.emit(GlobalEvents.MAP_CREATED);
         });
     }
@@ -128,6 +129,7 @@ export class MapAPI extends CommonMapAPI {
 
         // now destroy the map
         super.destroyMap();
+
         this.$iApi.event.emit(GlobalEvents.MAP_DESTROYED);
     }
 
@@ -568,7 +570,10 @@ export class MapAPI extends CommonMapAPI {
      * @param {number | undefined} index optional order index to add the layer to
      * @returns {Promise<void>} a promise that resolves when the layer has been added to the map
      */
-    addLayer(layer: LayerInstance, index: number | undefined = undefined): Promise<void> {
+    async addLayer(layer: LayerInstance, index: number | undefined = undefined): Promise<void> {
+        // lets us queue layers prior to the map existing
+        await this.loadPromise();
+
         return new Promise((resolve, reject) => {
             if (!this.esriMap) {
                 this.noMapErr();


### PR DESCRIPTION
### Changes
- Adds a promise that resolves when a map is created
- Improves ugly code to lovely code 🌷 
- Fixes an alphabet crime (`#blameelsa`)

### Notes

We had a common and un-ergonomic scenario when code needed to wait for the map to be created. The map could already be created, so was very possible that the creation event was already fired and long gone, meaning the code would need to use the following gross pattern:

```text
if map.created
  doStuff™
else
  add event listener on map/create that runs doStuff™ when triggered
```

Stealing promise technology from the layer classes, we now have a handy promise to wait on. If map is already created, the promise will just roll through, otherwise it will wait patiently.

### QA Testing


Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

- Map loads
- Overview map loads
- Click a Happy feature. Ensure highlight shows
- Try Enhanced Sample 13, ensure drawing tools work

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/2999)
<!-- Reviewable:end -->
