### PR TITLE
Correct draw import checks

### DIFF
--- a/src/fixtures/draw/shape-io.ts
+++ b/src/fixtures/draw/shape-io.ts
@@ -186,9 +186,14 @@ export const parseDrawShapesPayload = (payload: unknown): DrawShapeImportRecord[
     if (Array.isArray(shapes)) {
         if (shapes.length) {
             const records = shapes.map(normalizeImportRecord);
-            return records.every(Boolean) ? (records as DrawShapeImportRecord[]) : [];
+            if (records.every(Boolean)) {
+                return records as DrawShapeImportRecord[];
+            } else {
+                // stuff in our payload could not be normalized. treat payload as bad
+                return undefined;
+            }
         } else {
-            // empty, avoid doing pointless parsing
+            // empty payload. treat as valid, avoid doing pointless parsing
             return [];
         }
     } else {


### PR DESCRIPTION
### Related Item(s)

- Fixes a mistake introduced in https://github.com/ramp4-pcar4/ramp4-pcar4/pull/3041

### Changes
- Fixes the drawing tool import logic to properly flag files with bad content.

### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

Download these three files to your hard drive.

[shapes-circle.json](https://github.com/user-attachments/files/30900952/shapes-circle.json)
[shapes-empty.json](https://github.com/user-attachments/files/30900955/shapes-empty.json)
[shapes-error.json](https://github.com/user-attachments/files/30900957/shapes-error.json)

Use Enhanced Sample 13 (Drawing Tools) for each site.  On each site, use the Default Drawing Settings panel (gear icon in the drawing tool), and use the `Import` button at the bottom to load the three files.

---

**Old (Good) Logic**: This site is running the code prior to the Drawing API enhancement.  The good logic will load the circle, load the empty file without complaint, and grouse about the error file.

https://james-rae.github.io/ramp4-pcar4/milesdraw/demos/enhanced-samples.html?sample=13

---

**Main (Bad) Logic**: This is after the Drawing API enhancement.  The error file will load without complaint. It loads nothing, so not a brutal bug, but the user is unaware there was a problem with the content.

https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html?sample=13

---

**This PR (Good)**: Should work same as the old logic, loading the circle and the empty, and grousing about the error.

https://james-rae.github.io/ramp4-pcar4/drawimportfix/demos/enhanced-samples.html?sample=13

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3043)
<!-- Reviewable:end -->
