### PR TITLE
Enhance Draw Fixture API

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -499,7 +499,7 @@
             "description": "Determines where to render the panel instead of its usual spot in the panel stack.",
             "properties": {
                 "target": {
-                    "type": ["string", "element"],
+                    "type": ["string", "object"],
                     "description": "The target container where the panel will be rendered. Can be the element itself or a string query selector."
                 },
                 "showHeader": {
@@ -2010,7 +2010,7 @@
                     "description": "Name to be displayed as the header of the metadata panel."
                 },
                 "xmlType": {
-                    "type": "enum",
+                    "type": "string",
                     "description": "What xslt to match to the metadata XML. HNAP and DCAT are currently supported.",
                     "enum": ["HNAP", "DCAT"],
                     "default": "HNAP"

--- a/src/fixtures/draw/api/draw-api.ts
+++ b/src/fixtures/draw/api/draw-api.ts
@@ -1,14 +1,18 @@
 import { toRaw } from 'vue';
 
 import { FixtureInstance } from '@/api';
-import type { InstanceAPI } from '@/api';
+import type { GraphicLayer, InstanceAPI } from '@/api';
+import { Extent, GeometryType } from '@/geo/api';
 import type { BaseGeometry, IdentifyGeometryProvider, MapClick } from '@/geo/api';
-import { EsriIntersectsOperator } from '@/geo/esri';
+import { EsriIntersectsOperator, EsriSpatialReference } from '@/geo/esri';
 import type { EsriGeometry } from '@/geo/esri';
 
-import { DRAW_GRAPHICS_LAYER_ID } from '../constants';
+import { DRAW_EDIT_GRAPHICS_LAYER_ID, DRAW_GRAPHICS_LAYER_ID, DRAW_HIGHLIGHT_GRAPHICS_LAYER_ID } from '../constants';
 import { openDrawShapeDetailsPanel } from '../panel-utils';
 import {
+    cloneDrawBufferSettings,
+    cloneDrawStyleSettings,
+    createDefaultDrawMapLabelSettings,
     createDrawBufferGeometry,
     createDrawBufferOnlyGeometry,
     DRAW_SHAPE_DETAILS_PANEL_ID,
@@ -16,12 +20,12 @@ import {
     resolveGraphicBufferSettings,
     resolveGraphicIdentifyBufferMode
 } from '../settings';
-import type { DrawBufferSettings, DrawIdentifyBufferMode } from '../settings';
+import type { DrawBufferSettings, DrawBufferUnit, DrawIdentifyBufferMode } from '../settings';
 import {
+    createDrawShapeExportRecord,
     createDrawShapesExportFile,
     downloadDrawShapes,
     getDrawShapeId,
-    getPayloadShapes,
     parseDrawShapesPayload
 } from '../shape-io';
 import type { DrawShapeExportRecord, DrawShapesExportFile } from '../shape-io';
@@ -169,23 +173,17 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
      */
     async importShapes(source: DrawShapeImportSource): Promise<number> {
         const payload =
-            typeof source === 'string' || source instanceof URL ? await this.fetchDrawShapesPayload(source) : source;
-
-        const shapes = getPayloadShapes(payload);
-        if (!shapes) {
-            throw new Error('Invalid draw shape payload.');
-        }
-        if (!shapes.length) {
-            return 0;
-        }
+            typeof source === 'string' || source instanceof URL ? await fetchDrawShapesPayload(source) : source;
 
         const records = parseDrawShapesPayload(payload);
-        if (!records.length) {
+        if (Array.isArray(records)) {
+            if (records.length) {
+                this.store.requestImportShapes(records);
+            }
+            return records.length;
+        } else {
             throw new Error('Invalid draw shape payload.');
         }
-
-        this.store.requestImportShapes(records);
-        return records.length;
     }
 
     /**
@@ -219,10 +217,9 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
         return downloadDrawShapes(this.resolveExportGraphics(selection), fileName ?? optionFileName);
     }
 
-    /**
-     * Prevent default map identify while the draw fixture is creating or editing graphics.
-     */
     suppressIdentify(mapClick: MapClick): boolean {
+        // Prevent the default map identify while the draw fixture is creating or editing graphics.
+
         if (this.store.identifyGeometryGraphicId) {
             return false;
         }
@@ -262,16 +259,11 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
         return drawingToolEnabled || editActive;
     }
 
-    private async fetchDrawShapesPayload(source: string | URL): Promise<unknown> {
-        const response = await fetch(source);
-
-        if (!response.ok) {
-            throw new Error(`Unable to import draw shapes from ${source.toString()}.`);
-        }
-
-        return response.json();
-    }
-
+    /**
+     * Based on a "selection" of draw-shapes, generates an array of their ids.
+     * @param selection supports: id string, array of id strings, object with prop id containing string or array of string ids.
+     * @returns array of ids, or undefined if input doesn't conform
+     */
     private getExportSelectionIds(
         selection?: DrawShapeExportSelection | DrawShapeDownloadSelection
     ): string[] | undefined {
@@ -292,10 +284,6 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
         return Array.isArray(selection.ids) ? selection.ids : [selection.ids];
     }
 
-    private getDrawGraphicId(graphic: DrawGraphicLike): string | undefined {
-        return getDrawShapeId(graphic);
-    }
-
     private resolveExportGraphics(
         selection?: DrawShapeExportSelection | DrawShapeDownloadSelection
     ): DrawGraphicLike[] {
@@ -305,7 +293,7 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
 
         const idSet = new Set(ids);
         return graphics.filter(graphic => {
-            const id = this.getDrawGraphicId(graphic);
+            const id = getDrawShapeId(graphic);
             return id ? idSet.has(id) : false;
         });
     }
@@ -341,6 +329,13 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
             });
     }
 
+    /**
+     * For a point / click on the map, return the geometry in the drawing layer that should represent
+     * the identifiable area (think of selecting a shape to use as an identify region).
+     *
+     * @param mapClick point on the map to look for a drawing graphic
+     * @returns the drawing graphic, including any buffer, as a RAMP Geometry. Undefined if no shapes found.
+     */
     getIdentifyGeometry(mapClick: MapClick): BaseGeometry | undefined {
         const hitGraphic = this.getHitDrawGraphic(mapClick);
 
@@ -358,4 +353,140 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
 
         return this.$iApi.geo.geom.geomEsriToRamp(identifyGeometry, hitGraphic.id ?? hitGraphic.attributes?.id);
     }
+
+    /**
+     * Remove all drawings
+     */
+    removeAll(): void {
+        this.store.removeAll();
+
+        // TODO is there an easier way to find these layers? It looks like the only pointer is cooked into draw.vue
+        [DRAW_GRAPHICS_LAYER_ID, DRAW_EDIT_GRAPHICS_LAYER_ID, DRAW_HIGHLIGHT_GRAPHICS_LAYER_ID].forEach(layerId => {
+            const drawLayer = this.$iApi.geo.layer.getLayer(layerId);
+            if (drawLayer) {
+                (drawLayer as GraphicLayer).removeGraphic();
+            }
+        });
+    }
+
+    /**
+     * Set the current buffer distance (for the fixture, not for an already existing drawing)
+     * @param distance distance value, non-negative, in whatever the current buffer unit is
+     */
+    setBufferDistance(distance: number) {
+        this.store.setBufferDistance(distance);
+    }
+
+    /**
+     * Set the units for the buffer distance (for the fixture, not for an already existing drawing)
+     * @param {DrawBufferUnit} unit the unit string
+     */
+    setBufferUnit(unit: DrawBufferUnit) {
+        this.store.setBufferUnit(unit);
+    }
+
+    /**
+     * Import ramp geometries to the drawing tool. The "new shape" settings will be applied (styles, buffers, etc).
+     * @param rampGeoms a ramp geometry or array of ramp geometries
+     */
+    async importRampGeometry(rampGeoms: BaseGeometry | Array<BaseGeometry>): Promise<void> {
+        const rampGeomArray = Array.isArray(rampGeoms) ? rampGeoms : [rampGeoms];
+
+        const drawingGeoms = rampGeomArray.map(rampG => {
+            // handle extent case
+            const safeRampGeom = rampG.type === GeometryType.EXTENT ? (rampG as Extent).toPolygon() : rampG;
+
+            const esriGeom = this.$iApi.geo.geom.geomRampToEsri(safeRampGeom);
+
+            const drawGeom = {
+                spatialReference: esriGeom.spatialReference,
+                // @ts-expect-error grabbing all possibilities, the "type" on the final object will know which ones to use
+                rings: esriGeom.rings,
+                // @ts-expect-error grabbing all possibilities, the "type" on the final object will know which ones to use
+                paths: esriGeom.paths,
+                // @ts-expect-error grabbing all possibilities, the "type" on the final object will know which ones to use
+                x: esriGeom.x,
+                // @ts-expect-error grabbing all possibilities, the "type" on the final object will know which ones to use
+                y: esriGeom.y
+            };
+
+            const drawShape: DrawShapeExportRecord = {
+                // TODO not sure how important id is. we might be risking ramp duplicates. but using the ramp id allows us
+                //      to track the imported geometry in the drawing tool.
+                id: rampG.id,
+                type: esriGeom.type,
+                geometry: drawGeom,
+                settings: {
+                    drawStyle: cloneDrawStyleSettings(this.store.styleSettings),
+                    drawBuffer: cloneDrawBufferSettings(this.store.bufferSettings),
+                    drawIdentifyBufferMode: this.store.identifyBufferMode,
+                    // note: there is currently no global setting for lables (that I can find). So just using the default
+                    drawMapLabels: createDefaultDrawMapLabelSettings()
+                }
+            };
+
+            return drawShape;
+        });
+
+        await this.importShapes(drawingGeoms);
+    }
+
+    /**
+     * Convert all the drawings to RAMP Geometries.
+     * Some fidelity will be lost (e.g. special types like circles and rectangles become polygons,
+     * styles are dropped, buffers are currently not included)
+     * @returns array of RAMP geometries
+     */
+    exportRampGeometry(): Array<BaseGeometry> {
+        return (this.store.graphics as DrawGraphicLike[])
+            .map(drawingGraphic => {
+                // note this "export record create" is needed. using the raw graphic from the store
+                // explodes things somehow (missing geometry?? doesn't make sense but thats the erro).
+                // Maybe can revisit with deep dive through all the methods later, but this WOMM.
+                const fancyGraphic = createDrawShapeExportRecord(drawingGraphic)!;
+                if (!fancyGraphic.geometry) {
+                    return undefined;
+                }
+
+                // convert the drawing type to a neutral esri geometry type.
+                let esriGeomType: string;
+
+                switch (fancyGraphic.type) {
+                    case 'point':
+                    case 'polyline':
+                    case 'multipoint':
+                    case 'polygon':
+                        esriGeomType = fancyGraphic.type;
+                        break;
+
+                    case 'rectangle':
+                    case 'circle':
+                        esriGeomType = 'polygon';
+                        break;
+
+                    default:
+                        console.error(`Encountered unhandled drawing type ${fancyGraphic.type}`);
+                        return undefined;
+                }
+
+                // make an esri-ish geometry, having enough stuff for our esri-to-ramp converter.
+                // the converter needs a real esri SR so that gets enhanced
+                const esriLikeGeom: any = fancyGraphic.geometry;
+                esriLikeGeom.type = esriGeomType;
+                esriLikeGeom.spatialReference = new EsriSpatialReference(esriLikeGeom.spatialReference);
+
+                return this.$iApi.geo.geom.geomEsriToRamp(esriLikeGeom, drawingGraphic.id);
+            })
+            .filter(x => !!x);
+    }
+}
+
+async function fetchDrawShapesPayload(source: string | URL): Promise<unknown> {
+    const response = await fetch(source);
+
+    if (!response.ok) {
+        throw new Error(`Unable to import draw shapes from ${source.toString()}.`);
+    }
+
+    return response.json();
 }

