### PR TITLE
Enhance identify result layer order

### DIFF
--- a/src/geo/layer/layer.ts
+++ b/src/geo/layer/layer.ts
@@ -282,7 +282,8 @@ export class LayerAPI extends APIScope {
 
     /**
      * Returns all map-based layers currently on the map.
-     * Result can be ordered in map stack order. Unordered is more performant.
+     * Result can be ordered in map stack order (lowest in visibility to highest).
+     * Unordered is more performant.
      *
      * @param {boolean} [inMapOrder=true] if result array should be sorted by map order.
      * @returns {Array<LayerInstance>} all layers on the map

--- a/src/geo/map/ramp-map.ts
+++ b/src/geo/map/ramp-map.ts
@@ -1356,7 +1356,11 @@ export class MapAPI extends CommonMapAPI {
      * @returns {MapIdentifyResult} results of the identify
      */
     runIdentify(targetPoint: MapClick | Point): MapIdentifyResult {
-        const layers = this.$iApi.geo.layer.allLayersOnMap(false).filter(l => l.canIdentify());
+        // get valid layers in map order, highest showing first
+        const layers = this.$iApi.geo.layer
+            .allLayersOnMap(true)
+            .filter(l => l.canIdentify())
+            .toReversed();
 
         let mapClick: MapClick;
         if (targetPoint instanceof Point) {


### PR DESCRIPTION

### Related Item(s)
- https://github.com/ramp4-pcar4/ramp4-pcar4/issues/3063

### Changes
- Makes identify result layer list match the map layer stack order

### Notes
It was a very difficult change, be we persevered and got it done.

### QA Testing
Please test against `main` branch https://ramp4-pcar4.github.io/ramp4-pcar4/main/demos/enhanced-samples.html

### Testing

Steps:

1. Use Enhanced Sample 5 (the pink states and the dots over them are probably easiest).
2. Open the reorder panel to see map layer order, then do identifys and see that the layer icon sidebar aligns.

Fancy test (still on E-Sample 5):

1. Click a pink state. See that the state layer is the active one in the identify panel
2. Keeping the identify panel open, use the layer order panel to push the state layer (`Zipped FlatGeobeuf`) up in the stack until its higher than the `Shape` layer.
3. Click another pink state, ensuring your mouse is also over a blue dot.
4. Ensure the identify result keeps the pink state layer as active, and that it now appears in the new position in the layer stack.

Extra test:

1. Use Enhanced Sample 13
2. Pick the inspect shape tool from the drawing button-bar (ℹ️)
3. Select the square overlapping happy.
4. Click the `Run Identify` button in the Shape Inspector panel.
5. See that you get the happy results.  Be aware this shape is set to identify only on the buffer, so "Right Eye" won't be in the result set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/ramp4-pcar4/3064)
<!-- Reviewable:end -->
