### PR TITLE
Small enhancements

### DIFF
--- a/src/geo/layer/map-image-sublayer.ts
+++ b/src/geo/layer/map-image-sublayer.ts
@@ -29,7 +29,7 @@ export class MapImageSublayer extends AttribLayer {
 
         this.maptips = false;
         this.url = this.parentLayer?.url;
-        this.canReload = !!(this.url || this.origRampConfig.caching);
+        this.canReload = true; // CommonLayer constructor would have failed to figure this out since .url was not set yet.
 
         if (!parent.esriLayer) {
             throw new Error('Map Image Layer with no internal esri layer encountered in sublayer creation');

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -1147,7 +1147,7 @@ export class MapAPI extends CommonMapAPI {
      * @param {EsriUserSettings} options ESRI takeScreenshot() options
      * @returns {Promise<Screenshot>} a promise that resolves with a Screenshot
      */
-    async takeScreenshot(options: Partial<EsriUserSettings>): Promise<Screenshot> {
+    async takeScreenshot(options: Partial<EsriUserSettings> = {}): Promise<Screenshot> {
         if (this.esriView) {
             if (!options.quality) {
                 options.quality = 1;


### PR DESCRIPTION
### Changes
- Stops the map `takeScreenshot()` from going :boom: when the caller wants default options but doesn't provide `{}` as an options payload.
- Removes some nonsense logic from MIL Sublayer constructor that got cut-n-pasted

 

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open Enhanced Sample 4
2. Verify that the layers have a `Reload` menu item enabled in their legend `...` menus.
3. Run an export and confirm it still works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3006)
<!-- Reviewable:end -->