--- a/src/fixtures/draw/draw.vue
+++ b/src/fixtures/draw/draw.vue
@@ -79,7 +79,7 @@ import type { DrawShapeDetailsTab } from './panel-utils';
 import { getDrawShapeId } from './shape-io';
 import type { DrawShapeImportRecord } from './shape-io';
 import { useDrawStore } from './store';
-import type { DrawGraphicLike } from './types';
+import type { DrawGraphicLike, DrawGraphicType } from './types';
 import { buildDrawSegments, buildDrawVertices, parseDrawMeasurementTargetKey } from './measurement-utils';
 import { useDrawIdentify } from './use-draw-identify';
 import { useDrawKeyboard } from './use-draw-keyboard';
@@ -118,6 +118,10 @@ let viewClickHandler: { remove: () => void } | null = null;
 let sketchEventsRegistered = false;
 let drawToolsInitId = 0;
 let sketchUpdateTimeout: number | null = null;
+
+/**
+ * Maps an id from a drawn graphic (the raw, non-buffered geometry) to the graphic that represents the buffer of that graphic
+ */
 let bufferGraphics = new Map<string, EsriGraphic>();
 let editActivationRequestId = 0;
 const drawGraphicIdCounters: Record<string, number> = {};
@@ -716,7 +720,7 @@ const importDrawShapes = async (records: DrawShapeImportRecord[]): Promise<numbe
             if (!geometry) continue;
 
             const projectedGeometry = await projectGeometryToMapSR(geometry, record.id);
