### PR TITLE
prevent details symbology from expanding when clicking on panel

### DIFF
--- a/src/fixtures/details/components/symbology-list.vue
+++ b/src/fixtures/details/components/symbology-list.vue
@@ -8,11 +8,7 @@
         @blur.self="handleItemBlur"
         v-focus-list
         :content="t('details.layers.results.list.tooltip')"
-        v-tippy="{
-            trigger: 'manual',
-            placement: 'top-start',
-            touch: false
-        }"
+        v-tippy="{ trigger: 'manual', placement: 'top-start', touch: false }"
         ref="el"
     >
         <div class="flex justify-start relative" v-for="(item, idx) in props.results" :key="idx">
@@ -110,13 +106,15 @@ const handleMouseLeave = () => {
 };
 
 /**
- * Activates when an item in the list is focused.
+ * Activates when an item in the list is focused. Will only activate if focus is applied via keyboard.
  */
-const handleItemFocus = () => {
-    if (!hovering.value) {
-        expanded.value = true;
+const handleItemFocus = (event: FocusEvent) => {
+    if ((event.target as HTMLElement)?.matches(':focus-visible')) {
+        if (!hovering.value) {
+            expanded.value = true;
+        }
+        hovering.value = true;
     }
-    hovering.value = true;
 };
 
 /**


### PR DESCRIPTION
### Related Item(s)
#2974

### Changes
- Fixes an issue where clicking on the details panel would result in the symbology list expanding.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open up a demo page which contains a map that has two or more layers, like enhanced sample 3.
2. Perform an identify on one of the features on the map
3. Click on the details panel that pops up. The symbology list should not automatically open.
4. Ensure that tabbing to the symbology list still makes it expand.
5. Ensure that hovering over the symbology list still makes it expand.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3008)
<!-- Reviewable:end -->
