### PR TITLE
Add checkActive to config changes watcher

### DIFF
--- a/demos/enhanced-samples.html
+++ b/demos/enhanced-samples.html
@@ -65,6 +65,7 @@
                         'basemap',
                         'crosshairs',
                         'details',
+                        'extentguard',
                         'geosearch',
                         'grid',
                         'help',

--- a/src/fixtures/extentguard/index.ts
+++ b/src/fixtures/extentguard/index.ts
@@ -77,7 +77,10 @@ class ExtentguardFixture extends ExtentguardAPI {
         // watch for configuration changes
         const unwatch = this.$vApp.$watch(
             () => this.config,
-            (value: ExtentguardConfig | undefined) => this._parseConfig(value)
+            (value: ExtentguardConfig | undefined) => {
+                this._parseConfig(value);
+                this.checkActive();
+            }
         );
 
         // override the removed method here to get access to scope


### PR DESCRIPTION
### Related Item(s)
Issue #3026 & [comment](https://github.com/ramp4-pcar4/ramp4-pcar4/issues/3026#issuecomment-5024424836)

### Changes
- Added `checkActive()` in the watcher for configuration changes

### Notes 
- Added `extentguard` to `startingFixtures` for testing.
- ~~Temporarily exposed the config store through `debugConfigStore` to validate runtime configuration changes. This will be removed before merging.~~

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing
Steps:
1. Go to enhanced sample 1
2. Verify `extentguard` is loaded but has no active extent configuration
3. Pan out into the ocean. The map should allow panning outside the boundary.
4. Return to Canada and run this in the console: 
<del><code>  debugConfigStore.config.fixtures.extentguard = { extentSetIds: ["EXT_NRCAN_Lambert_3978"] };
</code></del>
```
debugInstance.useStore("config").getActiveConfig(debugInstance.$i18n.locale.value).fixtures.extentguard = {
    extentSetIds: ["EXT_NRCAN_Lambert_3978"]
};
```
5. Attempt to pan far into the ocean again. The map should return to the configured extent boundary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3027)
<!-- Reviewable:end -->