-            const type = record.type || projectedGeometry.type;
+            const type = (record.type || projectedGeometry.type) as DrawGraphicType;
             const graphic = new EsriGraphic({
                 geometry: projectedGeometry,
                 attributes: {

--- a/src/fixtures/draw/shape-io.ts
+++ b/src/fixtures/draw/shape-io.ts
@@ -29,6 +29,11 @@ export interface DrawShapeSettingsExport {
 export interface DrawShapeExportRecord {
     id?: string;
     type: string;
+
+    /**
+     * this has the format of an ESRI geometry, but lacks the .type property.
+     * typically only has the coordinate props (e.g. rings, paths, x, y) and spatialReference
+     */
     geometry: unknown;
     settings: DrawShapeSettingsExport;
 }
@@ -113,6 +118,12 @@ export const downloadDrawShapes = (graphics: DrawGraphicLike[], fileName?: strin
     return true;
 };
 
+/**
+ * Takes a payload and attempts to extract the shapes
+ *
+ * @param payload typically an export file format, an individual drawing shape, or an array of drawing shapes
+ * @returns an array of shape objects, or undefined if the payload is a bad format
+ */
 export const getPayloadShapes = (payload: unknown): unknown[] | undefined => {
     if (Array.isArray(payload)) return payload;
 
@@ -164,17 +175,33 @@ const normalizeImportRecord = (payload: unknown): DrawShapeImportRecord | undefi
     };
 };
 
-export const parseDrawShapesPayload = (payload: unknown): DrawShapeImportRecord[] => {
+/**
+ * Attempts to parse various shape payloads into a standarized format.
+ *
+ * @param payload typically an export file format, an individual drawing shape, or an array of drawing shapes
+ * @returns an array of normalized drawing shapes (records), or undefined if the payload could not be processed
+ */
+export const parseDrawShapesPayload = (payload: unknown): DrawShapeImportRecord[] | undefined => {
     const shapes = getPayloadShapes(payload);
-    if (!shapes?.length) return [];
-
-    const records = shapes.map(normalizeImportRecord);
-    return records.every(Boolean) ? (records as DrawShapeImportRecord[]) : [];
+    if (Array.isArray(shapes)) {
+        if (shapes.length) {
+            const records = shapes.map(normalizeImportRecord);
+            return records.every(Boolean) ? (records as DrawShapeImportRecord[]) : [];
+        } else {
+            // empty, avoid doing pointless parsing
+            return [];
+        }
+    } else {
+        // something failed
+        return undefined;
+    }
 };
 
 export const readDrawShapeFiles = async (files: File[]): Promise<DrawShapeImportRecord[]> => {
+    const badFileMsg = 'Invalid draw shape file.';
+
     if (!files.length) {
-        throw new Error('Invalid draw shape file.');
+        throw new Error(badFileMsg);
     }
 
     const importedShapes: DrawShapeImportRecord[] = [];
@@ -184,20 +211,22 @@ export const readDrawShapeFiles = async (files: File[]): Promise<DrawShapeImport
         try {
             payload = JSON.parse(await file.text());
         } catch {
-            throw new Error('Invalid draw shape file.');
+            throw new Error(badFileMsg);
         }
-
-        const shapes = getPayloadShapes(payload);
-        if (!shapes) {
-            throw new Error('Invalid draw shape file.');
-        }
-        if (!shapes.length) continue;
 
         const records = parseDrawShapesPayload(payload);
-        if (!records.length) {
-            throw new Error('Invalid draw shape file.');
+
+        if (Array.isArray(records)) {
+            if (records.length) {
+                importedShapes.push(...records);
+            } else {
+                // empty, avoid doing pointless parsing
+                return [];
+            }
+        } else {
+            // something failed
+            throw new Error(badFileMsg);
         }
-        importedShapes.push(...records);
     }
 
     return importedShapes;

--- a/src/fixtures/draw/store/draw-store.ts
+++ b/src/fixtures/draw/store/draw-store.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { computed, reactive, ref } from 'vue';
 
 import type { DrawTypeConfig } from '../api/draw-api';
+import type { DrawGraphicLike } from '../types';
 import {
     cloneDrawBufferSettings,
     cloneDrawMapLabelSettings,
@@ -41,7 +42,11 @@ export const useDrawStore = defineStore('draw', () => {
     const supportedTypes = ref<DrawTypeConfig[]>([]);
     const configParsed = ref(false);
     const activeTool = ref<ActiveToolList>(null);
-    const graphics = reactive<any[]>([]);
+
+    /**
+     * List of graphics that have been drawn. The type is DrawGraphicLike
+     */
+    const graphics = reactive<any[]>([]); // using the type instead of `any` here leads to billions of casts since pinapple store likes to disrespect types
     const selectedGraphicId = ref<string | null>(null);
     const mapNavEl = ref<unknown | null>(null);
     const measurementsEnabled = ref(false);
@@ -85,13 +90,21 @@ export const useDrawStore = defineStore('draw', () => {
         activeTool.value = tool;
     }
 
-    function addGraphic(graphic: any) {
+    function addGraphic(graphic: DrawGraphicLike) {
         const id = graphic.id ?? graphic.attributes?.id ?? `graphic-${Date.now()}-${++graphicIdCounter}`;
         graphics.push({
             ...graphic,
             id
         });
         return id;
+    }
+
+    function setNoGraphicsState() {
+        // just a re-usable worker for setting stuff when we have no graphics
+        shapeDetailsPickEnabled.value = false;
+        shapeDetailsLabelsVisible.value = false;
+        shapeDetailsLabelsUseSettings.value = false;
+        shapeDetailsActiveTab.value = 'details';
     }
 
     function removeGraphic(id: string) {
@@ -105,13 +118,30 @@ export const useDrawStore = defineStore('draw', () => {
                 selectedGraphicId.value = null;
             }
             if (graphics.length === 0) {
-                shapeDetailsPickEnabled.value = false;
-                shapeDetailsLabelsVisible.value = false;
-                shapeDetailsLabelsUseSettings.value = false;
-                shapeDetailsActiveTab.value = 'details';
+                setNoGraphicsState();
             }
             clearMeasurementInteraction();
         }
+    }
+
+    function removeAll() {
+        // pop-clear so we keep the pointer to the same array
+        while (graphics.length) {
+            const gId = graphics.at(-1).id;
+
+            // measurement labels lurk in the map view, and its tricky to get at them
+            // unless you are in draw.vue.  This appears to be the best way, as draw.vue
+            // has watcher on the Request Id and will then scrub the Graphic Id
+            mapLabelSettingsUpdatedGraphicId.value = gId;
+            mapLabelSettingsUpdateRequestId.value++;
+
+            delete shapeFeatureCounts[gId];
+
+            graphics.pop();
+        }
+
+        setNoGraphicsState();
+        clearSelection();
     }
 
     function selectGraphic(id: string) {
@@ -431,94 +461,95 @@ export const useDrawStore = defineStore('draw', () => {
     }
 
     return {
-        supportedTypes,
-        configParsed,
-        activeTool,
-        graphics,
-        selectedGraphicId,
-        measurementsEnabled,
-        hoveredSegmentKey,
-        selectedSegmentKey,
         activeSegmentKey,
-        hoveredVertexKey,
-        selectedVertexKey,
+        activeTool,
         activeVertexKey,
-        shapeDetailsPickEnabled,
-        shapeDetailsLabelsVisible,
-        shapeDetailsLabelsUseSettings,
-        shapeDetailsActiveTab,
+        bufferSettings,
+        cancelEditModeClearSelection,
+        cancelEditModeRequestId,
+        configParsed,
         deleteSelectedGraphicRequestId,
         editSelectedGraphicRequestId,
+        graphics,
+        hoveredSegmentKey,
+        hoveredVertexKey,
+        identifyBufferMode,
+        identifyGeometryGraphicId,
         identifySelectedGraphicRequestId,
-        shapePanelFocusRequestId,
-        stopEditModeRequestId,
-        stopEditModeClearSelection,
-        cancelEditModeRequestId,
-        cancelEditModeClearSelection,
-        refreshSelectedGraphicFeatureCountsRequestId,
-        selectedGraphicSettingsUpdateRequestId,
-        selectedGraphicSettingsUpdatedGraphicId,
+        importShapeRecords,
+        importShapesRequestId,
         mapLabelSettingsUpdateRequestId,
         mapLabelSettingsUpdatedGraphicId,
-        importShapesRequestId,
-        importShapeRecords,
-        identifyGeometryGraphicId,
-        styleSettings,
-        bufferSettings,
-        identifyBufferMode,
+        mapNavEl,
+        measurementsEnabled,
+        refreshSelectedGraphicFeatureCountsRequestId,
+        selectedGraphicId,
+        selectedGraphicSettingsUpdateRequestId,
+        selectedGraphicSettingsUpdatedGraphicId,
+        selectedSegmentKey,
+        selectedVertexKey,
+        shapeDetailsActiveTab,
+        shapeDetailsLabelsUseSettings,
+        shapeDetailsLabelsVisible,
+        shapeDetailsPickEnabled,
         shapeFeatureCounts,
-        setSupportedTypes,
-        setActiveTool,
+        shapePanelFocusRequestId,
+        stopEditModeClearSelection,
+        stopEditModeRequestId,
+        styleSettings,
+        supportedTypes,
         addGraphic,
-        removeGraphic,
-        selectGraphic,
+        clearImportShapes,
+        clearMeasurementInteraction,
         clearSelection,
+        getSelectedGraphic,
+        removeAll,
+        removeGraphic,
+        requestCancelEditMode,
         requestDeleteSelectedGraphic,
         requestEditSelectedGraphic,
         requestIdentifySelectedGraphic,
-        requestStopEditMode,
-        requestCancelEditMode,
+        requestImportShapes,
         requestRefreshSelectedGraphicFeatureCounts,
         requestShapePanelFocus,
-        requestImportShapes,
-        clearImportShapes,
-        getSelectedGraphic,
-        updateGraphicGeometry,
-        updateGraphic,
-        setGraphicMapLabelSettings,
-        setSelectedGraphicStyleSettings,
-        setSelectedGraphicFillColor,
-        setSelectedGraphicBorderColor,
-        setSelectedGraphicBufferColor,
-        setSelectedGraphicOpacity,
-        setSelectedGraphicBufferSettings,
-        setSelectedGraphicBufferDistance,
-        setSelectedGraphicBufferUnit,
-        setSelectedGraphicIdentifyBufferMode,
-        setMeasurementsEnabled,
-        toggleMeasurements,
-        setHoveredSegmentKey,
-        setSelectedSegmentKey,
-        setHoveredVertexKey,
-        setSelectedVertexKey,
-        clearMeasurementInteraction,
-        setShapeDetailsPickEnabled,
-        setShapeDetailsLabelsVisible,
-        setShapeDetailsLabelsUseSettings,
-        setShapeDetailsActiveTab,
-        toggleShapeDetailsPickEnabled,
-        setFillColor,
+        requestStopEditMode,
+        selectGraphic,
+        setActiveTool,
         setBorderColor,
         setBufferColor,
-        setOpacity,
-        setStyleSettings,
         setBufferDistance,
-        setBufferUnit,
         setBufferSettings,
+        setBufferUnit,
+        setFillColor,
+        setGraphicMapLabelSettings,
+        setHoveredSegmentKey,
+        setHoveredVertexKey,
         setIdentifyBufferMode,
         setIdentifyGeometryGraphicId,
+        setMeasurementsEnabled,
+        setOpacity,
+        setSelectedGraphicBorderColor,
+        setSelectedGraphicBufferColor,
+        setSelectedGraphicBufferDistance,
+        setSelectedGraphicBufferSettings,
+        setSelectedGraphicBufferUnit,
+        setSelectedGraphicFillColor,
+        setSelectedGraphicIdentifyBufferMode,
+        setSelectedGraphicOpacity,
+        setSelectedGraphicStyleSettings,
+        setSelectedSegmentKey,
+        setSelectedVertexKey,
+        setShapeDetailsActiveTab,
+        setShapeDetailsLabelsUseSettings,
+        setShapeDetailsLabelsVisible,
+        setShapeDetailsPickEnabled,
         setShapeFeatureCounts,
         setShapeFeatureCountsLoading,
-        mapNavEl
+        setStyleSettings,
+        setSupportedTypes,
+        toggleMeasurements,
+        toggleShapeDetailsPickEnabled,
+        updateGraphic,
+        updateGraphicGeometry
     };
 });

--- a/src/fixtures/draw/types.ts
+++ b/src/fixtures/draw/types.ts
@@ -4,8 +4,25 @@ export type Vertex = [number, number];
 
 export type DrawMeasurementTargetKind = 'segment' | 'vertex';
 
+// this list matches the values of the CreateTool type in the esri Sketch widget,
+// plus the values of esri geometry `type` property (extent is the only item in that
+// property that is not in CreateTool)
+export type DrawGraphicType =
+    | 'point'
+    | 'multipoint'
+    | 'polyline'
+    | 'polygon'
+    | 'circle'
+    | 'rectangle'
+    | 'mesh'
+    | 'freehandPolyline'
+    | 'freehandPolygon'
+    | 'text'
+    | 'extent';
+
 export type DrawGraphicLike = {
     id?: string;
+    type?: DrawGraphicType;
     attributes?: any;
     geometry?: EsriGeometry | null;
 };

--- a/src/fixtures/draw/use-draw-measurements.ts
+++ b/src/fixtures/draw/use-draw-measurements.ts
@@ -27,7 +27,7 @@ import {
 } from './measurement-utils';
 import { resolveGraphicMapLabelSettings } from './settings';
 import { useDrawStore } from './store';
-import type { Vertex } from './types';
+import type { DrawGraphicLike, Vertex } from './types';
 
 type MeasurementGraphicKind = 'vertex-marker' | 'vertex-label';
 
@@ -1400,7 +1400,8 @@ export const useDrawMeasurements = ({
         return labels;
     };
 
-    const getGraphicId = (graphic: EsriGraphic | null | undefined): string | undefined => graphic?.attributes?.id;
+    const getGraphicId = (graphic: EsriGraphic | DrawGraphicLike | null | undefined): string | undefined =>
+        graphic?.attributes?.id;
 
     const makeMeasurableGraphic = (
         id: string,

--- a/src/geo/api/geo-defs.ts
+++ b/src/geo/api/geo-defs.ts
@@ -333,7 +333,11 @@ export interface MapClick {
  */
 export interface IdentifyGeometryProvider {
     /**
-     * Return true when this provider wants the map identify request blocked.
+     * Allows the provider to stop the standard map identify request, and do
+     * processing on the map click.
+     *
+     * @param {MapClick} mapClick the incoming click for the identify request.
+     * @returns {boolean} true if this provider wants the map identify request blocked.
      */
     suppressIdentify?(mapClick: MapClick): boolean;
 

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -1287,6 +1287,7 @@ export class MapAPI extends CommonMapAPI {
 
     /**
      * Checks whether any optional provider wants to suppress the current identify request.
+     * Will only process the first provider that wants suppression.
      *
      * @param mapClick map click that initiated identify
      * @returns true if identify should be skipped


### PR DESCRIPTION
### Related Item(s)

- In support of https://github.com/ramp4-pcar4/ramp4-pcar4/issues/3024

### Changes
- Adds the following methods on the Draw fixture API
  - `removeAll`: smites all the drawings
  - `setBufferDistance`, `setBufferUnit`: allows updating of the default buffer values.
  - `importRampGeometry`: allows adding Ramp Geometries as drawing shapes
  - `exportRampGeometry`: converts all drawing shapes to Ramp Geometries
- Changes the logic of the drawing import methods to avoid parsing the payload twice.
- Adds some comments to mystery methods.
- Sorted the massive export in the draw store.
- Corrects some invalid types in the schema file.


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Use Enhanced Sample 13.  Bring up the `F12` console.

Run this first.

```js
const df = debugInstance.fixture.get('draw');
```

Test the buffer methods.

```js
df.setBufferUnit('meters');
df.setBufferDistance(8500);
```

Open the default draw settings panel (gear in the draw-bar), ensure the values reflect on screen.

Test the import of RAMP geoms.

```js
const geojson = [
  { "type": "Point", "coordinates": [-115.7668647, 54.9016419] },
  { "type": "Point", "coordinates": [-114.058959, 54.921442] },
  {
    "type": "LineString",
    "coordinates": [
      [-115.1242588, 54.675883 ],
      [-115.8620774, 54.1463139],
      [-114.9023089, 54.1500213]
    ]
  },
  {
    "type": "Polygon",
    "coordinates": [
      [
        [-115.4975893, 53.8524931],
        [-116.0618723, 53.6692915],
        [-115.9861217, 53.2828726],
        [-115.1094133, 53.2253621],
        [-114.256622,  53.3197159],
        [-113.8958764, 53.6293694],
        [-114.255329,  53.90009  ],
        [-114.9940368, 53.892709 ],
        [-115.4975893, 53.8524931]
      ]
    ]
  }
];

const rampgeoms = geojson.map(gj => debugInstance.geo.geom.geomGeoJsonToRamp(gj));

df.importRampGeometry(rampgeoms);
```

You should see a face appear in Alberta. It should have the buffer we set, and respect whatever colour is in the default settings panel.

Test the RAMP geom export. Code is outputting the type since Vue bindings make the objects ugly to inspect.

```js
const mahExport = df.exportRampGeometry();
console.log(mahExport);
mahExport.forEach(g => console.log(g.type));
```

Smite the shapes.

```js
df.removeAll();
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3041)
<!-- Reviewable:end -->
