### PR TITLE
Fix draw tool when no shapes to import/export

### DIFF
--- a/src/fixtures/draw/api/draw-api.ts
+++ b/src/fixtures/draw/api/draw-api.ts
@@ -17,7 +17,13 @@ import {
     resolveGraphicIdentifyBufferMode
 } from '../settings';
 import type { DrawBufferSettings, DrawIdentifyBufferMode } from '../settings';
-import { createDrawShapesExportFile, downloadDrawShapes, getDrawShapeId, parseDrawShapesPayload } from '../shape-io';
+import {
+    createDrawShapesExportFile,
+    downloadDrawShapes,
+    getDrawShapeId,
+    getPayloadShapes,
+    parseDrawShapesPayload
+} from '../shape-io';
 import type { DrawShapeExportRecord, DrawShapesExportFile } from '../shape-io';
 import { useDrawStore } from '../store';
 import type { ActiveToolList } from '../store';
@@ -164,6 +170,14 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
     async importShapes(source: DrawShapeImportSource): Promise<number> {
         const payload =
             typeof source === 'string' || source instanceof URL ? await this.fetchDrawShapesPayload(source) : source;
+
+        const shapes = getPayloadShapes(payload);
+        if (!shapes) {
+            throw new Error('Invalid draw shape payload.');
+        }
+        if (!shapes.length) {
+            return 0;
+        }
 
         const records = parseDrawShapesPayload(payload);
         if (!records.length) {

--- a/src/fixtures/draw/draw-defaults-screen.vue
+++ b/src/fixtures/draw/draw-defaults-screen.vue
@@ -134,6 +134,7 @@
                         class="rv-action-button"
                         :title="t('draw.export.all.tooltip')"
                         :aria-label="t('draw.export.all.tooltip')"
+                        :disabled="!hasShapes"
                         @click="exportAllShapes"
                     >
                         <download-icon class="w-16 h-16"></download-icon>
@@ -196,8 +197,11 @@ const identifyBufferMode = computed({
 });
 
 const importOpen = computed(() => isPanelOpen(panelStore, DRAW_IMPORT_PANEL_ID));
+const hasShapes = computed(() => drawStore.graphics.length > 0);
 
 const exportAllShapes = () => {
+    if (!hasShapes.value) return;
+
     const exported = downloadDrawShapes(drawStore.graphics, createDrawShapesFileName('ramp-draw-shapes'));
     iApi.updateAlert(t(exported ? 'draw.export.all.success' : 'draw.export.none'));
 };
@@ -268,6 +272,9 @@ const toggleImport = () => {
     display: block;
     height: 16px;
     width: 16px;
+}
+.rv-action-button:disabled {
+    @apply text-gray-400;
 }
 .rv-active-action-button {
     @apply text-indigo-700 bg-indigo-50;

--- a/src/fixtures/draw/shape-io.ts
+++ b/src/fixtures/draw/shape-io.ts
@@ -113,7 +113,7 @@ export const downloadDrawShapes = (graphics: DrawGraphicLike[], fileName?: strin
     return true;
 };
 
-const getPayloadShapes = (payload: unknown): unknown[] | undefined => {
+export const getPayloadShapes = (payload: unknown): unknown[] | undefined => {
     if (Array.isArray(payload)) return payload;
 
     if (!isRecord(payload)) return undefined;
@@ -173,6 +173,10 @@ export const parseDrawShapesPayload = (payload: unknown): DrawShapeImportRecord[
 };
 
 export const readDrawShapeFiles = async (files: File[]): Promise<DrawShapeImportRecord[]> => {
+    if (!files.length) {
+        throw new Error('Invalid draw shape file.');
+    }
+
     const importedShapes: DrawShapeImportRecord[] = [];
 
     for (const file of files) {
@@ -183,15 +187,17 @@ export const readDrawShapeFiles = async (files: File[]): Promise<DrawShapeImport
             throw new Error('Invalid draw shape file.');
         }
 
+        const shapes = getPayloadShapes(payload);
+        if (!shapes) {
+            throw new Error('Invalid draw shape file.');
+        }
+        if (!shapes.length) continue;
+
         const records = parseDrawShapesPayload(payload);
         if (!records.length) {
             throw new Error('Invalid draw shape file.');
         }
         importedShapes.push(...records);
-    }
-
-    if (!importedShapes.length) {
-        throw new Error('Invalid draw shape file.');
     }
 
     return importedShapes;


### PR DESCRIPTION
### Related Item(s)
#3007

### Changes
- [FIX] Disable the Draw Defaults export button when there are no shapes to export.
- [FIX] Allow imports with no shapes

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:
1. Open sample 13. Drawing Tools -> https://milespetrov.github.io/ramp4-pcar4/3007-draw-no-shape/demos/enhanced-samples.html?sample=13
2. Open draw default settings panel
3. Click on the export button, see download
4. Paste the following in the browser console:

```js
(async () => {
    const rInstance = window.debugInstance;
    if (!rInstance) throw new Error('window.debugInstance was not found.');

    const draw = rInstance.fixture.get('draw');
    if (!draw) throw new Error('Draw fixture API was not found.');

    // Delete all current draw shapes.
    const ids = draw.getShapeIds();
    ids.forEach(id => draw.store.removeGraphic(id));
    draw.store.clearSelection();

    // Clear the visible draw graphics layer too.
    rInstance.geo.layer.getLayer(draw.graphicsLayerId)?.esriLayer?.removeAll();

    console.log('Deleted shape IDs:', ids);
    console.log('Shape IDs after delete:', draw.getShapeIds());

    // Export with no shapes.
    const exported = draw.exportShapes();
    console.log('Exported empty payload:', exported);

    // Import the empty export. Expected result after the fix: resolves to 0, no error.
    const importedCount = await draw.importShapes(exported);
    console.log('Import result:', importedCount);
    console.log('Shape IDs after import:', draw.getShapeIds());

    return { exported, importedCount, finalShapeIds: draw.getShapeIds() };
})();
```

5. See the export button disabled, clicking it has no effect
6. See the console output confirming the empty import/export is working correctly

Note: ignore the shape segment/vertices remaining on the map, the delete for the test only targets the shapes themselves

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3017)
<!-- Reviewable:end -->
