### PR TITLE
[FEATURE] Add `pinable` option to config (a counterpart to `reorderable`) to allow disabling pin control

### DIFF
--- a/demos/starter-scripts/teleport-wet.js
+++ b/demos/starter-scripts/teleport-wet.js
@@ -428,7 +428,8 @@ let config = {
                 }
             },
             panels: {
-                reorderable: false
+                reorderable: false,
+                pinable: false
             },
             system: { animate: true, scrollToInstance: true }
         }

--- a/demos/starter-scripts/wet.js
+++ b/demos/starter-scripts/wet.js
@@ -416,7 +416,8 @@ let config = {
                 }
             },
             panels: {
-                reorderable: false
+                reorderable: false,
+                pinable: false
             },
             system: { animate: true }
         }

--- a/docs/api-guides/panels.md
+++ b/docs/api-guides/panels.md
@@ -81,6 +81,7 @@ One of the top level sections of the config is `panels`, where you may include t
     - `screen` - the ID of the screen to show on the panel.
     - `pin` - a boolean indicating whether to pin the panel as well (in addition to opening).
 * `reorderable` - a boolean indicating whether the panel reorder controls are enabled.
+* `pinable` - a boolean indicating whether the panel pin controls are enabled.
 
 ## Creating Your Own Panel (using Vue)
 

--- a/schema.json
+++ b/schema.json
@@ -2906,6 +2906,11 @@
                     "type": "boolean",
                     "description": "Enables panel reorder controls.",
                     "default": true
+                },
+                "pinable": {
+                    "type": "boolean",
+                    "description": "Enables panel pin controls.",
+                    "default": true
                 }
             },
             "additionalProperties": false

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -248,8 +248,9 @@ export class InstanceAPI {
                     });
                 }
 
-                // enable/disable reorder controls
+                // enable/disable reorder/pin controls
                 panelStore.reorderable = activeConfig.panels.reorderable ?? true;
+                panelStore.pinable = activeConfig.panels.pinable ?? true;
             }
 
             // disable animations if needed

--- a/src/components/panel-stack/panel-screen.vue
+++ b/src/components/panel-stack/panel-screen.vue
@@ -37,7 +37,7 @@
                 <div class="flex" v-if="!panel.teleport">
                     <left v-if="reorderable" @click="move('left')" :active="!panel.isLeftMostPanel" />
                     <right v-if="reorderable" @click="move('right')" :active="!panel.isRightMostPanel" />
-                    <pin @click="panel.pin()" :active="panel.isPinned" />
+                    <pin v-if="pinable" @click="panel.pin()" :active="panel.isPinned" />
                     <expand
                         v-if="panel.controls && panel.controls.expand"
                         @click="panel.expand()"
@@ -110,6 +110,7 @@ const props = defineProps({
 const temporary = computed((): Array<string> | undefined => (iApi.fixture.get('appbar') ? appbarStore.temporary : []));
 const mobileView = computed(() => panelStore.mobileView);
 const reorderable = computed(() => panelStore.reorderable);
+const pinable = computed(() => panelStore.pinable);
 const FOCUS_CONTAINER_ATTR = 'focus-container';
 const ACTIVE_FOCUS_CONTAINER_ATTR = 'focus-container-active';
 // Managed focus descendants own keyboard traversal; wrapper should not become a competing tab stop.

--- a/src/stores/panel/panel-state.ts
+++ b/src/stores/panel/panel-state.ts
@@ -85,6 +85,14 @@ export interface PanelState {
      * @memberof PanelState
      */
     reorderable: boolean;
+
+    /**
+     * True if panels have the pin/unpin controls enabled.
+     *
+     * @type {boolean}
+     * @memberof PanelState
+     */
+    pinable: boolean;
 }
 
 // this should have been `AsyncComponentPromise` type, but something is off there

--- a/src/stores/panel/panel-store.ts
+++ b/src/stores/panel/panel-store.ts
@@ -13,6 +13,7 @@ export interface PanelStore {
     remWidth: Ref<number>;
     mobileView: Ref<boolean>;
     reorderable: Ref<boolean>;
+    pinable: Ref<boolean>;
     items: Ref<{ [name: string]: PanelInstance }>;
     regPromises: Ref<{ [name: string]: DefPromise<PanelInstance> }>;
     orderedItems: Ref<[]>;
@@ -45,6 +46,7 @@ export const usePanelStore = defineStore('panel', () => {
     const remWidth = ref(0);
     const mobileView = ref(false);
     const reorderable = ref(true);
+    const pinable = ref(true);
     const items = ref<{ [name: string]: PanelInstance }>({});
     const regPromises = ref<{ [name: string]: DefPromise<PanelInstance> }>({});
     const orderedItems = ref<PanelInstance[]>([]);
@@ -314,6 +316,7 @@ export const usePanelStore = defineStore('panel', () => {
         remWidth,
         mobileView,
         reorderable,
+        pinable,
         teleported,
         getRemainingWidth,
         getVisible,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -16,6 +16,7 @@ export interface RampConfig {
             pin?: boolean;
         }[];
         reorderable?: boolean;
+        pinable?: boolean;
     };
     system?: {
         proxyUrl?: string;


### PR DESCRIPTION
### Changes
- [FEATURE] This task adds a new, optional configuration value `pinable` which allows disabling the pin/unpin button.  This is a counterpart to the existing `reorderable` which allows disabling the reorder button.  `pinable` is disabled by default (like `reorderable`)

### Notes
* `pinable` is disabled by default and exists everywhere that `reorderable` does

### QA Testing
* Updated the existing "wet" demo (which already disables reordering) to also disable pinning

<img width="695" height="701" alt="image" src="https://github.com/user-attachments/assets/58b6e9e9-d62d-4ef7-849a-aed6356f8047" />
<img width="663" height="686" alt="image" src="https://github.com/user-attachments/assets/44cd918c-ebd0-4e07-ae7c-5a620b6c3fa5" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3016)
<!-- Reviewable:end -->
