### PR TITLE
New Draw and Detail Events

### DIFF
--- a/docs/using-ramp4/default-setup.md
+++ b/docs/using-ramp4/default-setup.md
@@ -72,6 +72,9 @@ These events will be present if the associated core fixtures are running
 | Event Name                           | Payload                                                 | Event Announces                                                |
 | ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------- |
 | DETAILS_TOGGLE<br>'details/toggle'   | { data: any, uid: string, format: string }, boolean (optional)         | A feature's details panel toggle was requested with optional force open/close       |
+| DETAILS_VIEW<br>'details/view'       | _identifyItem_: IdentifyItem, _uid_: string             | An individual item has loaded and displayed in the detail panel |
+| DRAW_EDIT<br>'draw/edit'             | _id_: string, _drawing_: DrawShapeExportRecord, _rampGeom_: BaseGeometry  | A drawing shape was edited |
+| DRAW_NEW<br>'draw/new'             | _id_: string, _drawing_: DrawShapeExportRecord, _rampGeom_: BaseGeometry, _user_: boolean  | A drawing shape was created |
 | GEOSEARCH_ZOOM<br>'geosearch/zoom'   | _zoomPromise_: Promise, _searchItem_: ISearchResult     | An item in GeoSearch was selected and zoomed to |
 | GRID_TOGGLE<br>'grid/toggle'         | _layer_: LayerInstance, _open_: boolean (optional)      | Grid panel toggle was requested with optional force open/close |
 | HELP_TOGGLE<br>'help/toggle'         | boolean (optional)                                      | Help panel toggle was requested with optional force open/close |

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -45,10 +45,30 @@ export enum GlobalEvents {
     CONFIG_CHANGE = 'config/configchanged',
 
     /**
-     * Fires when a request is issued to toggle (show if hidden, hide if showing) the details of an identify result.
-     * Payload: `({ identifyItem: IdentifyItem, uid: string, format: string }, force?: boolean)`
+     * Fires when a request is issued to toggle (show if hidden, hide if showing) the details panel with a given payload.
+     * Payload: `({ data: any, uid: string, format: string }, force?: boolean)`
      */
     DETAILS_TOGGLE = 'details/toggle',
+
+    /**
+     * Fires when a single item's details are viewed in the detail panel. If another item is viewed before the current item's
+     * data finishes loading, the event will not fire.
+     * Payload: `({ identifyItem: IdentifyItem, uid: string })`
+     */
+    DETAILS_VIEW = 'details/view',
+
+    /**
+     * Fires when a drawing has been edited.
+     * Payload: `({ id: string, drawing: DrawShapeExportRecord, rampGeom: BaseGeometry })`
+     */
+    DRAW_EDIT_DRAWING = 'draw/edit',
+
+    /**
+     * Fires when a new drawing is created.
+     * The user flag is true if it was drawn via the drawing tools. False if imported from file/api.
+     * Payload: `({ id: string, drawing: DrawShapeExportRecord, rampGeom: BaseGeometry, user: boolean })`
+     */
+    DRAW_NEW_DRAWING = 'draw/new',
 
     /**
      * Fires when a filter is changed.

--- a/src/fixtures/details/components/result-item.vue
+++ b/src/fixtures/details/components/result-item.vue
@@ -103,7 +103,7 @@ import ESRIDefault from '../templates/esri-default.vue';
 import HTMLDefault from '../templates/html-default.vue';
 
 import type { FieldDefinition } from '@/geo/api';
-import { NotificationType } from '@/api';
+import { GlobalEvents, NotificationType } from '@/api';
 import type { IdentifyItem, InstanceAPI, LayerInstance } from '@/api';
 
 const layerStore = useLayerStore();
@@ -194,8 +194,20 @@ const makeHtmlLink = (html: any): any => {
  * Called whenever the displayed item changes
  */
 const itemChanged = () => {
+    const thisViewRequest = Date.now();
+    detailsStore.lastestDetailView = thisViewRequest;
+
+    const emitDetailViewEvent = () => {
+        // only emit if not in list view, and the item we think we are viewing is still
+        // the latest item being viewed.
+        if (!props.inList && thisViewRequest === detailsStore.lastestDetailView) {
+            iApi.event.emit(GlobalEvents.DETAILS_VIEW, { identifyItem: props.data, uid: props.uid });
+        }
+    };
+
     updateZoomStatus('none');
     if (props.data.loaded) {
+        emitDetailViewEvent();
         fetchIcon();
     } else {
         // request any details download and wait.
@@ -206,6 +218,7 @@ const itemChanged = () => {
         //      will cause issue #2156
 
         props.data.load().then(() => {
+            emitDetailViewEvent();
             fetchIcon();
         });
 

--- a/src/fixtures/details/store/details-store.ts
+++ b/src/fixtures/details/store/details-store.ts
@@ -35,6 +35,12 @@ export const useDetailsStore = defineStore('details', () => {
     const lastHilight = ref<number>(0);
 
     /**
+     * Indicates the time of the lastest "view" request of a detail item (a specific item, or a list view).
+     * Used to mitigate slow loading items and fast clicking users.
+     */
+    const lastestDetailView = ref<number>(0);
+
+    /**
      * Whether or not the details hilight toggle is on.
      */
     const hilightToggle = ref<boolean>(true);
@@ -63,6 +69,7 @@ export const useDetailsStore = defineStore('details', () => {
         defaultTemplates,
         currentFeatureId,
         activeGreedy,
+        lastestDetailView,
         lastHilight,
         hilightToggle,
         origin,

--- a/src/fixtures/draw/api/draw-api.ts
+++ b/src/fixtures/draw/api/draw-api.ts
@@ -4,7 +4,7 @@ import { FixtureInstance } from '@/api';
 import type { GraphicLayer, InstanceAPI } from '@/api';
 import { Extent, GeometryType } from '@/geo/api';
 import type { BaseGeometry, IdentifyGeometryProvider, MapClick } from '@/geo/api';
-import { EsriIntersectsOperator, EsriSpatialReference } from '@/geo/esri';
+import { EsriIntersectsOperator } from '@/geo/esri';
 import type { EsriGeometry } from '@/geo/esri';
 
 import { DRAW_EDIT_GRAPHICS_LAYER_ID, DRAW_GRAPHICS_LAYER_ID, DRAW_HIGHLIGHT_GRAPHICS_LAYER_ID } from '../constants';
@@ -22,9 +22,9 @@ import {
 } from '../settings';
 import type { DrawBufferSettings, DrawBufferUnit, DrawIdentifyBufferMode } from '../settings';
 import {
-    createDrawShapeExportRecord,
     createDrawShapesExportFile,
     downloadDrawShapes,
+    drawingToRampGeom,
     getDrawShapeId,
     parseDrawShapesPayload
 } from '../shape-io';
@@ -439,45 +439,9 @@ export class DrawAPI extends FixtureInstance implements IdentifyGeometryProvider
      */
     exportRampGeometry(): Array<BaseGeometry> {
         return (this.store.graphics as DrawGraphicLike[])
-            .map(drawingGraphic => {
-                // note this "export record create" is needed. using the raw graphic from the store
-                // explodes things somehow (missing geometry?? doesn't make sense but thats the erro).
-                // Maybe can revisit with deep dive through all the methods later, but this WOMM.
-                const fancyGraphic = createDrawShapeExportRecord(drawingGraphic)!;
-                if (!fancyGraphic.geometry) {
-                    return undefined;
-                }
-
-                // convert the drawing type to a neutral esri geometry type.
-                let esriGeomType: string;
-
-                switch (fancyGraphic.type) {
-                    case 'point':
-                    case 'polyline':
-                    case 'multipoint':
-                    case 'polygon':
-                        esriGeomType = fancyGraphic.type;
-                        break;
-
-                    case 'rectangle':
-                    case 'circle':
-                        esriGeomType = 'polygon';
-                        break;
-
-                    default:
-                        console.error(`Encountered unhandled drawing type ${fancyGraphic.type}`);
-                        return undefined;
-                }
-
-                // make an esri-ish geometry, having enough stuff for our esri-to-ramp converter.
-                // the converter needs a real esri SR so that gets enhanced
-                const esriLikeGeom: any = fancyGraphic.geometry;
-                esriLikeGeom.type = esriGeomType;
-                esriLikeGeom.spatialReference = new EsriSpatialReference(esriLikeGeom.spatialReference);
-
-                return this.$iApi.geo.geom.geomEsriToRamp(esriLikeGeom, drawingGraphic.id);
-            })
-            .filter(x => !!x);
+            .map(drawingGraphic => drawingToRampGeom(drawingGraphic, this.$iApi))
+            .filter(x => !!x)
+            .map(nugget => nugget.ramp);
     }
 }
 

--- a/src/fixtures/draw/draw.vue
+++ b/src/fixtures/draw/draw.vue
@@ -76,10 +76,10 @@ import {
 import type { DrawBufferSettings, DrawIdentifyBufferMode, DrawMapLabelSettings, DrawStyleSettings } from './settings';
 import { isPanelOpen, openDrawShapeDetailsPanel } from './panel-utils';
 import type { DrawShapeDetailsTab } from './panel-utils';
-import { getDrawShapeId } from './shape-io';
+import { drawingToRampGeom, getDrawShapeId } from './shape-io';
 import type { DrawShapeImportRecord } from './shape-io';
 import { useDrawStore } from './store';
-import type { DrawGraphicLike, DrawGraphicType } from './types';
+import type { DrawGraphicLike, DrawGraphicType, DrawingEventPayload, NewDrawingEventPayload } from './types';
 import { buildDrawSegments, buildDrawVertices, parseDrawMeasurementTargetKey } from './measurement-utils';
 import { useDrawIdentify } from './use-draw-identify';
 import { useDrawKeyboard } from './use-draw-keyboard';
@@ -464,11 +464,11 @@ const applySketchSymbols = () => {
     sketch.polygonSymbol = createDrawSymbol('polygon', style) as any;
 };
 
-const syncGraphicStoreRecord = (graphic: EsriGraphic) => {
+const syncGraphicStoreRecord = (graphic: EsriGraphic): DrawGraphicLike | undefined => {
     const id = graphic.attributes?.id;
-    if (!id) return;
+    if (!id) return undefined;
 
-    drawStore.updateGraphic(id, {
+    return drawStore.updateGraphic(id, {
         type: graphic.attributes?.type,
         geometry: graphic.geometry,
         attributes: graphic.attributes
@@ -708,6 +708,22 @@ const deleteSelectedGraphic = (): boolean => {
     return true;
 };
 
+const emitNewGraphicEvent = (drawGraphic: DrawGraphicLike, byUser: boolean): void => {
+    const graphicConversion = drawingToRampGeom(drawGraphic, iApi);
+
+    if (graphicConversion) {
+        // graphicConversion should always exist. using the IF here just to avoid runtime bomb in very weird cases
+        const eventPayload: NewDrawingEventPayload = {
+            id: drawGraphic.id!,
+            drawing: graphicConversion.draw,
+            rampGeom: graphicConversion.ramp,
+            user: byUser
+        };
+
+        iApi.event.emit(GlobalEvents.DRAW_NEW_DRAWING, eventPayload);
+    }
+};
+
 const importDrawShapes = async (records: DrawShapeImportRecord[]): Promise<number> => {
     if (!records.length || !graphicsLayer) return 0;
 
@@ -733,12 +749,17 @@ const importDrawShapes = async (records: DrawShapeImportRecord[]): Promise<numbe
             });
             const id = prepareDrawGraphic(graphic, type, record.id);
             importedGraphics.push(graphic);
-            drawStore.addGraphic({
+
+            const drawGraphic: DrawGraphicLike = {
                 id,
                 type,
                 geometry: graphic.geometry,
                 attributes: graphic.attributes
-            });
+            };
+
+            drawStore.addGraphic(drawGraphic);
+
+            emitNewGraphicEvent(drawGraphic, false);
         } catch {
             // File validation already happened in the import panel. Skip any shape that still cannot hydrate.
         }
@@ -2069,13 +2090,18 @@ const handleSketchCreateEvent = (event: EsriSketchCreateEvent) => {
         }
         const id = prepareDrawGraphic(graphic, event.tool);
         syncBufferGraphic(graphic);
-        drawStore.addGraphic({
+
+        const drawGraphic: DrawGraphicLike = {
             id,
             type: event.tool,
             geometry: graphic.geometry,
             attributes: graphic.attributes
-        });
+        };
+
+        drawStore.addGraphic(drawGraphic);
         void refreshMeasurementGraphics(graphic, event.tool);
+
+        emitNewGraphicEvent(drawGraphic, true);
 
         if (event.tool !== 'point') {
             drawStore.setActiveTool('');
@@ -2118,16 +2144,32 @@ const handleSketchUpdateEvent = (event: EsriSketchUpdateEvent) => {
         const sourceGraphic = syncActiveSketchEditToSource() ?? graphic;
         clearActiveSketchEdit({ restoreSource: true });
 
+        let finalStoreGraphic: DrawGraphicLike | undefined = undefined;
+
         if (sourceGraphic.attributes?.id) {
             applyDrawSymbol(sourceGraphic);
             syncBufferGraphic(sourceGraphic);
-            syncGraphicStoreRecord(sourceGraphic);
+            finalStoreGraphic = syncGraphicStoreRecord(sourceGraphic);
             cancelPendingFeatureCountRefresh();
             void refreshSelectedGraphicFeatureCounts(sourceGraphic);
             iApi.updateAlert(t('draw.graphic.updated'));
         }
         highlightSelectedGraphic(shapeDetailsPanelOpen() ? sourceGraphic : undefined);
         void refreshMeasurementGraphics(sourceGraphic, sourceGraphic.attributes?.type);
+
+        if (finalStoreGraphic) {
+            const graphicConversion = drawingToRampGeom(finalStoreGraphic, iApi);
+
+            if (graphicConversion) {
+                const eventPayload: DrawingEventPayload = {
+                    id: finalStoreGraphic.id!,
+                    drawing: graphicConversion.draw,
+                    rampGeom: graphicConversion.ramp
+                };
+
+                iApi.event.emit(GlobalEvents.DRAW_EDIT_DRAWING, eventPayload);
+            }
+        }
     }
 };
 

--- a/src/fixtures/draw/shape-io.ts
+++ b/src/fixtures/draw/shape-io.ts
@@ -1,6 +1,6 @@
 import FileSaver from 'file-saver';
 
-import { EsriGeometryFromJson } from '@/geo/esri';
+import { EsriGeometryFromJson, EsriSpatialReference } from '@/geo/esri';
 
 import {
     cloneDrawBufferSettings,
@@ -14,6 +14,8 @@ import {
 } from './settings';
 import type { DrawBufferSettings, DrawIdentifyBufferMode, DrawMapLabelSettings, DrawStyleSettings } from './settings';
 import type { DrawGraphicLike } from './types';
+import type { InstanceAPI } from '@/api';
+import type { BaseGeometry } from '@/geo/api';
 
 export const DRAW_SHAPES_FILE_TYPE = 'ramp4-draw-shapes';
 export const DRAW_SHAPES_FILE_VERSION = 1;
@@ -235,4 +237,56 @@ export const readDrawShapeFiles = async (files: File[]): Promise<DrawShapeImport
     }
 
     return importedShapes;
+};
+
+/**
+ * Converts a drawing graphic thing to a RAMP geometry
+ *
+ * @param drawShape drawing graphic internal thing
+ * @param rampInstance a ramp instance
+ * @returns resolves with Ramp geometry and the Drawing Export shape, or undefined if things went weird
+ */
+export const drawingToRampGeom = (
+    drawShape: DrawGraphicLike,
+    rampInstance: InstanceAPI
+): { ramp: BaseGeometry; draw: DrawShapeExportRecord } | undefined => {
+    // note this "export record create" is needed. using the raw graphic from the store
+    // explodes things somehow (missing geometry?? doesn't make sense but thats the erro).
+    // Maybe can revisit with deep dive through all the methods later, but this WOMM.
+    const drawExportShape = createDrawShapeExportRecord(drawShape)!;
+    if (!drawExportShape.geometry) {
+        return undefined;
+    }
+
+    // convert the drawing type to a neutral esri geometry type.
+    let esriGeomType: string;
+
+    switch (drawExportShape.type) {
+        case 'point':
+        case 'polyline':
+        case 'multipoint':
+        case 'polygon':
+            esriGeomType = drawExportShape.type;
+            break;
+
+        case 'rectangle':
+        case 'circle':
+            esriGeomType = 'polygon';
+            break;
+
+        default:
+            console.error(`Encountered unhandled drawing type ${drawExportShape.type}`);
+            return undefined;
+    }
+
+    // make an esri-ish geometry, having enough stuff for our esri-to-ramp converter.
+    // the converter needs a real esri SR so that gets enhanced
+    const esriLikeGeom: any = drawExportShape.geometry;
+    esriLikeGeom.type = esriGeomType;
+    esriLikeGeom.spatialReference = new EsriSpatialReference(esriLikeGeom.spatialReference);
+
+    return {
+        ramp: rampInstance.geo.geom.geomEsriToRamp(esriLikeGeom, drawShape.id),
+        draw: drawExportShape
+    };
 };

--- a/src/fixtures/draw/store/draw-store.ts
+++ b/src/fixtures/draw/store/draw-store.ts
@@ -210,11 +210,13 @@ export const useDrawStore = defineStore('draw', () => {
         }
     }
 
-    function updateGraphic(id: string, updates: any) {
+    function updateGraphic(id: string, updates: any): DrawGraphicLike | undefined {
         const graphic = graphics.find(g => g.id === id);
         if (graphic) {
             Object.assign(graphic, updates);
         }
+
+        return graphic;
     }
 
     function setGraphicMapLabelSettings(id: string, settings: Partial<DrawMapLabelSettings>) {

--- a/src/fixtures/draw/types.ts
+++ b/src/fixtures/draw/types.ts
@@ -1,4 +1,6 @@
 import type { EsriGeometry } from '@/geo/esri';
+import type { BaseGeometry } from '@/geo/api';
+import type { DrawShapeExportRecord } from './shape-io';
 
 export type Vertex = [number, number];
 
@@ -26,3 +28,16 @@ export type DrawGraphicLike = {
     attributes?: any;
     geometry?: EsriGeometry | null;
 };
+
+export interface DrawingEventPayload {
+    id: string;
+    drawing: DrawShapeExportRecord;
+    rampGeom: BaseGeometry;
+}
+
+export interface NewDrawingEventPayload extends DrawingEventPayload {
+    /**
+     * True if the user drew it via the tools. False if imported.
+     */
+    user: boolean;
+}


### PR DESCRIPTION
### Related Item(s)

- In support of https://github.com/ramp4-pcar4/ramp4-pcar4/issues/3024

### Changes
- Adds these new events
  - When a new "drawing" (shape) is made in drawing tool
  - When an existing "drawing" is edited in drawing tool
  - When an individual Detail item is viewed (either via identify or show details)

### Notes

The edit-drawing event has the following gap:


This works

1. Select Shape Inspector from drawing toolbar and pick a shape.
2. Go to `Edit` tab in the inspector panel.
3. Drag the edit handle nubbins to resize the shape on the map.
4. Click in an empty part of the map.
5. Edit mode ends, edit event appears on the console.

This does not

1. Select Shape Inspector from drawing toolbar and pick a shape.
2. Go to `Edit` tab in the inspector panel.
3. Drag the edit handle nubbins to resize the shape on the map.
4. Close the inspector panel via the panel `X`.
5. Edit mode ends, edit event does not fire.

There must be an alternate "finish the editing" path that I've been unable to find in the code haystack. If no experts (_cough_ Miles) can point it out, will log a new issue to track the problem.


### QA Testing

 
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

 
### Testing

---

**Drawing events:**  Use Enhanced Sample 13.  Run this code in the console, then try out the editor while watching the console.

```js
const huh = mystery => mystery === undefined ? '??' : mystery;

const spammer = payload => {
  const isNew = huh(payload.user) !== '??';
  const message = ['Evt Type: ', isNew ? 'New Draw' : 'Edit Draw', ' | Id: ', huh(payload.id), ' | Draw Type: ', huh(payload.drawing?.type), ' | Ramp Type: ', huh(payload.rampGeom?.type), isNew ? (' | User flag: ' + payload.user) : ''];
  console.log('----');
  console.log(message.join(''));
  console.log('Raw payload', payload);
};

debugInstance.event.on('draw/new', p => spammer(p));
debugInstance.event.on('draw/edit', p => spammer(p));
```

Here is a file to upload a new shape to test the "user false" flag on the new drawing event:
[shapes-circle.json](https://github.com/user-attachments/files/31190141/shapes-circle.json)

---

**Details event:** Use Enhanced Sample 3.  Run this code in the console then try identifying points. See the event trigger in the console when the individual detail view updates. It should do nothing when in "list view".  Try the arrow scrollers, entrance from list view, etc.

```js
debugInstance.event.on('details/view', p => {
  console.log('----');
  const layer = debugInstance.geo.layer.getLayer(p.uid);
  console.log('Detail for layer: ' + (layer?.id || '???') + ' | ' + layer?.name);
  console.log(p.identifyItem?.data?.Name || '???');
  console.log(p.identifyItem);
});
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3050)
<!-- Reviewable:end -->
