### PR TITLE
add showThousandsSeparator config option

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -3092,6 +3092,11 @@
                     "type": "boolean",
                     "description": "If set to true, the app will display numbers in plain decimal format instead of formatting them based on the app language.",
                     "default": false
+                },
+                "showThousandsSeparator": {
+                    "type": "boolean",
+                    "description": "If set to true, the app will group digits and display a thousands separator based on the app language when formatting numbers.",
+                    "default": false
                 }
             },
             "required": [],

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -84,6 +84,7 @@ export class InstanceAPI {
         formatNumber: (num: number) => string;
         scrollToInstance: boolean;
         suppressNumberLocalization: boolean;
+        showThousandsSeparator: boolean;
         escapeHtml: (content: string) => string;
 
         /**
@@ -136,6 +137,7 @@ export class InstanceAPI {
             formatNumber: () => '',
             scrollToInstance: false,
             suppressNumberLocalization: false,
+            showThousandsSeparator: false,
             escapeHtml: () => '',
             isPlainText: () => true
         };
@@ -274,6 +276,9 @@ export class InstanceAPI {
             if (activeConfig.system?.suppressNumberLocalization) {
                 this.ui.suppressNumberLocalization = activeConfig.system?.suppressNumberLocalization;
             }
+            if (activeConfig.system?.showThousandsSeparator) {
+                this.ui.showThousandsSeparator = activeConfig.system?.showThousandsSeparator;
+            }
 
             // set up key to SVG bindings for zoom icons
             const zoomSvgs: { [key: string]: string } = {
@@ -290,7 +295,9 @@ export class InstanceAPI {
             };
 
             this.ui.formatNumber = (num: number) => {
-                return this.ui.suppressNumberLocalization ? num.toString() : this.$i18n.n(num, 'number');
+                return this.ui.suppressNumberLocalization
+                    ? num.toString()
+                    : this.$i18n.n(num, { key: 'number', useGrouping: this.ui.showThousandsSeparator } as any);
             };
 
             /**

--- a/src/fixtures/export-scalebar/index.ts
+++ b/src/fixtures/export-scalebar/index.ts
@@ -25,7 +25,7 @@ class ExportScalebarFixture extends FixtureInstance implements ExportSubFixture 
 
             const fbScaleText = new fabric.Text(
                 this.$iApi.$i18n.t('export.scaleBar.approx', [
-                    `${this.$iApi.$i18n.n(sInfo[i].distance, 'number')}${sInfo[i].units}`
+                    `${this.$iApi.ui.formatNumber(sInfo[i].distance)}${sInfo[i].units}`
                 ]),
                 {
                     fontFamily: 'Montserrat, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif',

--- a/src/geo/map/caption.ts
+++ b/src/geo/map/caption.ts
@@ -207,7 +207,7 @@ export class MapCaptionAPI extends APIScope {
 
         mapCaptionStore.scale = {
             width: `${scaleInfo.pixels}px`,
-            label: `${this.$iApi.$i18n.n(scaleInfo.distance, 'number')}${scaleInfo.units}`,
+            label: `${this.$iApi.ui.formatNumber(scaleInfo.distance)}${scaleInfo.units}`,
             isImperialScale: isImperialScale
         };
     }
@@ -343,16 +343,17 @@ export class MapCaptionAPI extends APIScope {
         const mx = Math.floor(Math.abs((lon - dx) * 60));
         const sx = Math.floor((Math.abs(lon) - Math.abs(dx) - mx / 60) * 3600);
 
-        return `${this.$iApi.$i18n.n(Math.abs(dy), 'number')}${degreeSymbol} ${this.$iApi.$i18n.n(my, 'number', {
+        return `${this.$iApi.ui.formatNumber(Math.abs(dy))}${degreeSymbol} ${this.$iApi.$i18n.n(my, 'number', {
             minimumIntegerDigits: 2
         } as any)}' ${this.$iApi.$i18n.n(sy, 'number', {
             minimumIntegerDigits: 2
-        } as any)}" ${this.$iApi.$i18n.t('map.coordinates.' + (lat > 0 ? 'north' : 'south'))} | ${this.$iApi.$i18n.n(
-            Math.abs(dx),
-            'number'
-        )}${degreeSymbol} ${this.$iApi.$i18n.n(mx, 'number', {
-            minimumIntegerDigits: 2
-        } as any)}' ${this.$iApi.$i18n.n(sx, 'number', {
+        } as any)}" ${this.$iApi.$i18n.t('map.coordinates.' + (lat > 0 ? 'north' : 'south'))} | ${this.$iApi.ui.formatNumber(Math.abs(dx))}${degreeSymbol} ${this.$iApi.$i18n.n(
+            mx,
+            'number',
+            {
+                minimumIntegerDigits: 2
+            } as any
+        )}' ${this.$iApi.$i18n.n(sx, 'number', {
             minimumIntegerDigits: 2
         } as any)}" ${this.$iApi.$i18n.t('map.coordinates.' + (0 > lon ? 'west' : 'east'))}`;
     }
@@ -379,18 +380,19 @@ export class MapCaptionAPI extends APIScope {
         const dx = Math.floor(Math.abs(lon)) * (lon < 0 ? -1 : 1);
         const mx = Math.abs((lon - dx) * 60);
 
-        return `${this.$iApi.$i18n.n(Math.abs(dy), 'number')}${degreeSymbol} ${this.$iApi.$i18n.n(my, 'number', {
+        return `${this.$iApi.ui.formatNumber(Math.abs(dy))}${degreeSymbol} ${this.$iApi.$i18n.n(my, 'number', {
             minimumIntegerDigits: 2,
             minimumFractionDigits: 5,
             maximumFractionDigits: 5
-        } as any)} ${this.$iApi.$i18n.t('map.coordinates.' + (lat > 0 ? 'north' : 'south'))} | ${this.$iApi.$i18n.n(
-            Math.abs(dx),
-            'number'
-        )}${degreeSymbol} ${this.$iApi.$i18n.n(mx, 'number', {
-            minimumIntegerDigits: 2,
-            minimumFractionDigits: 5,
-            maximumFractionDigits: 5
-        } as any)} ${this.$iApi.$i18n.t('map.coordinates.' + (0 > lon ? 'west' : 'east'))}`;
+        } as any)} ${this.$iApi.$i18n.t('map.coordinates.' + (lat > 0 ? 'north' : 'south'))} | ${this.$iApi.ui.formatNumber(Math.abs(dx))}${degreeSymbol} ${this.$iApi.$i18n.n(
+            mx,
+            'number',
+            {
+                minimumIntegerDigits: 2,
+                minimumFractionDigits: 5,
+                maximumFractionDigits: 5
+            } as any
+        )} ${this.$iApi.$i18n.t('map.coordinates.' + (0 > lon ? 'west' : 'east'))}`;
     }
 
     /**
@@ -436,10 +438,9 @@ export class MapCaptionAPI extends APIScope {
         // project using Web-Mercator wkid
         const projectedPoint: any = await this.$iApi.geo.proj.projectGeometry(102100, p);
 
-        return `${this.$iApi.$i18n.n(
-            Math.floor(projectedPoint.x),
-            'number'
-        )} m | ${this.$iApi.$i18n.n(Math.floor(projectedPoint.y), 'number')} m`;
+        return `${this.$iApi.ui.formatNumber(Math.floor(projectedPoint.x))} m | ${this.$iApi.ui.formatNumber(
+            Math.floor(projectedPoint.y)
+        )} m`;
     }
 
     /**
@@ -453,9 +454,9 @@ export class MapCaptionAPI extends APIScope {
         // project using Lambert wkid
         const projectedPoint: any = await this.$iApi.geo.proj.projectGeometry(3978, p);
 
-        return `${this.$iApi.$i18n.n(Math.abs(Math.floor(projectedPoint.x)), 'number')} m ${this.$iApi.$i18n.t(
+        return `${this.$iApi.ui.formatNumber(Math.abs(Math.floor(projectedPoint.x)))} m ${this.$iApi.$i18n.t(
             'map.coordinates.' + (0 > projectedPoint.x ? 'west' : 'east')
-        )} | ${this.$iApi.$i18n.n(Math.abs(Math.floor(projectedPoint.y)), 'number')} m ${this.$iApi.$i18n.t(
+        )} | ${this.$iApi.ui.formatNumber(Math.abs(Math.floor(projectedPoint.y)))} m ${this.$iApi.$i18n.t(
             'map.coordinates.' + (projectedPoint.y > 0 ? 'north' : 'south')
         )}`;
     }
@@ -481,12 +482,10 @@ export class MapCaptionAPI extends APIScope {
 
         return `${this.$iApi.$i18n.n(zone, 'number', {
             minimumIntegerDigits: 2
-        } as any)} ${this.$iApi.$i18n.t('map.coordinates.' + (lat > 0 ? 'north' : 'south'))} ${this.$iApi.$i18n.n(
-            Math.floor(projectedPoint.x),
-            'number'
-        )} m${this.$iApi.$i18n.t('map.coordinates.east')} | ${this.$iApi.$i18n.n(
-            Math.abs(Math.floor(projectedPoint.y)),
-            'number'
+        } as any)} ${this.$iApi.$i18n.t('map.coordinates.' + (lat > 0 ? 'north' : 'south'))} ${this.$iApi.ui.formatNumber(
+            Math.floor(projectedPoint.x)
+        )} m${this.$iApi.$i18n.t('map.coordinates.east')} | ${this.$iApi.ui.formatNumber(
+            Math.abs(Math.floor(projectedPoint.y))
         )} m${this.$iApi.$i18n.t('map.coordinates.north')}`;
     }
 
@@ -501,6 +500,6 @@ export class MapCaptionAPI extends APIScope {
         // project the point using the basemaps spatial reference
         const projectedPoint: any = await this.$iApi.geo.proj.projectGeometry(this.$iApi.geo.map.getSR(), p);
 
-        return `${this.$iApi.$i18n.n(projectedPoint.x, 'number')} | ${this.$iApi.$i18n.n(projectedPoint.y, 'number')}`;
+        return `${this.$iApi.ui.formatNumber(projectedPoint.x)} | ${this.$iApi.ui.formatNumber(projectedPoint.y)}`;
     }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -26,6 +26,7 @@ export interface RampConfig {
         zoomIcon?: string;
         scrollToInstance?: boolean;
         suppressNumberLocalization?: boolean;
+        showThousandsSeparator?: boolean;
     };
 }
 


### PR DESCRIPTION
  - Related Item(s): #3048
  - Changes:
    - [FEATURE] Add system.showThousandsSeparator config option (default false)
    - [REFACTOR] Route plain number display calls through ui.formatNumber
  - Notes: opt-in flag, default behavior unchanged; coordinate calls in caption.ts keep $i18n.n because they need options formatNumber doesn't accept; attach before/after screenshots of the grid + 2,000km scale.
  - QA Testing: Please test against main branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html
  - Testing steps:   The option is off by default, so you must enable it to see any change.

  Steps:
  1. Enable the flag: in `demos/enhanced-samples.html`, add `showThousandsSeparator: true` to the `system` block of both the `en` and `fr` configs (e.g. `system: { animate: true, showThousandsSeparator: true }`).
  2. Run `npm run dev` and open the enhanced-samples page.
  3. Load a feature layer with a large numeric column, open its datatable, and confirm values render with commas (e.g. `1,234,567`).
  4. Zoom the map fully out and confirm the scale reads e.g. `2,000km`.
  5. Set the flag back to `false` and confirm the separators disappear — verifying it's opt-in and default behavior is unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3049)
<!-- Reviewable:end -->
