### PR TITLE
Centroids

### DIFF
--- a/src/fixtures/draw/measurement-utils.ts
+++ b/src/fixtures/draw/measurement-utils.ts
@@ -278,23 +278,32 @@ export const segmentLengthMeters = (
         })
     );
 
-export const polygonLabelPoint = (polygon: EsriPolygon): EsriPoint | undefined => {
-    try {
-        const centroid = EsriCentroidOperator(polygon);
-        if (centroid) {
-            return centroid;
-        }
-    } catch {
-        // Fall back to the extent center below.
+/**
+ * Finds the centroid of an ESRI geometry, if possible
+ * @param geometry an esri geometry
+ * @returns the geometry centroid as an esri point, or undefined if we couldn't derive it
+ */
+export const centroidEsri = (geometry: EsriGeometry | undefined): EsriPoint | undefined => {
+    if (!geometry) return undefined;
+
+    if (geometry.type === 'point') {
+        return geometry as EsriPoint;
     }
 
-    const extent = polygon.extent;
+    try {
+        const centroid = EsriCentroidOperator(geometry);
+        if (centroid) return centroid;
+    } catch {
+        // Fall back to extent center below.
+    }
+
+    const extent = geometry.extent;
     if (!extent) return undefined;
 
     return new EsriPoint({
         x: (extent.xmin + extent.xmax) / 2,
         y: (extent.ymin + extent.ymax) / 2,
-        spatialReference: polygon.spatialReference
+        spatialReference: geometry.spatialReference
     });
 };
 

--- a/src/fixtures/draw/shape-inspector-screen.vue
+++ b/src/fixtures/draw/shape-inspector-screen.vue
@@ -572,7 +572,7 @@ import 'vue-slider-component/theme/default.css';
 import type { PanelInstance } from '@/api';
 import type { InstanceAPI } from '@/api/internal';
 import { Point, SpatialReference } from '@/geo/api';
-import { EsriCentroidOperator, EsriPoint, EsriPolygon, EsriPolyline } from '@/geo/esri';
+import { EsriPoint, EsriPolygon, EsriPolyline } from '@/geo/esri';
 import type { EsriGeometry } from '@/geo/esri';
 
 import CopyIcon from './icons/copy-icon.vue';
@@ -584,6 +584,7 @@ import DrawColorControl from './color-control.vue';
 import {
     buildDrawSegments,
     buildDrawVertices,
+    centroidEsri,
     formatDrawLength,
     loadDrawMeasurementOperators,
     measureDrawPolygonPerimeterMeters,
@@ -891,32 +892,6 @@ const buildSegmentRows = async (
     });
 };
 
-const centroidPoint = (geometry: EsriGeometry | undefined): EsriPoint | undefined => {
-    if (!geometry) return undefined;
-
-    if (geometry.type === 'point') {
-        return geometry as EsriPoint;
-    }
-
-    if (geometry.type === 'polygon') {
-        try {
-            const centroid = EsriCentroidOperator(geometry as EsriPolygon);
-            if (centroid) return centroid;
-        } catch {
-            // Fall back to extent center below.
-        }
-    }
-
-    const extent = geometry.extent;
-    if (!extent) return undefined;
-
-    return new EsriPoint({
-        x: (extent.xmin + extent.xmax) / 2,
-        y: (extent.ymin + extent.ymax) / 2,
-        spatialReference: geometry.spatialReference
-    });
-};
-
 const esriPointToRampPoint = (point: EsriPoint): Point =>
     new Point(
         'draw-coordinate',
@@ -1018,7 +993,7 @@ const refreshDetails = async () => {
     }
 
     detailsLoading.value = true;
-    const centroid = centroidPoint(geometry);
+    const centroid = centroidEsri(geometry);
     const graphicId = selectedGraphicId.value ? String(selectedGraphicId.value) : undefined;
     const vertices = showVerticesSection.value && graphicId ? buildDrawVertices(geometry, graphicId) : [];
     const vertexPoints = vertices.map(
@@ -1681,9 +1656,9 @@ onUnmounted(() => {
     position: relative;
     height: 72px;
     border: 1px solid #e5e7eb;
-    background: linear-gradient(45deg, #f8fafc 25%, transparent 25%),
-        linear-gradient(-45deg, #f8fafc 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #f8fafc 75%),
-        linear-gradient(-45deg, transparent 75%, #f8fafc 75%);
+    background:
+        linear-gradient(45deg, #f8fafc 25%, transparent 25%), linear-gradient(-45deg, #f8fafc 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, #f8fafc 75%), linear-gradient(-45deg, transparent 75%, #f8fafc 75%);
     background-size: 18px 18px;
     background-position:
         0 0,

--- a/src/fixtures/draw/use-draw-identify.ts
+++ b/src/fixtures/draw/use-draw-identify.ts
@@ -3,11 +3,11 @@ import { toRaw } from 'vue';
 import type { IdentifyResult } from '@/api';
 import type { InstanceAPI } from '@/api/internal';
 import { Point } from '@/geo/api';
-import { EsriCentroidOperator, EsriPoint } from '@/geo/esri';
-import type { EsriGeometry, EsriGraphic, EsriPolygon } from '@/geo/esri';
+import type { EsriGeometry, EsriGraphic } from '@/geo/esri';
 
 import { createDrawBufferGeometry, createDrawBufferOnlyGeometry, loadDrawBufferOperators } from './settings';
 import type { DrawBufferSettings, DrawIdentifyBufferMode } from './settings';
+import { centroidEsri } from './measurement-utils';
 import { useDrawStore } from './store';
 import type { DrawGraphicLike } from './types';
 
@@ -160,37 +160,11 @@ export const useDrawIdentify = ({
         }, 350);
     };
 
-    const identifyPointForGeometry = (geometry: EsriGeometry | undefined): EsriPoint | undefined => {
-        if (!geometry) return undefined;
-
-        if (geometry.type === 'point') {
-            return geometry as EsriPoint;
-        }
-
-        if (geometry.type === 'polygon') {
-            try {
-                const centroid = EsriCentroidOperator(geometry as EsriPolygon);
-                if (centroid) return centroid;
-            } catch {
-                // Fall back to extent center below.
-            }
-        }
-
-        const extent = geometry.extent;
-        if (!extent) return undefined;
-
-        return new EsriPoint({
-            x: (extent.xmin + extent.xmax) / 2,
-            y: (extent.ymin + extent.ymax) / 2,
-            spatialReference: geometry.spatialReference
-        });
-    };
-
     const runIdentifyForSelectedGraphic = async () => {
         const graphic = getSelectedFeatureCountGraphic();
         const id = getDrawGraphicId(graphic);
         const geometry = toRaw(graphic?.geometry) as EsriGeometry | undefined;
-        const identifyPoint = identifyPointForGeometry(geometry);
+        const identifyPoint = centroidEsri(geometry);
         if (!id || !identifyPoint) return;
 
         await refreshSelectedGraphicFeatureCounts(graphic);

--- a/src/fixtures/draw/use-draw-measurements.ts
+++ b/src/fixtures/draw/use-draw-measurements.ts
@@ -18,12 +18,12 @@ import type {
 import {
     buildDrawSegments,
     buildDrawVertices,
+    centroidEsri,
     formatDrawLength,
     formatDrawMapArea,
     loadDrawMeasurementOperators,
     measureDrawPolygonSquareMeters,
-    parseDrawMeasurementTargetKey,
-    polygonLabelPoint
+    parseDrawMeasurementTargetKey
 } from './measurement-utils';
 import { resolveGraphicMapLabelSettings } from './settings';
 import { useDrawStore } from './store';
@@ -349,6 +349,10 @@ export const useDrawMeasurements = ({
             : ring;
 
     const polygonScreenCentroid = (polygon: EsriPolygon, view: EsriMapView): ScreenPoint | undefined => {
+        // TODO figure out if this centroid algo is same as centroidEsri, or something fancier.
+        //      It does appear to be doing stuff in the Screen coordinates.
+        //      Some method documentation would have really helped.
+
         const rings = polygon.rings as Vertex[][];
         let areaSum = 0;
         let centroidX = 0;
@@ -1360,7 +1364,7 @@ export const useDrawMeasurements = ({
 
         const polygon = geometry as EsriPolygon;
         const area = measureDrawPolygonSquareMeters(polygon);
-        const point = polygonLabelPoint(polygon);
+        const point = centroidEsri(polygon);
 
         if (!area || area < 0.01 || !point) {
             return undefined;

--- a/src/geo/api/graphic/geometry/geometry.ts
+++ b/src/geo/api/graphic/geometry/geometry.ts
@@ -34,7 +34,7 @@ import type {
     EsriViewDoubleClickEvent,
     EsriViewPointerMoveEvent
 } from '@/geo/esri';
-import { EsriGraphic } from '@/geo/esri';
+import { EsriCentroidOperator, EsriGraphic } from '@/geo/esri';
 
 import { LineStyle } from '../style/line-style';
 import { PolygonStyle } from '../style/polygon-style';
@@ -334,5 +334,44 @@ export class GeometryAPI {
      */
     isImageUrl(text: string): boolean {
         return PointStyle.isImageUrl(text);
+    }
+
+    /**
+     * Given a RAMP geometry, find its centroid
+     *
+     * @param geom A ramp geometry
+     * @returns a point at the centroid
+     */
+    getCentroid(geom: BaseGeometry): Point {
+        const pointMaker = (x: number, y: number, sr: any): Point => {
+            return new Point('centroid', [x, y], sr);
+        };
+
+        if (geom.type === GeometryType.POINT) {
+            // clone & return
+            return pointMaker((geom as Point).x, (geom as Point).y, geom.sr);
+        }
+
+        const esriGeom = geom.toESRI();
+
+        try {
+            const centroid = EsriCentroidOperator(esriGeom);
+            if (centroid) {
+                return pointMaker(centroid.x, centroid.y, geom.sr);
+            }
+        } catch {
+            // Fall back to extent center below.
+        }
+
+        const extent = esriGeom.extent;
+        if (extent) {
+            return pointMaker((extent.xmin + extent.xmax) / 2, (extent.ymin + extent.ymax) / 2, geom.sr);
+        }
+
+        // ping here for now. if we find this occurs with any regularity, could add a dumb manual extent builder.
+        // essentially find min and max X & Y across all verticies of the geometry, then do the above / 2 middle math.
+        console.error('Encountered a geometry that we could not centroid');
+        console.log(geom, esriGeom);
+        return pointMaker(1, 1, undefined);
     }
 }


### PR DESCRIPTION
### Changes
- Adds a centroid finder for RAMP geometries. Will help shut up an annoying error in Egret and hopefully has some general usefulness living in RAMP API
- Consolidates some duplicate ESRI-based centroid finders in the drawing fixture


### QA Testing

Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html


### Testing

To test the new API, open Enhanced Sample 1 and run this code in the console. It will spit out the centroid and zoom the map to it, which should be the middle of one of the Happy Eyes.  You can bop the zoom-out button to back away and prove you were in the middle.

```js
const ring =  [[
    [-90.3515625,        53.73571574532637 ],
    [-92.13134765625,    53.199451902831555],
    [-91.29638671875,    51.93071827931289 ],
    [-88.9453125,        51.83577752045248 ],
    [-87.71484375,       52.96187505907603 ],
    [-88.59374999999999, 53.68369534495075 ],
    [-90.3515625,        53.73571574532637 ]
]];

const poly = new debugInstance.geo.geom.Polygon('fun', ring);
const centroid = debugInstance.geo.geom.getCentroid(poly);
debugInstance.geo.map.zoomMapTo(centroid) 
console.log(centroid.y + ', ' + centroid.x);
```

Then do some basic sanity testing on Enhanced Sample 13.  
- Labels look aligned / properly placed
- The identify in shape inspector works
- Centroid readouts in the shape inspector look correct (I validated a bunch with google earth, WOMM).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3055)
<!-- Reviewable:end -->
