### PR TITLE
Make geolocate avialable on api

### DIFF
--- a/docs/using-ramp4/default-setup.md
+++ b/docs/using-ramp4/default-setup.md
@@ -42,6 +42,7 @@ TODO if we have API docs that expose the payload interfaces, link to those defin
 | MAP_DOUBLECLICK<br>'map/doubleclick'               | MapClick object                                                | The map was double clicked                       |
 | MAP_EXTENTCHANGE<br>'map/extentchanged'            | RAMP Extent object                                             | The map extent changed                           |
 | MAP_FOCUS<br>'map/focus'                           | KeyboardEvent object                                           | The map gained focus                             |
+| MAP_GEOLOCATE<br>'map/geolocate'                   | _success_: boolean, _coord_: Point, _error_: string            | The map geolocated the user                      |
 | MAP_GRAPHICHIT<br>'map/graphichit'                 | _layer_: LayerInstance object, _graphicHit_: object, _attributes_: object, _icon_: string, _screenPoint_: object            | A graphic was found where the mouse/crosshair is |
 | MAP_IDENTIFY<br>'map/identify'                     | MapIdentifyResult object                                       | A map identify was requested                     |
 | MAP_KEYDOWN<br>'map/keydown'                       | KeyboardEvent object                                           | A key was pressed                                |

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -195,6 +195,12 @@ export enum GlobalEvents {
     MAP_FOCUS = 'map/focus',
 
     /**
+     * Fires when the map attempts to geolocate the user.
+     * Payload: `( { success: boolean, coord: Point, error: string })`
+     */
+    MAP_GEOLOCATE = 'map/geolocate',
+
+    /**
      * Fires when the mouse enters the graphic of a vector layer symbol.
      * Payload: TODO huge untyped object. Create type? Type it all out?
      */

--- a/src/fixtures/mapnav/buttons/geolocator-nav.vue
+++ b/src/fixtures/mapnav/buttons/geolocator-nav.vue
@@ -9,54 +9,20 @@
 </template>
 
 <script setup lang="ts">
-import { InstanceAPI, NotificationType } from '@/api';
-import { Point, SpatialReference } from '@/geo/api';
-import { inject, reactive } from 'vue';
+import { InstanceAPI } from '@/api';
+
+import { inject } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 const iApi = inject('iApi') as InstanceAPI;
 
-let geolocation = reactive<Array<number>>([]);
-
-// These exist in all browsers but aren't predefined, so this tells eslint everything is a-ok
-/* global GeolocationPosition, GeolocationPositionError, PositionOptions */
-
 const geolocate = async () => {
-    // use cached location
-    if (!geolocation.length) {
-        // request current location from browser
-        const position = await browserLocate({
-            maximumAge: Infinity,
-            timeout: 5000
-        }).catch((error: GeolocationPositionError) => {
-            if (error.code === GeolocationPositionError.PERMISSION_DENIED) {
-                // send an error message for a denied permission error
-                iApi.notify.show(NotificationType.ERROR, t('mapnav.geolocator.error.permission'));
-            } else {
-                // send an error message for an internal/timeout error
-                iApi.notify.show(NotificationType.ERROR, t('mapnav.geolocator.error.internal'));
-            }
-        });
-        if (position) {
-            // store geolocation as array for speedy zoomIn
-            geolocation = [position.coords.longitude, position.coords.latitude];
-            zoomIn(geolocation);
-        }
-    } else {
-        zoomIn(geolocation);
+    const glAttempt = await iApi.geo.getGeolocation();
+
+    if (glAttempt.success) {
+        iApi.geo.map.zoomMapTo(glAttempt.coord!);
     }
-};
-
-// zoom to point
-const zoomIn = (coords: Array<number>): void => {
-    const zoomTarget = new Point('geolocation', coords, SpatialReference.latLongSR(), true);
-    iApi.geo.map.zoomMapTo(zoomTarget);
-};
-
-// prompt user to geolocate via browser
-const browserLocate = (options: PositionOptions): Promise<GeolocationPosition> => {
-    return new Promise((resolve, reject) => navigator.geolocation.getCurrentPosition(resolve, reject, options));
 };
 </script>
 

--- a/src/geo/geo.ts
+++ b/src/geo/geo.ts
@@ -1,9 +1,26 @@
 // the structure of the geo element of the RAMP API
 
-import { APIScope, AttributeAPI, InstanceAPI, LayerAPI, MapAPI, QueryAPI, SymbologyAPI } from '@/api/internal';
+import {
+    APIScope,
+    AttributeAPI,
+    GlobalEvents,
+    InstanceAPI,
+    LayerAPI,
+    MapAPI,
+    NotificationType,
+    QueryAPI,
+    SymbologyAPI
+} from '@/api/internal';
 import { geo } from '@/main';
+import { Point, SpatialReference } from '@/geo/api';
 import type { GeometryAPI, ProjectionAPI, SharedUtilsAPI } from '@/geo/api';
 import { EsriConfig } from '@/geo/esri';
+
+interface GeolocationResult {
+    success: boolean;
+    coord?: Point | undefined;
+    error?: 'permission' | 'internal';
+}
 
 export class GeoAPI extends APIScope {
     attributes: AttributeAPI;
@@ -64,5 +81,75 @@ export class GeoAPI extends APIScope {
      */
     get proxy(): string {
         return EsriConfig.request.proxyUrl || '';
+    }
+
+    /**
+     * Stores any geolocation result to avoid multiple hits
+     * @private
+     */
+    private glCoord: Array<number> = [];
+
+    // These exist in all browsers but aren't predefined, so this tells eslint everything is a-ok
+    /* global GeolocationPosition, GeolocationPositionError, PositionOptions */
+
+    /**
+     * Gets the geolocation of the user's browser. May prompt the user for permission.
+     * Will also emit event 'map/geolocate' when done.
+     *
+     * @param {boolean} [hideFailNotification=false] option to suppress a RAMP notification if the request fails
+     * @returns resolves with an object containing the these properties:
+     *          - success (boolean)
+     *          - coord (Point) location in lat lon if successful
+     *          - error ('permission' | 'internal') if not successful, indicates if it's a permission problem or something else
+     */
+    async getGeolocation(hideFailNotification: boolean = false): Promise<GeolocationResult> {
+        // prompt user to geolocate via browser
+        const browserLocate = (options: PositionOptions): Promise<GeolocationPosition> => {
+            return new Promise((resolve, reject) => navigator.geolocation.getCurrentPosition(resolve, reject, options));
+        };
+
+        const greatSuccess = (): GeolocationResult => ({
+            success: true,
+            coord: new Point('geolocation', this.glCoord, SpatialReference.latLongSR(), true)
+        });
+
+        let resultObj: GeolocationResult;
+
+        // use cached location
+        if (this.glCoord.length) {
+            resultObj = greatSuccess();
+        } else {
+            // request current location from browser
+            const positionOrError = await browserLocate({
+                maximumAge: Infinity,
+                timeout: 5000
+            }).catch((error: GeolocationPositionError) => {
+                return error.code === GeolocationPositionError.PERMISSION_DENIED ? 'permission' : 'internal';
+            });
+
+            if (!positionOrError || typeof positionOrError === 'string') {
+                // got a nothing result or the .catch hit
+
+                const safeError = positionOrError || 'internal';
+
+                if (!hideFailNotification) {
+                    // lang key search helpers:  mapnav.geolocator.error.permission  mapnav.geolocator.error.internal
+
+                    this.$iApi.notify.show(
+                        NotificationType.ERROR,
+                        this.$iApi.$i18n.t('mapnav.geolocator.error.' + safeError)
+                    );
+                }
+                resultObj = { success: false, error: safeError };
+            } else {
+                // store geolocation as array for speedy zoomIn
+                this.glCoord = [positionOrError.coords.longitude, positionOrError.coords.latitude];
+                resultObj = greatSuccess();
+            }
+        }
+
+        this.$iApi.event.emit(GlobalEvents.MAP_GEOLOCATE, resultObj);
+
+        return resultObj;
     }
 }


### PR DESCRIPTION
### Related Item(s)

- In preparation for https://github.com/ramp4-pcar4/ramp4-pcar4/issues/3024

### Changes
- Takes the geolocation logic out of the navbar button and puts it on the `.geo` API
- Adds an event to allow things to react to when the navbar geolocate is hit.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Note: if ur testing on an ECCC laptop, your system location service is probably turned off and locked. Great for testing the failure scenario.  To test the success you'll need to test on a home pc / device with location services on (WOMM).

Steps:
1. Open Enhanced Sample 1
2. Hit the `Your Location` button in the navbar (lower right, target icon)
3. If no location powers, see a message in the notification tray
4. If location powers, you are zoomed to where you are lurking

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3028)
<!-- Reviewable:end -->
